### PR TITLE
Wrap parsing of Maven versions in a try-catch both when they contain a dash and when they don't.

### DIFF
--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
@@ -15,20 +15,21 @@ public class MvnVersion implements Comparable<MvnVersion> {
 	public static final MvnVersion parseString(String versionStr) {
 		MvnVersion result;
 		
-		int dashIndex = versionStr.indexOf('-');
-		if (dashIndex < 0) {
-			result = new MvnVersion(Version.parseVersion(versionStr));
-		} else {
-			String qualifier = versionStr.substring(dashIndex + 1);
+		try {
+			int dashIndex = versionStr.indexOf('-');
+			if (dashIndex < 0) {
+				result = new MvnVersion(Version.parseVersion(versionStr));
+			} else {
+				String qualifier = versionStr.substring(dashIndex + 1);
 
-			try {
-				Version v = Version.parseVersion(versionStr.substring(0, dashIndex));
-				Version osgiVersion = new Version(v.getMajor(), v.getMinor(), v.getMicro(), qualifier);
+				Version v = Version.parseVersion(versionStr.substring(0,
+						dashIndex));
+				Version osgiVersion = new Version(v.getMajor(), v.getMinor(),
+						v.getMicro(), qualifier);
 				result = new MvnVersion(osgiVersion);
 			}
-			catch(IllegalArgumentException e) { // bad format
-				result = null;
-			}
+		} catch (IllegalArgumentException e) { // bad format
+			result = null;
 		}
 		return result;
 	}


### PR DESCRIPTION
Maven is not very strict with regards to versions. For example, it allows version with non-numeric contents in micro position (and possibly others too). 
Without this change, if even one such invalid version for a particular groupId:artifactId is present in the repository, the artifact is unsable because bnd refuses to resolve ANY version of this artifact.
I've came across it when trying to use org.webjars:angularjs:1.2.22 as a dependency. The error reported was: `IllegalArgumentException: Invalid version syntax in 1.2.0rc1` (I'm not sure about exact wording).
This is the problematic entry: http://search.maven.org/#artifactdetails%7Corg.webjars%7Cangularjs%7C1.2.0rc1%7Cjar
After applying this patch, the invalid version is ignored, and version 1.2.22 is resolved correctly.
