### PR TITLE
More flexibility in parsing Maven versions.

### DIFF
--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
@@ -1,8 +1,12 @@
 package aQute.bnd.deployer.repository.aether;
 
+import java.util.regex.*;
+
 import aQute.bnd.version.*;
 
 public class MvnVersion implements Comparable<MvnVersion> {
+	
+	private static final Pattern QUALIFIER = Pattern.compile("[-.]?([^0-9.].*)$");
 	
 	private static final String	QUALIFIER_SNAPSHOT	= "SNAPSHOT";
 
@@ -16,14 +20,14 @@ public class MvnVersion implements Comparable<MvnVersion> {
 		MvnVersion result;
 		
 		try {
-			int dashIndex = versionStr.indexOf('-');
-			if (dashIndex < 0) {
+			Matcher m = QUALIFIER.matcher(versionStr);
+			if (!m.find()) {
 				result = new MvnVersion(Version.parseVersion(versionStr));
 			} else {
-				String qualifier = versionStr.substring(dashIndex + 1);
+				String qualifier = m.group(1);
 
 				Version v = Version.parseVersion(versionStr.substring(0,
-						dashIndex));
+						m.start()));
 				Version osgiVersion = new Version(v.getMajor(), v.getMinor(),
 						v.getMicro(), qualifier);
 				result = new MvnVersion(osgiVersion);

--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
@@ -1,0 +1,58 @@
+package aQute.bnd.deployer.repository.aether;
+
+import junit.framework.*;
+
+import aQute.bnd.version.*;
+
+public class MvnVersionTest extends TestCase {
+
+	public void testMajorMinorMicro() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3");
+		assertEquals(new Version(1, 2, 3), mv.getOSGiVersion());
+	}
+
+	public void testMajorMinor() {
+		MvnVersion mv = MvnVersion.parseString("1.2");
+		assertEquals(new Version(1, 2), mv.getOSGiVersion());
+	}
+
+	public void testMajor() {
+		MvnVersion mv = MvnVersion.parseString("1");
+		assertEquals(new Version(1), mv.getOSGiVersion());
+	}
+
+	public void testSnapshot() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3-SNAPSHOT");
+		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
+		assertTrue(mv.isSnapshot());
+	}
+
+	public void testQualifierWithDashSeparator() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3-beta-1");
+		assertEquals(new Version(1, 2, 3, "beta-1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
+
+	public void testQualifierWithoutSeparator() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3rc1");
+		assertEquals(new Version(1, 2, 3, "rc1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}	
+	
+	public void testQualifierWithDotSeparator() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3.beta-1");
+		assertEquals(new Version(1, 2, 3, "beta-1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
+	
+	public void testMajorMinorWithQualifierWithDotSeparator() {
+		MvnVersion mv = MvnVersion.parseString("1.2.beta-1");
+		assertEquals(new Version(1, 2, 0, "beta-1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
+	
+	public void testInvalid() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3.4.5");
+		assertNull(mv);
+	}
+}


### PR DESCRIPTION
This change allows more flexibility in parsing Maven version that differ from OSGi convention, for example:
"1.2.0rc1" => Version(1, 2, 0, "rc1")
"1.2.rc1" => Version(1, 2, 0, "rc1")

Please check the included test case, if the altered behavior is fine. Parsing could be relaxed further to parse
"1.2.3.4.5" as Version(1, 2, 3, "4.5") but I'm not sure if this is desirable.

This PR is based on https://github.com/bndtools/bnd/pull/636, let me know if you prefer it squashed or rebased.
