### PR TITLE
Rationalize the java version used in the bnd nature repo projects

### DIFF
--- a/biz.aQute.bnd.bootstrap/.classpath
+++ b/biz.aQute.bnd.bootstrap/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/biz.aQute.bnd.bootstrap/bnd.bnd
+++ b/biz.aQute.bnd.bootstrap/bnd.bnd
@@ -1,4 +1,5 @@
 -buildpath:  \
+    ee.j2se;version=${javac.ee},\
 	osgi.core,\
 	osgi.cmpn,\
 	biz.aQute.bnd.annotation;version=2.3,\

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -1,14 +1,16 @@
+javac.source = 1.5
+javac.target = 1.5
+javac.ee = '[1.5,1.6)'
+
 -buildpath: com.springsource.org.junit;version='[4.11,5)',\
 	osgi.cmpn;version=4.3.1,\
 	biz.aQute.bndlib;version=project,\
 	aQute.libg;version=project,\
 	osgi.core;version=4.3.1,\
-	ee.j2se;version=1.5
+	ee.j2se;version=${javac.ee}
 	
 Tester-Plugin: aQute.junit.plugin.ProjectTesterImpl
 
-javac.source = 1.5
-javac.target = 1.5
 
 Private-Package: aQute.junit.*,\
 	junit.*,\

--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -1,7 +1,11 @@
+javac.source = 1.5
+javac.target = 1.5
+javac.ee = '[1.5,1.6)'
+
 -buildpath: biz.aQute.bndlib;version=project,\
 	aQute.libg;version=project,\
 	osgi.core;version=4.3.1,\
-	ee.j2se;version=1.5
+	ee.j2se;version=${javac.ee}
 #	ee.minimum;version=1.2.1
 -testpath: \
 	junit.osgi;version=3.8.2
@@ -12,7 +16,5 @@ Launcher-Plugin: aQute.launcher.plugin.ProjectLauncherImpl
 Private-Package: aQute.launcher.*
 	
 Bundle-Version: 1.4.0.${tstamp}
-javac.source = 1.5
-javac.target = 1.5
 
 Premain-Class: aQute.launcher.agent.LauncherAgent

--- a/biz.aQute.repository.aether/.classpath
+++ b/biz.aQute.repository.aether/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/biz.aQute.repository.aether/bnd.bnd
+++ b/biz.aQute.repository.aether/bnd.bnd
@@ -3,7 +3,7 @@ Bundle-Version: 0.0.1.${tstamp}
 aether-version: 0.9.0.M3
 
 -buildpath:\
-	ee.j2se; version='[1.6,1.7)',\
+	ee.j2se; version=${javac.ee},\
 	aQute.libg; version=project,\
 	biz.aQute.bndlib; version=project,\
 	biz.aQute.repository; version=project,\

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -17,7 +17,7 @@ jetty.libs: lib/javax.servlet-2.5.0.jar;version=file,\
 	osgi.cmpn;version=4.3.1,\
 	osgi.r5;version=1.0.1,\
 	javax.xml.stream-1.0.1.jar;version=file,\
-	ee.j2se;version='[1.6,1.7)',\
+	ee.j2se;version=${javac.ee},\
 	${jetty.libs},\
 	aQute.jpm.bndrepo;version=1.0
 -testpath: \


### PR DESCRIPTION
.classpath files are cleared of JRE_CONTAINER references. ee.j2se;
version=${javac.ee} used consistently.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
