### PR TITLE
Added transitive property on a project to be optionally used with eclipse

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -206,6 +206,7 @@ public interface Constants {
 	String							WAB											= "-wab";
 	String							WABLIB										= "-wablib";
 	String							REQUIRE_BND									= "-require-bnd";
+	String							TRANSITIVE									= "-transitive";
 
 	// Deprecated
 	String							CLASSPATH									= "-classpath";


### PR DESCRIPTION
Added transitive property on a project to be optionally used with eclipse processing of dependencies.

This is used by the cooresponding bndtools change. Unused in bnd.

Signed-off-by: Carter Smithhart <carter.smithhart@gmail.com>