### PR TITLE
Be able to validate the packages imported by an AnalyzerPlugin

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -690,6 +690,10 @@ public class Analyzer extends Processor {
 		return apiUses;
 	}
 
+	public Packages getClasspathExports() {
+		return classpathExports;
+	}
+
 	/**
 	 * Get the version for this bnd
 	 * 


### PR DESCRIPTION
When writing a aQute.bnd.service.AnalyzerPlugin I would like to be a able to check that the package to import is accessible from the classpath or from the own bundle. In order to do that I actually need to access the classpathExports field of the Analyzer in order to check that with the following code

``` java
String pkg = ....; // name of a package found by the plugin
PackageRef pack = analyzer.getPackageRef(pkg);
if (analyzer.getContained().containsKey(pack) || analyzer.getClasspathExports().contains(pack)) {
    // add the package in the import list
    if (!analyzer.getReferred().containsKey(pack)) {
        analyzer.getReferred().put(pack);
    }
} else {
    analyzer.error("References non existing or inaccessible package: %s", pkg);
}
```

But actually there is no such getter getClasspathExports so I added one.
Feel free to comment if you don't think this is the right way to implement this check.
