### PR TITLE
FELIX-3585: check binary class name starts with L and ends with ; before extracting it

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -354,7 +354,7 @@ public class Descriptors {
 				}
 				// falls trough for other 1 letter class names
 			}
-			if (binaryClassName.startsWith("L")) {
+			if (binaryClassName.startsWith("L") && binaryClassName.endsWith(";")) {
 				binaryClassName = binaryClassName.substring(1, binaryClassName.length() - 1);
 			}
 			ref = typeRefCache.get(binaryClassName);


### PR DESCRIPTION
Follow up to https://github.com/bndtools/bnd/pull/328 which fixed a related issue for primitive prefixes (ie. overly-eager matching).
