### PR TITLE
Fix JPM repository's "Update All" action

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
+++ b/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
@@ -1276,7 +1276,7 @@ public class Repository implements Plugin, RepositoryPlugin, Closeable, Refresha
 	 */
 
 	void updateAll() throws Exception {
-		for (String bsn : index.getBsns()) {
+		for (String bsn : new ArrayList<String>(index.getBsns())) {
 			update(bsn);
 		}
 	}


### PR DESCRIPTION
`TreeSet` requires its elements to be Comparable, causing an exception in this code path.  Change to a `List` instead because order should be guaranteed by the `SortedSet` returned by `Index.getVersions()`.

Signed-off-by: Sean Bright sean@malleable.com
