### PR TITLE
[analyzer] use fuzzy version logic when comparing manifest version to package version

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1760,7 +1760,7 @@ public class Analyzer extends Processor {
 									// and we have set it.
 									if (key.equals(Constants.VERSION_ATTRIBUTE)) {
 										Version fromExport = new Version(cleanupVersion(exporterAttributes.getVersion()));
-										Version fromSet = new Version(cleanupVersion(attributes.getVersion());
+										Version fromSet = new Version(cleanupVersion(attributes.getVersion()));
 										if (!fromExport.equals(fromSet)) {
 											SetLocation location = warning(
 													"Version for package %s is set to different values in the source (%s) and in the manifest (%s). The version in the manifest is not "

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1759,24 +1759,17 @@ public class Analyzer extends Processor {
 									// we have the attribute from the classpath
 									// and we have set it.
 									if (key.equals(Constants.VERSION_ATTRIBUTE)) {
-										try {
-											Version fromExport = new Version(exporterAttributes.getVersion());
-											Version fromSet = new Version(attributes.getVersion());
-											if (!fromExport.equals(fromSet)) {
-												SetLocation location = warning(
-														"Version for package %s is set to different values in the source (%s) and in the manifest (%s). The version in the manifest is not "
-																+ "picked up by an other sibling bundles in this project or projects that directly depend on this project",
-														packageName, attributes.get(key), exporterAttributes.get(key));
-												if (getPropertiesFile() != null)
-													location.file(getPropertiesFile().getAbsolutePath());
-												location.header(EXPORT_PACKAGE);
-												location.context(packageName);
-											}
-										}
-										catch (Exception e) {
-											e.printStackTrace();
-											// Ignored here, is picked up in
-											// other places
+										Version fromExport = new Version(cleanupVersion(exporterAttributes.getVersion()));
+										Version fromSet = new Version(cleanupVersion(attributes.getVersion());
+										if (!fromExport.equals(fromSet)) {
+											SetLocation location = warning(
+													"Version for package %s is set to different values in the source (%s) and in the manifest (%s). The version in the manifest is not "
+															+ "picked up by an other sibling bundles in this project or projects that directly depend on this project",
+													packageName, attributes.get(key), exporterAttributes.get(key));
+											if (getPropertiesFile() != null)
+												location.file(getPropertiesFile().getAbsolutePath());
+											location.header(EXPORT_PACKAGE);
+											location.context(packageName);
 										}
 									}
 								}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1759,17 +1759,23 @@ public class Analyzer extends Processor {
 									// we have the attribute from the classpath
 									// and we have set it.
 									if (key.equals(Constants.VERSION_ATTRIBUTE)) {
-										Version fromExport = new Version(cleanupVersion(exporterAttributes.getVersion()));
-										Version fromSet = new Version(cleanupVersion(attributes.getVersion()));
-										if (!fromExport.equals(fromSet)) {
-											SetLocation location = warning(
-													"Version for package %s is set to different values in the source (%s) and in the manifest (%s). The version in the manifest is not "
-															+ "picked up by an other sibling bundles in this project or projects that directly depend on this project",
-													packageName, attributes.get(key), exporterAttributes.get(key));
-											if (getPropertiesFile() != null)
-												location.file(getPropertiesFile().getAbsolutePath());
-											location.header(EXPORT_PACKAGE);
-											location.context(packageName);
+										try {
+											Version fromExport = new Version(cleanupVersion(exporterAttributes.getVersion()));
+											Version fromSet = new Version(cleanupVersion(attributes.getVersion()));
+											if (!fromExport.equals(fromSet)) {
+												SetLocation location = warning(
+														"Version for package %s is set to different values in the source (%s) and in the manifest (%s). The version in the manifest is not "
+																+ "picked up by an other sibling bundles in this project or projects that directly depend on this project",
+														packageName, attributes.get(key), exporterAttributes.get(key));
+												if (getPropertiesFile() != null)
+													location.file(getPropertiesFile().getAbsolutePath());
+												location.header(EXPORT_PACKAGE);
+												location.context(packageName);
+											}
+										}
+										catch (Exception e) {
+											// Ignored here, is picked up in
+											// other places
 										}
 									}
 								}


### PR DESCRIPTION
Issue: https://github.com/bndtools/bnd/issues/915

Use fuzzy version grokking logic when comparing manifest and package versions - exactly as we do later, via `cleanupVersion`

Alternative solution: https://github.com/bndtools/bnd/pull/914