### PR TITLE
Sanitize URIs for when dropped from external browser

### DIFF
--- a/aQute.libg/src/aQute/lib/converter/Converter.java
+++ b/aQute.libg/src/aQute/lib/converter/Converter.java
@@ -1,6 +1,7 @@
 package aQute.lib.converter;
 
 import java.lang.reflect.*;
+import java.net.URI;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.regex.*;
@@ -222,6 +223,9 @@ public class Converter {
 			if (resultType == Pattern.class) {
 				return Pattern.compile(input);
 			}
+			if (resultType == URI.class) {
+				return new URI(sanitizeInputForURI(input));
+			}
 
 			try {
 				Constructor< ? > c = resultType.getConstructor(String.class);
@@ -300,6 +304,13 @@ public class Converter {
 		}
 
 		return error("No conversion found for " + o.getClass() + " to " + type);
+	}
+
+	private String sanitizeInputForURI(String input) {
+		int newline = input.indexOf("\n");
+		if (newline > -1)
+			return input.substring(0, newline).trim();
+		return input;
 	}
 
 	private Number number(Object o) {

--- a/aQute.libg/test/aQute/lib/converter/ConverterTest.java
+++ b/aQute.libg/test/aQute/lib/converter/ConverterTest.java
@@ -3,6 +3,7 @@ package aQute.lib.converter;
 import java.io.*;
 import java.lang.reflect.*;
 import java.math.*;
+import java.net.URI;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -443,5 +444,17 @@ public class ConverterTest extends TestCase {
 		assertEquals(Arrays.asList(1L), Converter.cnv(new TypeReference<List<Long>>() {}, new BigDecimal[] {
 				new BigDecimal(1)
 			}));
+	}
+
+	public void testURIs() throws Exception {
+		URI expected = new URI("https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0");
+		assertEquals(expected,
+			Converter.cnv(URI.class,"https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0"));
+		assertEquals(expected,
+			Converter.cnv(URI.class,"https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0\n"));
+		assertEquals(expected,
+			Converter.cnv(URI.class,"https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0\n1.3.1"));
+		assertEquals(expected,
+			Converter.cnv(URI.class,"https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0\r\n1.3.1"));
 	}
 }


### PR DESCRIPTION
While going through the latest enRoute tutorials on Linux I noticed that when using the external browser (setup through preferences) and I drag-n-drop the vignette onto the local jpm repository, it fails to parse the URL and load the dependency.  I traced through both bndtools and bnd code and found that the URL that is coming in has invalid characters for a URI object, namely it has a "\n" in the string that is copied from the system clipboard like this:

```
https://www.jpm4j.org/#!/p/sha/C621B54583719AC0310404463D6D99DB27E1052C//0.0.0\n1.3.1
```

When the conversion from String to URI happens it will fail with a URI exception.  So in the Converter class here as well as one place in bndtools I needed to add some code to sanitize the string before trying to allow the URI conversion to take place.  
