### PR TITLE
Always setup cwd as same as project base

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -76,6 +76,8 @@ public abstract class ProjectLauncher {
 	 * @throws Exception
 	 */
 	protected void updateFromProject() throws Exception {
+		setCwd(project.getBase());
+
 		// pkr: could not use this because this is killing the runtests.
 		// project.refresh();
 		runbundles.clear();

--- a/biz.aQute.launcher/test/aQute/launcher/plugin/ProjectLaunchImplTest.java
+++ b/biz.aQute.launcher/test/aQute/launcher/plugin/ProjectLaunchImplTest.java
@@ -31,6 +31,7 @@ public class ProjectLaunchImplTest extends TestCase {
 	public static void testParseSystemCapabilities() throws Exception {
 		Workspace ws = Workspace.getWorkspace(IO.getFile("test/ws"));
 		Project project = ws.getProject("p1");
+		project.getTarget().mkdirs();
 		String systemCaps = null;
 
 		try {
@@ -46,5 +47,11 @@ public class ProjectLaunchImplTest extends TestCase {
 		assertEquals(
 				"osgi.native;osgi.native.osname:List<String>=\"Win7,Windows7,Windows 7\";osgi.native.osversion:Version=6.1",
 				systemCaps);
+	}
+
+	public void testCwdIsProjectBase() throws Exception {
+		Workspace ws = Workspace.getWorkspace(IO.getFile("test/ws"));
+		Project project = ws.getProject("p1");
+		assertEquals(project.getBase(), new ProjectLauncherImpl(project).getCwd());
 	}
 }

--- a/biz.aQute.launcher/test/aQute/launcher/plugin/ProjectLaunchImplTest.java
+++ b/biz.aQute.launcher/test/aQute/launcher/plugin/ProjectLaunchImplTest.java
@@ -31,7 +31,7 @@ public class ProjectLaunchImplTest extends TestCase {
 	public static void testParseSystemCapabilities() throws Exception {
 		Workspace ws = Workspace.getWorkspace(IO.getFile("test/ws"));
 		Project project = ws.getProject("p1");
-		project.getTarget().mkdirs();
+		project.prepare();
 		String systemCaps = null;
 
 		try {
@@ -52,6 +52,7 @@ public class ProjectLaunchImplTest extends TestCase {
 	public void testCwdIsProjectBase() throws Exception {
 		Workspace ws = Workspace.getWorkspace(IO.getFile("test/ws"));
 		Project project = ws.getProject("p1");
+		project.prepare();
 		assertEquals(project.getBase(), new ProjectLauncherImpl(project).getCwd());
 	}
 }


### PR DESCRIPTION
Better fix for setting projectLauncher.cwd == project.base

See discussion at https://github.com/bndtools/bndtools/pull/982