### PR TITLE
gradle template: ensure buildDir exists before building

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -183,6 +183,7 @@ public class BndPlugin implements Plugin<Project> {
           }
           outputs.files bndProject.deliverables.collect { it.file }, new File(buildDir, 'buildfiles')
           doLast {
+            buildDir.mkdirs()
             def built
             try {
               built = bndProject.build()


### PR DESCRIPTION
bnd doesn't ensure this

Signed-off-by: Ferry Huberts ferry.huberts@pelagic.nl
