### PR TITLE
Expose browse URL from SearchableRepo

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/repository/SearchableRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/repository/SearchableRepository.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import org.osgi.resource.*;
 
+import aQute.bnd.annotation.ProviderType;
 import aQute.bnd.version.*;
 
 /**
@@ -13,6 +14,7 @@ import aQute.bnd.version.*;
  * backed by a database. This interface provides a query interface for text
  * search as well as a requirement based search.
  */
+@ProviderType
 public interface SearchableRepository {
 	/**
 	 * Describes a resource that is a member of the underlying remote
@@ -131,4 +133,17 @@ public interface SearchableRepository {
 	 * @throws Exception
 	 */
 	Set<ResourceDescriptor> findResources(Requirement requirement, boolean includeDependencies) throws Exception;
+
+	/**
+	 * Return the URL to a web page that allows browsing or searching of the
+	 * repository.
+	 * 
+	 * @param searchString
+	 *            A search string, or null for general browsing
+	 * @return A URL that may be opened in a web browser, or null if the
+	 *         repository does not support web browsing.
+	 * @throws Exception
+	 */
+	URI browse(String searchString) throws Exception;
+
 }

--- a/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
+++ b/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
@@ -44,6 +44,10 @@ public class Repository implements Plugin, RepositoryPlugin, Closeable, Refresha
 	public static final String						REPO_DEFAULT_URI			= "http://repo.jpm4j.org/";
 
 	private static final PutOptions					DEFAULT_OPTIONS				= new PutOptions();
+
+	private static final String						SEARCH_PREFIX				= "/#!/search?q=";
+	private static final String						UTF_8						= "UTF-8";
+
 	private final String							DOWN_ARROW					= " \u21E9";
 	protected final DownloadListener[]				EMPTY_LISTENER				= new DownloadListener[0];
 	private Pattern									SHA							= Pattern.compile(
@@ -1864,6 +1868,14 @@ public class Repository implements Plugin, RepositoryPlugin, Closeable, Refresha
 		}
 		
 		return query(query);
+	}
+
+	@Override
+	public URI browse(String searchString) throws Exception {
+		if (searchString == null)
+			return url;
+
+		return url.resolve(SEARCH_PREFIX + URLEncoder.encode(searchString, UTF_8));
 	}
 
 	/**


### PR DESCRIPTION
Expose the browse/search URL of the SearchableRepo, so that Bndtools can go to a hosted JPM instead of the public one on jpm4j.org