### PR TITLE
Fix file repo tests on windows

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/deployer/FileRepoTest.java
+++ b/biz.aQute.bndlib.tests/src/test/deployer/FileRepoTest.java
@@ -199,8 +199,8 @@ public class FileRepoTest extends TestCase {
 			}
 			repo.close();
 			String s = collect(new File(root, "report"));
-			s = s.replaceAll(root.getAbsolutePath(), "@");
-			s = s.replaceAll(File.separator, "/");
+			s = s.replaceAll("\\\\", "/");
+			s = s.replaceAll(root.getAbsolutePath().replaceAll("\\\\", "/"), "@");
 			System.out.println(s);
 
 			String parts[] = s.split("\r?\n");

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -699,34 +699,53 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 	 * @param target
 	 */
 	void exec(String line, Object... args) {
-		if (line == null)
+		if (line == null) {
 			return;
+		}
 
 		try {
-			if (args != null)
+			if (args != null) {
 				for (int i = 0; i < args.length; i++) {
-					if (i == 0)
-						line = line.replaceAll("\\$\\{@\\}", args[0].toString());
-					line = line.replaceAll("\\$" + i, args[i].toString());
+					if (i == 0) {
+						// replaceAll backslash magic ensures windows paths
+						// remain intact
+						line = line.replaceAll("\\$\\{@\\}", args[0].toString().replaceAll("\\\\", "\\\\\\\\"));
+					}
+					// replaceAll backslash magic ensures windows paths remain
+					// intact
+					line = line.replaceAll("\\$" + i, args[i].toString().replaceAll("\\\\", "\\\\\\\\"));
 				}
-
-			if (shell == null) {
-				shell = System.getProperty("os.name").toLowerCase().indexOf("win") > 0 ? "cmd.exe" : "sh";
 			}
-			Command cmd = new Command(shell);
+			// purge remaining placeholders
+			line = line.replaceAll("\\s*\\$[0-9]\\s*", "");
 
-			if (path != null) {
-				cmd.inherit();
-				String oldpath = cmd.var("PATH");
-				path = path.replaceAll("\\s*,\\s*", File.pathSeparator);
-				path = path.replaceAll("\\$\\{@\\}", oldpath);
-				cmd.var("PATH", path);
-			}
-
-			cmd.setCwd(getRoot());
+			int result = 0;
 			StringBuilder stdout = new StringBuilder();
 			StringBuilder stderr = new StringBuilder();
-			int result = cmd.execute(line, stdout, stderr);
+			if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
+
+				// FIXME ignoring possible shell setting stdin approach used
+				// below does not work in windows
+				Command cmd = new Command("cmd.exe /C " + line);
+				cmd.setCwd(getRoot());
+				result = cmd.execute(stdout, stderr);
+
+			} else {
+				if (shell == null) {
+					shell = "sh";
+				}
+				Command cmd = new Command(shell);
+				cmd.setCwd(getRoot());
+
+				if (path != null) {
+					cmd.inherit();
+					String oldpath = cmd.var("PATH");
+					path = path.replaceAll("\\s*,\\s*", File.pathSeparator);
+					path = path.replaceAll("\\$\\{@\\}", oldpath);
+					cmd.var("PATH", path);
+				}
+				result = cmd.execute(line, stdout, stderr);
+			}
 			if (result != 0) {
 				reporter.error("Command %s failed with %s %s %s", line, result, stdout, stderr);
 			}


### PR DESCRIPTION
While adressing some windows/io issue in the FileRepo I ran into more junit test issue when running on windows. These patches "solve" it in the sense that all tests in FileRepoTest are green on windows. 

It's mostly wip, I can not guarantee that this is accoring to design and the command code needs a good review and testing on linux/mac.

I thought I'd just share it. Feel free to reject or direct me in the proper direction.
