### PR TITLE
gradle: Allow bnd_defaultTask property to specify multiple tasks

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -50,7 +50,7 @@ public class BndPlugin implements Plugin<Project> {
       plugins.apply 'java'
 
       if (project.hasProperty('bnd_defaultTask')) {
-        defaultTasks = [bnd_defaultTask]
+        defaultTasks = bnd_defaultTask.trim().split(/\s*,\s*/)
       }
 
       /* We use the same directory for java and resources. */


### PR DESCRIPTION
The tasks names are comma separated.

Fixes #574.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
