### PR TITLE
Fixes for junit test reports

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/JunitXmlReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JunitXmlReport.java
@@ -221,7 +221,7 @@ public class JunitXmlReport implements TestReporter {
 	public void endTest(Test test) {
 		String[] outs = basic.getCaptured();
 		if (outs[0] != null) {
-			Tag sysout = new Tag(testcase, "sysem-out");
+			Tag sysout = new Tag(testcase, "system-out");
 			sysout.addContent(outs[0]);
 		}
 


### PR DESCRIPTION
-Added failures, errors and skipped attributes because some build servers expect those.
-Renamed sys-out to system-out because this is the name used by most tools.
