### PR TITLE
FELIX-3585: don't assume a binary reference starting with [VBCISDFJZ] is a primitive type

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -331,7 +331,7 @@ public class Descriptors {
 			ref = getTypeRef(binaryClassName.substring(1));
 			ref = new ArrayRef(ref);
 		} else {
-			if (binaryClassName.length() >= 1) {
+			if (binaryClassName.length() == 1) {
 				switch (binaryClassName.charAt(0)) {
 					case 'V' :
 						return VOID;
@@ -351,11 +351,11 @@ public class Descriptors {
 						return LONG;
 					case 'Z' :
 						return BOOLEAN;
-					case 'L' :
-						binaryClassName = binaryClassName.substring(1, binaryClassName.length() - 1);
-						break;
 				}
 				// falls trough for other 1 letter class names
+			}
+			if (binaryClassName.startsWith("L")) {
+				binaryClassName = binaryClassName.substring(1, binaryClassName.length() - 1);
 			}
 			ref = typeRefCache.get(binaryClassName);
 			if (ref != null)


### PR DESCRIPTION
... because it could be a class in the default package such as JDOMAbout.

See https://issues.apache.org/jira/browse/FELIX-3585 for original issue and test project.

Note: this fix assumes that primitive type references will only be single letters and anything longer will be a class reference. If this is not the case (I don't know enough about who calls this code to be sure of this) then the fix will need adjusting accordingly.
