### PR TITLE
Avoid NPE while checking header equality

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -258,7 +258,7 @@ public class Attrs implements Map<String,String> {
 
 		Attrs other = o;
 
-		if (size() != other.size())
+		if (other == null || size() != other.size())
 			return false;
 
 		if (isEmpty())
@@ -270,7 +270,10 @@ public class Attrs implements Map<String,String> {
 			return false;
 
 		for (String key : keySet()) {
-			if (!get(key).equals(other.get(key)))
+			Object value = get(key);
+			Object valueo = other.get(key);
+			if (!((value == null && valueo == null) || (value != null && 
+					value.isEqual(valueo))))
 				return false;
 		}
 		return true;

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
@@ -185,7 +185,7 @@ public class Parameters implements Map<String,Attrs> {
 		if (this == other)
 			return true;
 
-		if (size() != other.size())
+		if (other == null || size() != other.size())
 			return false;
 
 		if (isEmpty())
@@ -197,7 +197,10 @@ public class Parameters implements Map<String,Attrs> {
 			return false;
 
 		for (String key : keySet()) {
-			if (!get(key).isEqual(other.get(key)))
+			Object value = get(key);
+			Object valueo = other.get(key);
+			if (!((value == null && valueo == null) || (value != null && 
+					value.isEqual(valueo))))
 				return false;
 		}
 		return true;


### PR DESCRIPTION
While applying Parameters#isEqual(Object) method...

Parameters mergedClauses = OSGiHeader.parseHeader( oldValue );
Parameters clauses = OSGiHeader.parseHeader( value );
if ( !mergedClauses.isEqual( clauses) ) ...

...I ended up with NPE as follows

java.lang.NullPointerException
        at aQute.bnd.header.Attrs.isEqual(Attrs.java:261)
        at aQute.bnd.header.Parameters.isEqual(Parameters.java:200)
