### PR TITLE
make ProvideCapability and RequireCapability annotations repeatable

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/ProvideCapabilities.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/ProvideCapabilities.java
@@ -1,0 +1,15 @@
+package aQute.bnd.annotation.headers;
+
+import java.lang.annotation.*;
+
+/**
+ * Container type for {@link aQute.bnd.annotation.headers.ProvideCapability}
+ * annotations.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+		ElementType.ANNOTATION_TYPE, ElementType.TYPE
+})
+public @interface ProvideCapabilities {
+	ProvideCapability[] value();
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/ProvideCapability.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/ProvideCapability.java
@@ -26,6 +26,7 @@ import java.lang.annotation.*;
 @Target({
 		ElementType.ANNOTATION_TYPE, ElementType.TYPE
 })
+@Repeatable(ProvideCapabilities.class)
 public @interface ProvideCapability {
 	/**
 	 * Appended at the end of the clause (after a ';'). Can be used to add

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapabilities.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapabilities.java
@@ -1,0 +1,15 @@
+package aQute.bnd.annotation.headers;
+
+import java.lang.annotation.*;
+
+/**
+ * Container type for {@link aQute.bnd.annotation.headers.RequireCapability}
+ * annotations.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+		ElementType.ANNOTATION_TYPE, ElementType.TYPE
+})
+public @interface RequireCapabilities {
+	RequireCapability[] value();
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/annotation/headers/RequireCapability.java
@@ -1,9 +1,6 @@
 package aQute.bnd.annotation.headers;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * <p>
@@ -48,6 +45,7 @@ import java.lang.annotation.Target;
 @Target({
 		ElementType.ANNOTATION_TYPE, ElementType.TYPE
 })
+@Repeatable(RequireCapabilities.class)
 public @interface RequireCapability {
 
 	String value() default "";


### PR DESCRIPTION
Use the `@Repeatable` annotation allow multiple ProvideCapability and RequireCapability annotations (#961). Probably this also requires changes to the annotation processing to also take into account the container annotation types?