### PR TITLE
Unix style line endings (LF) for component and metatype generation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
@@ -16,7 +16,7 @@ public class TagResource extends WriteResource {
 	public void write(OutputStream out) throws UnsupportedEncodingException {
 		OutputStreamWriter ow = new OutputStreamWriter(out, "UTF-8");
 		PrintWriter pw = new PrintWriter(ow);
-		pw.println("<?xml version=\"1.0\"?>");
+		pw.print("<?xml version=\"1.0\"?>" + "\n");
 		try {
 			tag.print(0, pw);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/make/metatype/MetaTypeReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/metatype/MetaTypeReader.java
@@ -265,7 +265,7 @@ public class MetaTypeReader extends WriteResource {
 			throw new RuntimeException(e);
 		}
 		PrintWriter pw = new PrintWriter(new OutputStreamWriter(out, "UTF-8"));
-		pw.println("<?xml version='1.0'?>");
+		pw.print("<?xml version='1.0'?>" + "\n");
 		metadata.print(0, pw);
 		pw.flush();
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/TagResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/TagResource.java
@@ -16,7 +16,7 @@ public class TagResource extends WriteResource {
 	public void write(OutputStream out) throws UnsupportedEncodingException {
 		OutputStreamWriter ow = new OutputStreamWriter(out, "UTF-8");
 		PrintWriter pw = new PrintWriter(ow);
-		pw.println("<?xml version=\"1.0\"?>");
+		pw.print("<?xml version=\"1.0\"?>" + "\n");
 		try {
 			tag.print(0, pw);
 		}


### PR DESCRIPTION
As discussed here https://groups.google.com/d/msg/bndtools-dev/_8k9LfzONac/v_iIz7D28MQJ

Separated the line delimiter to allow a refactoring as configuration value

Signed-off-by: Peter Kirschner <peter@kirschners.de>