### PR TITLE
bndlib: Fix Packages.containsBinaryName

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Packages.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Packages.java
@@ -166,7 +166,7 @@ public class Packages implements Map<PackageRef,Attrs> {
 
 		for (Map.Entry<PackageRef,Attrs> pr : map.entrySet()) {
 			if (pr.getKey().getBinary().equals(s))
-				pr.getValue();
+				return pr.getValue();
 		}
 		return null;
 	}
@@ -176,7 +176,7 @@ public class Packages implements Map<PackageRef,Attrs> {
 	}
 
 	public boolean containsBinaryName(String s) {
-		return getByFQN(s) != null;
+		return getByBinaryName(s) != null;
 	}
 
 	@Override


### PR DESCRIPTION
The method referenced getByFQN instead of getByBinaryName. Also
getByBinaryName was broken since it always return null.

Fixes https://github.com/bndtools/bnd/issues/782

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>