### PR TITLE
Use consistent EOLs when creating DS & Metatype resources

### DIFF
--- a/aQute.libg/src/aQute/lib/tag/Tag.java
+++ b/aQute.libg/src/aQute/lib/tag/Tag.java
@@ -203,7 +203,7 @@ public class Tag {
 	 */
 	public Tag print(int indent, PrintWriter pw) {
 		if (indent >= 0) {
-			pw.print("\n");
+			pw.println();
 			spaces(pw, indent);
 		}
 		pw.print('<');
@@ -238,7 +238,7 @@ public class Tag {
 				}
 			}
 			if (indent >= 0) {
-				pw.print("\n");
+				pw.println();
 				spaces(pw, indent);
 			}
 			pw.print("</");
@@ -260,7 +260,7 @@ public class Tag {
 			char c = s.charAt(i);
 			if (i == 0 || (Character.isWhitespace(c) && pos > width - 3)) {
 				if (left >= 0 && width > 0) {
-					pw.print("\n");
+					pw.println();
 					spaces(pw, left);
 				}
 				pos = 0;


### PR DESCRIPTION
MetaTypeReader and TagResource both use PrintWriter.println() to output the XML declaration and then delegate to Tag.print() to generate the XML document.  Tag.print() uses PrintWriter.print("\n") to generate newlines in the XML document.

PrintWriter.println() on Windows will use \r\n, so we end up with inconsistent whitespace in the file.  This patch changes Tag.print() to invoke PrintWriter.println() instead of hard coding the EOL character. This is only a presentation issue, but it also "resolves" this bndtools issue (assuming you are looking at a JAR created on your platform):

https://github.com/bndtools/bndtools/issues/864

An alternate approach would be to change MetaTypeReader and TagResource to explicitly use a \n when rendering the XML declaration rather than using PrintWriter.println().
