### PR TITLE
launcher: deleteFiles should recurse on contained file

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -845,7 +845,7 @@ public class Launcher implements ServiceListener {
 	protected void deleteFiles(File wd) {
 		if ( wd.isDirectory()) {
 			for ( File sub : wd.listFiles()) {
-				deleteFiles(wd);
+				deleteFiles(sub);
 			}
 		}
 		wd.delete();


### PR DESCRIPTION
It was mistakenly recursing on itself.

Fixes https://github.com/bndtools/bnd/issues/598

Signed-off-by: BJ Hargrave bj@bjhargrave.com
