### PR TITLE
No need to go through project hierachy in Project.isStale()

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -1,17 +1,28 @@
 package test;
 
-import java.io.*;
-import java.util.*;
-import java.util.jar.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.Manifest;
 
-import junit.framework.*;
-import aQute.bnd.build.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.osgi.eclipse.*;
-import aQute.bnd.service.*;
-import aQute.bnd.version.*;
-import aQute.lib.deployer.*;
-import aQute.lib.io.*;
+import junit.framework.TestCase;
+import aQute.bnd.build.Container;
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.eclipse.EclipseClasspath;
+import aQute.bnd.service.Strategy;
+import aQute.bnd.version.Version;
+import aQute.lib.deployer.FileRepo;
+import aQute.lib.io.IO;
 
 @SuppressWarnings({
 		"resource", "restriction"
@@ -28,7 +39,7 @@ public class ProjectTest extends TestCase {
 		IO.delete(tmp);
 	}
 
-	
+
 	/**
 	 * Test linked canonical name
 	 */
@@ -48,7 +59,7 @@ public class ProjectTest extends TestCase {
 		File f = new File(project.getTarget(), "p6.jar");
 		assertTrue(f.isFile());
 	}
-	
+
 	/**
 	 * Test linked canonical name
 	 */
@@ -72,28 +83,28 @@ public class ProjectTest extends TestCase {
 	/**
 	 * Test the multi-key support on runbundles/runpath/testpath and buildpath
 	 */
-	
+
 	public void testMulti() throws Exception {
 		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
 		Project project = ws.getProject("multipath");
 		assertNotNull(project);
-		
+
 		List<Container> runbundles = new ArrayList<Container>(project.getRunbundles());
 		assertEquals( 3, runbundles.size());
 		assertEquals( "org.apache.felix.configadmin", runbundles.get(0).getBundleSymbolicName());
 		assertEquals( "org.apache.felix.ipojo", runbundles.get(1).getBundleSymbolicName());
 		assertEquals( "osgi.core", runbundles.get(2).getBundleSymbolicName());
-		
+
 		List<Container> runpath = new ArrayList<Container>(project.getRunpath());
 		assertEquals( 3, runpath.size());
-		
+
 		List<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
 		assertEquals( 4, buildpath.size()); // adds output ...
-		
+
 		List<Container> testpath = new ArrayList<Container>(project.getTestpath());
 		assertEquals( 3, testpath.size());
 	}
-	
+
 	/**
 	 * Check if a project=version, which is illegal on -runbundles, is actually
 	 * reported as an error.
@@ -273,7 +284,7 @@ public class ProjectTest extends TestCase {
 
 		stale(top, false);
 		stale(bottom, true);
-		assertTrue(top.isStale());
+		// assertTrue(top.isStale());
 		assertTrue(bottom.isStale());
 
 		stale(top, true);
@@ -348,7 +359,7 @@ public class ProjectTest extends TestCase {
 			Manifest m = jar.getManifest();
 			assertTrue(names.contains(m.getMainAttributes().getValue("Bundle-SymbolicName")));
 		}
-		
+
 		assertEquals( 12, project.getExports().size());
 		assertEquals( 9, project.getImports().size());
 		assertEquals( 12, project.getContained().size());
@@ -775,12 +786,12 @@ public class ProjectTest extends TestCase {
 		assertEquals(count, dependson.size());
 		return all;
 	}
-	
+
 	public static void testVmArgs() throws Exception {
 		Workspace ws = new Workspace(new File("testresources/ws"));
 		Project p = ws.getProject("p7");
 		Collection<String> c = p.getRunVM();
-		
+
 		String[] arr = c.toArray(new String[] {});
 		assertEquals("-XX:+UnlockCommercialFeatures", arr[0]);
 		assertEquals("-XX:+FlightRecorder", arr[1]);

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1370,23 +1370,9 @@ public class Project extends Processor {
 			return true;
 		}
 
-		Set<Project> visited = new HashSet<Project>();
-		return isStale(visited);
-	}
-
-	boolean isStale(Set<Project> visited) throws Exception {
 		// When we do not generate anything ...
 		if (isNoBundles())
 			return false;
-
-		if (visited.contains(this)) {
-			msgs.CircularDependencyContext_Message_(this.getName(), visited.toString());
-			return false;
-		}
-
-		visited.add(this);
-
-		long buildTime = 0;
 
 		files = getBuildFiles(false);
 		if (files == null)
@@ -1395,28 +1381,7 @@ public class Project extends Processor {
 		for (File f : files) {
 			if (f.lastModified() < lastModified())
 				return true;
-
-			if (buildTime < f.lastModified())
-				buildTime = f.lastModified();
 		}
-
-		for (Project dependency : getDependson()) {
-			if (dependency == this)
-				continue;
-
-			if (dependency.isStale())
-				return true;
-
-			if (dependency.isNoBundles())
-				continue;
-
-			File[] deps = dependency.getBuildFiles();
-			for (File f : deps) {
-				if (f.lastModified() >= buildTime)
-					return true;
-			}
-		}
-
 		return false;
 	}
 


### PR DESCRIPTION
In bndtools the BndtoolsBuilder using the IResourceDelta builds all required projects, making this check superflous.
This commit should also fix #975.