### PR TITLE
build: Set heap size for main test bucket

### DIFF
--- a/biz.aQute.bndlib.tests/build.gradle
+++ b/biz.aQute.bndlib.tests/build.gradle
@@ -1,0 +1,5 @@
+test {
+  // set heap size for the test JVM(s)
+  minHeapSize = "512m"
+  maxHeapSize = "1024m"
+}


### PR DESCRIPTION
Travis container based build was having intermittent failures running
the biz.aQute.bndlib.test:test target.
