### PR TITLE
Special treatment for artifacts with version numbers consisting only of ...

### DIFF
--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
@@ -50,6 +50,12 @@ public class MvnVersionTest extends TestCase {
 		assertEquals(new Version(1, 2, 0, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}
+
+	public void testReleaseNumberOnly() {
+		MvnVersion mv = MvnVersion.parseString("r03");
+		assertEquals(new Version(0, 0, 3, null), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
 	
 	public void testInvalid() {
 		MvnVersion mv = MvnVersion.parseString("1.2.3.4.5");


### PR DESCRIPTION
I have been using the Aether repository plugin with success so far, but it a small bump in the road today when trying to fetch the Google Guava library from Maven Central. When adding a build dependency to "com.google.guava:guava;version=18.0;strategy=exact" the bndtools build fails with an Exception in aQute.bnd.version.Version.parseVersion(), since the version number "r03" gets passed there without proper handling.

This pull request suggests that version numbers following consisting of just a raw revision number (as "r03") be treated as if they had major and minor numbers 0 and a micro number corresponding to the build number.