### PR TITLE
Add blueprint support to the Spring plugin

### DIFF
--- a/biz.aQute.bndlib/src/aQute/lib/spring/extract.xsl
+++ b/biz.aQute.bndlib/src/aQute/lib/spring/extract.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:beans="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context" xmlns:jee="http://www.springframework.org/schema/jee" xmlns:jms="http://www.springframework.org/schema/jms" xmlns:lang="http://www.springframework.org/schema/lang" xmlns:osgi-compendium="http://www.springframework.org/schema/osgi-compendium" xmlns:osgi="http://www.springframework.org/schema/osgi" xmlns:tool="http://www.springframework.org/schema/tool" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:util="http://www.springframework.org/schema/util" xmlns:webflow-config="http://www.springframework.org/schema/webflow-config">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:beans="http://www.springframework.org/schema/beans" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:context="http://www.springframework.org/schema/context" xmlns:jee="http://www.springframework.org/schema/jee" xmlns:jms="http://www.springframework.org/schema/jms" xmlns:lang="http://www.springframework.org/schema/lang" xmlns:osgi-compendium="http://www.springframework.org/schema/osgi-compendium" xmlns:osgi="http://www.springframework.org/schema/osgi" xmlns:tool="http://www.springframework.org/schema/tool" xmlns:tx="http://www.springframework.org/schema/tx" xmlns:util="http://www.springframework.org/schema/util" xmlns:webflow-config="http://www.springframework.org/schema/webflow-config" xmlns:blueprint="http://www.eclipse.org/gemini/blueprint/schema/blueprint">
 	<xsl:output method="text" />
 
 	<xsl:template match="/">
@@ -20,6 +20,7 @@
 			|	//jee:*/@business-interface
 			|	//lang:*/@script-interfaces
 			|	//osgi:*/@interface
+			|	//blueprint:*/@interface
 			|	//util:list/@list-class
 			|	//util:set/@set-class
 			|	//util:map/@map-class


### PR DESCRIPTION
Eclipse Blueprint uses a different namespace for its spring configuration.
Add this xml namespace to extract.xsl
