### PR TITLE
[resolver] Allow users to configure opt-out namespaces for resolve.effective

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/GenericResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/GenericResolveContext.java
@@ -48,7 +48,7 @@ public class GenericResolveContext extends ResolveContext {
 
 	protected final Comparator<Capability>			capabilityComparator		= new CapabilityComparator();
 
-	protected Set<String>							effectiveSet;
+	protected Map<String, Set<String>>				effectiveSet;
 
 	protected final List<ResolverHook>				resolverHooks				= new ArrayList<ResolverHook>();
 	protected final List<ResolutionCallback>		callbacks					= new LinkedList<ResolutionCallback>();
@@ -244,7 +244,8 @@ public class GenericResolveContext extends ResolveContext {
 		if (effective == null || Namespace.EFFECTIVE_RESOLVE.equals(effective))
 			return true;
 
-		if (effectiveSet != null && effectiveSet.contains(effective))
+		if (effectiveSet != null && effectiveSet.containsKey(effective) && 
+				!effectiveSet.get(effective).contains(requirement.getNamespace()))
 			return true;
 
 		return false;
@@ -529,7 +530,12 @@ public class GenericResolveContext extends ResolveContext {
 	}
 
 	public void addEffectiveDirective(String effectiveDirective) {
-		this.effectiveSet.add(effectiveDirective);
+		this.effectiveSet.put(effectiveDirective, new HashSet<String>());
+	}
+
+	public void addEffectiveDirective(String effectiveDirective, Set<String> excludedNamespaces) {
+		this.effectiveSet.put(effectiveDirective, 
+				excludedNamespaces != null ? excludedNamespaces : new HashSet<String>());
 	}
 
 	protected void postProcessProviders(Requirement requirement, Set<Capability> wired, List<Capability> candidates) {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/internal/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/internal/BndrunResolveContext.java
@@ -82,9 +82,13 @@ public class BndrunResolveContext extends GenericResolveContext {
 		if (effective == null)
 			effectiveSet = null;
 		else {
-			effectiveSet = new HashSet<String>();
-			for (Entry<String,Attrs> entry : new Parameters(effective).entrySet())
-				effectiveSet.add(entry.getKey());
+			effectiveSet = new HashMap<String, Set<String>>();
+			for (Entry<String,Attrs> entry : new Parameters(effective).entrySet()) {
+				String skip = entry.getValue().get("skip:");
+				Set<String> toSkip = skip == null ? new HashSet<String>() : 
+					new HashSet<String>(Arrays.asList(skip.split(",")));
+				effectiveSet.put(entry.getKey(), toSkip);
+			}
 		}
 	}
 

--- a/biz.aQute.resolve/test/biz/aQute/resolve/internal/BndrunResolveContextTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/internal/BndrunResolveContextTest.java
@@ -54,6 +54,28 @@ public class BndrunResolveContextTest extends TestCase {
         assertTrue(context.isEffective(noEffectiveDirectiveReq));
     }
 
+    public static void testEffective3() {
+    	BndEditModel model = new BndEditModel();
+    	model.genericSet(BndrunResolveContext.RUN_EFFECTIVE_INSTRUCTION, "active;skip:=\"filtered.ns,another.filtered.ns\", arbitrary");
+    	
+    	BndrunResolveContext context = new BndrunResolveContext(model, new MockRegistry(), log);
+    	
+    	Requirement resolveReq = new CapReqBuilder("dummy.ns").addDirective(Namespace.REQUIREMENT_EFFECTIVE_DIRECTIVE, Namespace.EFFECTIVE_RESOLVE).buildSyntheticRequirement();
+    	Requirement activeReq = new CapReqBuilder("dummy.ns").addDirective(Namespace.REQUIREMENT_EFFECTIVE_DIRECTIVE, Namespace.EFFECTIVE_ACTIVE).buildSyntheticRequirement();
+    	Requirement filteredActiveReq = new CapReqBuilder("filtered.ns").addDirective(Namespace.REQUIREMENT_EFFECTIVE_DIRECTIVE, Namespace.EFFECTIVE_ACTIVE).buildSyntheticRequirement();
+    	Requirement anotherFilteredActiveReq = new CapReqBuilder("another.filtered.ns").addDirective(Namespace.REQUIREMENT_EFFECTIVE_DIRECTIVE, Namespace.EFFECTIVE_ACTIVE).buildSyntheticRequirement();
+    	Requirement arbitrary1Req = new CapReqBuilder("dummy.ns").addDirective(Namespace.REQUIREMENT_EFFECTIVE_DIRECTIVE, "arbitrary").buildSyntheticRequirement();
+    	
+    	Requirement noEffectiveDirectiveReq = new CapReqBuilder("dummy.ns").buildSyntheticRequirement();
+    	
+    	assertTrue(context.isEffective(resolveReq));
+    	assertTrue(context.isEffective(activeReq));
+    	assertTrue(context.isEffective(arbitrary1Req));
+    	assertFalse(context.isEffective(filteredActiveReq));
+    	assertFalse(context.isEffective(anotherFilteredActiveReq));
+    	assertTrue(context.isEffective(noEffectiveDirectiveReq));
+    }
+
     public static void testEmptyInitialWirings() {
         assertEquals(0, new BndrunResolveContext(new BndEditModel(), new MockRegistry(), log).getWirings().size());
     }


### PR DESCRIPTION
This pull request forms part of the proposed fix for bndtools/bndtools#859 - it allows a set of namespaces to be excluded from effectiveness. The other half of the fix is in bndtools/bndtools/pull/871
