### PR TITLE
Gradle sourcepath only if sources true

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -142,9 +142,9 @@ class BundleTaskConvention {
         // Include entire contents of Jar task generated jar except the manifest
         def String includes = builder.getProperty(Constants.INCLUDERESOURCE)
         if (isEmpty(includes)) {
-          includes = "@${jar}!/!META-INF/MANIFEST.MF"
+          includes = "\"@${jar}!/!META-INF/MANIFEST.MF\""
         } else {
-          includes = "@${jar}!/!META-INF/MANIFEST.MF,${includes}"
+          includes = "\"@${jar}!/!META-INF/MANIFEST.MF\",${includes}"
         }
         builder.setProperty(Constants.INCLUDERESOURCE, includes)
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -134,10 +134,12 @@ class BundleTaskConvention {
         builder.setClasspath(artifacts.toArray(new File[artifacts.size()]))
         logger.debug 'builder classpath: {}', builder.getClasspath()*.getSource()
 
-        // set builder sourcepath
-        def Set<File> srcDirs = new LinkedHashSet<File>(sourceSet.java.srcDirs)
-        builder.setSourcepath(srcDirs.toArray(new File[srcDirs.size()]))
-        logger.debug 'builder sourcepath: {}', builder.getSourcePath()
+        // set builder sourcepath if -sources=true
+        if (builder.hasSources()) {
+          def Set<File> srcDirs = new LinkedHashSet<File>(sourceSet.java.srcDirs)
+          builder.setSourcepath(srcDirs.toArray(new File[srcDirs.size()]))
+          logger.debug 'builder sourcepath: {}', builder.getSourcePath()
+        }
 
         // Include entire contents of Jar task generated jar except the manifest
         def String includes = builder.getProperty(Constants.INCLUDERESOURCE)


### PR DESCRIPTION
This avoids the need for the user to set a SourceSet or for the default
SourceSet to exist when -sources is not set.

Also quote jar name for -includeresource.