### PR TITLE
Keep startup order from bndrun when launching remote

### DIFF
--- a/biz.aQute.remote/src/aQute/remote/agent/AgentServer.java
+++ b/biz.aQute.remote/src/aQute/remote/agent/AgentServer.java
@@ -150,19 +150,19 @@ public class AgentServer implements Agent, Closeable, FrameworkListener {
 	}
 
 	@Override
-	public String update(Map<String,String> bundles) throws InterruptedException {
+	public String update(LinkedHashMap<String,String> bundles) throws InterruptedException {
 
 		refresh.await();
 
 		Formatter out = new Formatter();
 		if (bundles == null) {
-			bundles = Collections.emptyMap();
+			bundles = new LinkedHashMap<String,String>();
 		}
 
 		Set<String> toBeDeleted = new HashSet<String>(installed.keySet());
 		toBeDeleted.removeAll(bundles.keySet());
 
-		Set<String> toBeInstalled = new HashSet<String>(bundles.keySet());
+		Set<String> toBeInstalled = new LinkedHashSet<String>(bundles.keySet());
 		toBeInstalled.removeAll(installed.keySet());
 
 		Map<String,String> changed = new HashMap<String,String>(bundles);

--- a/biz.aQute.remote/src/aQute/remote/api/Agent.java
+++ b/biz.aQute.remote/src/aQute/remote/api/Agent.java
@@ -108,12 +108,13 @@ public interface Agent {
 	 * differences are reflected in the installed bundles. That is, a change in
 	 * the SHA will update, a new entry will install, and a removed entry will
 	 * uninstall. This is the preferred way to keep the remote framework
-	 * synchronized since it is idempotent.
+	 * synchronized since it is idempotent. Bundles are passed as a
+	 * LinkedHashMap to preserve the startup order.
 	 * 
 	 * @param bundles
 	 *            the bundles to update
 	 */
-	String update(Map<String,String> bundles) throws Exception;
+	String update(LinkedHashMap<String,String> bundles) throws Exception;
 
 	/**
 	 * Redirect I/O from port. Port can be {@link #CONSOLE},

--- a/biz.aQute.remote/src/aQute/remote/plugin/RunSessionImpl.java
+++ b/biz.aQute.remote/src/aQute/remote/plugin/RunSessionImpl.java
@@ -135,7 +135,7 @@ public class RunSessionImpl implements RunSession {
 		return agent.createFramework(dto.name, runpath.values(), properties);
 	}
 
-	void update(Map<String,String> newer) throws Exception {
+	void update(LinkedHashMap<String,String> newer) throws Exception {
 		supervisor.getAgent().update(newer);
 	}
 
@@ -147,19 +147,20 @@ public class RunSessionImpl implements RunSession {
 		supervisor.close();
 	}
 
-	Map<String,String> getBundles(Collection<String> collection, String header) throws Exception {
-		Map<String,String> newer = new LinkedHashMap<String,String>();
+	LinkedHashMap<String,String> getBundles(Collection<String> collection, String header) throws Exception {
+		LinkedHashMap<String,String> newer = new LinkedHashMap<String,String>();
 
 		for (String c : collection) {
 			File f = new File(c);
 			String sha = supervisor.addFile(f);
 			newer.put(c, sha);
 		}
+
 		return newer;
 	}
 
 	void update(RunRemoteDTO dto) throws Exception {
-		Map<String,String> newer = getBundles(launcher.getRunBundles(), Constants.RUNBUNDLES);
+		LinkedHashMap<String,String> newer = getBundles(launcher.getRunBundles(), Constants.RUNBUNDLES);
 		if (shell != dto.shell) {
 			supervisor.getAgent().redirect(dto.shell);
 			shell = dto.shell;

--- a/biz.aQute.remote/test/biz/aQute/remote/RemoteTest.java
+++ b/biz.aQute.remote/test/biz/aQute/remote/RemoteTest.java
@@ -113,7 +113,7 @@ public class RemoteTest extends TestCase {
 		String sha1 = supervisor.addFile(t1);
 		String sha2 = supervisor.addFile(t2);
 
-		Map<String,String> update = new HashMap<String,String>();
+		LinkedHashMap<String,String> update = new LinkedHashMap<String,String>();
 		update.put(t1.getAbsolutePath(), sha1);
 
 		String errors = supervisor.getAgent().update(update);
@@ -132,7 +132,7 @@ public class RemoteTest extends TestCase {
 		// Now add a new one
 		//
 
-		update = new HashMap<String,String>();
+		update = new LinkedHashMap<String,String>();
 		update.put(t1.getAbsolutePath(), sha1);
 		update.put(t2.getAbsolutePath(), sha2);
 		errors = supervisor.getAgent().update(update);
@@ -146,7 +146,7 @@ public class RemoteTest extends TestCase {
 
 		t1 = create("bsn-1", new Version(2, 0, 0));
 		sha1 = supervisor.addFile(t1);
-		update = new HashMap<String,String>();
+		update = new LinkedHashMap<String,String>();
 		update.put(t1.getAbsolutePath(), sha1);
 		update.put(t2.getAbsolutePath(), sha2);
 		errors = supervisor.getAgent().update(update);
@@ -164,7 +164,7 @@ public class RemoteTest extends TestCase {
 		// Now delete t1
 		//
 
-		update = new HashMap<String,String>();
+		update = new LinkedHashMap<String,String>();
 		update.put(t2.getAbsolutePath(), sha2);
 		errors = supervisor.getAgent().update(update);
 		assertNull(errors);


### PR DESCRIPTION
In order to make sure that the startup order of the bundles specified in the bndrun configuration is preserved when launching remote, a LinkedHashMap should be used in the Agent API. Peter already changed the implementation in commit b7285748eda20bcdbab0a632d7b4ef3465c99d05 , but this is not sufficient as the Map is serialized and deserialized by the converter in the remote call.

For the standard launcher startup order is preserved (also see issue #141) so it would be nice to have the same behaviour for the remote launcher.