### PR TITLE
Fix #662: R6 @ProviderType annotation does not produce provider range

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/VersionPolicyTest.java
+++ b/biz.aQute.bndlib.tests/src/test/VersionPolicyTest.java
@@ -126,6 +126,28 @@ public class VersionPolicyTest extends TestCase {
 		assertEquals("[1.2,1.3)", attrs.get("version"));
 
 	}
+	
+	/**
+	 * Test if the implementation of "AnnotatedProviderInterface", which is annotated with OSGi R6
+	 * @ProviderType, causes import of the api package to use the provider version policy
+	 */
+	public static void testProviderTypeR6() throws Exception {
+		Builder b = new Builder();
+		b.addClasspath(new File("bin"));
+		b.setPrivatePackage("test.versionpolicy.implemented.osgi");
+		b.setProperty("build", "123");
+
+		Jar jar = b.build();
+		assertTrue(b.check());
+		Manifest m = jar.getManifest();
+		m.write(System.err);
+		
+		Domain d = Domain.domain(m);
+		Parameters params = d.getImportPackage();
+		Attrs attrs = params.get("test.version.annotations.osgi");
+		assertNotNull(attrs);
+		assertEquals("[1.2,1.3)", attrs.get("version"));
+	}
 
 	/**
 	 * Tests if the implementation of the EventHandler (which is marked as a

--- a/biz.aQute.bndlib.tests/src/test/version/annotations/osgi/AnnotatedProviderInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/version/annotations/osgi/AnnotatedProviderInterface.java
@@ -1,0 +1,8 @@
+package test.version.annotations.osgi;
+
+import org.osgi.annotation.versioning.*;
+
+@ProviderType
+public interface AnnotatedProviderInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/versionpolicy/implemented/osgi/ImplementR5AnnotatedProviderInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/versionpolicy/implemented/osgi/ImplementR5AnnotatedProviderInterface.java
@@ -1,0 +1,7 @@
+package test.versionpolicy.implemented.osgi;
+
+import test.version.annotations.osgi.*;
+
+public class ImplementR5AnnotatedProviderInterface implements AnnotatedProviderInterface {
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1675,7 +1675,8 @@ public class Analyzer extends Processor {
 			return false;
 
 		TypeRef pt = getTypeRefFromFQN(ProviderType.class.getName());
-		boolean result = c.annotations.contains(pt);
+		TypeRef r6pt = getTypeRefFromFQN("org.osgi.annotation.versioning.ProviderType");
+		boolean result = c.annotations.contains(pt) || c.annotations.contains(r6pt);
 		return result;
 	}
 


### PR DESCRIPTION
Signed-off-by: Neil Bartlett njbartlett@gmail.com
