### PR TITLE
test: Set cwd to Project.getBase() as the default for ProjectTester

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/LauncherTest.java
+++ b/biz.aQute.bndlib.tests/src/test/LauncherTest.java
@@ -336,12 +336,13 @@ public class LauncherTest extends TestCase {
 		project.clear();
 		project.setProperty(Constants.RUNTRACE, "true");
 		
+		String mandatorynoversion = new File("jar/mandatorynoversion.jar").getAbsolutePath();
 		String runbundles = project.getProperty( Constants.RUNBUNDLES);
-		project.setProperty(Constants.RUNBUNDLES, runbundles+",jar/mandatorynoversion.jar;version=file");
+		project.setProperty(Constants.RUNBUNDLES, runbundles + "," + mandatorynoversion + ";version=file");
 		ProjectTester tester = project.getProjectTester();
 
 		ProjectLauncher l = tester.getProjectLauncher();
-		l.addRunBundle("jar/mandatorynoversion.jar");
+		l.addRunBundle(mandatorynoversion);
 		l.setTimeout(5000, TimeUnit.MILLISECONDS);
 		l.setTrace(true);
 		assertEquals(1, l.launch());

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
@@ -12,11 +12,11 @@ public abstract class ProjectTester {
 	final List<String>			tests		= new ArrayList<String>();
 	File						reportDir;
 	boolean						continuous	= true;
-	File						cwd;
 
 	public ProjectTester(Project project) throws Exception {
 		this.project = project;
 		launcher = project.getProjectLauncher();
+		launcher.setCwd(project.getBase());
 		launcher.addRunVM("-ea");
 		testbundles = project.getTestpath();
 		continuous = project.is(Constants.TESTCONTINUOUS);
@@ -69,11 +69,11 @@ public abstract class ProjectTester {
 	}
 	
 	public File getCwd() {
-		return cwd;
+		return launcher.getCwd();
 	}
 	
 	public void setCwd(File dir) {
-		this.cwd = dir;
+		launcher.setCwd(dir);
 	}
 
 	public boolean prepare() throws Exception {

--- a/biz.aQute.junit/src/aQute/junit/plugin/ProjectTesterImpl.java
+++ b/biz.aQute.junit/src/aQute/junit/plugin/ProjectTesterImpl.java
@@ -1,6 +1,5 @@
 package aQute.junit.plugin;
 
-import java.io.*;
 import java.util.*;
 
 import aQute.bnd.build.*;
@@ -37,17 +36,6 @@ public class ProjectTesterImpl extends ProjectTester implements TesterConstants,
 			launcher.getRunProperties().put(TESTER_CONTINUOUS, "" + getContinuous());
 			if (Processor.isTrue(project.getProperty(Constants.RUNTRACE)))
 				launcher.getRunProperties().put(TESTER_TRACE, "true");
-
-			try {
-				// use reflection to avoid NoSuchMethodError due to change in
-				// API
-				File cwd = (File) getClass().getMethod("getCwd").invoke(this);
-				if (cwd != null)
-					launcher.setCwd(cwd);
-			}
-			catch (NoSuchMethodException e) {
-				// ignore
-			}
 
 			Collection<String> testnames = getTests();
 			if (testnames.size() > 0) {


### PR DESCRIPTION
Set the default working directory for running tests to be the base of the project. Prior to this change, the working directory what what ever the current working directory happened to be. When running the `check` gradle task, this could easily be the workspace or some other project which can result in test failures if the test case expected the current directory to be the project's directory.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
