### PR TITLE
Per RFC 190: Change osgi.ds to osgi.component

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/indexer/Namespaces.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/indexer/Namespaces.java
@@ -65,6 +65,6 @@ public final class Namespaces {
 
 	/** Known contracts and extenders */
 	public static final String CONTRACT_OSGI_FRAMEWORK = "OSGiFramework";
-	public static final String EXTENDER_SCR = "osgi.ds";
+	public static final String EXTENDER_SCR = "osgi.component";
 	public static final String EXTENDER_BLUEPRINT = "osgi.blueprint";
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/indexer/analyzers/known-bundles.properties
+++ b/biz.aQute.bndlib/src/aQute/bnd/indexer/analyzers/known-bundles.properties
@@ -3,19 +3,19 @@
 ######################
 
 ds_1_0: osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.0;\
 	uses:=org.osgi.service.component;\
 	effective:=active
 
 ds_1_1: osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.1;\
 	uses:=org.osgi.service.component;\
 	effective:=active
 
 ds_1_2: osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.2;\
 	uses:=org.osgi.service.component;\
 	effective:=active
@@ -24,8 +24,10 @@ org.eclipse.equinox.ds;[1.0,1.1);cap: ${ds_1_0}
 org.eclipse.equinox.ds;[1.1,1.4)cap: ${ds_1_1}
 org.eclipse.equinox.ds;[1.4,1.5);cap: ${ds_1_2}
 
-org.apache.felix.scr;[1.4,2);cap: ${ds_1_1}
-org.apache.felix.scr;[1.4,2);req: osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.cm)(version>=1.2.0)(!(version>=2.0.0)))"
+org.apache.felix.scr;[1.4,1.8);cap: ${ds_1_1}
+org.apache.felix.scr;[1.4,1.8);req: osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.cm)(version>=1.2.0)(!(version>=2.0.0)))"
+org.apache.felix.scr;[1.8,2);cap: ${ds_1_2}
+org.apache.felix.scr;[1.8,2);req: osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.cm)(version>=1.2.0)(!(version>=2.0.0)))"
 
 ###########
 # Blueprint

--- a/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
@@ -63,7 +63,7 @@ public class JpmRepoTest extends TestCase {
 		model.setRunFw("org.apache.felix.framework");
 
 		List<Requirement> requires = new ArrayList<Requirement>();
-		CapReqBuilder capReq = CapReqBuilder.createSimpleRequirement("osgi.extender", "osgi.ds", "[1.1,2)");
+		CapReqBuilder capReq = CapReqBuilder.createSimpleRequirement("osgi.extender", "osgi.component", "[1.1,2)");
 		requires.add(capReq.buildSyntheticRequirement());
 
 		Map<Requirement,Collection<Capability>> shell = repo.findProviders(requires);

--- a/org.osgi.impl.bundle.repoindex.api/src/org/osgi/service/indexer/Namespaces.java
+++ b/org.osgi.impl.bundle.repoindex.api/src/org/osgi/service/indexer/Namespaces.java
@@ -66,6 +66,6 @@ public final class Namespaces {
 
 	/** Known contracts and extenders */
 	public static final String CONTRACT_OSGI_FRAMEWORK = "OSGiFramework";
-	public static final String EXTENDER_SCR = "osgi.ds";
+	public static final String EXTENDER_SCR = "osgi.component";
 	public static final String EXTENDER_BLUEPRINT = "osgi.blueprint";
 }

--- a/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/known-bundles.properties
+++ b/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/known-bundles.properties
@@ -3,19 +3,19 @@
 ######################
 
 ds_1_0: cap=osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.0;\
 	uses:=org.osgi.service.component;\
 	effective:=active
 
 ds_1_1: cap=osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.1;\
 	uses:=org.osgi.service.component;\
 	effective:=active
 
 ds_1_2: cap=osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.2;\
 	uses:=org.osgi.service.component;\
 	effective:=active
@@ -24,7 +24,11 @@ org.eclipse.equinox.ds;[1.0,1.1): ${ds_1_0}
 org.eclipse.equinox.ds;[1.1,1.4): ${ds_1_1}
 org.eclipse.equinox.ds;[1.4,1.5): ${ds_1_2}
 
-org.apache.felix.scr;[1.4,2): ${ds_1_1},\
+org.apache.felix.scr;[1.4,1.8): ${ds_1_1},\
+	req=osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.cm)(version>=1.2.0)(!(version>=2.0.0)))",\
+	req=osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.metatype)(version>=1.1)(!(version>=2.0.0)))"
+
+org.apache.felix.scr;[1.8,2): ${ds_1_2},\
 	req=osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.cm)(version>=1.2.0)(!(version>=2.0.0)))",\
 	req=osgi.wiring.package;filter:="(&(osgi.wiring.package=org.osgi.service.metatype)(version>=1.1)(!(version>=2.0.0)))"
 

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-15.txt
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-15.txt
@@ -19,7 +19,7 @@
     <attribute name="bundle-version" type="Version" value="0.0.0"/>
   </capability>
   <requirement namespace="osgi.extender">
