### PR TITLE
gradle: Include Project.isNoBundles() in release task enabled expression

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -212,7 +212,7 @@ public class BndPlugin implements Plugin<Project> {
         description 'Release the project to the release repository.'
         dependsOn assemble
         group 'release'
-        enabled !bnd(Constants.RELEASEREPO, 'unset').empty
+        enabled !bndProject.noBundles && !bnd(Constants.RELEASEREPO, 'unset').empty
         if (enabled) {
           inputs.files bndProject.deliverables*.file
           doLast {


### PR DESCRIPTION
Only release a project if -nobundles is not set.

Fixes https://github.com/bndtools/bnd/issues/592

Signed-off-by: BJ Hargrave bj@bjhargrave.com
