### PR TITLE
windows test fixes: Windows EOL includes CR

### DIFF
--- a/org.osgi.impl.bundle.repoindex.lib/test/org/osgi/service/indexer/impl/TestIndexer.java
+++ b/org.osgi.impl.bundle.repoindex.lib/test/org/osgi/service/indexer/impl/TestIndexer.java
@@ -157,7 +157,7 @@ public class TestIndexer extends TestCase {
 		indexer.index(files, out, config);
 
 		String unpackedXML = Utils.readStream(new FileInputStream("testdata/unpacked.xml"));
-		String expected = unpackedXML.replaceAll("[\\n\\t]*", "");
+		String expected = unpackedXML.replaceAll("\\r?\\n|\\t", "");
 		assertEquals(expected, Utils.decompress(out.toByteArray()));
 	}
 

--- a/org.osgi.impl.bundle.repoindex.test/test/org/example/tests/cli/TestCommandLine.java
+++ b/org.osgi.impl.bundle.repoindex.test/test/org/example/tests/cli/TestCommandLine.java
@@ -83,7 +83,7 @@ public class TestCommandLine extends TestCase {
 		assertTrue(new File("generated/index.xml.gz").exists());
 
 		String formatted = Utils.readStream(getClass().getResourceAsStream("/testdata/expect.xml"));
-		String expected = formatted.replaceAll("[\\n\\t]*", "");
+		String expected = formatted.replaceAll("\\r?\\n|\\t", "");
 		String actual = Utils.readStream(new GZIPInputStream(new FileInputStream("generated/index.xml.gz")));
 		assertEquals(expected, actual);
 	}
@@ -98,7 +98,7 @@ public class TestCommandLine extends TestCase {
 		assertTrue(outputFile.exists());
 
 		String formatted = Utils.readStream(getClass().getResourceAsStream("/testdata/expect-workingdir.xml"));
-		String expected = formatted.replaceAll("[\\n\\t]*", "");
+		String expected = formatted.replaceAll("\\r?\\n|\\t", "");
 		String actual = Utils.readStream(new GZIPInputStream(new FileInputStream(outputFile)));
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
The tests used regex for \n but did not allow for \r\n on windows. This
left \r in the expected result which did not match the actual result.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
