### PR TITLE
defaults: set test related defaults

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/defaults.bnd
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/defaults.bnd
@@ -11,6 +11,8 @@ project.testpath        = ${p-testpath;:}
 project:      ${basedir}
 src:          src
 bin:          bin
+testsrc:      test
+testbin:      bin_test
 target-dir:   generated
 target:       ${project}/${target-dir}
 build:        ${workspace}/cnf


### PR DESCRIPTION
I need this to make the ant & gradle builds flexible w.r.t. src/bin and testsrc/testbin locations.

currently the test related objects are not set by bnd, resulting in hard-coded testsrc/testbin locations in the build scripts
