### PR TITLE
bndlib: Remove recursion in macro warning

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -225,7 +225,7 @@ public class Macro {
 		if (value != null)
 			return value;
 		if (!flattening && !key.startsWith("@"))
-			domain.warning("No translation found for macro: %s, in %s", key, domain);
+			domain.warning("No translation found for macro: %s", key);
 		return "${" + key + "}";
 	}
 


### PR DESCRIPTION
This recursion caused out of memory errors.

Fixes https://github.com/bndtools/bnd/issues/724

Helped-by: Andreas Kuhtz @akuhtz
Signed-off-by: BJ Hargrave <bj@bjhargrave.com>