### PR TITLE
system-independent locale for parsing 'lastmodified' property

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1044,7 +1044,7 @@ public class Analyzer extends Processor {
 		return getBndInfo("version", "<unknown>");
 	}
 
-	static SimpleDateFormat	df	= new SimpleDateFormat("EEE MMM dd hh:mm:ss z yyyy", Locale.US);
+	static SimpleDateFormat	df	= new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.US);
 
 	public long getBndLastModified() {
 		String time = getBndInfo("lastmodified", "0");


### PR DESCRIPTION
Follow-up to https://github.com/bndtools/bnd/issues/260 - date parser produces exceptions on non-English locale.
