### PR TITLE
gradle plugin: Use method names for bnd types

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -85,8 +85,8 @@ if (projectNames.remove('')) {
 projectNames.each { projectName ->
   include projectName
   def project = getBndProject(workspace, projectName)
-  project?.dependson.each {
-    include it.name
+  project?.getDependson()*.getName().each {
+    include it
   }
 }
 
@@ -103,10 +103,10 @@ def getBndProject(Workspace workspace, String projectName) {
 
   project.getInfo(workspace, "${rootDir} :")
   def errorCount = 0
-  project.warnings.each {
+  project.getWarnings().each {
     println "Warning: ${it}"
   }
-  project.errors.each {
+  project.getErrors().each {
     println "Error  : ${it}"
     errorCount++
   }


### PR DESCRIPTION
Some bnd types have non-private fields with the "same" name as the
getter method. For example: sourcepath and getSourcepath. Groovy
was picking the field instead of the getter. This caused an error
when the impl details of the field changed while the method did not.
So we now always use method calls in the Groovy code to make sure we
always call the getter and not access the field.

Replaces https://github.com/bndtools/bnd/pull/856.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>