### PR TITLE
Fix #419: bnd generates xml 1.1 documents, should stick to 1.0

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
@@ -16,7 +16,7 @@ public class TagResource extends WriteResource {
 	public void write(OutputStream out) throws UnsupportedEncodingException {
 		OutputStreamWriter ow = new OutputStreamWriter(out, "UTF-8");
 		PrintWriter pw = new PrintWriter(ow);
-		pw.println("<?xml version='1.1'?>");
+		pw.println("<?xml version=\"1.0\"?>");
 		try {
 			tag.print(0, pw);
 		}


### PR DESCRIPTION
Also change the quotes to those that are normally used.

Signed-off-by: Ferry Huberts ferry.huberts@pelagic.nl
