### PR TITLE
Change dependency from maven-plugin-api to maven-core. 

### DIFF
--- a/bnd-maven-plugin/pom.xml
+++ b/bnd-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
+			<artifactId>maven-core</artifactId>
 			<version>3.0</version>
 		</dependency>
 
@@ -42,13 +42,6 @@
 			<artifactId>mockito-all</artifactId>
 			<version>1.9.0</version>
 			<scope>test</scope>
-		</dependency>
-	
-	<!-- TODO If I remove the following dep then the code does not compile anymore??????-->
-		<dependency>
-			<groupId>org.twdata.maven</groupId>
-			<artifactId>mojo-executor</artifactId>
-			<version>2.0</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
This allows getting rid of org.twdata.maven:mojo-executor dependency.
