### PR TITLE
Fixes for Windows

### DIFF
--- a/aQute.libg/src/aQute/lib/io/IO.java
+++ b/aQute.libg/src/aQute/lib/io/IO.java
@@ -1,13 +1,40 @@
 package aQute.lib.io;
 
-import java.io.*;
-import java.lang.reflect.*;
-import java.net.*;
-import java.nio.*;
-import java.security.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
-import aQute.libg.glob.*;
+import aQute.libg.glob.Glob;
 
 public class IO {
 	static final int			BUFFER_SIZE	= IOConstants.PAGE_SIZE * 16;
@@ -72,7 +99,13 @@ public class IO {
 	}
 
 	public static void copy(byte[] data, File file) throws FileNotFoundException, IOException {
-		copy(data, new FileOutputStream(file));
+		FileOutputStream out = new FileOutputStream(file);
+		try {
+			copy(data, out);
+		}
+		finally {
+			out.close();
+		}
 	}
 
 	public static void copy(byte[] r, OutputStream w) throws IOException {
@@ -183,7 +216,13 @@ public class IO {
 			http.setRequestMethod(method);
 		}
 		c.setDoOutput(true);
-		copy(in, c.getOutputStream());
+		OutputStream os = c.getOutputStream();
+		try {
+			copy(in, os);
+		}
+		finally {
+			os.close();
+		}
 	}
 
 	public static void copy(File a, File b) throws IOException {
@@ -499,29 +538,16 @@ public class IO {
 	}
 
 	public static void store(Object o, File out, String encoding) throws IOException {
-		FileOutputStream fout = new FileOutputStream(out);
-		try {
-			store(o, fout, encoding);
-		}
-		finally {
-			fout.close();
-		}
+		store(o, new FileOutputStream(out), encoding);
 	}
 
-	public static void store(Object o, OutputStream fout) throws UnsupportedEncodingException, IOException {
+	public static void store(Object o, OutputStream fout) throws IOException {
 		store(o, fout, "UTF-8");
 	}
 
-	public static void store(Object o, OutputStream fout, String encoding) throws UnsupportedEncodingException,
-			IOException {
-		String s;
-
-		if (o == null)
-			s = "";
-		else
-			s = o.toString();
-
+	public static void store(Object o, OutputStream fout, String encoding) throws IOException {
 		try {
+			String s = (o == null) ? "" : o.toString();
 			fout.write(s.getBytes(encoding));
 		}
 		finally {

--- a/aQute.libg/src/aQute/libg/remote/source/SourceFS.java
+++ b/aQute.libg/src/aQute/libg/remote/source/SourceFS.java
@@ -1,23 +1,27 @@
 package aQute.libg.remote.source;
 
-import java.io.*;
-import java.security.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.File;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.lib.collections.*;
-import aQute.lib.io.*;
-import aQute.libg.cryptography.*;
-import aQute.libg.remote.*;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.io.IO;
+import aQute.libg.cryptography.SHA1;
+import aQute.libg.remote.Delta;
+import aQute.libg.remote.Sink;
 
 class SourceFS {
-	static Pattern							WINDOWS_PREFIX	= Pattern
-																	.compile("([a-z]):/(.*)", Pattern.CASE_INSENSITIVE);
-	static Pattern							WINDOWS_FILE_P	= Pattern.compile(
-																	"([a-z]:|\\\\)(\\\\[\\w\\d-_+.~@$%&=]+)*",
-																	Pattern.CASE_INSENSITIVE);
-	static Pattern							UNIX_FILE_P		= Pattern.compile("(/[\\w\\d-_+.~@$%&=]+)+",
-																	Pattern.CASE_INSENSITIVE);
+	static Pattern							WINDOWS_PREFIX	= Pattern.compile("(\\p{Alpha}):\\\\(.*)");
+	static Pattern							WINDOWS_FILE_P	= Pattern
+																	.compile("(?:\\p{Alpha}:|\\\\)(\\\\[\\p{Alnum}-_+.~@$%&=]+)*");
+	static Pattern							UNIX_FILE_P		= Pattern.compile("(/[\\p{Alnum}-_+.~@$%&=]+)+");
 	static Pattern							LOCAL_P			= File.separatorChar == '\\' ? WINDOWS_FILE_P : UNIX_FILE_P;
 
 	private MultiMap<String,File>			shas			= new MultiMap<String,File>();

--- a/aQute.libg/test/aQute/lib/remote/RemoteTest.java
+++ b/aQute.libg/test/aQute/lib/remote/RemoteTest.java
@@ -1,12 +1,13 @@
 package aQute.lib.remote;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Formatter;
 
-import junit.framework.*;
-import aQute.lib.io.*;
-import aQute.libg.remote.sink.*;
-import aQute.libg.remote.source.*;
+import junit.framework.TestCase;
+import aQute.lib.io.IO;
+import aQute.libg.remote.sink.RemoteSink;
+import aQute.libg.remote.source.RemoteSource;
 
 public class RemoteTest extends TestCase {
 	File	sinkDir;
@@ -15,8 +16,8 @@ public class RemoteTest extends TestCase {
 	private RemoteSink		sink;
 
 	public void setUp() throws Exception {
-		sinkDir = create("generated/sink", null);
-		sourceDir = create("generated/source", "testresources/remote");
+		sinkDir = create("generated/sink/" + getName(), null);
+		sourceDir = create("generated/source/" + getName(), "testresources/remote");
 		super.setUp();
 		source = new RemoteSource();
 		sink = new RemoteSink(sinkDir, source);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: '{build}'
+clone_depth: 10
+environment:
+  JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+  TERM: dumb
+install:
+- gradlew.bat --version
+cache: C:\Users\appveyor\.gradle
+build_script:
+- gradlew.bat --continue

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestFixedIndexedRepo.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestFixedIndexedRepo.java
@@ -1,21 +1,25 @@
 package aQute.bnd.deployer.repository;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import junit.framework.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.*;
-import aQute.bnd.version.*;
-import aQute.lib.io.*;
+import junit.framework.TestCase;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.version.Version;
+import aQute.lib.io.IO;
 
 public class TestFixedIndexedRepo extends TestCase {
 
-	static File	tmp;
+	private File	tmp;
 
 	public void setUp() {
-		tmp = IO.getFile("tmp");
+		tmp = IO.getFile("generated/tmp/" + getName());
 		IO.delete(tmp);
 		tmp.mkdirs();
 	}
@@ -38,7 +42,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		return count;
 	}
 
-	public static void testIndex1() throws Exception {
+	public void testIndex1() throws Exception {
 		Processor reporter = new Processor();
 		FixedIndexedRepo repo = new FixedIndexedRepo();
 		Map<String,String> props = new HashMap<String,String>();
@@ -59,7 +63,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testIndex2() throws Exception {
+	public void testIndex2() throws Exception {
 		Processor reporter = new Processor();
 
 		FixedIndexedRepo repo = new FixedIndexedRepo();
@@ -75,7 +79,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testIndex2Compressed() throws Exception {
+	public void testIndex2Compressed() throws Exception {
 		Processor reporter = new Processor();
 		FixedIndexedRepo repo = new FixedIndexedRepo();
 		Map<String,String> props = new HashMap<String,String>();
@@ -90,7 +94,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testObr() throws Exception {
+	public void testObr() throws Exception {
 		Processor reporter = new Processor();
 		FixedIndexedRepo repo = new FixedIndexedRepo();
 
@@ -113,7 +117,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testAmbiguous() throws Exception {
+	public void testAmbiguous() throws Exception {
 		Processor reporter = new Processor();
 		FixedIndexedRepo repo = new FixedIndexedRepo();
 		Map<String,String> config = new HashMap<String,String>();
@@ -129,7 +133,7 @@ public class TestFixedIndexedRepo extends TestCase {
 		assertEquals(0, bsns.size());
 	}
 
-	public static void testExternalEntitiesNotFetched() throws Exception {
+	public void testExternalEntitiesNotFetched() throws Exception {
 		final AtomicInteger accessCount = new AtomicInteger(0);
 
 		FixedIndexedRepo repo;
@@ -180,7 +184,7 @@ public class TestFixedIndexedRepo extends TestCase {
 	 * making it blow up. This checks if we can use spaces in the name.
 	 */
 
-	public static void testSpaceInName() throws Exception {
+	public void testSpaceInName() throws Exception {
 
 		FixedIndexedRepo repo;
 		Map<String,String> config;

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestLocalIndexedRepo.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestLocalIndexedRepo.java
@@ -1,23 +1,25 @@
 package aQute.bnd.deployer.repository;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
-import junit.framework.*;
-import test.lib.*;
-import aQute.bnd.osgi.*;
-import aQute.lib.io.*;
+import junit.framework.TestCase;
+import test.lib.NanoHTTPD;
+import aQute.bnd.osgi.Processor;
+import aQute.lib.io.IO;
 
 public class TestLocalIndexedRepo extends TestCase {
 
-	private static File		outputDir;
-	private static NanoHTTPD	httpd;
-	private static int			httpdPort;
+	private File		outputDir;
+	private NanoHTTPD	httpd;
+	private int			httpdPort;
 
 	protected void setUp() throws Exception {
 		// Ensure output directory exists and is empty
-		outputDir = new File("generated" + File.separator + "testoutput");
+		outputDir = IO.getFile("generated/testoutput/" + getName());
 		IO.deleteWithException(outputDir);
 		if (!outputDir.exists() && !outputDir.mkdirs()) {
 			throw new IOException("Could not create directory " + outputDir);
@@ -32,7 +34,7 @@ public class TestLocalIndexedRepo extends TestCase {
 		httpd.stop();
 	}
 
-	public static void testLocalIndexLocation() throws Exception {
+	public void testLocalIndexLocation() throws Exception {
 		Processor reporter = new Processor();
 		LocalIndexedRepo repo = new LocalIndexedRepo();
 		Map<String,String> config = new HashMap<String,String>();
@@ -46,7 +48,7 @@ public class TestLocalIndexedRepo extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testLocalAndRemoteIndexLocations() throws Exception {
+	public void testLocalAndRemoteIndexLocations() throws Exception {
 		Processor reporter = new Processor();
 		LocalIndexedRepo repo = new LocalIndexedRepo();
 		Map<String,String> config = new HashMap<String,String>();

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestLocalObrGeneration.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestLocalObrGeneration.java
@@ -1,23 +1,28 @@
 package aQute.bnd.deployer.repository;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import junit.framework.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.*;
+import junit.framework.TestCase;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin.PutResult;
-import aQute.lib.io.*;
+import aQute.lib.io.IO;
 
 public class TestLocalObrGeneration extends TestCase {
 
-	private static LocalIndexedRepo	repo;
-	private static File				outputDir;
-	private static Processor			reporter;
+	private LocalIndexedRepo	repo;
+	private File				outputDir;
+	private Processor			reporter;
 
 	protected void setUp() throws Exception {
 		// Ensure output directory exists and is empty
-		outputDir = IO.getFile("generated/testoutput");
+		outputDir = IO.getFile("generated/testoutput/" + getName());
 		IO.delete(outputDir);
 		if (!outputDir.exists() && !outputDir.mkdirs()) {
 			throw new IOException("Could not create directory " + outputDir);
@@ -41,20 +46,21 @@ public class TestLocalObrGeneration extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testInitiallyEmpty() throws Exception {
+	public void testInitiallyEmpty() throws Exception {
 		List<String> list = repo.list(".*");
 		assertNotNull(list);
 		assertEquals(0, list.size());
 	}
 
-	public static void testDeployBundle() throws Exception {
+	public void testDeployBundle() throws Exception {
 		PutResult r = repo.put(new BufferedInputStream(new FileInputStream("testdata/bundles/name.njbartlett.osgi.emf.minimal-2.6.1.jar")), new RepositoryPlugin.PutOptions());
 		File deployedFile = new File(r.artifact);
 
-		assertEquals(IO.getFile("generated/testoutput/name.njbartlett.osgi.emf.minimal/name.njbartlett.osgi.emf.minimal-2.6.1.jar")
+		assertEquals(
+				IO.getFile(outputDir, "name.njbartlett.osgi.emf.minimal/name.njbartlett.osgi.emf.minimal-2.6.1.jar")
 			.getAbsolutePath(), deployedFile.getAbsolutePath());
 		
-		File indexFile = IO.getFile("generated/testoutput/repository.xml");
+		File indexFile = IO.getFile(outputDir, "repository.xml");
 		assertTrue(indexFile.exists());
 		assertTrue(IO.collect(indexFile).length() > 0);
 

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestMultipleLocalIndexGeneration.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/TestMultipleLocalIndexGeneration.java
@@ -1,28 +1,33 @@
 package aQute.bnd.deployer.repository;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 
-import org.osgi.impl.bundle.bindex.*;
+import org.osgi.impl.bundle.bindex.BundleIndexerImpl;
 
-import test.lib.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.*;
+import test.lib.MockRegistry;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin.PutResult;
-import aQute.lib.io.*;
+import aQute.lib.io.IO;
 
 public class TestMultipleLocalIndexGeneration extends TestCase {
 
-	private static Processor			reporter;
-	private static LocalIndexedRepo	repo;
-	private static File				outputDir;
-	private static MockRegistry		registry;
+	private Processor			reporter;
+	private LocalIndexedRepo	repo;
+	private File				outputDir;
+	private MockRegistry		registry;
 
 	protected void setUp() throws Exception {
 		// Ensure output directory exists and is empty
-		outputDir = IO.getFile("generated/testoutput");
+		outputDir = IO.getFile("generated/testoutput/" + getName());
 		IO.deleteWithException(outputDir);
 		if (!outputDir.exists() && !outputDir.mkdirs()) {
 			throw new IOException("Could not create directory " + outputDir);
@@ -53,25 +58,25 @@ public class TestMultipleLocalIndexGeneration extends TestCase {
 		assertEquals(0, reporter.getWarnings().size());
 	}
 
-	public static void testInitiallyEmpty() throws Exception {
+	public void testInitiallyEmpty() throws Exception {
 		List<String> list = repo.list(".*");
 		assertNotNull(list);
 		assertEquals(0, list.size());
 	}
 
-	public static void testDeployBundle() throws Exception {
+	public void testDeployBundle() throws Exception {
 		PutResult r = repo.put(new BufferedInputStream(new FileInputStream("testdata/bundles/name.njbartlett.osgi.emf.minimal-2.6.1.jar")), new RepositoryPlugin.PutOptions());
 		File deployedFile = new File(r.artifact);
 
 		assertEquals(
 				IO.getFile(
-						"generated/testoutput/name.njbartlett.osgi.emf.minimal/name.njbartlett.osgi.emf.minimal-2.6.1.jar")
+outputDir, "name.njbartlett.osgi.emf.minimal/name.njbartlett.osgi.emf.minimal-2.6.1.jar")
 						.getAbsolutePath(), deployedFile.getAbsolutePath());
 
-		File r5IndexFile = IO.getFile("generated/testoutput/index.xml.gz");
+		File r5IndexFile = IO.getFile(outputDir, "index.xml.gz");
 		assertTrue(r5IndexFile.exists());
 
-		File obrIndexFile = IO.getFile("generated/testoutput/repository.xml");
+		File obrIndexFile = IO.getFile(outputDir, "repository.xml");
 		assertTrue(obrIndexFile.exists());
 
 		AbstractIndexedRepo checkRepo;
@@ -90,7 +95,7 @@ public class TestMultipleLocalIndexGeneration extends TestCase {
 		assertEquals(deployedFile.getAbsoluteFile(), files[0]);
 	}
 
-	public static void testReadMixedRepoTypes() throws Exception {
+	public void testReadMixedRepoTypes() throws Exception {
 		FixedIndexedRepo repo = new FixedIndexedRepo();
 		Map<String,String> config = new HashMap<String,String>();
 		config.put("locations",

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/wrapper/TestWrapper.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/wrapper/TestWrapper.java
@@ -1,26 +1,39 @@
 package aQute.bnd.deployer.repository.wrapper;
 
-import java.io.*;
-import java.util.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 
-import org.osgi.resource.*;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
 
-import aQute.bnd.build.*;
-import aQute.bnd.jpm.*;
-import aQute.bnd.osgi.resource.*;
-import aQute.bnd.service.repository.*;
-import aQute.bnd.version.*;
-import aQute.lib.deployer.*;
-import aQute.lib.io.*;
-import aQute.lib.utf8properties.*;
-import aQute.libg.map.*;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.jpm.Repository;
+import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.service.repository.InfoRepository;
+import aQute.bnd.version.Version;
+import aQute.lib.deployer.InfoFileRepo;
+import aQute.lib.io.IO;
+import aQute.lib.utf8properties.UTF8Properties;
+import aQute.libg.map.MAP;
 
 public class TestWrapper extends TestCase {
-	File	tmp	= new File("tmp");
+	private File	tmp;
 
 	public void setUp() throws Exception {
+		tmp = IO.getFile("generated/test/" + getName());
 		System.setProperty("jpm4j.in.test", "true");
 		tmp.mkdirs();
 		IO.delete(tmp);


### PR DESCRIPTION
We now use AppVeyor to CI build bnd. This showed a number of test failures on Windows (which did not fail on *ix). This PR includes fixes for these failures so that bnd now builds/tests clean on Windows.