### PR TITLE
bndlib: Correct isValid check for workspace to look for build.bnd in the...

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/WorkspaceTest.java
+++ b/biz.aQute.bndlib.tests/src/test/WorkspaceTest.java
@@ -106,4 +106,17 @@ public class WorkspaceTest extends TestCase {
 		assertEquals("src", p.mergeProperties("src"));
 	}
 
+	public static void testIsValid() throws Exception {
+		Workspace ws = Workspace.getWorkspace(IO.getFile("testresources/ws"));
+		assertEquals(true, ws.isValid());
+
+		Workspace invalidWs = new Workspace(IO.getFile("testresource/not a workspace"));
+		try
+		{
+			assertEquals(false, invalidWs.isValid());
+		}
+		finally {
+			invalidWs.close();
+		}
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -746,9 +746,9 @@ public class Workspace extends Processor {
 		if (!buildDir.isDirectory())
 			error("No directory for cnf %s", buildDir);
 		else {
-			File build = IO.getFile(buildDir, "build.bnd");
+			File build = IO.getFile(buildDir, BUILDFILE);
 			if (build.isFile()) {
-				error("No build.bnd file in %s", buildDir);
+				error("No %s file in %s", BUILDFILE, buildDir);
 			}
 		}
 	}
@@ -758,7 +758,7 @@ public class Workspace extends Processor {
 	}
 
 	public boolean isValid() {
-		return getFile(BUILDFILE).isFile();
+		return IO.getFile(buildDir, BUILDFILE).isFile();
 	}
 
 	public RepositoryPlugin getRepository(String repo) {


### PR DESCRIPTION
... cnf folder.

Also, update rest of class to use constant instead of build.bnd string literal

Fixes #874

Signed-off-by: Humeniuk, Dave <david.humeniuk@udri.udayton.edu>