### PR TITLE
ResolutionBlacklistFilter filters out bundles from bundle resolution input

### DIFF
--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -33,6 +33,7 @@ Export-Package: aQute.bnd.annotation.*,\
 	aQute.bnd.properties,\
 	aQute.bnd.build.model,\
 	aQute.bnd.build.model.clauses,\
+	aQute.bnd.build.model.conversions,\
 	aQute.service.reporter,\
 	aQute.bnd.maven.support,\
 	aQute.bnd.url

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResolutionBlacklistFilter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResolutionBlacklistFilter.java
@@ -1,0 +1,71 @@
+package aQute.bnd.osgi.resource;
+
+import java.util.*;
+
+import org.osgi.resource.*;
+
+import aQute.bnd.build.model.clauses.*;
+import aQute.bnd.build.model.conversions.*;
+import aQute.bnd.service.*;
+import aQute.bnd.service.resolve.hook.*;
+import aQute.bnd.version.*;
+import aQute.service.reporter.*;
+
+/**
+ * ResolutionBlacklistFilter removes bundles from being resolution inputs.
+ * 
+ * Format for blacklist argument is 
+ * bundle;version=version or
+ * bundle;version=versionrange
+ */
+public class ResolutionBlacklistFilter implements ResolverHook, Plugin {
+
+	public static final String BLACKLIST_PROPERTYNAME = "blacklist";
+	
+	private Reporter reporter;
+	private HashMap<String, List<VersionRange>> filterOut = new HashMap<String, List<VersionRange>>();
+	private Converter<List<VersionedClause>,String>	converter	= new ClauseListConverter<VersionedClause>(new VersionedClauseConverter());
+	
+	public void setProperties(Map<String,String> map) {
+		if (map.containsKey(BLACKLIST_PROPERTYNAME)) {
+			List<VersionedClause> l = converter.convert(map.get(BLACKLIST_PROPERTYNAME));
+			for (VersionedClause vc : l) {
+				String name = vc.getName();
+				String range = vc.getVersionRange();
+				if (!filterOut.containsKey(name)) {
+					filterOut.put(name, new LinkedList<VersionRange>());
+				}
+				List<VersionRange> vclist = filterOut.get(name);
+				VersionRange vr = new VersionRange(vc.getVersionRange());
+				vclist.add(vr);
+			}
+		}
+	}
+
+	public void setReporter(Reporter processor) {
+		this.reporter = processor;
+	}
+
+	public void filterMatches(Requirement requirement, List<Capability> candidates) {
+		for (Iterator<Capability> iter = candidates.iterator(); iter.hasNext();) {
+			Capability c = iter.next();
+			Object id = c.getResource().getCapabilities("osgi.identity").get(0).getAttributes().get("osgi.identity");
+			//Version v = c.getResource().getCapabilities("osgi.identity").get(0).getAttributes().get("osgi.identity");
+			Object vv = c.getResource().getCapabilities("osgi.identity").get(0).getAttributes().get("version");
+			Version v = null;
+			if (vv != null) {
+				v = new Version(vv.toString());
+			}
+			if (id != null && v != null && filterOut.containsKey(id)) {
+				List<VersionRange> versionsToFilter = filterOut.get(id);
+				for (VersionRange vr : versionsToFilter) {
+					if (vr.includes(v)) {
+						iter.remove();
+						break;
+					}
+				}
+			}
+		}
+		
+	}
+}

--- a/biz.aQute.resolve/test/biz/aQute/resolve/internal/BndrunResolveContextTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/internal/BndrunResolveContextTest.java
@@ -230,6 +230,91 @@ public class BndrunResolveContextTest extends TestCase {
         // The capability from osgi.cmpn is NOT here
     }
 
