### PR TITLE
[junit] junit 4 "unrooted" tests with parametrized tests

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/LauncherTest.java
+++ b/biz.aQute.bndlib.tests/src/test/LauncherTest.java
@@ -1,14 +1,19 @@
 package test;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.jar.*;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Manifest;
 
-import junit.framework.*;
-import aQute.bnd.build.*;
-import aQute.bnd.osgi.*;
-import aQute.lib.io.*;
+import junit.framework.TestCase;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.ProjectLauncher;
+import aQute.bnd.build.ProjectTester;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
+import aQute.lib.io.IO;
 
 public class LauncherTest extends TestCase {
 
@@ -20,6 +25,23 @@ public class LauncherTest extends TestCase {
 			project.close();
 			workspace.close();
 		}
+	}
+
+	/**
+	 * junit 4 "unrooted" tests with parametrized tests #661
+	 * 
+	 * @throws Exception
+	 */
+	public static void testJuni4Tester() throws Exception {
+		Project project = getProject();
+		project.clear();
+		project.build();
+
+		ProjectTester pt = project.getProjectTester();
+		pt.addTest("test.Juni4TestCase");
+
+		assertEquals(0, pt.test());
+		assertTrue(project.check());
 	}
 
 	// public static void testLocalLaunch() throws Exception {

--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -1,18 +1,40 @@
 package aQute.junit;
 
-import java.io.*;
-import java.lang.annotation.*;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.regex.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.StringTokenizer;
+import java.util.Vector;
+import java.util.regex.Pattern;
 
-import junit.framework.*;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
 
-import org.junit.runner.*;
-import org.junit.runner.manipulation.*;
-import org.osgi.framework.*;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.Constants;
+import org.osgi.framework.SynchronousBundleListener;
+import org.osgi.framework.Version;
 
-import aQute.junit.constants.*;
+import aQute.junit.constants.TesterConstants;
 
 public class Activator implements BundleActivator, TesterConstants, Runnable {
 	BundleContext		context;
@@ -415,6 +437,7 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 		}
 
 		trace("using JUnit 4");
+
 		JUnit4TestAdapter adapter = new JUnit4TestAdapter(clazz);
 		if (method != null) {
 			trace("method specified " + clazz + ":" + method);
@@ -516,8 +539,10 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 				list.add(test);
 				
 				for ( Test t : ((JUnit4TestAdapter) test).getTests()) {
-					realCount++;
-					list.add(t);
+					if (t instanceof TestSuite) {
+						realCount += flatten(list, (TestSuite) t);
+					} else
+						list.add(t);
 				}
 				continue;
 			}

--- a/demo/src/test/Juni4TestCase.java
+++ b/demo/src/test/Juni4TestCase.java
@@ -1,0 +1,34 @@
+package test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class Juni4TestCase {
+
+	@Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{
+						10, 1
+				}, {
+						10, 1
+				}
+		});
+	}
+
+	public Juni4TestCase(int i, int j) {
+		System.out.println("out: " + i + " " + j);
+	}
+
+
+	@Test
+	public void foo() {
+		System.out.println("foo");
+	}
+}

--- a/demo/src/test/TestCase1.java
+++ b/demo/src/test/TestCase1.java
@@ -1,6 +1,6 @@
 package test;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 
 public class TestCase1 extends TestCase {
 


### PR DESCRIPTION
The @RunWith annotation was creating new TestSuite objects that were not correctly reported to Eclipse. Due to the JUnit4Adapter we did not properly flatten the list. I.e. we assumed always had a Test under the JUnit4Adapter

We now properly recurse.

Fixes #661

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>