### PR TITLE
bnd-maven-plugin: Handle projects with no source code

### DIFF
--- a/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -94,21 +94,25 @@ public class BndMavenPlugin extends AbstractMojo {
 				if (artifactFile != null)
 					classpath.add(artifactFile);
 			}
-			classpath.add(classesDir);
+			if (classesDir.isDirectory()) {
+				classpath.add(classesDir);
+			}
 			builder.setClasspath(classpath.toArray(new File[classpath.size()]));
 			
 			// Set bnd sourcepath
-			if (builder.hasSources())
+			if (builder.hasSources() && sourceDir.isDirectory())
 				builder.setSourcepath(new File[] { sourceDir });
 
 			// Include local project packages automatically
-			String includes = builder.getProperty(Constants.INCLUDERESOURCE);
-			StringBuilder newIncludes = new StringBuilder().append('"').append(classesDir.getAbsolutePath().replaceAll("\"", "\\\\\"")).append('"');
-			if (includes == null || includes.trim().isEmpty())
-				includes = newIncludes.toString();
-			else
-				includes = newIncludes.append(',').append(includes).toString();
-			builder.setProperty(Constants.INCLUDERESOURCE, includes);
+			if (classesDir.isDirectory()) {
+				String includes = builder.getProperty(Constants.INCLUDERESOURCE);
+				StringBuilder newIncludes = new StringBuilder().append('"').append(classesDir.getAbsolutePath().replaceAll("\"", "\\\\\"")).append('"');
+				if (includes == null || includes.trim().isEmpty())
+					includes = newIncludes.toString();
+				else
+					includes = newIncludes.append(',').append(includes).toString();
+				builder.setProperty(Constants.INCLUDERESOURCE, includes);
+			}
 
 			// Set Bundle-Version
 			MavenVersion mvnVersion = new MavenVersion(project.getVersion());

--- a/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -14,5 +14,6 @@
 	<modules>
 		<module>test-api-bundle</module>
 		<module>test-impl-bundle</module>
+		<module>test-wrapper-bundle</module>
 	</modules>
 </project>

--- a/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/README.txt
+++ b/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/README.txt
@@ -1,0 +1,7 @@
+This is an example bundle that has no source but wraps some jar.
+
+Points of interest:
+
+* The target/classes folder will not be created by other maven plugins since
+there is no source code in this project. bnd-maven-plugin must handle that it
+does not exist and create it when necessary.

--- a/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd.bnd
+++ b/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd.bnd
@@ -1,0 +1,3 @@
+Export-Package: \
+	org.example.api,\
+	org.example.types

--- a/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
+++ b/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+	<artifactId>test-wrapper-bundle</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>test-api-bundle</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>default-bnd-process</id>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!--
+			The following configuration is required because bnd-maven-plugin generates the manifest to 
+			target/classes/META-INF/MANIFEST.MF but the normal maven-jar-plugin does not use it. If the jar-plugin
+			is patched to pick up the manifest from this location, then the following config is not needed.
+			-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -1,1 +1,4 @@
 println "TODO: Need to write some test code for the generated bundles!"
+println "basedir ${basedir}"
+println "localRepositoryPath ${localRepositoryPath}"
+println "mavenVersion ${mavenVersion}"


### PR DESCRIPTION
The project might just want to wrap some other jars. This fix will test
for the target/classes dir and if it is not a directory, it will not
add it to bnd's classpath or the -includeresource directive.

Also added a new test project to the integration-test to test building
a project with no source code.

Fixes https://github.com/bndtools/bnd/issues/925

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>