### PR TITLE
Analyzer.calcManifest() Javadoc does not match implementation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -331,8 +331,7 @@ public class Analyzer extends Processor {
 
 	/**
 	 * One of the main workhorses of this class. This will analyze the current
-	 * setp and calculate a new manifest according to this setup. This method
-	 * will also set the manifest on the main jar dot
+	 * setup and calculate a new manifest according to this setup. 
 	 * 
 	 * @return
 	 * @throws IOException


### PR DESCRIPTION
calcManifest() no longer sets the manifest on the JAR. but the Javadoc still says so.

This is a breaking API change I ran into when upgrading Pax Swissbox from bndlib 1.x to 2.1.0.
