### PR TITLE
gradle: Use method names for bnd types

### DIFF
--- a/cnf/gradle/maven-artifacts.gradle
+++ b/cnf/gradle/maven-artifacts.gradle
@@ -2,7 +2,7 @@ task(type: Jar, 'sourcesJar') {
   description 'Jar the sources.'
   group 'documentation'
   dependsOn jar
-  enabled !bnd.project.noBundles
+  enabled !bnd.project.isNoBundles()
   if (enabled) {
     inputs.file jar.archivePath
     from zipTree(jar.archivePath).matching {
@@ -23,7 +23,7 @@ task('pom') {
   dependsOn jar
   def pomname = "${archivesBaseName}-${version}.pom"
   ext.pomfile = new File(buildDir, pomname)
-  enabled !bnd.project.noBundles
+  enabled !bnd.project.isNoBundles()
   if (enabled) {
     inputs.file jar.archivePath
     outputs.file pomfile

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -29,7 +29,7 @@ task('index') {
 
   /* indexers */
   def bindexJar = file('bindex/org.osgi.impl.bundle.bindex.jar')
-  def repoindexJar = bnd.project.getBundle('org.osgi.impl.bundle.repoindex.cli', 'latest', null, ['strategy':'highest']).file
+  def repoindexJar = bnd.project.getBundle('org.osgi.impl.bundle.repoindex.cli', 'latest', null, ['strategy':'highest']).getFile()
 
   /* Bundles to index. */
   def bundles = fileTree(releaserepo) {


### PR DESCRIPTION
Some bnd types have non-private fields with the "same" name as the
getter method. For example: sourcepath and getSourcepath. Groovy
was picking the field instead of the getter. This caused an error
when the impl details of the field changed while the method did not.
So we now always use method calls in the Groovy code to make sure we
always call the getter and not access the field.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>