-    <directive name="filter" value="(&amp;(osgi.extender=osgi.ds)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
     <directive name="effective" value="active"/>
   </requirement>
 </resource>

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_0.txt
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_0.txt
@@ -19,7 +19,7 @@
     <attribute name="bundle-version" type="Version" value="0.0.0"/>
   </capability>
   <requirement namespace="osgi.extender">
-    <directive name="filter" value="(&amp;(osgi.extender=osgi.ds)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
     <directive name="effective" value="active"/>
   </requirement>
 </resource>

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_1.txt
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_1.txt
@@ -19,7 +19,7 @@
     <attribute name="bundle-version" type="Version" value="0.0.0"/>
   </capability>
   <requirement namespace="osgi.extender">
-    <directive name="filter" value="(&amp;(osgi.extender=osgi.ds)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
     <directive name="effective" value="active"/>
   </requirement>
 </resource>

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_2.txt
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr1_2.txt
@@ -19,7 +19,7 @@
     <attribute name="bundle-version" type="Version" value="0.0.0"/>
   </capability>
   <requirement namespace="osgi.extender">
-    <directive name="filter" value="(&amp;(osgi.extender=osgi.ds)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
     <directive name="effective" value="active"/>
   </requirement>
 </resource>

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr_services.txt
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/fragment-scr_services.txt
@@ -50,7 +50,7 @@
     <directive name="effective" value="active"/>
   </requirement>
   <requirement namespace="osgi.extender">
-    <directive name="filter" value="(&amp;(osgi.extender=osgi.ds)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
     <directive name="effective" value="active"/>
   </requirement>
 </resource>

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/known-bundles.properties
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/known-bundles.properties
@@ -1,6 +1,6 @@
 org.apache.felix.scr;[1.6,1.7):\
 	cap=osgi.extender;\
-	osgi.extender=osgi.ds;\
+	osgi.extender=osgi.component;\
 	version:Version=1.1;\
 	uses:=org.osgi.service.component
 

--- a/org.osgi.impl.bundle.repoindex.lib/testdata/org.apache.felix.scr-1.6.0.xml
+++ b/org.osgi.impl.bundle.repoindex.lib/testdata/org.apache.felix.scr-1.6.0.xml
@@ -33,7 +33,7 @@
     <directive name="uses" value="org.osgi.framework"/>
   </capability>
   <capability namespace="osgi.extender">
-    <attribute name="osgi.extender" value="osgi.ds"/>
+    <attribute name="osgi.extender" value="osgi.component"/>
     <attribute name="version" type="Version" value="1.1.0"/>
     <directive name="uses" value="org.osgi.service.component"/>
     <directive name="effective" value="active"/>

--- a/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0-extra.xml
+++ b/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0-extra.xml
@@ -84,7 +84,7 @@
       <attribute name="bundle-version" type="Version" value="1.4.0.v20120522-1841"/>
     </capability>
     <capability namespace="osgi.extender">
-      <attribute name="osgi.extender" value="osgi.ds"/>
+      <attribute name="osgi.extender" value="osgi.component"/>
       <attribute name="version" type="Version" value="1.2.0"/>
       <directive name="uses" value="org.osgi.service.component"/>
       <directive name="effective" value="active"/>

--- a/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.extra-fragment.txt
+++ b/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.extra-fragment.txt
@@ -82,7 +82,7 @@
     <attribute name="bundle-version" type="Version" value="1.4.0.v20120522-1841"/>
   </capability>
   <capability namespace="osgi.extender">
-    <attribute name="osgi.extender" value="osgi.ds"/>
+    <attribute name="osgi.extender" value="osgi.component"/>
     <attribute name="version" type="Version" value="1.2.0"/>
     <directive name="uses" value="org.osgi.service.component"/>
     <directive name="effective" value="active"/>

--- a/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.fragment.txt
+++ b/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.fragment.txt
@@ -82,7 +82,7 @@
     <attribute name="bundle-version" type="Version" value="1.4.0.v20120522-1841"/>
   </capability>
   <capability namespace="osgi.extender">
-    <attribute name="osgi.extender" value="osgi.ds"/>
+    <attribute name="osgi.extender" value="osgi.component"/>
     <attribute name="version" type="Version" value="1.2.0"/>
     <directive name="uses" value="org.osgi.service.component"/>
     <directive name="effective" value="active"/>

--- a/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.xml
+++ b/org.osgi.impl.bundle.repoindex.test/src/testdata/org.eclipse.equinox.ds-1.4.0.xml
@@ -84,7 +84,7 @@
       <attribute name="bundle-version" type="Version" value="1.4.0.v20120522-1841"/>
     </capability>
     <capability namespace="osgi.extender">
-      <attribute name="osgi.extender" value="osgi.ds"/>
+      <attribute name="osgi.extender" value="osgi.component"/>
       <attribute name="version" type="Version" value="1.2.0"/>
       <directive name="uses" value="org.osgi.service.component"/>
       <directive name="effective" value="active"/>


### PR DESCRIPTION
Also indicate that Felix SCR 1.8+ supports version 1.2 of the DS
specification.

Signed-off-by: Sean Bright sean@malleable.com
