### PR TITLE
[analyzer] suppress spurious version parsing errors

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1774,9 +1774,9 @@ public class Analyzer extends Processor {
 											}
 										}
 										catch (Exception e) {
-											e.printStackTrace();
-											// Ignored here, is picked up in
-											// other places
+											// ignore version parsing errors; they will be resolved later during cleanupVersion
+											if (!e.getMessage().startsWith("Invalid syntax for version"))
+												e.printStackTrace();
 										}
 									}
 								}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1774,9 +1774,8 @@ public class Analyzer extends Processor {
 											}
 										}
 										catch (Exception e) {
-											// ignore version parsing errors; they will be resolved later during cleanupVersion
-											if (!e.getMessage().startsWith("Invalid syntax for version"))
-												e.printStackTrace();
+											// Ignored here, is picked up in
+											// other places
 										}
 									}
 								}


### PR DESCRIPTION
Issue: https://github.com/bndtools/bnd/issues/915

Alternative solution: https://github.com/bndtools/bnd/pull/916

Suppress printing exceptions like the following. Invalid versions are not a problem at that stage of analysis; they will be fuzzy matched later into valid OSGi versions during `cleanupVersion`.

```
java.lang.IllegalArgumentException: Invalid syntax for version: 0.27.4-SNAPSHOT
	at aQute.bnd.version.Version.<init>(Version.java:46)
	at aQute.bnd.osgi.Analyzer.augmentExports(Analyzer.java:1711)
	at aQute.bnd.osgi.Analyzer.analyze(Analyzer.java:229)
	at aQute.bnd.osgi.Builder.analyze(Builder.java:344)
	at aQute.bnd.osgi.Analyzer.calcManifest(Analyzer.java:618)
	at org.apache.felix.bundleplugin.ManifestPlugin.getAnalyzer(ManifestPlugin.java:213)
	at org.apache.felix.bundleplugin.ManifestPlugin.getManifest(ManifestPlugin.java:114)
	at org.apache.felix.bundleplugin.ManifestPlugin.execute(ManifestPlugin.java:69)
	at org.apache.felix.bundleplugin.BundlePlugin.execute(BundlePlugin.java:294)
	at org.apache.felix.bundleplugin.BundlePlugin.execute(BundlePlugin.java:285)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
	at org.twdata.maven.mojoexecutor.MojoExecutor.executeMojoImpl(MojoExecutor.java:172)
	at org.twdata.maven.mojoexecutor.MojoExecutor$ExecutionEnvironmentM3.executeMojo(MojoExecutor.java:476)
	at org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo(MojoExecutor.java:75)
	at com.atlassian.maven.plugins.amps.MavenGoals.generateBundleManifest(MavenGoals.java:1405)
	at com.atlassian.maven.plugins.amps.osgi.GenerateManifestMojo.execute(GenerateManifestMojo.java:71)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.MojoExecutor.executeForkedExecutions(MojoExecutor.java:364)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:198)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:355)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:216)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:160)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
```