### PR TITLE
Gradle builder plugin: Add gradle support for non-Workspace environments

### DIFF
--- a/biz.aQute.bnd.gradle/.classpath
+++ b/biz.aQute.bnd.gradle/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry excluding="**/*.groovy" kind="src" output="bin" path="src"/>
 	<classpathentry kind="src" output="bin_test" path="test"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="output" path="bin"/>

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -1,12 +1,20 @@
 apply plugin: 'groovy'
 
 repositories {
+  maven { 
+    url 'http://dl.bintray.com/bnd/gradle'
+  }
   jcenter()
 }
 
 dependencies {
     compile 'org.gradle:gradle-core:2.0'
+    compile 'org.gradle:gradle-base-services:2.0'
+    compile 'org.gradle:gradle-base-services-groovy:2.0'
+    compile 'org.gradle:gradle-plugins:2.0'
+    compile 'org.gradle:gradle-native:2.0'
     compile 'org.codehaus.groovy:groovy-all:2.3.3'
+    compile 'org.slf4j:slf4j-api:1.7.5'
 }
 
 sourceSets {

--- a/biz.aQute.bnd.gradle/resources/META-INF/gradle-plugins/biz.aQute.bnd.builder.properties
+++ b/biz.aQute.bnd.gradle/resources/META-INF/gradle-plugins/biz.aQute.bnd.builder.properties
@@ -1,0 +1,1 @@
+implementation-class=aQute.bnd.gradle.BndBuilderPlugin

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -1,0 +1,29 @@
+/*
+ * BndBuilderPlugin for Gradle.
+ *
+ * <p>
+ * This plugin applies the java plugin to a project and modifies the jar
+ * task by adding the properties from the BundleTaskConvention and building
+ * the jar file as a bundle.
+ */
+
+package aQute.bnd.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public class BndBuilderPlugin implements Plugin<Project> {
+  void apply(Project p) {
+    p.configure(p) { project ->
+      plugins.apply 'java'
+
+      jar {
+        description 'Assembles a bundle containing the main classes.'
+        convention.plugins.bundle = new BundleTaskConvention(jar)
+        doLast {
+          Bundle.build(jar)
+        }
+      }
+    }
+  }
+}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -1,8 +1,6 @@
 /*
  * BndPlugin for Gradle.
  *
- * The bnd classes must be available on the classpath for this script.
- *
  * If the bndWorkspace property is set, it will be used for the bnd Workspace.
  *
  * If the bnd_defaultTask property is set, it will be used for the the default

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
@@ -1,0 +1,145 @@
+/*
+ * Bundle task type for Gradle.
+ *
+ * <p>
+ * This task type extends the Jar task type and can be used 
+ * for tasks that make bundles. The Bundle task type adds the
+ * properties from the BundleTaskConvention.
+ *
+ * <p>
+ * Here is an example of using the Bundle task type:
+ * <pre>
+ * import aQute.bnd.gradle.Bundle
+ * task bundle(type: Bundle) {
+ *   description 'Build my bundle'
+ *   group 'build'
+ *   from sourceSets.bundle.output
+ *   bndfile = project.file('bundle.bnd')
+ *   configuration = configurations.bundleCompile
+ *   sourceSet = sourceSets.bundle
+ * }
+ * </pre>
+ */
+
+package aQute.bnd.gradle
+
+import aQute.bnd.osgi.Builder
+import aQute.bnd.osgi.Constants
+import aQute.bnd.osgi.Jar
+import aQute.bnd.version.Version
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.SourceSet
+
+public class Bundle extends org.gradle.api.tasks.bundling.Jar {
+
+  public Bundle() {
+    super()
+    convention.plugins.bundle = new BundleTaskConvention(this)
+  }
+
+  @TaskAction
+  protected void copy() {
+    super.copy()
+    build(this)
+  }
+
+  public static void build(org.gradle.api.tasks.bundling.Jar task) {
+    task.configure {
+      // create Builder and set trace level from gradle
+      def Builder builder = new Builder()
+      builder.setTrace(logger.isEnabled(LogLevel.DEBUG))
+      try {
+        // load any task manifest entries into the builder
+        builder.addProperties(manifest.effectiveManifest.attributes)
+
+        // if the bnd file exists, set it as the builder properties
+        if (bndfile.isFile()) {
+          builder.setProperties(bndfile, project.projectDir)
+        } else {
+          builder.setBase(project.projectDir)
+        }
+
+        // If no bundle to be built, we have nothing to do
+        if (Builder.isTrue(builder.getProperty(Constants.NOBUNDLES))) {
+          return
+        }
+
+        // Reject sub-bundle projects
+        if ((builder.getSubBuilders().size() != 1) || ((builder.getPropertiesFile() != null) && !bndfile.equals(builder.getPropertiesFile()))) {
+          throw new GradleException('Sub-bundles are not supported by this task')
+        }
+
+        // copy Jar task generated jar to temporaryDir
+        project.copy {
+          from archivePath
+          into temporaryDir
+        }
+        def File jar = new File(temporaryDir, archivePath.name)
+
+        // set builder classpath
+        def Set<File> artifacts = new LinkedHashSet<File>(configuration.resolvedConfiguration.resolvedArtifacts*.file)
+        artifacts.add(jar)
+        builder.setClasspath(artifacts.toArray(new File[artifacts.size()]))
+        logger.debug "builder classpath: ${builder.getClasspath()*.getSource()}"
+
+        // set builder sourcepath
+        def Set<File> srcDirs = new LinkedHashSet<File>(sourceSet.java.srcDirs)
+        builder.setSourcepath(srcDirs.toArray(new File[srcDirs.size()]))
+        logger.debug "builder sourcepath: ${builder.getSourcePath()}"
+
+        // Include entire contents of Jar task generated jar except the manifest
+        def String includes = builder.getProperty(Constants.INCLUDERESOURCE)
+        if (isEmpty(includes)) {
+          includes = "@${jar}!/!META-INF/MANIFEST.MF"
+        } else {
+          includes = "@${jar}!/!META-INF/MANIFEST.MF,${includes}"
+        }
+        builder.setProperty(Constants.INCLUDERESOURCE, includes)
+
+        // set bundle symbolic name from tasks's baseName property if necessary
+        def String bundleSymbolicName = builder.getProperty(Constants.BUNDLE_SYMBOLICNAME)
+        if (isEmpty(bundleSymbolicName)) {
+          builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, baseName)
+        }
+
+        // set bundle version from task's version if necessary
+        def String bundleVersion = builder.getProperty(Constants.BUNDLE_VERSION)
+        if (isEmpty(bundleVersion)) {
+          builder.setProperty(Constants.BUNDLE_VERSION, Version.parseVersion(version).toString())
+        }
+
+        logger.debug "builder properties: ${builder.getProperties()}"
+
+        // Build bundle (in memory)
+        def Jar bundleJar = builder.build()
+        bundleJar.updateModified(jar.lastModified(), 'time of Jar task generated jar')
+
+        // check for warnings and errors
+        builder.getWarnings().each {
+          logger.warn "Warning: ${it}"
+        }
+        builder.getErrors().each {
+          logger.error "Error  : ${it}"
+        }
+        if (!builder.getErrors().isEmpty()) {
+          throw new GradleException('Bundle build has errors')
+        }
+
+        try {
+          bundleJar.write(archivePath)
+        } finally {
+          bundleJar.close()
+        }
+      } finally {
+        builder.close()
+      }
+    }
+  }
+
+  private static boolean isEmpty(String header) {
+    return (header == null) || header.trim().isEmpty() || Constants.EMPTY_HEADER.equals(header)
+  }
+}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -1,0 +1,63 @@
+/*
+ * BundleTaskConvention for Gradle.
+ *
+ * Adds properties to bundle builder tasks.
+ *
+ * <p>
+ * Properties:
+ * <ul>
+ * <li>bndfile - This is the name of the bnd file to use to make the bundle.
+ * This defaults to 'bnd.bnd' in the projectDir. The bndfile does not need
+ * to exist. It supersedes any information in the jar task's manifest.</li>
+ * <li>configuration - This is the Configuration to use for the buildpath
+ * for the bnd builder. It defaults to the 'compile' Configuration.</li>
+ * <li>sourceSet - This is the SourceSet to use for the sourcepath for the
+ * bnd builder. It defaults to the 'main' SourceSet.</li>
+ * </ul>
+ */
+
+package aQute.bnd.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.SourceSet
+
+class BundleTaskConvention {
+  private File bndfile
+  private Configuration configuration
+  private SourceSet sourceSet
+
+  BundleTaskConvention(Task task) {
+    def Project project = task.project
+    // Set default property values
+    setBndfile(project.file('bnd.bnd'))
+    setConfiguration(project.configurations.compile)
+    setSourceSet(project.sourceSets.main)
+    // Add bndfile to task inputs
+    task.inputs.file {
+      getBndfile()
+    }
+  }
+
+  File getBndfile() {
+    return bndfile
+  }
+  void setBndfile(File bndfile) {
+    this.bndfile = bndfile
+  }
+
+  Configuration getConfiguration() {
+    return configuration
+  }
+  void setConfiguration(Configuration configuration) {
+    this.configuration = configuration
+  }
+
+  SourceSet getSourceSet() {
+    return sourceSet
+  }
+  void setSourceSet(SourceSet sourceSet) {
+    this.sourceSet = sourceSet
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# JVM args to run gradle
+org.gradle.jvmargs=-Xms1024m -Xmx2048m -XX:MaxPermSize=512m
+
 # cnf project name
 bnd_cnf=cnf
 


### PR DESCRIPTION
A new Bundle task type is defined which extends the Jar task type and
uses the bnd Builder class to make the jar into a bundle. An
biz.aQute.bnd.builder plugin is defined which, when applied to a project
modifies the jar task to use the bnd Builder class to make the jar into
a bundle.