### PR TITLE
binfo.version returns the newer version

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/differ/Baseline.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/Baseline.java
@@ -206,7 +206,7 @@ public class Baseline {
 
 		binfo.bsn = bsn;
 		binfo.suggestedVersion = suggestedVersion;
-		binfo.version = olderVersion;
+		binfo.version = newerVersion;
 
 		if (newerVersion.getWithoutQualifier().equals(olderVersion.getWithoutQualifier())) {
 			// We have a special case, the current and repository revisions


### PR DESCRIPTION
BundleInfo.version returned by Baseline should contain the version of the newer jar, not the older
