### PR TITLE
[verifier] clock recognized as invalid file name

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/VerifierTest.java
+++ b/biz.aQute.bndlib.tests/src/test/VerifierTest.java
@@ -51,8 +51,9 @@ public class VerifierTest extends TestCase {
 		testFileName("XYZ", null, true);
 		testFileName("XYZ", "XYZ|${@}", false);
 		testFileName("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", ".{33,}|${@}", false);
-		testFileName("clock$", ".{1,32}|${@}", false);
 		testFileName("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", null, true);
+		testFileName("clock$", null, false);
+		testFileName("clock", null, true);
 	}
 
 	private void testFileName(String segment, String pattern, boolean answer) throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -12,7 +12,7 @@ import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
 import aQute.bnd.util.dto.*;
 import aQute.bnd.version.*;
-import aQute.lib.base64.Base64;
+import aQute.lib.base64.*;
 import aQute.lib.filter.*;
 import aQute.lib.io.*;
 import aQute.libg.cryptography.*;
@@ -84,7 +84,7 @@ public class Verifier extends Processor {
 
 	public final static Pattern	ReservedFileNames				= Pattern
 																		.compile(
-																				"CON(\\..+)?|PRN(\\..+)?|AUX(\\..+)?|CLOCK$|NUL(\\..+)?|COM[1-9](\\..+)?|LPT[1-9](\\..+)?|"
+																				"CON(\\..+)?|PRN(\\..+)?|AUX(\\..+)?|CLOCK\\$|NUL(\\..+)?|COM[1-9](\\..+)?|LPT[1-9](\\..+)?|"
 																						+ "\\$Mft|\\$MftMirr|\\$LogFile|\\$Volume|\\$AttrDef|\\$Bitmap|\\$Boot|\\$BadClus|\\$Secure|"
 																						+ "\\$Upcase|\\$Extend|\\$Quota|\\$ObjId|\\$Reparse",
 																				Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
The pattern for invalid file names was using CLOCK$ and not CLOCK\$ so any name ending in CLOCK was wrong. 

#917 Close

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>