### PR TITLE
gradle: test task use the output folder set by the test-reports bnd prop

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -63,6 +63,7 @@ public class BndPlugin implements Plugin<Project> {
       buildDir = relativePath(bndProject.targetDir)
       plugins.apply 'java'
       libsDirName = '.'
+      testResultsDirName = bnd('test-reports', 'test-reports')
 
       if (project.hasProperty('bnd_defaultTask')) {
         defaultTasks = bnd_defaultTask.trim().split(/\s*,\s*/)


### PR DESCRIPTION
The default is different than the gradle java plugin default, but using
this property provides a consistent output location for the test and
check tasks and allows the user to configure via the bnd project property
test-reports.

Fixes https://github.com/bndtools/bnd/issues/730

Signed-off-by: BJ Hargrave bj@bjhargrave.com
