### PR TITLE
Use LF line endings in output files for build consistency

### DIFF
--- a/aQute.libg/src/aQute/lib/tag/Tag.java
+++ b/aQute.libg/src/aQute/lib/tag/Tag.java
@@ -1,8 +1,14 @@
 package aQute.lib.tag;
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The Tag class represents a minimal XML tree. It consist of a named element
@@ -232,7 +238,7 @@ public class Tag {
 						pw.print(escape((String) c));
 				} else if (c instanceof Tag) {
 					if ((last == null) && (indent >= 0)) {
-						pw.println();
+						pw.print('\n');
 					}
 					Tag tag = (Tag) c;
 					tag.print(indent + 2, pw);
@@ -247,7 +253,7 @@ public class Tag {
 		}
 		pw.print('>');
 		if (indent >= 0) {
-			pw.println();
+			pw.print('\n');
 		}
 		return this;
 	}

--- a/aQute.libg/src/aQute/libg/sed/Sed.java
+++ b/aQute.libg/src/aQute/libg/sed/Sed.java
@@ -1,10 +1,19 @@
 package aQute.libg.sed;
 
-import java.io.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.lib.io.*;
+import aQute.lib.io.IO;
 
 public class Sed {
 	final File					file;
@@ -67,7 +76,8 @@ public class Sed {
 						throw new IOException("where: " + line + ", pattern: " + p.pattern() + ": " + e.getMessage());
 					}
 				}
