### PR TITLE
pom: Change where default if groupid is set

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/MavenTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MavenTest.java
@@ -357,10 +357,13 @@ public class MavenTest extends TestCase {
 		testPom("pom.xml", "true", "com.example.foo", "1.2.3.qualifier", "com.example", "foo", "1.2.3.qualifier", null,
 				null);
 		testPom("pom.xml", "true", "uvw.xyz", "1.2.3", "uvw", "xyz", "1.2.3", null, null);
-		testPom("pom.xml", "groupid=abc.def.ghi,artifactid=jkl", "uvw.xyz", "1.2.3", "abc.def.ghi", "jkl", "1.2.3",
+		testPom("META-INF/maven/abc.def.ghi/jkl/pom.xml", "groupid=abc.def.ghi,artifactid=jkl", "uvw.xyz", "1.2.3",
+				"abc.def.ghi", "jkl", "1.2.3",
 				null, null);
-		testPom("pom.xml", "groupid=abc.def.ghi", "uvw.xyz", "1.2.3", "abc.def.ghi", "uvw.xyz", "1.2.3", null, null);
-		testPom("pom.xml", "groupid=abc.def.ghi,version=2.6.8", "uvw.xyz", "1.2.3", "abc.def.ghi", "uvw.xyz", "2.6.8",
+		testPom("META-INF/maven/abc.def.ghi/uvw.xyz/pom.xml", "groupid=abc.def.ghi", "uvw.xyz", "1.2.3", "abc.def.ghi",
+				"uvw.xyz", "1.2.3", null, null);
+		testPom("META-INF/maven/abc.def.ghi/uvw.xyz/pom.xml", "groupid=abc.def.ghi,version=2.6.8", "uvw.xyz", "1.2.3",
+				"abc.def.ghi", "uvw.xyz", "2.6.8",
 				null, null);
 		testPom("META-INF/maven/pom.xml", "groupid=abc.def.ghi,version=2.6.8,where=META-INF/maven/pom.xml", "uvw.xyz",
 				"1.2.3", "abc.def.ghi", "uvw.xyz", "2.6.8", null, null);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -114,13 +114,10 @@ public class Builder extends Analyzer {
 		if ( pom != null) {
 			if ( !pom.equalsIgnoreCase("false")) {
 				Map<String,String> map = OSGiHeader.parseProperties(pom);
-				String where = map.get("where");
-				if ( where == null)
-					where = "pom.xml";
-				
 				map.put(Constants.BUNDLE_SCM, getProperty(Constants.BUNDLE_SCM));
 				map.put(Constants.BUNDLE_DEVELOPERS, getProperty(Constants.BUNDLE_DEVELOPERS));
-				dot.putResource(where, new PomResource(map,dot.getManifest()));
+				PomResource pomResource = new PomResource(map, dot.getManifest());
+				dot.putResource(pomResource.getWhere(), pomResource);
 			}
 		}
 


### PR DESCRIPTION
Since groupid is a new key for -pom, it is safe to use a different
default for where when the groupid key is set. In this case the default
is META-INF/maven/${groupid}/${artifactid}/pom.xml instead of pom.xml.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
