### PR TITLE
issue 252.  Fix a lot of problems determining the ds namespace

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
@@ -63,10 +63,131 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	/**
-	 * The basic test. This test will take an all default component and a
-	 * component that has all values set. It looks like the xml tester needs a namespace, so we set one.
+	 * Check that a DS 1.0 compotible class with annotations ends up with the DS 1.0 (no) namespace
+	 *
 	 */
-	@Component(xmlns = "http://www.osgi.org/xmlns/scr/v1.1.0")
+	@Component()
+	public static class DS10_basic implements Serializable, Runnable {
+		private static final long	serialVersionUID	= 1L;
+
+		@Activate
+		void activate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Deactivate
+		void deactivate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Reference
+		void xsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		void unxsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		@Override
+		public void run() {
+			// TODO Auto-generated method stub
+
+		}
+	}
+
+	/**
+	 * Check that a DS 1.1 compotible class ends up with the DS 1.1 namespace and appropriate activate/deactivate attributes
+	 *
+	 */
+	@Component()
+	public static class DS11_basic implements Serializable, Runnable {
+		private static final long	serialVersionUID	= 1L;
+
+		@Activate
+		void activate(@SuppressWarnings("unused")ComponentContext cc, @SuppressWarnings("unused")BundleContext ctx) {}
+
+		@Deactivate
+		void deactivate(@SuppressWarnings("unused")ComponentContext cc, @SuppressWarnings("unused")int cause) {}
+
+		@Reference
+		void xsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		void unxsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		@Override
+		public void run() {
+			// TODO Auto-generated method stub
+
+		}
+	}
+
+	/**
+	 * Check that a DS 1.1 bind method causes a DS 1.1 namespace
+	 *
+	 */
+	@Component()
+	public static class DS11_ref1_basic implements Serializable, Runnable {
+		private static final long	serialVersionUID	= 1L;
+
+		@Activate
+		void activate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Deactivate
+		void deactivate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Reference
+		void xsetLogService(@SuppressWarnings("unused") LogService log, @SuppressWarnings("unused")  Map map) {
+
+		}
+
+		void unxsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		@Override
+		public void run() {
+			// TODO Auto-generated method stub
+
+		}
+	}
+
+	/**
+	 * Check that a DS 1.1 unbind method causes a DS 1.1 namespace
+	 *
+	 */
+	@Component()
+	public static class DS11_ref2_basic implements Serializable, Runnable {
+		private static final long	serialVersionUID	= 1L;
+
+		@Activate
+		void activate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Deactivate
+		void deactivate(@SuppressWarnings("unused")ComponentContext cc) {}
+
+		@Reference
+		void xsetLogService(@SuppressWarnings("unused") LogService log) {
+
+		}
+
+		void unxsetLogService(@SuppressWarnings("unused") LogService log, @SuppressWarnings("unused")  Map map) {
+
+		}
+
+		@Override
+		public void run() {
+			// TODO Auto-generated method stub
+
+		}
+	}
+
+	/**
+	 * The basic test. This test will take an all default component and a
+	 * component that has all values set.  Since the activate/deactivate methods have non-default names
+	 * and there is a modified methods, this is a DS 1.1 component.
+	 */
+	@Component()
 	public static class Defaults_basic implements Serializable, Runnable {
 		private static final long	serialVersionUID	= 1L;
 
@@ -152,6 +273,176 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 
 		{
+			//
+			// Test all the DS 1.0 defaults
+			//
+
+			Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$DS10_basic.xml");
+			System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+			assertNotNull(r);
+			r.write(System.err);
+			XmlTester xt = new XmlTester(r.openInputStream()); 
+
+			// Test the defaults
+			xt.assertAttribute("test.component.DSAnnotationTest$DS10_basic", "component/implementation/@class");
+
+			// Default must be the implementation class
+			xt.assertAttribute("test.component.DSAnnotationTest$DS10_basic", "component/@name");
+
+			xt.assertAttribute("", "component/@configuration-policy");
+			xt.assertAttribute("", "component/@immediate");
+			xt.assertAttribute("", "component/@enabled");
+			xt.assertAttribute("", "component/@factory");
+			xt.assertAttribute("", "component/@servicefactory");
+			xt.assertAttribute("", "component/@configuration-pid");
+			xt.assertAttribute("", "component/@activate");
+			xt.assertAttribute("", "component/@deactivate");
+			xt.assertAttribute("", "component/@modified");
+			xt.assertAttribute("java.io.Serializable", "component/service/provide[1]/@interface");
+			xt.assertAttribute("java.lang.Runnable", "component/service/provide[2]/@interface");
+
+			xt.assertAttribute("0", "count(component/properties)");
+			xt.assertAttribute("0", "count(component/property)");
+
+			xt.assertAttribute("xsetLogService", "component/reference[1]/@name");
+			xt.assertAttribute("", "component/reference[1]/@target");
+			xt.assertAttribute("xsetLogService", "component/reference[1]/@bind");
+			xt.assertAttribute("unxsetLogService", "component/reference[1]/@unbind");
+			xt.assertAttribute("", "component/reference[1]/@cardinality");
+			xt.assertAttribute("", "component/reference[1]/@policy");
+			xt.assertAttribute("", "component/reference[1]/@target");
+			xt.assertAttribute("", "component/reference[1]/@policy-option");
+	}
+	{
+			//
+			// Test the DS 1.1 defaults 
+			//
+
+			Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$DS11_basic.xml");
+			System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+			assertNotNull(r);
+			r.write(System.err);
+			XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.1.0"); // #136
+																												// was
+																												// http://www.osgi.org/xmlns/scr/1.1.0
+
+			// Test the defaults
+			xt.assertAttribute("test.component.DSAnnotationTest$DS11_basic", "scr:component/implementation/@class");
+
+			// Default must be the implementation class
+			xt.assertAttribute("test.component.DSAnnotationTest$DS11_basic", "scr:component/@name");
+
+			xt.assertAttribute("", "scr:component/@configuration-policy");
+			xt.assertAttribute("", "scr:component/@immediate");
+			xt.assertAttribute("", "scr:component/@enabled");
+			xt.assertAttribute("", "scr:component/@factory");
+			xt.assertAttribute("", "scr:component/@servicefactory");
+			xt.assertAttribute("", "scr:component/@configuration-pid");
+			xt.assertAttribute("activate", "scr:component/@activate");
+			xt.assertAttribute("deactivate", "scr:component/@deactivate");
+			xt.assertAttribute("", "scr:component/@modified");
+			xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
+			xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
+
+			xt.assertAttribute("0", "count(scr:component/properties)");
+			xt.assertAttribute("0", "count(scr:component/property)");
+
+			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
+			xt.assertAttribute("", "scr:component/reference[1]/@target");
+			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@bind");
+			xt.assertAttribute("unxsetLogService", "scr:component/reference[1]/@unbind");
+			xt.assertAttribute("", "scr:component/reference[1]/@cardinality");
+			xt.assertAttribute("", "scr:component/reference[1]/@policy");
+			xt.assertAttribute("", "scr:component/reference[1]/@target");
+			xt.assertAttribute("", "scr:component/reference[1]/@policy-option");
+	}
+	{
+		//
+		// Test a DS 1.1 bind method results in the DS 1.1 namespace
+		//
+
+		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$DS11_ref1_basic.xml");
+		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+		assertNotNull(r);
+		r.write(System.err);
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.1.0"); // #136
+																											// was
+																											// http://www.osgi.org/xmlns/scr/1.1.0
+
+		// Test the defaults
+		xt.assertAttribute("test.component.DSAnnotationTest$DS11_ref1_basic", "scr:component/implementation/@class");
+
+		// Default must be the implementation class
+		xt.assertAttribute("test.component.DSAnnotationTest$DS11_ref1_basic", "scr:component/@name");
+
+		xt.assertAttribute("", "scr:component/@configuration-policy");
+		xt.assertAttribute("", "scr:component/@immediate");
+		xt.assertAttribute("", "scr:component/@enabled");
+		xt.assertAttribute("", "scr:component/@factory");
+		xt.assertAttribute("", "scr:component/@servicefactory");
+		xt.assertAttribute("", "scr:component/@configuration-pid");
+		xt.assertAttribute("activate", "scr:component/@activate");
+		xt.assertAttribute("deactivate", "scr:component/@deactivate");
+		xt.assertAttribute("", "scr:component/@modified");
+		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
+		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
+
+		xt.assertAttribute("0", "count(scr:component/properties)");
+		xt.assertAttribute("0", "count(scr:component/property)");
+
+		xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
+		xt.assertAttribute("", "scr:component/reference[1]/@target");
+		xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@bind");
+		xt.assertAttribute("unxsetLogService", "scr:component/reference[1]/@unbind");
+		xt.assertAttribute("", "scr:component/reference[1]/@cardinality");
+		xt.assertAttribute("", "scr:component/reference[1]/@policy");
+		xt.assertAttribute("", "scr:component/reference[1]/@target");
+		xt.assertAttribute("", "scr:component/reference[1]/@policy-option");
+	}
+	{
+		//
+		// Test a DS 1.1 unbind method results in the DS 1.1 namespace
+		//
+
+		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$DS11_ref2_basic.xml");
+		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+		assertNotNull(r);
+		r.write(System.err);
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.1.0"); // #136
+																											// was
+																											// http://www.osgi.org/xmlns/scr/1.1.0
+
+		// Test the defaults
+		xt.assertAttribute("test.component.DSAnnotationTest$DS11_ref2_basic", "scr:component/implementation/@class");
+
+		// Default must be the implementation class
+		xt.assertAttribute("test.component.DSAnnotationTest$DS11_ref2_basic", "scr:component/@name");
+
+		xt.assertAttribute("", "scr:component/@configuration-policy");
+		xt.assertAttribute("", "scr:component/@immediate");
+		xt.assertAttribute("", "scr:component/@enabled");
+		xt.assertAttribute("", "scr:component/@factory");
+		xt.assertAttribute("", "scr:component/@servicefactory");
+		xt.assertAttribute("", "scr:component/@configuration-pid");
+		xt.assertAttribute("activate", "scr:component/@activate");
+		xt.assertAttribute("deactivate", "scr:component/@deactivate");
+		xt.assertAttribute("", "scr:component/@modified");
+		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
+		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
+
+		xt.assertAttribute("0", "count(scr:component/properties)");
+		xt.assertAttribute("0", "count(scr:component/property)");
+
+		xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
+		xt.assertAttribute("", "scr:component/reference[1]/@target");
+		xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@bind");
+		xt.assertAttribute("unxsetLogService", "scr:component/reference[1]/@unbind");
+		xt.assertAttribute("", "scr:component/reference[1]/@cardinality");
+		xt.assertAttribute("", "scr:component/reference[1]/@policy");
+		xt.assertAttribute("", "scr:component/reference[1]/@target");
+		xt.assertAttribute("", "scr:component/reference[1]/@policy-option");
+	}
+	{
 			//
 			// Test all the defaults
 			//

--- a/biz.aQute.bndlib/src/aQute/bnd/component/ReferenceDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/ReferenceDef.java
@@ -34,7 +34,7 @@ class ReferenceDef {
 			analyzer.error("No name for a reference");
 
 		if ((updated != null && !updated.equals("-")) || policyOption != null)
-			version = max(version, AnnotationReader.V1_2);
+			updateVersion(AnnotationReader.V1_2);
 
 		if (target != null) {
 			String error = Verifier.validateFilter(target);
@@ -81,16 +81,14 @@ class ReferenceDef {
 		return ref;
 	}
 
-	static <T extends Comparable<T>> T max(T a, T b) {
-		int n = a.compareTo(b);
-		if (n >= 0)
-			return a;
-		return b;
-	}
-
 	@Override
 	public String toString() {
 		return name;
 	}
+	
+	void updateVersion(Version version) {
+		this.version = ComponentDef.max(this.version, version);
+	}
+
 
 }


### PR DESCRIPTION
Compared to ds-9 this fixes determination of namespace from bind method signatures and makes the logic more straightforward for the signature to namespace determination.  Also there are more tests.