+	public static void testResolverHookFiltersResultWithBlacklist() {
+		MockRegistry registry = new MockRegistry();
+		registry.addPlugin(createRepo(new File("testdata/osgi.cmpn-4.3.0.index.xml")));
+		registry.addPlugin(createRepo(new File("testdata/org.apache.felix.framework-4.0.2.index.xml")));
+
+		// Add a hook that removes all capabilities from resource with id
+		// "osgi.cmpn"
+		HashMap<String,String> blacklistProp = new HashMap<String,String>();
+		blacklistProp.put(ResolutionBlacklistFilter.BLACKLIST_PROPERTYNAME, "osgi.cmpn;version=4.3.0");
+		ResolutionBlacklistFilter blacklist = new ResolutionBlacklistFilter();
+		blacklist.setProperties(blacklistProp);
+		registry.addPlugin(blacklist);
+
+		BndEditModel runModel = new BndEditModel();
+		runModel.setRunFw("org.apache.felix.framework");
+
+		Requirement requirement = new CapReqBuilder("osgi.wiring.package").addDirective("filter",
+				"(&(osgi.wiring.package=org.osgi.util.tracker)(version>=1.5)(!(version>=1.6)))")
+				.buildSyntheticRequirement();
+
+		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
+		List<Capability> providers = context.findProviders(requirement);
+
+		assertEquals(1, providers.size());
+		assertEquals(new File("testdata/org.apache.felix.framework-4.0.2.jar").toURI(), findContentURI(providers.get(0)
+				.getResource()));
+	}
+
+	public static void testResolverHookFiltersResultWithBlacklistAndVersionRange1() {
+		MockRegistry registry = new MockRegistry();
+		registry.addPlugin(createRepo(new File("testdata/osgi.cmpn-4.3.0.index.xml")));
+		registry.addPlugin(createRepo(new File("testdata/org.apache.felix.framework-4.0.2.index.xml")));
+
+		// Add a hook that removes all capabilities from resource with id
+		// "osgi.cmpn"
+		HashMap<String,String> blacklistProp = new HashMap<String,String>();
+		blacklistProp.put(ResolutionBlacklistFilter.BLACKLIST_PROPERTYNAME, "osgi.cmpn;version='[4.0.0,4.3.0)'");
+		ResolutionBlacklistFilter blacklist = new ResolutionBlacklistFilter();
+		blacklist.setProperties(blacklistProp);
+		registry.addPlugin(blacklist);
+
+		BndEditModel runModel = new BndEditModel();
+		runModel.setRunFw("org.apache.felix.framework");
+
+		Requirement requirement = new CapReqBuilder("osgi.wiring.package").addDirective("filter",
+				"(&(osgi.wiring.package=org.osgi.util.tracker)(version>=1.5)(!(version>=1.6)))")
+				.buildSyntheticRequirement();
+
+		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
+		List<Capability> providers = context.findProviders(requirement);
+
+		assertEquals(2, providers.size());
+		assertEquals(new File("testdata/org.apache.felix.framework-4.0.2.jar").toURI(), findContentURI(providers.get(0)
+				.getResource()));
+		assertEquals(new File("testdata/osgi.cmpn-4.3.0.jar").toURI(), findContentURI(providers.get(1).getResource()));
+	}
+
+	public static void testResolverHookFiltersResultWithBlacklistAndVersionRange2() {
+		MockRegistry registry = new MockRegistry();
+		registry.addPlugin(createRepo(new File("testdata/osgi.cmpn-4.3.0.index.xml")));
+		registry.addPlugin(createRepo(new File("testdata/org.apache.felix.framework-4.0.2.index.xml")));
+
+		// Add a hook that removes all capabilities from resource with id
+		// "osgi.cmpn"
+		HashMap<String,String> blacklistProp = new HashMap<String,String>();
+		blacklistProp.put(ResolutionBlacklistFilter.BLACKLIST_PROPERTYNAME, "osgi.cmpn;version='[4.0.0,4.4.0)'");
+		ResolutionBlacklistFilter blacklist = new ResolutionBlacklistFilter();
+		blacklist.setProperties(blacklistProp);
+		registry.addPlugin(blacklist);
+
+		BndEditModel runModel = new BndEditModel();
+		runModel.setRunFw("org.apache.felix.framework");
+
+		Requirement requirement = new CapReqBuilder("osgi.wiring.package").addDirective("filter",
+				"(&(osgi.wiring.package=org.osgi.util.tracker)(version>=1.5)(!(version>=1.6)))")
+				.buildSyntheticRequirement();
+
+		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
+		List<Capability> providers = context.findProviders(requirement);
+
+		assertEquals(1, providers.size());
+		assertEquals(new File("testdata/org.apache.felix.framework-4.0.2.jar").toURI(), findContentURI(providers.get(0)
+				.getResource()));
+	}
+	
     public static void testResolverHookCannotFilterFrameworkCapabilities() {
         MockRegistry registry = new MockRegistry();
         registry.addPlugin(createRepo(new File("testdata/osgi.cmpn-4.3.0.index.xml")));


### PR DESCRIPTION
ResolutionBlacklistFilter allows a means to blacklist a specific bundle or range of bundle versions from resolution input. We were finding that certain bundles were wrapped badly or for whatever reason shouldn't be allowed to be part of resolution. The ResolverHook existed thus this class was fairly easy to create.

It is added to -plugins in cnf/ext/repositories.bnd (or whichever .bnd file contains -plugins)
e.g.
-plugins: aQute.bnd.osgi.resource.ResolutionBlacklistFilter;blacklist="bsn;version=[1.0,2.0),bsn;version=4.3.3"

This is the rebased version off of master. The previous one off of next is #467
