### PR TITLE
Fix #937: @RequireCapability with 'value' attribute generates spuriou…

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
@@ -52,14 +52,19 @@ public class AnnotationHeadersTest extends TestCase {
 			// namespaces must be "osgi.ee", "nsx" and "nsy" ONLY
 			assertNotNull(p.get("nsx"));
 			assertNotNull(p.get("nsy"));
+			assertNotNull(p.get("nsz"));
 			assertNotNull(p.get("osgi.ee"));
-			assertEquals("spurious Require-Capability namespaces", 3, p.size());
+			assertEquals("spurious Require-Capability namespaces", 4, p.size());
 
 			attrs = p.get("nsx");
 			assertEquals(Arrays.asList("abc","def"), attrs.getTyped("foo"));
 
 			attrs = p.get("nsy");
 			assertEquals("hello", attrs.get("value"));
+
+			attrs = p.get("nsz");
+			assertEquals("(nsz=*)", attrs.get("filter:"));
+			assertEquals("world", attrs.get("hello"));
 		}
 		finally {
 			b.close();

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
@@ -1,16 +1,29 @@
 package test.annotationheaders;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.Arrays;
 import java.util.Map.Entry;
-import java.util.jar.*;
-import java.util.regex.*;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import junit.framework.*;
-import aQute.bnd.annotation.headers.*;
-import aQute.bnd.annotation.licenses.*;
-import aQute.bnd.header.*;
-import aQute.bnd.osgi.*;
+import aQute.bnd.annotation.headers.BundleCategory;
+import aQute.bnd.annotation.headers.BundleContributors;
+import aQute.bnd.annotation.headers.BundleCopyright;
+import aQute.bnd.annotation.headers.BundleDevelopers;
+import aQute.bnd.annotation.headers.BundleDocURL;
+import aQute.bnd.annotation.headers.Category;
+import aQute.bnd.annotation.headers.ProvideCapability;
+import aQute.bnd.annotation.headers.RequireCapability;
+import aQute.bnd.annotation.licenses.ASL_2_0;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import junit.framework.TestCase;
 
 public class AnnotationHeadersTest extends TestCase {
 
@@ -36,10 +49,17 @@ public class AnnotationHeadersTest extends TestCase {
 			assertEquals("abc", attrs.get("foo"));
 			
 			p = new Parameters(m.getMainAttributes().getValue("Require-Capability"));
+			// namespaces must be "osgi.ee", "nsx" and "nsy" ONLY
+			assertNotNull(p.get("nsx"));
+			assertNotNull(p.get("nsy"));
+			assertNotNull(p.get("osgi.ee"));
+			assertEquals("spurious Require-Capability namespaces", 3, p.size());
+
 			attrs = p.get("nsx");
-			assertNotNull(attrs);
 			assertEquals(Arrays.asList("abc","def"), attrs.getTyped("foo"));
-			
+
+			attrs = p.get("nsy");
+			assertEquals("hello", attrs.get("value"));
 		}
 		finally {
 			b.close();

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/AnnotationWithValue.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/AnnotationWithValue.java
@@ -1,0 +1,8 @@
+package test.annotationheaders.attrs;
+
+import aQute.bnd.annotation.headers.RequireCapability;
+
+@RequireCapability(ns = "nsy", effective = "active", filter = "(foo=bar)")
+public @interface AnnotationWithValue {
+	String value();
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
@@ -5,6 +5,7 @@ import test.annotationheaders.attrs.AnnotationWithAttrs.E;
 @AnnotationWithAttrs(bar=10, foo={"abc","def"}, en=E.A)
 @License(foo="abc")
 @ExtendedProvide(foo = 3, bar = 3)
+@AnnotationWithValue("hello")
 public class UsingAttrs {
 
 }

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
@@ -1,11 +1,13 @@
 package test.annotationheaders.attrs;
 
+import aQute.bnd.annotation.headers.RequireCapability;
 import test.annotationheaders.attrs.AnnotationWithAttrs.E;
 
 @AnnotationWithAttrs(bar=10, foo={"abc","def"}, en=E.A)
 @License(foo="abc")
 @ExtendedProvide(foo = 3, bar = 3)
 @AnnotationWithValue("hello")
+@RequireCapability(ns = "nsz", filter = "(nsz=*)", extra = "hello=world")
 public class UsingAttrs {
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
@@ -1,6 +1,9 @@
 package aQute.bnd.annotation.headers;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * The Bundle’s Require-Capability header
@@ -12,7 +15,10 @@ import java.lang.annotation.*;
 		ElementType.ANNOTATION_TYPE, ElementType.TYPE
 })
 public @interface RequireCapability {
+
 	String value() default "";
+
+	String extra() default "";
 
 	/**
 	 * The capability namespace. For example: {@code osgi.contract}.

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/packageinfo
@@ -1,2 +1,2 @@
-version 1.0
+version 1.1
  

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -318,7 +318,14 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 		p.put(annotation.ns(), attrs );
 
 		String s = p.toString();
-		
+
+		String extra = annotation.extra();
+		if (extra != null) {
+			extra = extra.trim();
+			if (extra.length() > 0)
+				s += ";" + extra;
+		}
+
 		add(Constants.REQUIRE_CAPABILITY, s);
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -1,15 +1,29 @@
 package aQute.bnd.osgi;
 
-import java.io.*;
-import java.util.*;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
-import aQute.bnd.annotation.headers.*;
-import aQute.bnd.header.*;
+import aQute.bnd.annotation.headers.BundleCategory;
+import aQute.bnd.annotation.headers.BundleContributors;
+import aQute.bnd.annotation.headers.BundleCopyright;
+import aQute.bnd.annotation.headers.BundleDevelopers;
+import aQute.bnd.annotation.headers.BundleDocURL;
+import aQute.bnd.annotation.headers.BundleLicense;
+import aQute.bnd.annotation.headers.Category;
+import aQute.bnd.annotation.headers.ProvideCapability;
+import aQute.bnd.annotation.headers.RequireCapability;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
-import aQute.bnd.version.*;
-import aQute.lib.collections.*;
-import aQute.lib.strings.*;
+import aQute.bnd.version.Version;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.strings.Strings;
 
 /**
  * This class parses the 'header annotations'. Header annotations are
@@ -305,9 +319,6 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 
 		String s = p.toString();
 		
-		if (annotation.value() != null)
-			s += ";" + annotation.value();
-
 		add(Constants.REQUIRE_CAPABILITY, s);
 	}
 


### PR DESCRIPTION
@pkriens Please review, especially the removal of lines 308-310 of `AnnotationHeaders.java`, which were the direct cause of the bug. I don't understand why those lines were there in the first place, maybe you can recall the reason you wrote them.