### PR TITLE
gradle plugin: Target a specific gradle version: gradle 2.0

### DIFF
--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -1,8 +1,12 @@
 apply plugin: 'groovy'
 
+repositories {
+  jcenter()
+}
+
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
+    compile 'org.gradle:gradle-core:2.0'
+    compile 'org.codehaus.groovy:groovy-all:2.3.3'
 }
 
 sourceSets {


### PR DESCRIPTION
The bnd gradle plugin should target a specific gradle version rather than
just the version of gradle used to compile bnd.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>