### PR TITLE
build: Update bundle metadata in cnf/build.bnd

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -61,16 +61,16 @@ Git-SHA:                ${system-allow-fail;git rev-list -1 HEAD}
 repo:                   ${workspace}/cnf/repo
 releaserepo:            ${workspace}/dist/bundles
 
-copyright:              Copyright (c) aQute (2000, ${tstamp;yyyy}). All Rights Reserved.
-copyright.html:         Copyright &copy; aQute (2000, ${tstamp;yyyy}). All Rights Reserved.
+copyright:              Copyright (c) aQute SARL (2000, ${tstamp;yyyy}) and others. All Rights Reserved.
+copyright.html:         Copyright &copy; aQute SARL (2000, ${tstamp;yyyy}) and others. All Rights Reserved.
 
-Bundle-Vendor:          aQute SARL http://www.aQute.biz
+Bundle-Vendor:          http://bndtools.org/
 Bundle-Copyright:       ${copyright}
 Bundle-License:         http://www.opensource.org/licenses/apache2.0.php; \
                           description="Apache License, Version 2.0"; \
                           link=http://www.apache.org/licenses/LICENSE-2.0.html
-Bundle-DocURL:          http://www.aQute.biz/Code/Bnd
-Bundle-SCM:             git://github.com/bndtools/bnd.git
+Bundle-DocURL:          http://bnd.bndtools.org/
+Bundle-SCM:             https://github.com/bndtools/bnd.git
 
 
 # default version policies


### PR DESCRIPTION
Add "and others" to copyright notice. Set vendor to bndtools.org. Set
docurl to bnd.bndtools.org. Set SCM url to anonymous (https) URL.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
