### PR TITLE
Issue349: support workspace with space in it - fix test

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/LauncherTest.java
+++ b/biz.aQute.bndlib.tests/src/test/LauncherTest.java
@@ -72,30 +72,40 @@ public class LauncherTest extends TestCase {
 		assertEquals(42, l.launch());
 	}
 
-//	public static void testWorkspaceWithSpace() throws Exception {
-//		Project project = getProjectFromWorkspaceWithSpace();
-//		
-//		project.clear();
-//		project.clean();
-//		
-//		// reuse built .class files from the demo project.
-//		String base = new File("").getAbsoluteFile().getParentFile().getAbsolutePath();
-//		
-//		new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/").mkdirs();
-//		
-//		IO.copy(new File(base + "/demo/bin/test/TestActivator$1.class"),
-//				new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/TestActivator$1.class"));
-//		IO.copy(new File(base + "/demo/bin/test/TestActivator.class"),
-//				new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/TestActivator.class"));
-//		
-//		project.clear();
-//		project.build();
-//
-//		ProjectLauncher l = project.getProjectLauncher();
-//		l.setTrace(true);
-//		l.getRunProperties().put("test.cmd", "exit");
-//		assertEquals(42, l.launch());
-//	}
+	public static void testWorkspaceWithSpace() throws Exception {
+		Project project = getProjectFromWorkspaceWithSpace();
+		
+		project.clear();
+		project.clean();
+		
+		// reuse built .class files from the demo project.
+		String base = new File("").getAbsoluteFile().getParentFile().getAbsolutePath();
+		
+		new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/").mkdirs();
+		
+		IO.copy(new File(base + "/demo/bin/test/TestActivator$1.class"),
+				new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/TestActivator$1.class"));
+		IO.copy(new File(base + "/demo/bin/test/TestActivator.class"),
+				new File(base + "/biz.aQute.bndlib.tests/test/a space/test/bin/test/TestActivator.class"));
+		
+		// populate the launcher jar.
+		File launcher = new File(base + "/biz.aQute.launcher/generated/biz.aQute.launcher.jar");
+		File newlauncher = new File(base + "/biz.aQute.bndlib.tests/test/a space/cnf/local/biz.aQute.launcher/biz.aQute.launcher-1.0.0.jar");
+		if (newlauncher.exists()) {
+			assertTrue(newlauncher.delete());
+		}
+		newlauncher.getParentFile().mkdirs();
+		IO.copy(launcher, newlauncher);
+		assertTrue(newlauncher.exists());
+		
+		project.clear();
+		project.build();
+
+		ProjectLauncher l = project.getProjectLauncher();
+		l.setTrace(true);
+		l.getRunProperties().put("test.cmd", "exit");
+		assertEquals(42, l.launch());
+	}
 	
 	/**
 	 * @return

--- a/biz.aQute.bndlib.tests/test/a space/cnf/build.bnd
+++ b/biz.aQute.bndlib.tests/test/a space/cnf/build.bnd
@@ -3,5 +3,5 @@ dir: ${workspace}/../../../
 -pluginpath: ${dir}/biz.aQute.repository/generated/biz.aQute.repository.jar
 
 -plugin:\
-	aQute.lib.deployer.FileRepo; name=Bndtools Local; location=${dir}/dist/bundles,\
+	aQute.lib.deployer.FileRepo; name=Bndtools Local; location=${workspace}/cnf/local,\
 	aQute.lib.deployer.FileRepo; name=Build;          location=${dir}/cnf/repo


### PR DESCRIPTION
The test I had submitted made an assumption that "ant dist" had been run.
I removed that dependency, so the unit test runs without ant dist. It does assume that the launcher jar has been built - which should be fine for the cloudbees build.

Tested on Windows and Linux.
