### PR TITLE
Build maven artifacts

### DIFF
--- a/biz.aQute.bnd.annotation/build.gradle
+++ b/biz.aQute.bnd.annotation/build.gradle
@@ -1,0 +1,1 @@
+apply from: cnf.file('gradle/maven-artifacts.gradle')

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -14,17 +14,9 @@ sourceSets {
     }
 }
 
-task groovydocJar(type: Jar) {
-  description 'Jar the groovydoc.'
-  group 'documentation'
+apply from: cnf.file('gradle/maven-artifacts.gradle')
+
+javadocJar {
   dependsOn groovydoc
   from groovydoc.destinationDir
-  classifier = 'javadoc'
-}
-
-task sourcesJar(type: Jar) {
-  description 'Jar the groovy sources.'
-  group 'documentation'
-  from sourceSets.main.allSource
-  classifier = 'sources'
 }

--- a/biz.aQute.bnd/build.gradle
+++ b/biz.aQute.bnd/build.gradle
@@ -1,0 +1,1 @@
+apply from: cnf.file('gradle/maven-artifacts.gradle')

--- a/biz.aQute.bndlib/build.gradle
+++ b/biz.aQute.bndlib/build.gradle
@@ -1,0 +1,1 @@
+apply from: cnf.file('gradle/maven-artifacts.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ subprojects {
   def bndProject = bndWorkspace.getProject(name)
   if (bndProject != null) {
     plugins.apply 'biz.aQute.bnd'
+    group bnd('groupid')
+    version bnd('base.version')
   }
 }
 

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -66,6 +66,7 @@ copyright.html:         Copyright &copy; aQute SARL (2000, ${tstamp;yyyy}) and o
 
 base.version:           3.0.0
 build.version:          ${base.version}.${tstamp}
+-outputmask:            ${@bsn}-${version;===;${@version}}.jar
 groupid:                biz.aQute.bnd
 Bundle-Version:         ${build.version}
 Bundle-Vendor:          Bndtools http://bndtools.org/

--- a/cnf/gradle/maven-artifacts.gradle
+++ b/cnf/gradle/maven-artifacts.gradle
@@ -1,0 +1,59 @@
+task(type: Jar, 'sourcesJar') {
+  description 'Jar the sources.'
+  group 'documentation'
+  dependsOn jar
+  enabled !bnd.project.noBundles
+  if (enabled) {
+    inputs.file jar.archivePath
+    from zipTree(jar.archivePath).matching {
+      include 'OSGI-OPT/src/**'
+      include '*'
+    }
+    eachFile { FileCopyDetails fcp ->
+      fcp.path = fcp.path - 'OSGI-OPT/src/'
+    }
+    includeEmptyDirs = false
+    classifier = 'sources'
+  }
+}
+
+task('pom') {
+  description 'Generate the pom file.'
+  group 'documentation'
+  dependsOn jar
+  def pomname = "${archivesBaseName}-${version}.pom"
+  ext.pomfile = new File(buildDir, pomname)
+  enabled !bnd.project.noBundles
+  if (enabled) {
+    inputs.file jar.archivePath
+    outputs.file pomfile
+    doLast {
+      copy {
+        from zipTree(jar.archivePath).matching {
+          include "META-INF/maven/${project.group}/${archivesBaseName}/pom.xml"
+        }
+        eachFile { FileCopyDetails fcp ->
+          fcp.path = pomname
+        }
+        into buildDir
+        includeEmptyDirs = false
+      }
+    }
+  }
+}
+
+task(type: Jar, 'javadocJar') {
+  description 'Jar the javadoc.'
+  group 'documentation'
+  dependsOn javadoc
+  from javadoc.destinationDir
+  classifier 'javadoc'
+}
+
+artifacts {
+  archives sourcesJar
+  archives javadocJar
+  archives(pom.pomfile) {
+    builtBy pom
+  }
+}

--- a/org.osgi.impl.bundle.repoindex.cli/build.gradle
+++ b/org.osgi.impl.bundle.repoindex.cli/build.gradle
@@ -1,0 +1,1 @@
+apply from: cnf.file('gradle/maven-artifacts.gradle')

--- a/org.osgi.impl.bundle.repoindex.test/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.test/bnd.bnd
@@ -7,6 +7,9 @@
   org.mockito.mockito-all;version=1.9,\
   com.springsource.org.junit;version=4.10.0
 
+-testpath:\
+  biz.aQute.bndlib;version=latest
+
 # This is required to ensure the cli JAR is built before
 # running the integration tests
 -dependson: org.osgi.impl.bundle.repoindex.cli

--- a/org.osgi.impl.bundle.repoindex.test/test/org/example/tests/cli/TestCommandLine.java
+++ b/org.osgi.impl.bundle.repoindex.test/test/org/example/tests/cli/TestCommandLine.java
@@ -1,29 +1,34 @@
 package org.example.tests.cli;
 
-import static org.example.tests.utils.Utils.copyToTempFile;
-import static org.example.tests.utils.Utils.createTempDir;
-import static org.example.tests.utils.Utils.deleteWithException;
+import static org.example.tests.utils.Utils.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-import java.util.zip.GZIPInputStream;
+import java.io.*;
+import java.util.*;
+import java.util.zip.*;
 
-import junit.framework.TestCase;
+import junit.framework.*;
 
-import org.example.tests.utils.Utils;
+import org.example.tests.utils.*;
+
+import aQute.bnd.build.*;
+import aQute.bnd.service.*;
+import aQute.lib.io.*;
 
 public class TestCommandLine extends TestCase {
 
-	private static final String BINDEX2_LIB_PATH = "../org.osgi.impl.bundle.repoindex.cli/generated/org.osgi.impl.bundle.repoindex.cli.jar";
+	private static final String	CLI	= "org.osgi.impl.bundle.repoindex.cli";
 
 	private File tempDir;
+	private Workspace			ws;
+	private File				jarFile;
+
 
 	@Override
 	protected void setUp() throws Exception {
+		ws = new Workspace(IO.getFile(".."));
+		Project cli = ws.getProject(CLI);
+		jarFile = cli.getBundle(CLI, "latest", Strategy.HIGHEST, null).getFile();
+
 		File index = new File("index.xml");
 		if (index.exists())
 			index.delete();
@@ -37,6 +42,7 @@ public class TestCommandLine extends TestCase {
 
 	@Override
 	protected void tearDown() throws Exception {
+		ws.close();
 		deleteWithException(tempDir);
 	}
 
@@ -45,8 +51,6 @@ public class TestCommandLine extends TestCase {
 	}
 
 	private void execute(String[] args, boolean runInTempDir) throws Exception {
-		File jarFile = new File(BINDEX2_LIB_PATH);
-
 		List<String> cmdLine = new LinkedList<String>();
 		cmdLine.add("java");
 		// cmdLine.add("-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=9001,suspend=y");


### PR DESCRIPTION
Certain bnd projects are released to maven central. These commits build the needed maven artifacts for those projects as part of the normal bnd build. For the projects which opt-in (by applying cnf/gradle/maven-artifacts.gradle), the project's build will create a pom file, a -sources.jar and a -javadoc.jar in addition to the .jar.