### PR TITLE
Close Jar before rename on file

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
@@ -166,17 +166,8 @@ public class LocalIndexedRepo extends FixedIndexedRepo implements Refreshable, P
 			newFilesInCoordination.clear();
 		}
 		for (URI entry : clone) {
-			Jar jar = null;
-			try {
-				File file = new File(entry);
-				jar = new Jar(file);
-				fireBundleAdded(jar, file);
-			}
-			finally {
-				if (jar != null) {
-					jar.close();
-				}
-			}
+			File file = new File(entry);
+			fireBundleAdded(file);
 		}
 	}
 
@@ -322,17 +313,24 @@ public class LocalIndexedRepo extends FixedIndexedRepo implements Refreshable, P
 		return storageDir;
 	}
 
-	protected void fireBundleAdded(Jar jar, File file) {
+	protected void fireBundleAdded(File file) {
 		if (registry == null)
 			return;
 		List<RepositoryListenerPlugin> listeners = registry.getPlugins(RepositoryListenerPlugin.class);
+		Jar jar = null;
 		for (RepositoryListenerPlugin listener : listeners) {
 			try {
+				if (jar == null)
+					jar = new Jar(file);
 				listener.bundleAdded(this, jar, file);
 			}
 			catch (Exception e) {
 				if (reporter != null)
 					reporter.warning("Repository listener threw an unexpected exception: %s", e);
+			}
+			finally {
+				if (jar != null)
+					jar.close();
 			}
 		}
 	}


### PR DESCRIPTION
The Jar class holds a Zipfile that keeps references open to the underlying
file. This will typicaly fail io operations such as rename/delete on
windows systems.
