### PR TITLE
Allow workspace with space in it to work

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/LauncherTest.java
+++ b/biz.aQute.bndlib.tests/src/test/LauncherTest.java
@@ -72,6 +72,19 @@ public class LauncherTest extends TestCase {
 		assertEquals(42, l.launch());
 	}
 
+//	public static void testWorkspaceWithSpace() throws Exception {
+//		Project project = getProjectFromWorkspaceWithSpace();
+//		project.clear();
+//
+//		//[cs] This fails due to not finding the Launcher Plugin. I don't quite
+//		// understand what needs to be in the test workspace with a space
+//		// to make it find the launcher plugin.
+//		ProjectLauncher l = project.getProjectLauncher();
+//		l.setTrace(true);
+//		l.getRunProperties().put("test.cmd", "exit");
+//		assertEquals(42, l.launch());
+//	}
+	
 	/**
 	 * @return
 	 * @throws Exception
@@ -79,6 +92,12 @@ public class LauncherTest extends TestCase {
 	static Project getProject() throws Exception {
 		Workspace workspace = Workspace.getWorkspace(new File("").getAbsoluteFile().getParentFile());
 		Project project = workspace.getProject("demo");
+		return project;
+	}
+	
+	static Project getProjectFromWorkspaceWithSpace() throws Exception {
+		Workspace workspace = Workspace.getWorkspace(new File("test/w o r k s p a c e"));
+		Project project = workspace.getProject("p r o j e c t");
 		return project;
 	}
 

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -21,7 +21,8 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		propertiesFile = File.createTempFile("launch", ".properties", project.getTarget());
 		project.trace(MessageFormat.format("launcher plugin using temp launch file {0}",
 				propertiesFile.getAbsolutePath()));
-		addRunVM("-D" + LauncherConstants.LAUNCHER_PROPERTIES + "=\"" + propertiesFile.getAbsolutePath() + "\"");
+		String escapedPropertiesFile = propertiesFile.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\").replaceAll(" ", "\\\\ ");
+		addRunVM("-D" + LauncherConstants.LAUNCHER_PROPERTIES + "=" + escapedPropertiesFile);
 
 		if (project.getRunProperties().get("noframework") != null) {
 			setRunFramework(NONE);


### PR DESCRIPTION
This passes the 5 tests on Linux and Windows 7.
All tests pass on Linux after this change.

Windows has other outstanding test failures.. :(

It's possible a better implementation would use ProcessBuilder to launch the process instead of java.exec. I only escaped backslashes and spaces, which isn't full coverage of characters that might need escaping. Unfortunately the set of characters is probably OS specific -- and this might be where ProcessBuilder comes in.

If you want me to investigate ProcessBuilder, I could.
