### PR TITLE
gradle plugin: jar task rebuild for -dependson project's artifact changes

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -23,6 +23,7 @@ import aQute.bnd.osgi.Constants
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 
@@ -239,6 +240,10 @@ public class BndPlugin implements Plugin<Project> {
             exclude sourceSets.test.java.srcDirs.collect { relativePath(it) }
             exclude sourceSets.test.output.files.collect { relativePath(it) }
             exclude relativePath(buildDir)
+          }
+          /* project dependencies' artifacts should trigger jar task */
+          configurations.compile.dependencies.withType(ProjectDependency.class).each {
+            inputs.files it.dependencyProject.configurations.archives.artifacts.files
           }
           outputs.files configurations.archives.artifacts.files, new File(buildDir, Constants.BUILDFILES)
           doLast {


### PR DESCRIPTION
The jar task would rebuild if any of the -buildpath dependencies change
but when a -dependson dependency changes, the jar task would not rebuild.
The OSGi build uses -dependson for packaging projects like osgi.ct to
depend up on the various ct projects. But when a ct project rebuilt, the
osgi.ct project would not rebuild the packaging jar. This change means
that the jar task will rebuild if the jar of any dependency in -buildpath
or -dependson changes.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>