### PR TITLE
build: Revert to using latest gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,7 @@ bnd_cnf=cnf
 bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:latest
 
 # The URL to the repo to load the bnd gradle plugin
-#bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
-bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/567/artifact/dist/bundles
+bnd_repourl=https://bndtools.ci.cloudbees.com/job/bnd.master/lastSuccessfulBuild/artifact/dist/bundles
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=dist


### PR DESCRIPTION
After fixing https://github.com/bndtools/bnd/pull/857

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>