### PR TITLE
Use different tmp files for each test method

### DIFF
--- a/aQute.libg/test/aQute/lib/index/TestIndex.java
+++ b/aQute.libg/test/aQute/lib/index/TestIndex.java
@@ -2,13 +2,13 @@ package aQute.lib.index;
 
 import java.io.*;
 
-import aQute.lib.io.*;
 import junit.framework.*;
+import aQute.lib.io.*;
 
 public class TestIndex extends TestCase {
 
 	public void testPersistence() throws Exception {
-		File test = IO.getFile("tmp/test.tmp");
+		File test = IO.getFile("tmp/" + getName() + ".tmp");
 		test.delete();
 		test.getParentFile().mkdirs();
 		Index index = new Index(test, 2000);
@@ -60,7 +60,7 @@ public class TestIndex extends TestCase {
 	}
 
 	public void testBasic() throws Exception {
-		File test = IO.getFile("tmp/test.tmp");
+		File test = IO.getFile("tmp/" + getName() + ".tmp");
 		test.delete();
 		test.getParentFile().mkdirs();
 		Index index = new Index(test, 2000);
@@ -98,7 +98,7 @@ public class TestIndex extends TestCase {
 	}
 
 	// public void testMany() throws Exception {
-	// File test = IO.getFile("tmp/test.tmp");
+	// File test = IO.getFile("tmp/"+getName()+".tmp");
 	// test.delete();
 	// Index index = new Index(test, 1000);
 	// for ( int i = 1; i<127; i++)


### PR DESCRIPTION
Using the same file created problems on windows when it sometimes could
not be deleted.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
