### PR TITLE
gradle: Use fixed file name for downloaded bnd jar

### DIFF
--- a/cnf/gradle/init.gradle
+++ b/cnf/gradle/init.gradle
@@ -15,7 +15,7 @@ buildscript {
     if (bndURI.scheme != 'file') {
       /* If not a local file, copy to a local file in cnf/cache */
       def cnfCache = mkdir("${rootDir}/${bnd_cnf}/cache")
-      def bndJarFile = new File(cnfCache, bndURI.path.tokenize('/')[-1])
+      def bndJarFile = new File(cnfCache, 'biz.aQute.bnd.jar')
       if (!bndJarFile.exists()) {
         println "Downloading ${bndURI} to ${bndJarFile} ..."
         bndURI.toURL().withInputStream { is ->


### PR DESCRIPTION
The URI provided by the bnd_jar property may not have a valid file name
as the last component of the URI's path. This is true for JPM URLs.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
