### PR TITLE
gradle plugin: Exclude bndlib pom from META-INF

### DIFF
--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -15,5 +15,5 @@ Bundle-Description: The bnd gradle plugin.
 -includeresource: \
   OSGI-OPT/src=src, \
   resources, \
-  @${repo;biz.aQute.bndlib;latest}!/!META-INF, \
+  @${repo;biz.aQute.bndlib;latest}!/!META-INF/*, \
   @${repo;biz.aQute.bnd;latest}!/embedded-repo.jar


### PR DESCRIPTION
Signed-off-by: BJ Hargrave <bj@bjhargrave.com>