### PR TITLE
Allowing preparedPaths to be true even if there are errors.

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -285,8 +285,10 @@ public class Project extends Processor {
 					for (Project project : dependson) {
 						allsourcepath.addAll(project.getSourcePath());
 					}
-					if (isOk())
-						preparedPaths = true;
+					//[cs] Testing this commented out. If bad issues, never setting this to true means that
+					// TONS of extra preparing is done over and over again on the same projects.
+					//if (isOk())
+					preparedPaths = true;
 				}
 				finally {
 					inPrepare = false;


### PR DESCRIPTION
This change means that if there are TONS of errors, the project won't be
reprocessed over and over and over again. A simple way to see where
this would be a problem is if you had many projects that included
each other in their buildpaths. Now remove one of the foundational
projects from your workspace -- actually delete the files, not
just delete the eclipse project. the Project class will get hung up
because it continues to process all Projects because none of them
are ever "Ok".

I tried looking for all usages of -failok and isOk() and I believe this might be a decent update? But this needs another set of eyes.
