### PR TITLE
gradle plugin: Escape any quote chars in jar file path

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -142,11 +142,12 @@ class BundleTaskConvention {
         }
 
         // Include entire contents of Jar task generated jar except the manifest
+        def String jarInclude = "\"@${jar.absolutePath.replaceAll(/"/, /\\"/)}!/!META-INF/MANIFEST.MF\""
         def String includes = builder.getProperty(Constants.INCLUDERESOURCE)
         if (isEmpty(includes)) {
-          includes = "\"@${jar}!/!META-INF/MANIFEST.MF\""
+          includes = jarInclude
         } else {
-          includes = "\"@${jar}!/!META-INF/MANIFEST.MF\",${includes}"
+          includes = "${jarInclude},${includes}"
         }
         builder.setProperty(Constants.INCLUDERESOURCE, includes)
 


### PR DESCRIPTION
Since we quote the jar path for -includeresource, we also need to escape
any quote chars in the path.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>