### PR TITLE
Cleanup packages

### DIFF
--- a/biz.aQute.bnd.test/bnd.bnd
+++ b/biz.aQute.bnd.test/bnd.bnd
@@ -6,7 +6,7 @@ Export-Package:         aQute.bnd.test.*
 -buildpath: \
 	ee.j2se;version=${javac.ee},\
     aQute.libg;version=project,\
-	biz.aQute.bndlib;version=project;packages=*,\
+	biz.aQute.bndlib;version=project,\
 	osgi.core;version=4.3.1,\
 	osgi.cmpn;version=4.3.1,\
 	junit.osgi

--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -43,7 +43,7 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
 
 -buildpath: aQute.libg;version=latest,\
 	ee.j2se;version=${javac.ee},\
-	biz.aQute.bndlib;version=project;packages=*,\
+	biz.aQute.bndlib;version=project,\
 	org.apache.tools.ant,\
 	org.osgi.service.component.annotations;version=1.3.0,\
 	org.osgi.service.metatype.annotations;version=1.3.0,\

--- a/biz.aQute.bndlib.tests/bnd.bnd
+++ b/biz.aQute.bndlib.tests/bnd.bnd
@@ -3,7 +3,7 @@
 
 -buildpath: \
 	aQute.libg;version=project,\
-    biz.aQute.bndlib;version=project;packages=*,\
+    biz.aQute.bndlib;version=project,\
     biz.aQute.bnd.test;version=project,\
 	org.osgi.service.component;version=1.3.0,\
 	org.osgi.service.component.annotations;version=1.3.0;packages=*,\

--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -14,16 +14,16 @@ Export-Package: \
 	aQute.bnd.osgi;-noimport:=true,\
 	aQute.bnd.service.lifecycle;-noimport:=true,\
 	aQute.bnd.osgi.resource;-noimport:=true,\
-	aQute.bnd.maven,\
+	aQute.bnd.maven;-noimport:=true,\
 	aQute.bnd.build;-noimport:=true,\
-	aQute.bnd.osgi.eclipse,\
+	aQute.bnd.osgi.eclipse;-noimport:=true,\
 	aQute.bnd.differ;-noimport:=true,\
 	aQute.bnd.service.*;-noimport:=true,\
 	aQute.bnd.help.*;-noimport:=true,\
 	aQute.bnd.header;-noimport:=true,\
 	aQute.bnd.version;-noimport:=true,\
 	aQute.bnd.filerepo;-noimport:=true,\
-	aQute.lib.deployer,\
+	aQute.lib.deployer;-noimport:=true,\
 	aQute.bnd.properties;-noimport:=true,\
 	aQute.bnd.build.model;-noimport:=true,\
 	aQute.bnd.build.model.clauses;-noimport:=true,\

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -10,8 +10,8 @@ jetty.libs: lib/javax.servlet-2.5.0.jar;version=file,\
 	osgi.core;version=4.3.1,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
-	org.osgi.impl.bundle.bindex;packages=*,\
-	org.osgi.impl.bundle.repoindex.lib;version=latest;packages=*,\
+	org.osgi.impl.bundle.bindex;packages=org.osgi.*.bindex.*,\
+	org.osgi.impl.bundle.repoindex.lib;version=latest,\
 	osgi.cmpn;version=4.3.1,\
 	osgi.r5;version=1.0.1,\
 	lib/javax.xml.stream-1.0.1.jar;version=file,\

--- a/biz.aQute.resolve/bnd.bnd
+++ b/biz.aQute.resolve/bnd.bnd
@@ -10,7 +10,7 @@
 	biz.aQute.bndlib;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	ee.j2se;version=${javac.ee},\
-	org.apache.felix.resolver;version=1.1;packages=*,\
+	org.apache.felix.resolver;version=1.1;packages=org.apache.felix.resolver.*,\
 	osgi.cmpn;version=4.3.1
 	
 -testpath: \

--- a/org.osgi.impl.bundle.repoindex.cli/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.cli/bnd.bnd
@@ -1,7 +1,7 @@
 # Build settings
 -buildpath: \
 	org.osgi.impl.bundle.repoindex.api;version=project,\
-	org.osgi.impl.bundle.repoindex.lib;version=project;packages=*,\
+	org.osgi.impl.bundle.repoindex.lib;version=project,\
 	ee.j2se;version=${javac.ee},\
 	osgi.core;version=4.3.1,\
 	osgi.cmpn;version=4.3.1,\

--- a/org.osgi.impl.bundle.repoindex.test/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.test/bnd.bnd
@@ -1,6 +1,6 @@
 -buildpath:\
   org.osgi.impl.bundle.repoindex.api;version=project,\
-  org.osgi.impl.bundle.repoindex.lib;version=project;packages=*,\
+  org.osgi.impl.bundle.repoindex.lib;version=project,\
   ee.j2se;version=${javac.ee},\
   osgi.core;version=4.3.1,\
   osgi.cmpn;version=4.3.1,\


### PR DESCRIPTION
Recent changes mean a number of projects no longer need packages=* to
remove Discouraged warnings. Also narrowed packages for some older
bundles.