### PR TITLE
build: Add packages=** to -buildpath entries that need it

### DIFF
--- a/org.osgi.impl.bundle.repoindex.test/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.test/bnd.bnd
@@ -1,6 +1,6 @@
 -buildpath:\
   org.osgi.impl.bundle.repoindex.api;version=project,\
-  org.osgi.impl.bundle.repoindex.lib;version=project,\
+  org.osgi.impl.bundle.repoindex.lib;version=project;packages=**,\
   ee.j2se;version=${javac.ee},\
   osgi.core;version=4.3.1,\
   osgi.cmpn;version=4.3.1,\


### PR DESCRIPTION
This change clears Discouraged warnings from the new classpath container
in bndtools.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>