### PR TITLE
Fixing version in generated service component descriptor XML

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/ComponentDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/ComponentDef.java
@@ -51,7 +51,7 @@ class ComponentDef {
 
 	Tag getTag() {
 		Tag component = new Tag("scr:component");
-		component.addAttribute("xmlns:scr", NAMESPACE_STEM + "/" + version);
+		component.addAttribute("xmlns:scr", NAMESPACE_STEM + "/v" + version);
 		component.addAttribute("name", name);
 
 		if (servicefactory != null)


### PR DESCRIPTION
According to the specifications, XML namespace should include 'v' before actual version number (e.g,  "http://www.osgi.org/xmlns/scr/v1.2.0").

P.S. Note that fix affects support for new DS annotations, which is enabled by undocumented "-dsannotations" instruction.
