### PR TITLE
Support UUID class in Converter and JSONCodec

### DIFF
--- a/aQute.libg/src/aQute/lib/converter/Converter.java
+++ b/aQute.libg/src/aQute/lib/converter/Converter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -108,6 +109,11 @@ public class Converter {
 				return sb.toString();
 			}
 			return o.toString();
+		}
+
+		// or make a UUID
+		if (resultType == UUID.class) {
+			return UUID.fromString(o.toString());
 		}
 
 		//

--- a/aQute.libg/src/aQute/lib/json/JSONCodec.java
+++ b/aQute.libg/src/aQute/lib/json/JSONCodec.java
@@ -1,10 +1,26 @@
 package aQute.lib.json;
 
-import java.io.*;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.regex.*;
+import java.io.EOFException;
+import java.io.File;
+import java.io.OutputStream;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 /**
  * This is a simple JSON Coder and Encoder that uses the Java type system to
@@ -52,6 +68,7 @@ public class JSONCodec {
 	private static DateHandler						sdh					= new DateHandler();
 	private static FileHandler						fh					= new FileHandler();
 	private static ByteArrayHandler					byteh				= new ByteArrayHandler();
+	private static UUIDHandler						uuidh				= new UUIDHandler();
 
 	boolean											ignorenull;
 	Map<Type,Handler>								localHandlers		= new ConcurrentHashMap<Type,Handler>();
@@ -132,6 +149,9 @@ public class JSONCodec {
 
 		if (File.class == type)
 			return fh;
+
+		if (UUID.class == type)
+			return uuidh;
 
 		if (type instanceof GenericArrayType) {
 			Type sub = ((GenericArrayType) type).getGenericComponentType();

--- a/aQute.libg/src/aQute/lib/json/UUIDHandler.java
+++ b/aQute.libg/src/aQute/lib/json/UUIDHandler.java
@@ -1,0 +1,21 @@
+package aQute.lib.json;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.UUID;
+
+public class UUIDHandler extends Handler {
+	@Override
+	public
+	void encode(Encoder app, Object object, Map<Object,Type> visited) throws IOException, Exception {
+		StringHandler.string(app, object.toString());
+	}
+
+	@Override
+	public
+	Object decode(Decoder dec, String s) throws Exception {
+		return UUID.fromString(s);
+	}
+
+}


### PR DESCRIPTION
I regularly use UUIDs as identifiers, and when using for example the REST provider, I also want to use UUIDs there as arguments or attributes from my returning (DTO) class. To support this, I added an UUID handler to the JSONCodec to convert UUID from/to String, and also add a conversion in the Converter class when resultType is UUID.class. 