### PR TITLE
#140: properly quote '$' characters in target string during replaceAll()

### DIFF
--- a/biz.aQute.bndlib/src/aQute/lib/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/lib/osgi/Analyzer.java
@@ -1376,7 +1376,7 @@ public class Analyzer extends Processor {
 			} else
 				// This is for backward compatibility 0.0.287
 				// can be deprecated over time
-				override = override.replaceAll(USES_USES, sb.toString()).trim();
+				override = override.replaceAll(USES_USES, sb.toString().replaceAll("[$]", "\\\\\\$")).trim();
 
 			if (override.endsWith(","))
 				override = override.substring(0, override.length() - 1);


### PR DESCRIPTION
While #140 is closed as fixed, it is still reproducible in current master as of 50847ee7a5be13c6ae2cfce1ac437a89749a5115.

The attached changeset resolves this.
