### PR TITLE
Fix the issue #154

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1335,7 +1335,9 @@ public class Project extends Processor {
 					s = s.trim();
 					File ff = new File(s);
 					if (!ff.isFile()) {
-						error("buildfile lists file but the file does not exist %s", ff);
+						//error("buildfile lists file but the file does not exist %s", ff);
+						warning("buildfile lists file but the file does not exist %s", ff);
+						return null;
 					} else
 						files.add(ff);
 				}


### PR DESCRIPTION
when jar under generated directory is deleted and buildfiles only exist, ant build will failed.
https://github.com/bndtools/bnd/issues/154
