### PR TITLE
maven version: Support additional forms of maven versions

### DIFF
--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/AetherRepository.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/AetherRepository.java
@@ -308,10 +308,12 @@ public class AetherRepository implements Plugin, RegistryPlugin, RepositoryPlugi
 		// Add to the result
 		SortedSet<Version> versions = new TreeSet<Version>();
 		for (org.eclipse.aether.version.Version version : rangeResult.getVersions()) {
-			MvnVersion parsed = MvnVersion.parseString(version.toString());
-
-			if (parsed != null)
-				versions.add(parsed.getOSGiVersion());
+			try {
+				versions.add(MvnVersion.parseString(version.toString()).getOSGiVersion());
+			}
+			catch (IllegalArgumentException e) {
+				// ignore version
+			}
 		}
 		return versions;
 	}

--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/MvnVersion.java
@@ -5,47 +5,41 @@ import java.util.regex.*;
 import aQute.bnd.version.*;
 
 public class MvnVersion implements Comparable<MvnVersion> {
-	
-	private static final Pattern QUALIFIER = Pattern.compile("[-.]?([^0-9.].*)$");
-	
-	private static final String	QUALIFIER_SNAPSHOT	= "SNAPSHOT";
 
-	private final Version osgiVersion;
+	public static final String		VERSION_STRING		= "(\\d{1,9})(\\.(\\d{1,9})(\\.(\\d{1,9}))?)?([-\\.]?([-_\\.\\da-zA-Z]+))?";
+
+	private static final Pattern	VERSION				= Pattern.compile(VERSION_STRING);
+
+	private static final String		QUALIFIER_SNAPSHOT	= "SNAPSHOT";
+
+	private final Version			osgiVersion;
 
 	public MvnVersion(Version osgiVersion) {
 		this.osgiVersion = osgiVersion;
 	}
-	
-	public static final MvnVersion parseString(String versionStr) {
-		MvnVersion result;
-		
-		try {
-			Matcher m = QUALIFIER.matcher(versionStr);
-			if (!m.find()) {
-				result = new MvnVersion(Version.parseVersion(versionStr));
-			} else {
-				String qualifier = m.group(1);
 
-				Version v = Version.parseVersion(versionStr.substring(0,
-						m.start()));
-				Version osgiVersion = new Version(v.getMajor(), v.getMinor(),
-						v.getMicro(), qualifier);
-				result = new MvnVersion(osgiVersion);
-			}
-		} catch (IllegalArgumentException e) { // bad format
-			result = null;
-		}
-		return result;
+	public static final MvnVersion parseString(String versionStr) {
+		versionStr = versionStr.trim();
+		Matcher m = VERSION.matcher(versionStr);
+		if (!m.matches())
+			throw new IllegalArgumentException("Invalid syntax for version: " + versionStr);
+
+		int major = Integer.parseInt(m.group(1));
+		int minor = (m.group(3) != null) ? Integer.parseInt(m.group(3)) : 0;
+		int micro = (m.group(5) != null) ? Integer.parseInt(m.group(5)) : 0;
+		String qualifier = m.group(7);
+		Version version = new Version(major, minor, micro, qualifier);
+		return new MvnVersion(version);
 	}
-	
+
 	public Version getOSGiVersion() {
 		return osgiVersion;
 	}
-	
+
 	public boolean isSnapshot() {
 		return QUALIFIER_SNAPSHOT.equals(osgiVersion.getQualifier());
 	}
-	
+
 	public int compareTo(MvnVersion other) {
 		return this.osgiVersion.compareTo(other.osgiVersion);
 	}

--- a/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
+++ b/biz.aQute.repository.aether/test/aQute/bnd/deployer/repository/aether/MvnVersionTest.java
@@ -1,7 +1,6 @@
 package aQute.bnd.deployer.repository.aether;
 
 import junit.framework.*;
-
 import aQute.bnd.version.*;
 
 public class MvnVersionTest extends TestCase {
@@ -25,6 +24,22 @@ public class MvnVersionTest extends TestCase {
 		MvnVersion mv = MvnVersion.parseString("1.2.3-SNAPSHOT");
 		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.2-SNAPSHOT");
+		assertEquals(new Version(1, 2, 0, "SNAPSHOT"), mv.getOSGiVersion());
+		assertTrue(mv.isSnapshot());
+		mv = MvnVersion.parseString("1-SNAPSHOT");
+		assertEquals(new Version(1, 0, 0, "SNAPSHOT"), mv.getOSGiVersion());
+		assertTrue(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.2.3.SNAPSHOT");
+		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
+		assertTrue(mv.isSnapshot());
+	}
+
+	public void testNumericQualifier() {
+		MvnVersion mv = MvnVersion.parseString("1.2.3-01");
+		assertEquals(new Version(1, 2, 3, "01"), mv.getOSGiVersion());
+		mv = MvnVersion.parseString("1.2.3.01");
+		assertEquals(new Version(1, 2, 3, "01"), mv.getOSGiVersion());
 	}
 
 	public void testQualifierWithDashSeparator() {
@@ -37,22 +52,48 @@ public class MvnVersionTest extends TestCase {
 		MvnVersion mv = MvnVersion.parseString("1.2.3rc1");
 		assertEquals(new Version(1, 2, 3, "rc1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.2rc1");
+		assertEquals(new Version(1, 2, 0, "rc1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1rc1");
+		assertEquals(new Version(1, 0, 0, "rc1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
 	}	
 	
 	public void testQualifierWithDotSeparator() {
 		MvnVersion mv = MvnVersion.parseString("1.2.3.beta-1");
 		assertEquals(new Version(1, 2, 3, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-	}
-	
-	public void testMajorMinorWithQualifierWithDotSeparator() {
-		MvnVersion mv = MvnVersion.parseString("1.2.beta-1");
+		mv = MvnVersion.parseString("1.2.beta-1");
 		assertEquals(new Version(1, 2, 0, "beta-1"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.beta-1");
+		assertEquals(new Version(1, 0, 0, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}
 	
-	public void testInvalid() {
+	public void testDotsInQualifier() {
 		MvnVersion mv = MvnVersion.parseString("1.2.3.4.5");
-		assertNull(mv);
+		assertEquals(new Version(1, 2, 3, "4.5"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.2.3-4.5");
+		assertEquals(new Version(1, 2, 3, "4.5"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1.2-4.5");
+		assertEquals(new Version(1, 2, 0, "4.5"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+		mv = MvnVersion.parseString("1-4.5");
+		assertEquals(new Version(1, 0, 0, "4.5"), mv.getOSGiVersion());
+		assertFalse(mv.isSnapshot());
+	}
+
+	public void testInvalidVersion() {
+		try {
+			MvnVersion mv = MvnVersion.parseString("Not a number");
+			fail();
+		}
+		catch (IllegalArgumentException e) {
+			// expected
+		}
 	}
 }


### PR DESCRIPTION
Simplify parsing using a single regex.

Added more tests and changes parseString method to throw
IllegalArgumentException instead of return null if the string argument
was invalid.

This is a replacement for https://github.com/bndtools/bnd/pull/854

Reported-by: Rafał Krzewski <rafal.krzewski@caltha.pl>

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>