### PR TITLE
gradle: Improve clean task by using BndProject.clean()

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -255,9 +255,10 @@ public class BndPlugin implements Plugin<Project> {
         group 'verification'
       }
 
-      clean {
-        /* Also clean compiler output */
-        dependsOn cleanCompileJava, cleanCompileTestJava
+      task ('clean', overwrite: true) {
+        doLast {
+          bndProject.clean()
+        }
       }
 
       javadoc {


### PR DESCRIPTION
This will then recreate the output folders after cleaning them. This will
solve the problem of using the clean task before other tasks in the same
gradle execution.

Based upon suggestion of https://github.com/bndtools/bnd/pull/555

Signed-off-by: BJ Hargrave bj@bjhargrave.com
