### PR TITLE
Corrected parsing of Maven versions with numerical qualifiers

### DIFF
--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
@@ -5,47 +5,50 @@ import java.util.regex.*;
 import aQute.bnd.version.*;
 
 public class MvnVersion implements Comparable<MvnVersion> {
-	
-	private static final Pattern QUALIFIER = Pattern.compile("[-.]?([^0-9.].*)$");
-	
-	private static final String	QUALIFIER_SNAPSHOT	= "SNAPSHOT";
 
-	private final Version osgiVersion;
+	private static final Pattern	QUALIFIER			= Pattern.compile("[-.]?([^0-9.].*)$");
+
+	private static final Pattern	NUM_QUALIFIER		= Pattern.compile("-[0-9]+");
+
+	private static final String		QUALIFIER_SNAPSHOT	= "SNAPSHOT";
+
+	private final Version			osgiVersion;
 
 	public MvnVersion(Version osgiVersion) {
 		this.osgiVersion = osgiVersion;
 	}
-	
+
 	public static final MvnVersion parseString(String versionStr) {
 		MvnVersion result;
-		
+
 		try {
 			Matcher m = QUALIFIER.matcher(versionStr);
 			if (!m.find()) {
 				result = new MvnVersion(Version.parseVersion(versionStr));
 			} else {
 				String qualifier = m.group(1);
-
-				Version v = Version.parseVersion(versionStr.substring(0,
-						m.start()));
-				Version osgiVersion = new Version(v.getMajor(), v.getMinor(),
-						v.getMicro(), qualifier);
+				if (NUM_QUALIFIER.matcher(qualifier).matches()) {
+					qualifier = qualifier.substring(1);
+				}
+				Version v = Version.parseVersion(versionStr.substring(0, m.start()));
+				Version osgiVersion = new Version(v.getMajor(), v.getMinor(), v.getMicro(), qualifier);
 				result = new MvnVersion(osgiVersion);
 			}
-		} catch (IllegalArgumentException e) { // bad format
+		}
+		catch (IllegalArgumentException e) { // bad format
 			result = null;
 		}
 		return result;
 	}
-	
+
 	public Version getOSGiVersion() {
 		return osgiVersion;
 	}
-	
+
 	public boolean isSnapshot() {
 		return QUALIFIER_SNAPSHOT.equals(osgiVersion.getQualifier());
 	}
-	
+
 	public int compareTo(MvnVersion other) {
 		return this.osgiVersion.compareTo(other.osgiVersion);
 	}

--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
@@ -55,8 +55,15 @@ public class MvnVersionTest extends TestCase {
 		assertFalse(mv.isSnapshot());
 	}
 	
-	public void testInvalid() {
+	public void testMajorWithQualifierWithDotSeparator() {
+		MvnVersion mv = MvnVersion.parseString("1.beta-1");
+		assertEquals(new Version(1, 0, 0, "beta-1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
+
+	public void testTooManyDots() {
 		MvnVersion mv = MvnVersion.parseString("1.2.3.4.5");
-		assertNull(mv);
+		assertEquals(new Version(1, 2, 3, "4.5"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
 	}
 }

--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
@@ -1,7 +1,6 @@
 package aQute.bnd.deployer.repository.aether;
 
 import junit.framework.*;
-
 import aQute.bnd.version.*;
 
 public class MvnVersionTest extends TestCase {
@@ -25,6 +24,11 @@ public class MvnVersionTest extends TestCase {
 		MvnVersion mv = MvnVersion.parseString("1.2.3-SNAPSHOT");
 		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
+	}
+
+	public void testNumericQualifier() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3-01");
+		assertEquals(new Version(1, 2, 3, "01"), mv.getOSGiVersion());
 	}
 
 	public void testQualifierWithDashSeparator() {


### PR DESCRIPTION
This is a follow up to https://github.com/bndtools/bnd/pull/637

After upgrading to Bndtoools 3.0.0.DEV, I've discovered that Maven versions with numerical qualifiers were parsed incorrectly "3.2.2-2" for example was parsed as Version(3, 2, 2, "-2"). I'm a bit puzzled that I haven't noticed that before because I'm dealing with precisely this type of versions in a toy project of mine. Apparently there was an even number of bugs canceling each other out, and now this symmetry got broken :)

Anyway, I have a fix that involves an additional pattern matching and overwriting qualifier that was already parsed. I've tinkered with it a bit, I wasn't able to devise a single pattern that would handle all the edge cases.

The patch contains whitespace changes introduced by Eclipse save action (enabled by https://github.com/bndtools/bnd/commit/603e4b769b62e95cde7486fd28fb609c27f9ff73)