### PR TITLE
embedded-repo: Add biz.aQute.repository

### DIFF
--- a/biz.aQute.bnd.embedded-repo/bnd.bnd
+++ b/biz.aQute.bnd.embedded-repo/bnd.bnd
@@ -7,12 +7,14 @@ Bundle-Description: Embedded Repo for bnd workspace.
 -includeresource: \
 	biz.aQute.launcher/biz.aQute.launcher-latest.jar=${repo;biz.aQute.launcher;snapshot}, \
 	biz.aQute.remote.launcher/biz.aQute.remote.launcher-latest.jar=${repo;biz.aQute.remote.launcher;snapshot}, \
-	biz.aQute.junit/biz.aQute.junit-latest.jar=${repo;biz.aQute.junit;snapshot}
+	biz.aQute.junit/biz.aQute.junit-latest.jar=${repo;biz.aQute.junit;snapshot}, \
+	biz.aQute.repository/biz.aQute.repository-latest.jar=${repo;biz.aQute.repository;snapshot}
 
 -dependson: \
     biz.aQute.junit, \
     biz.aQute.launcher, \
-    biz.aQute.remote
+    biz.aQute.remote, \
+    biz.aQute.repository
 
 -digests: MD5, SHA1
 

--- a/biz.aQute.bndlib.tests/src/test/WorkspaceRepositoryTest.java
+++ b/biz.aQute.bndlib.tests/src/test/WorkspaceRepositoryTest.java
@@ -107,7 +107,7 @@ public class WorkspaceRepositoryTest extends TestCase {
 
 	public void testGetExact() throws Exception {
 		File file = repo.get("p2", new Version("1.2.3"), new HashMap<String,String>());
-		assertTrue(workspace.check());
+		assertTrue(workspace.check("Couldn't find embedded-repo\\.jar in bundle"));
 		assertNotNull(file);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -502,7 +502,9 @@ public class Workspace extends Processor {
 			list.add(settings);
 
 			if (!isTrue(getProperty(NOBUILDINCACHE))) {
-				list.add(new CachedFileRepo());
+				CachedFileRepo cache = new CachedFileRepo();
+				cache.init(); // init early so the contents can be plugins
+				list.add(cache);
 			}
 
 			resourceRepositoryImpl = new ResourceRepositoryImpl();


### PR DESCRIPTION
This will make sure we can use the matching version of repository
with the bnd version in use. We init the embedded repo early, so we
can refer to the repository jar from -pluginpath.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>