### PR TITLE
Removing the possibilty of returning a null in the list of all projects

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -291,8 +291,12 @@ public class Workspace extends Processor {
 	public Collection<Project> getAllProjects() throws Exception {
 		List<Project> projects = new ArrayList<Project>();
 		for (File file : getBase().listFiles()) {
-			if (new File(file, Project.BNDFILE).isFile())
-				projects.add(getProject(file.getAbsoluteFile().getName()));
+			if (new File(file, Project.BNDFILE).isFile()) {
+				Project p = getProject(file.getAbsoluteFile().getName());
+				if (p != null) {
+					projects.add(p);
+				}
+			}
 		}
 		return projects;
 	}


### PR DESCRIPTION
If there was a problem obtaining a project object, don't return a null
object to the user, this is not intuitive nor documented in the API.

Signed-off-by: Carter Smithhart carter.smithhart@gmail.com
