### PR TITLE
Parameterise @RequireCapability filter using annotation attributes

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/AnnotationHeadersTest.java
@@ -53,8 +53,9 @@ public class AnnotationHeadersTest extends TestCase {
 			assertNotNull(p.get("nsx"));
 			assertNotNull(p.get("nsy"));
 			assertNotNull(p.get("nsz"));
+			assertNotNull(p.get("param"));
 			assertNotNull(p.get("osgi.ee"));
-			assertEquals("spurious Require-Capability namespaces", 4, p.size());
+			assertEquals("spurious Require-Capability namespaces", 5, p.size());
 
 			attrs = p.get("nsx");
 			assertEquals(Arrays.asList("abc","def"), attrs.getTyped("foo"));
@@ -65,6 +66,9 @@ public class AnnotationHeadersTest extends TestCase {
 			attrs = p.get("nsz");
 			assertEquals("(nsz=*)", attrs.get("filter:"));
 			assertEquals("world", attrs.get("hello"));
+
+			attrs = p.get("param");
+			assertEquals("(&(a=hello)(b=goodbye))", attrs.get("filter:"));
 		}
 		finally {
 			b.close();

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/ParameterisedAnnotation.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/ParameterisedAnnotation.java
@@ -1,0 +1,9 @@
+package test.annotationheaders.attrs;
+
+import aQute.bnd.annotation.headers.RequireCapability;
+
+@RequireCapability(ns = "param", effective = "active", filter = "(&(a=${param1})(b=${param2}))")
+public @interface ParameterisedAnnotation {
+	String param1();
+	String param2();
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/UsingAttrs.java
@@ -8,6 +8,7 @@ import test.annotationheaders.attrs.AnnotationWithAttrs.E;
 @ExtendedProvide(foo = 3, bar = 3)
 @AnnotationWithValue("hello")
 @RequireCapability(ns = "nsz", filter = "(nsz=*)", extra = "hello=world")
+@ParameterisedAnnotation(param1 = "hello", param2 = "goodbye")
 public class UsingAttrs {
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
@@ -6,7 +6,41 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>
  * The Bundle’s Require-Capability header
+ * </p>
+ * <p>
+ * Typically used as a meta-annotation, i.e. an annotation placed on another
+ * annotation, which we will call the <em>user-defined annotation</em>. When the
+ * user-defined annotation is found on a class within the bundle, an entry in
+ * the <code>Require-Capability</code> header is added. The filter expression of
+ * the requirement may be parameterised with values from the user-defined
+ * annotation. For example, given the following declarations:
+ * </p>
+ * 
+ * <pre>
+ * &#64;RequireCapability(
+ *         ns = "com.acme.engine",
+ *         effective = "active",
+ *         filter = "(com.acme.engine=${type})")
+ * public @interface Engine {
+ *     String type();
+ * }
+ * 
+ * &#64;Engine(type = "wankel")
+ * public class Vehicle { ... }
+ * </pre>
+ * <p>
+ * ... the following header will be generated in MANIFEST.MF:
+ * </p>
+ * 
+ * <pre>
+ * Require-Capability:\
+ *     com.acme.engine; \
+ *         effective:=active; \
+ *         filter:="(com.acme.engine=wankel)",\
+ *     ...
+ * </pre>
  * 
  * {@link About}
  */


### PR DESCRIPTION
Example:

    @RequireCapability(ns="foo", filter="(foo=${value})")
    public @interface Foo { String value(); }

    @Foo("hello")
    public class MyComponent { ... }

    ==> Require-Capability: foo; filter:="(foo=hello)"

Signed-off-by: Neil Bartlett <neil.bartlett@paremus.com>