### PR TITLE
#351 allow Bundle-RequiredExecutionEnvironment

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -23,12 +23,14 @@ public class Verifier extends Processor {
 	private boolean			r3;
 	private boolean			usesRequire;
 
-	final static Pattern	EENAME	= Pattern.compile("CDC-1\\.0/Foundation-1\\.0" + "|CDC-1\\.1/Foundation-1\\.1"
+	final static Pattern	EENAME	= Pattern.compile("^(?:"
+											+ "CDC-1\\.0/Foundation-1\\.0" + "|CDC-1\\.1/Foundation-1\\.1"
 											+ "|OSGi/(?:Minimum-1\\.[1-9]|EmbeddedDevice-1.0)"
 											+ "|JRE-1\\.1" + "|J2SE-1\\.[2345]"
 											+ "|JavaSE-1\\.[67]"
 											+ "|PersonalJava-1\\.[12]"
-											+ "|CDC-1\\.0/PersonalBasis-1\\.0" + "|CDC-1\\.0/PersonalJava-1\\.0");
+											+ "|CDC-1\\.0/PersonalBasis-1\\.0" + "|CDC-1\\.0/PersonalJava-1\\.0"
+											+ ")$");
 
 	final static int		V1_1	= 45;
 	final static int		V1_2	= 46;


### PR DESCRIPTION
3 commits :
- fix for #351 : allow `OSGI/EmbeddedDevice-1.0` as a valid value in the verifier for `Bundle-RequiredExecutionEnvironment`
- refactor the regex that does that check to use grouping with `[]` to improve efficiency and readability (for exemple `J2SE-1\.2|J2SE-1\.3|J2SE-1\.4|J2SE-1\.5` becomes `J2SE-1\.[2345]`)
- fix the regex to use strict matching by adding boundaries binding with `^` and `$`

Note: most patterns in that source probably also need the same fix for match binding.
