### PR TITLE
bnd: Delay Run Dependencies

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -143,6 +143,7 @@ public class ProjectTest extends TestCase {
 	public  void testProjectReferringToItself() throws Exception {
 		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
 		Project top = ws.getProject("bug194");
+		top.setDelayRunDependencies(false);
 		top.addClasspath(top.getOutput());
 		assertTrue(top.check("Circular dependency context"));
 	}
@@ -165,6 +166,7 @@ public class ProjectTest extends TestCase {
 	public  void testRunBundlesContainsSelf() throws Exception {
 		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
 		Project top = ws.getProject("p1");
+		top.setDelayRunDependencies(false);
 		top.setProperty("-runbundles", "p1;version=latest");
 		top.setChanged();
 		top.isStale();

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -62,7 +62,7 @@ public class Project extends Processor {
 	int							revision;
 	File						files[];
 	static List<Project>		trail					= new ArrayList<Project>();
-	boolean						delayRunDependencies	= false;
+	boolean						delayRunDependencies	= true;
 	final ProjectMessages		msgs					= ReporterMessages.base(this, ProjectMessages.class);
 	private Properties			ide;
 	final Packages				exportedPackages		= new Packages();


### PR DESCRIPTION
Set the default to delay run dependencies. This is important for gradle
builds. The init.gradle script can be simplified to avoid having to set
this for each project before processing the projects.

Two test cases needed to set delay run dependencies to false for the
specific circularity issue they were testing.

Fixes https://github.com/bndtools/bnd/issues/513

Signed-off-by: BJ Hargrave bj@bjhargrave.com