-				pw.println(line);
+				pw.print(line);
+				pw.print('\n');
 			}
 		}
 		finally {

--- a/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
@@ -1,26 +1,55 @@
 package aQute.bnd.main;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.jar.*;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
-import javax.xml.transform.*;
-import javax.xml.transform.stream.*;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
-import aQute.bnd.build.*;
-import aQute.bnd.differ.*;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectBuilder;
+import aQute.bnd.differ.Baseline;
 import aQute.bnd.differ.Baseline.BundleInfo;
 import aQute.bnd.differ.Baseline.Info;
-import aQute.bnd.header.*;
-import aQute.bnd.osgi.*;
+import aQute.bnd.differ.DiffPluginImpl;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Descriptors.PackageRef;
-import aQute.bnd.service.diff.*;
-import aQute.bnd.version.*;
-import aQute.lib.collections.*;
-import aQute.lib.getopt.*;
-import aQute.lib.tag.*;
+import aQute.bnd.osgi.Instructions;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.diff.Delta;
+import aQute.bnd.service.diff.Diff;
+import aQute.bnd.service.diff.Tree;
+import aQute.bnd.version.Version;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.collections.SortedList;
+import aQute.lib.getopt.Arguments;
+import aQute.lib.getopt.Description;
+import aQute.lib.getopt.Options;
+import aQute.lib.tag.Tag;
 
 /**
  * Implements commands to maintain the Package versions db.
@@ -385,7 +414,7 @@ public class BaselineCommands {
 		try {
 			PrintWriter pw = new PrintWriter(fw);
 			try {
-				pw.println("<?xml version='1.0'?>");
+				pw.print("<?xml version='1.0' encoding='UTF-8'?>\n");
 				top.print(0, pw);
 			}
 			finally {

--- a/biz.aQute.bnd/src/aQute/bnd/main/DiffCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/DiffCommand.java
@@ -1,15 +1,28 @@
 package aQute.bnd.main;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
-import aQute.bnd.build.*;
-import aQute.bnd.differ.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.diff.*;
-import aQute.configurable.*;
-import aQute.lib.getopt.*;
-import aQute.lib.tag.*;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectBuilder;
+import aQute.bnd.differ.DiffPluginImpl;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Instructions;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.diff.Delta;
+import aQute.bnd.service.diff.Diff;
+import aQute.bnd.service.diff.Differ;
+import aQute.bnd.service.diff.Tree;
+import aQute.configurable.Config;
+import aQute.lib.getopt.Arguments;
+import aQute.lib.getopt.Description;
+import aQute.lib.getopt.Options;
+import aQute.lib.tag.Tag;
 
 public class DiffCommand {
 	bnd	bnd;
@@ -139,7 +152,7 @@ public class DiffCommand {
 				if (all || options.resources())
 					tag.addContent(getTagFrom(diff.get("<resources>"), !options.full()));
 
-				pw.println("<?xml version='1.0'?>");
+				pw.print("<?xml version='1.0' encoding='UTF-8'?>\n");
 				tag.print(0, pw);
 			}
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/TagResource.java
@@ -1,9 +1,12 @@
 package aQute.bnd.component;
 
-import java.io.*;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 
-import aQute.bnd.osgi.*;
-import aQute.lib.tag.*;
+import aQute.bnd.osgi.WriteResource;
+import aQute.lib.tag.Tag;
 
 public class TagResource extends WriteResource {
 	final Tag	tag;
@@ -16,7 +19,7 @@ public class TagResource extends WriteResource {
 	public void write(OutputStream out) throws UnsupportedEncodingException {
 		OutputStreamWriter ow = new OutputStreamWriter(out, "UTF-8");
 		PrintWriter pw = new PrintWriter(ow);
-		pw.println("<?xml version=\"1.0\"?>");
+		pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
 		try {
 			tag.print(0, pw);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/make/metatype/MetaTypeReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/metatype/MetaTypeReader.java
@@ -1,15 +1,28 @@
 package aQute.bnd.make.metatype;
 
-import java.io.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.bnd.annotation.metatype.*;
-import aQute.bnd.osgi.*;
+import aQute.bnd.annotation.metatype.Configurable;
+import aQute.bnd.annotation.metatype.Meta;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Annotation;
+import aQute.bnd.osgi.ClassDataCollector;
+import aQute.bnd.osgi.Clazz;
 import aQute.bnd.osgi.Clazz.MethodDef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
-import aQute.lib.tag.*;
-import aQute.libg.generics.*;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.WriteResource;
+import aQute.lib.tag.Tag;
+import aQute.libg.generics.Create;
 
 public class MetaTypeReader extends WriteResource {
 	final Analyzer			reporter;
@@ -265,7 +278,7 @@ public class MetaTypeReader extends WriteResource {
 			throw new RuntimeException(e);
 		}
 		PrintWriter pw = new PrintWriter(new OutputStreamWriter(out, "UTF-8"));
-		pw.println("<?xml version='1.0'?>");
+		pw.print("<?xml version='1.0' encoding='UTF-8'?>\n");
 		metadata.print(0, pw);
 		pw.flush();
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
@@ -1,15 +1,25 @@
 package aQute.bnd.maven;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.jar.*;
-import java.util.regex.*;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.bnd.header.*;
-import aQute.bnd.osgi.*;
-import aQute.lib.io.*;
-import aQute.lib.tag.*;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.WriteResource;
+import aQute.lib.io.IO;
+import aQute.lib.tag.Tag;
 
 public class PomResource extends WriteResource {
 	private static final String	VERSION		= "version";
@@ -220,7 +230,7 @@ public class PomResource extends WriteResource {
 			}
 		}
 
-		pw.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
 		project.print(0, pw);
 		pw.flush();
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/TagResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/TagResource.java
@@ -1,9 +1,12 @@
 package aQute.bnd.metatype;
 
-import java.io.*;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 
-import aQute.bnd.osgi.*;
-import aQute.lib.tag.*;
+import aQute.bnd.osgi.WriteResource;
+import aQute.lib.tag.Tag;
 
 public class TagResource extends WriteResource {
 	final Tag	tag;
@@ -16,7 +19,7 @@ public class TagResource extends WriteResource {
 	public void write(OutputStream out) throws UnsupportedEncodingException {
 		OutputStreamWriter ow = new OutputStreamWriter(out, "UTF-8");
 		PrintWriter pw = new PrintWriter(ow);
-		pw.println("<?xml version=\"1.0\"?>");
+		pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
 		try {
 			tag.print(0, pw);
 		}

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/ObrContentProvider.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/ObrContentProvider.java
@@ -1,27 +1,48 @@
 package aQute.bnd.deployer.repository.providers;
 
-import static aQute.bnd.deployer.repository.api.Decision.*;
-import static javax.xml.stream.XMLStreamConstants.*;
+import static aQute.bnd.deployer.repository.api.Decision.accept;
+import static aQute.bnd.deployer.repository.api.Decision.reject;
+import static aQute.bnd.deployer.repository.api.Decision.undecided;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.PROCESSING_INSTRUCTION;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
-import javax.xml.stream.*;
-import javax.xml.transform.stream.*;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.stream.StreamSource;
 
-import org.osgi.framework.*;
-import org.osgi.framework.namespace.*;
-import org.osgi.namespace.service.*;
-import org.osgi.resource.*;
-import org.osgi.service.bindex.*;
-import org.osgi.service.log.*;
-import org.osgi.service.repository.*;
+import org.osgi.framework.Version;
+import org.osgi.framework.namespace.BundleNamespace;
+import org.osgi.framework.namespace.ExecutionEnvironmentNamespace;
+import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.namespace.IdentityNamespace;
+import org.osgi.framework.namespace.PackageNamespace;
+import org.osgi.namespace.service.ServiceNamespace;
+import org.osgi.resource.Namespace;
+import org.osgi.resource.Resource;
+import org.osgi.service.bindex.BundleIndexer;
+import org.osgi.service.log.LogService;
+import org.osgi.service.repository.ContentNamespace;
 
-import aQute.bnd.deployer.repository.api.*;
-import aQute.bnd.osgi.resource.*;
-import aQute.bnd.service.*;
-import aQute.lib.io.*;
+import aQute.bnd.deployer.repository.api.CheckResult;
+import aQute.bnd.deployer.repository.api.IRepositoryContentProvider;
+import aQute.bnd.deployer.repository.api.IRepositoryIndexProcessor;
+import aQute.bnd.deployer.repository.api.Referral;
+import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.bnd.service.Registry;
+import aQute.lib.io.IO;
 
 public class ObrContentProvider implements IRepositoryContentProvider {
 
@@ -29,7 +50,7 @@ public class ObrContentProvider implements IRepositoryContentProvider {
 	public static final String	NAME						= "OBR";
 
 	private static final String	INDEX_NAME					= "repository.xml";
-	private static final String	EMPTY_REPO_TEMPLATE			= "<?xml version='1.0' encoding='UTF-8'?>%n<repository name='%s' lastmodified='0' xmlns='http://www.osgi.org/xmlns/obr/v1.0.0'/>";
+	private static final String	EMPTY_REPO_TEMPLATE			= "<?xml version='1.0' encoding='UTF-8'?>\n<repository name='%s' lastmodified='0' xmlns='http://www.osgi.org/xmlns/obr/v1.0.0'/>";
 
 	private static final String	NS_URI						= "http://www.osgi.org/xmlns/obr/v1.0.0";
 	private static final String	PI_DATA_STYLESHEET			= "type='text/xsl' href='http://www2.osgi.org/www/obr2html.xsl'";


### PR DESCRIPTION
We want the output build on *ix and windows systems to be the same to
avoid baselining failures.

Closes https://github.com/bndtools/bnd/pull/908

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>