### PR TITLE
Fix the bnd ant task to fail the build if the builder fails.

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/ant/BndTask.java
+++ b/biz.aQute.bnd/src/aQute/bnd/ant/BndTask.java
@@ -222,7 +222,12 @@ public class BndTask extends BaseTask {
 				builder.setSourcepath(toFiles(sourcepath, "sourcepath"));
 				Jar jars[] = builder.builds();
 
-				if (!failok && report() && report(builder)) {
+				// Report both task failures and bnd build failures.
+				boolean taskFailed = report();
+				boolean bndFailed = report(builder);
+
+				// Fail this build if failure is not ok and either the task failed or the bnd build failed.
+				if (!failok && (taskFailed || bndFailed)) {
 					throw new BuildException("bnd failed", new org.apache.tools.ant.Location(file.getAbsolutePath()));
 				}
 


### PR DESCRIPTION
Previously the bnd task was not failing the build if there were any errors
in the bnd file or plugins were triggering errors. This is because the task
itself had no errors.  The builder was only checked for errors if the task
had errors due to conditional short-circuiting.
