### PR TITLE
Performance fixes

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -464,10 +464,12 @@ public class Project extends Processor {
 				Container found = null;
 
 				String versionRange = attrs.get("version");
+				boolean triedGetBundle = false;
 
 				if (versionRange != null) {
 					if (versionRange.equals(VERSION_ATTR_LATEST) || versionRange.equals(VERSION_ATTR_SNAPSHOT)) {
 						found = getBundle(bsn, versionRange, strategyx, attrs);
+						triedGetBundle = true;
 					}
 				}
 				if (found == null) {
@@ -501,7 +503,7 @@ public class Project extends Processor {
 						} else {
 							found = new Container(this, bsn, "file", Container.TYPE.EXTERNAL, f, error, attrs, null);
 						}
-					} else {
+					} else if (!triedGetBundle) {
 						found = getBundle(bsn, versionRange, strategyx, attrs);
 					}
 				}
@@ -1025,7 +1027,6 @@ public class Project extends Processor {
 		//
 
 		if (!range.equals(VERSION_ATTR_LATEST)) {
-			Container c = getBundleFromProject(bsn, attrs);
 			return new Container(this, bsn, range, Container.TYPE.ERROR, null, bsn + ";version=" + range
 					+ " Not found because latest was not specified."
 					+ " It is, however, present in the workspace. Add '" + bsn


### PR DESCRIPTION
Speeds up Project.prepare()

I was very surprised by the line I commented out and how much extra processing that caused in my environment. The triedGetBundle didn't seem to do much, but it seemed safer to put it there just in case extra getBundle() calls are made.

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>