### PR TITLE
gradle: No longer need to tell bnd to delay run dependencies

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -27,9 +27,6 @@ public class BndPlugin implements Plugin<Project> {
         if (bndWorkspace == null) {
           throw new GradleException("Unable to load bnd workspace ${rootDir}")
         }
-        bndWorkspace.allProjects.each {
-          it.setDelayRunDependencies(true)
-        }
       }
       if (!rootProject.hasProperty('bndWorkspaceInitialized')) {
         bndWorkspace.driver = Constants.BNDDRIVER_GRADLE

--- a/cnf/gradle/init.gradle
+++ b/cnf/gradle/init.gradle
@@ -42,11 +42,6 @@ if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }
 
-/* Delay run dependency evaluations since they may not yet be built */
-workspace.allProjects.each {
-  it.setDelayRunDependencies(true)
-}
-
 /* Add cnf project to the graph */
 include bnd_cnf
 


### PR DESCRIPTION
https://github.com/bndtools/bnd/pull/591 changed bnd to make the default
that run dependencies are delayed.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
