### PR TITLE
Fix for https://github.com/bndtools/bndtools/issues/518

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
@@ -167,6 +167,7 @@ public abstract class Domain implements Iterable<String> {
 	public Parameters getIncludeResource() {
 		Parameters ic = getParameters(INCLUDE_RESOURCE);
 		ic.putAll(getParameters(INCLUDERESOURCE));
+		ic.putAll(getParameters(WAB));
 		return ic;
 	}
 


### PR DESCRIPTION
While investingating why my -wab bundle was not being refreshed I found that 
aQute.bnd.osgi.Builder.isInScope(Collection<File>) was rejecting the changed resource because aQute.bnd.osgi.Domain.getIncludeResource() is only looking at Include-Resource header and -includeresource instruction.
I've tested the change locally and it worked fine - the WAB bundle was refreshed as expected.
