### PR TITLE
[build] Processor defaults

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/WorkspaceTest.java
+++ b/biz.aQute.bndlib.tests/src/test/WorkspaceTest.java
@@ -103,6 +103,7 @@ public class WorkspaceTest extends TestCase {
 		assertEquals("defaults", p.getProperty("myprop1"));
 		assertEquals("workspace", p.getProperty("myprop2"));
 		assertEquals("project", p.getProperty("myprop3"));
+		assertEquals("src", p.mergeProperties("src"));
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -365,23 +365,19 @@ public class Project extends Processor {
 	}
 
 	public File getSrcOutput() {
-		String deflt = Workspace.getDefaults().getProperty(Constants.DEFAULT_PROP_BIN_DIR);
-		return getFile(getProperty(Constants.DEFAULT_PROP_BIN_DIR, deflt));
+		return getFile(getProperty(Constants.DEFAULT_PROP_BIN_DIR));
 	}
 
 	public File getTestSrc() {
-		String deflt = Workspace.getDefaults().getProperty(Constants.DEFAULT_PROP_TESTSRC_DIR);
-		return getFile(getProperty(Constants.DEFAULT_PROP_TESTSRC_DIR, deflt));
+		return getFile(getProperty(Constants.DEFAULT_PROP_TESTSRC_DIR));
 	}
 
 	public File getTestOutput() {
-		String deflt = Workspace.getDefaults().getProperty(Constants.DEFAULT_PROP_TESTBIN_DIR);
-		return getFile(getProperty(Constants.DEFAULT_PROP_TESTBIN_DIR, deflt));
+		return getFile(getProperty(Constants.DEFAULT_PROP_TESTBIN_DIR));
 	}
 
 	public File getTargetDir() {
-		String deflt = Workspace.getDefaults().getProperty(Constants.DEFAULT_PROP_TARGET_DIR);
-		return getFile(getProperty(Constants.DEFAULT_PROP_TARGET_DIR, deflt));
+		return getFile(getProperty(Constants.DEFAULT_PROP_TARGET_DIR));
 	}
 
 	private void traverse(Collection<Project> dependencies, Set<Project> visited) throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -84,7 +84,7 @@ public class Workspace extends Processor {
 		if (defaults != null)
 			return defaults;
 
-		Properties props = new UTF8Properties();
+		UTF8Properties props = new UTF8Properties();
 		InputStream propStream = Workspace.class.getResourceAsStream("defaults.bnd");
 		if (propStream != null) {
 			try {
@@ -98,7 +98,7 @@ public class Workspace extends Processor {
 			}
 		} else
 			System.err.println("Cannot load defaults");
-		defaults = new Processor(props);
+		defaults = new Processor(props, false);
 
 		return defaults;
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -101,6 +101,13 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		this.parent = child;
 	}
 
+	public Processor(Properties props, boolean copy) {
+		if (copy)
+			properties = new UTF8Properties(props);
+		else
+			properties = props;
+	}
+
 	public void setParent(Processor processor) {
 		this.parent = processor;
 		Properties ext = new UTF8Properties(processor.properties);

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,8 @@ bnd_cnf=cnf
 bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:latest
 
 # The URL to the repo to load the bnd gradle plugin
-bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
+#bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
+bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/567/artifact/dist/bundles
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=dist


### PR DESCRIPTION
The Workspace defaults did not show up as keys in the Workspace because the processor did not directly use the Workspace.getDefaults() properties but created an intermediate. Therefore no keys were see, therefore the merge properties did not work for defaulted keys.


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>