### PR TITLE
Adding refreshCacheMetadata support to RemoveRepositoryPlugin interface

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/Refreshable.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/Refreshable.java
@@ -3,6 +3,11 @@ package aQute.bnd.service;
 import java.io.*;
 
 public interface Refreshable {
+	/**
+	 * Instructs a Refreshable to refresh itself
+	 * @return true if refreshed, false if not refreshed possibly due to error.
+	 * @throws Exception
+	 */
 	boolean refresh() throws Exception;
 
 	File getRoot();

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -663,12 +663,12 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 	public boolean refresh() throws Exception {
 		init();
 		exec(refresh, root);
-		if (dirty) {
-			dirty = false;
-			return true;
-		}
+//		if (dirty) {
+//			dirty = false;
+//			return true;
+//		}
 		rebuildIndex();
-		return false;
+		return true;
 	}
 
 	public String getName() {

--- a/biz.aQute.repository/src/aQute/bnd/deployer/obr/NexusOBR.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/obr/NexusOBR.java
@@ -291,4 +291,8 @@ public class NexusOBR extends AbstractIndexedRepo {
 				+ ".jar");
 	}
 
+	public File getRoot() {
+		return cacheDir;
+	}
+
 }

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/FixedIndexedRepo.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/FixedIndexedRepo.java
@@ -97,4 +97,8 @@ public class FixedIndexedRepo extends AbstractIndexedRepo {
 			return locations.toString();
 	}
 
+	public File getRoot() {
+		return cacheDir;
+	}
+
 }

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
@@ -337,6 +337,7 @@ public class LocalIndexedRepo extends FixedIndexedRepo implements Refreshable, P
 
 	public boolean refresh() {
 		reset();
+		regenerateAllIndexes();
 		return true;
 	}
 
@@ -453,5 +454,4 @@ public class LocalIndexedRepo extends FixedIndexedRepo implements Refreshable, P
 		
 		return null;
 	}
-
 }


### PR DESCRIPTION
This is to facilitate a tweak to the Bndtools menu -> refresh repos menu option.

This actually clears out cached indexes, which is what my users "believe" is going to happen when they select that option.

This was previously #466
