### PR TITLE
Fix problem parsing OSGi headers with an explicit empty attribute at …

### DIFF
--- a/aQute.libg/src/aQute/libg/qtokens/QuotedTokenizer.java
+++ b/aQute.libg/src/aQute/libg/qtokens/QuotedTokenizer.java
@@ -80,7 +80,7 @@ public class QuotedTokenizer {
 		if (!hadstring)
 			result = result.trim();
 
-		if (result.length() == 0 && index == string.length())
+		if (!hadstring && result.length() == 0 && index == string.length())
 			return null;
 		return result;
 	}

--- a/biz.aQute.bndlib.tests/src/test/TestQuotedTokenizer.java
+++ b/biz.aQute.bndlib.tests/src/test/TestQuotedTokenizer.java
@@ -64,8 +64,14 @@ public class TestQuotedTokenizer extends TestCase {
 		assertEquals("'y", s);
 	}
 	
-	public static void testExplicitEmptyStringTurnedToNull() {
+	public static void testExplicitEmptyString() {
 		QuotedTokenizer qt = new QuotedTokenizer("literal=''", ";=,");
+		qt.nextToken();
+		assertEquals("", qt.nextToken());
+	}
+
+	public static void testImplicitEmptyStringTurnedToNull() {
+		QuotedTokenizer qt = new QuotedTokenizer("literal=", ";=,");
 		qt.nextToken();
 		assertNull(qt.nextToken());
 	}


### PR DESCRIPTION
…the end.

For example:
  foo;a=\”\”
This is a valid header, but rejected by bndlib.