### PR TITLE
Fixed AetherRepository plugin resolution issues

### DIFF
--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/ConversionUtils.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/ConversionUtils.java
@@ -68,4 +68,14 @@ final class ConversionUtils {
 		return String.format("%s.%s", coords.substring(0, colonPos), coords.substring(artifactIdStart));
 	}
 
+	public static String[] getGroupAndArtifactForBsn(String bsn) {
+		int dotIndex = bsn.lastIndexOf(':');
+		if (dotIndex < 0)
+			throw new IllegalArgumentException("Cannot split bsn into group and artifact IDs: " + bsn);
+		String groupId = bsn.substring(0, dotIndex);
+		String artifactId = bsn.substring(dotIndex + 1);
+
+		return new String[] { groupId, artifactId };
+	}
+
 }

--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
@@ -21,9 +21,14 @@ public class MvnVersion implements Comparable<MvnVersion> {
 		} else {
 			String qualifier = versionStr.substring(dashIndex + 1);
 
-			Version v = Version.parseVersion(versionStr.substring(0, dashIndex));
-			Version osgiVersion = new Version(v.getMajor(), v.getMinor(), v.getMicro(), qualifier);
-			result = new MvnVersion(osgiVersion);
+			try {
+				Version v = Version.parseVersion(versionStr.substring(0, dashIndex));
+				Version osgiVersion = new Version(v.getMajor(), v.getMinor(), v.getMicro(), qualifier);
+				result = new MvnVersion(osgiVersion);
+			}
+			catch(IllegalArgumentException e) { // bad format
+				result = null;
+			}
 		}
 		return result;
 	}

--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/ConversionUtilsTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/ConversionUtilsTest.java
@@ -48,4 +48,9 @@ public class ConversionUtilsTest extends TestCase {
 		}
 	}
 
+	public void testGroupAndArtifactForBsn() throws Exception {
+		String[] coords = ConversionUtils.getGroupAndArtifactForBsn("com.example.group:example-api");
+		assertEquals("com.example.group", coords[0]);
+		assertEquals("example-api", coords[1]);
+	}
 }


### PR DESCRIPTION
- catch artifact parse failures so buildpaths can be mixed
   where some dependencies are resolved by *LocalRepo and
   GAV style dependencies can be picked up by AetherRepo
- normalized expected buildpath strings to expect
   <groupId>:<artifactId>
- Moved method for parsing bsn to utils and added
   unit test
