### PR TITLE
gradle plugin: Add ignoreFailures flag to check task

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -272,6 +272,7 @@ public class BndPlugin implements Plugin<Project> {
       check {
         dependsOn assemble
         enabled !parseBoolean(bnd(Constants.NOJUNITOSGI, 'false')) && !bndUnprocessed(Constants.TESTCASES, '').empty
+        ext.ignoreFailures = false
         if (enabled) {
           doLast {
             try {
@@ -279,7 +280,13 @@ public class BndPlugin implements Plugin<Project> {
             } catch (Exception e) {
               throw new GradleException("Project ${bndProject.name} failed to test", e)
             }
-            checkErrors()
+            try {
+              checkErrors()
+            } catch (Exception e) {
+              if (!ignoreFailures) {
+                throw e
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This allows the user to configure a project with:

```
check.ignoreFailures = true
```

to not fail the build if the check task fails.

See https://github.com/bndtools/bnd/issues/719

Signed-off-by: BJ Hargrave bj@bjhargrave.com
