### PR TITLE
Add runbundles.* rule and runbundles task

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
+++ b/biz.aQute.bnd/src/aQute/bnd/gradle/BndPlugin.gradle
@@ -314,6 +314,42 @@ public class BndPlugin implements Plugin<Project> {
         }
       }
 
+      tasks.addRule('Pattern: runbundles.<name>: Create a distribution of the runbundles in <name>.bndrun file.') { taskName ->
+        if (taskName.startsWith('runbundles.')) {
+          def bndrun = taskName - 'runbundles.'
+          task(taskName) {
+            description "Create a distribution of the runbundles in the ${bndrun}.bndrun file."
+            dependsOn assemble
+            group 'export'
+            def runFile = file("${bndrun}.bndrun")
+            def runbundlesDir = new File(distsDir, "runbundles/${bndrun}")
+            doFirst {
+              project.delete(runbundlesDir)
+              project.mkdir(runbundlesDir)
+            }
+            doLast {
+              logger.info "Creating a distribution of the runbundles in ${runFile.absolutePath} in directory ${runbundlesDir.absolutePath}"
+              try {
+                  bndProject.exportRunbundles(relativePath(runFile), runbundlesDir)
+              } catch (Exception e) {
+                throw new GradleException("Creating a distribution of the runbundles in ${runFile.absolutePath} failed", e)
+              }
+              checkErrors()
+            }
+          }
+        }
+      }
+
+      task('runbundles') {
+        description "Create a distribution of the runbundles in each of the bndrun files."
+        group 'export'
+        fileTree(projectDir) {
+            include '*.bndrun'
+        }.each {
+          dependsOn tasks.getByPath("runbundles.${it.name - '.bndrun'}")
+        }
+      }
+
       task('echo') {
         description 'Displays the bnd project information.'
         group 'help'

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1638,6 +1638,33 @@ public class Project extends Processor {
 			IO.close(outStream);
 		}
 	}
+	
+	/**
+	 * @since 2.4
+	 */
+	@SuppressWarnings("resource")
+	public void exportRunbundles(String runFilePath, File outputDir) throws Exception {
+		prepare();
+
+		Project packageProject;
+		if (runFilePath == null || runFilePath.length() == 0 || ".".equals(runFilePath)) {
+			packageProject = this;
+		} else {
+			File runFile = new File(getBase(), runFilePath);
+			if (!runFile.isFile())
+				throw new IOException(String.format("Run file %s does not exist (or is not a file).",
+						runFile.getAbsolutePath()));
+			packageProject = new Project(getWorkspace(), getBase(), runFile);
+			packageProject.setParent(this);
+		}
+
+		packageProject.clear();
+		Collection<Container> runbundles = packageProject.getRunbundles();
+		for (Container container : runbundles) {
+			File bundle = container.getFile();
+			IO.copy(bundle, new File(outputDir, bundle.getName()));
+		}
+	}
 
 	/**
 	 * Release.


### PR DESCRIPTION
The runbundles.\* tasks will export the Project.getRunbundles() files to the a folder named for the bndrun file in the distDir/runbundles folder.

New exportRunbundles method is added to Project in support of this new gradle task.
