### PR TITLE
Cleanup exact versions in case they contain snapshot-ish names

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -919,18 +919,19 @@ public class Project extends Processor {
 		List<RepositoryPlugin> plugins = workspace.getRepositories();
 
 		if (useStrategy == Strategy.EXACT) {
-			if (!Verifier.isVersion(range))
-				return new Container(this, bsn, range, Container.TYPE.ERROR, null, bsn + ";version=" + range
+			String exactRange = Analyzer.cleanupVersion(range);
+			if (!Verifier.isVersion(exactRange))
+				return new Container(this, bsn, exactRange, Container.TYPE.ERROR, null, bsn + ";version=" + exactRange
 						+ " Invalid version", null, null);
 
 			// For an exact range we just iterate over the repos
 			// and return the first we find.
-			Version version = new Version(range);
+			Version version = new Version(exactRange);
 			for (RepositoryPlugin plugin : plugins) {
 				DownloadBlocker blocker = new DownloadBlocker(this);
 				File result = plugin.get(bsn, version, attrs, blocker);
 				if (result != null)
-					return toContainer(bsn, range, attrs, result, blocker);
+					return toContainer(bsn, exactRange, attrs, result, blocker);
 			}
 		} else {
 			VersionRange versionRange = VERSION_ATTR_LATEST.equals(range) ? new VersionRange("0") : new VersionRange(


### PR DESCRIPTION
In my scenario I'm trying to use some liferay portal-service 7.0.0-SNAPSHOT versions in my 2.4.0 bndtools workspace using the AetherRepository plugin.  The problem is bndlib is preventing the getBundle() check from continuing before it gets to AetherRepository because it doesn't like 7.0.0-SNAPSHOT version, which I understand since its not very osgi friendly version.

However I searched the bndlib code and found a method in the Analyzer that will try to cleanup maven versions that look like that X.X.X-SNAPSHOT and make it more osgi friendly form, e.g. X.X.X.SNAPSHOT.

So I just called that same function from the Project.getBundle() method to help make my use-case possible and tested it in my local environment and it works for AetherRepository plugin.  So I'm sending the pull along.
