### PR TITLE
gradle: Pass bnd gradle plugin classpath to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,26 @@
 /*
  * Master Gradle build script
  *
- * Depends on bndWorkspace and bndURI properties set by settings.gradle.
+ * Depends on bndPlugin property set by settings.gradle.
+ * and bnd_* values from gradle.properties.
  */
 
-/* Add bnd as a script dependency */
+import aQute.bnd.build.Workspace
+
+/* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(bndURI)
+    classpath bndPlugin
   }
 }
+
+/* Initialize the bnd workspace */
+ext.bndWorkspace = Workspace.getWorkspace(rootDir, bnd_cnf)
+if (bndWorkspace == null) {
+  throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
+}
+
+ext.cnf = rootProject.project(bnd_cnf)
 
 /* Configure the subprojects */
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,17 @@
+# cnf project name
 bnd_cnf=cnf
-# bnd_jar can also be a relative path to a file in the workspace.
-bnd_jar=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles/biz.aQute.bnd.gradle/biz.aQute.bnd.gradle-latest.jar
+
+# bnd_plugin is the dependency declaration for the bnd gradle plugin
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:latest
+
+# The URL to the repo to load the bnd gradle plugin
+bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
+
+# bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=dist
+
+# Default gradle task to build
 bnd_defaultTask=build
+
+# This should be false. It only needs to be true in rare cases.
 bnd_preCompileRefresh=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,31 +6,33 @@
 
 import aQute.bnd.build.Workspace
 
-/* Add bnd as a script dependency */
+/* Add bnd gradle plugin as a script dependency */
 buildscript {
-  dependencies {
-    def bndURI = rootDir.toURI().resolve(bnd_jar)
-    if (bndURI.scheme != 'file') {
-      /* If not a local file, copy to a local file in cnf/cache */
-      def cnfCache = mkdir("${rootDir}/${bnd_cnf}/cache")
-      def bndJarFile = new File(cnfCache, 'biz.aQute.bnd.gradle.jar')
-      if (!bndJarFile.exists()) {
-        println "Downloading ${bndURI} to ${bndJarFile} ..."
-        bndURI.toURL().withInputStream { is ->
-          bndJarFile.withOutputStream { os ->
-            def bos = new BufferedOutputStream( os )
-            bos << is
-          }
-        }
+  repositories {
+    ivy { /* Configure the repository as an "ivy" repository */
+      url bnd_repourl
+      layout 'pattern', {
+            artifact '[module]/[artifact]-[revision].[ext]' /* OSGi repo pattern */
+            artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])' /* maven pattern */
       }
-      bndURI = bndJarFile.toURI()
     }
-    classpath files(bndURI)
-
-    /* After the rootProject is created, pass URI to projects */
-    gradle.rootProject { rootProject ->
-      rootProject.ext.bndURI = bndURI
+  }
+  dependencies {
+    classpath bnd_plugin
+  }
+  /* Since the files in the repository change with each build, we need to recheck for changes */
+  configurations.classpath.resolutionStrategy.cacheChangingModulesFor 30, 'minutes'
+  dependencies {
+    components {
+      eachComponent { ComponentMetadataDetails details ->
+        details.changing = true
+      }
     }
+  }
+  /* Pass bnd gradle plugin classpath to rootProject once created */
+  def bndPlugin = files(configurations.classpath.files)
+  gradle.rootProject { rootProject ->
+    rootProject.ext.bndPlugin = bndPlugin
   }
 }
 
@@ -118,10 +120,4 @@ def getBndProject(Workspace workspace, String projectName) {
     throw new GradleException("Project ${rootDir}/${projectName} is invalid, ${str}")
   }
   throw new GradleException("Project ${rootDir}/${projectName} is not a valid bnd project")
-}
-
-/* After the rootProject is created, set up some properties. */
-gradle.rootProject { rootProject ->
-  rootProject.ext.bndWorkspace = workspace
-  rootProject.ext.cnf = rootProject.project(bnd_cnf)
 }


### PR DESCRIPTION
Plugin coordinates are in gradle.properties and ivy repository is setup
in settings.gradle. We do that to use the plugin from the cloudbees
build.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
