### PR TITLE
[resolver] Added a URI resolver interface

### DIFF
--- a/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/BundleAnalyzer.java
+++ b/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/BundleAnalyzer.java
@@ -3,6 +3,7 @@ package org.osgi.service.indexer.impl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -189,6 +190,26 @@ public class BundleAnalyzer implements ResourceAnalyzer {
 
 		GeneratorState state = getStateLocal();
 		if (state != null) {
+
+			//
+			// Check if a resolver was specified
+			// If so, we give that preference over the automatic
+			// and template calculation
+			//
+
+			URLResolver resolver = state.getResolver();
+			if (resolver != null) {
+				try {
+					URI uri = resolver.resolver(path);
+					if (uri != null)
+						return uri.toString();
+				}
+				catch (Exception e) {
+					if (log != null)
+						log.log(LogService.LOG_ERROR, "Resolver failed on " + path + ", falling back to old method");
+				}
+			}
+
 			String rootUrl = state.getRootUrl().toString();
 			if (!rootUrl.endsWith("/"))
 				rootUrl += "/";

--- a/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/GeneratorState.java
+++ b/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/GeneratorState.java
@@ -6,10 +6,12 @@ class GeneratorState {
 
 	private final URL rootUrl;
 	private final String urlTemplate;
+	private URLResolver		resolver;
 
-	public GeneratorState(URL rootUrl, String urlTemplate) {
+	public GeneratorState(URL rootUrl, String urlTemplate, URLResolver resolver) {
 		this.rootUrl = rootUrl;
 		this.urlTemplate = urlTemplate;
+		this.resolver = resolver;
 	}
 
 	public URL getRootUrl() {
@@ -56,4 +58,7 @@ class GeneratorState {
 		return "GeneratorState [rootUrl=" + rootUrl + ", urlTemplate=" + urlTemplate + "]";
 	}
 
+	public URLResolver getResolver() {
+		return resolver;
+	}
 }

--- a/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/RepoIndex.java
+++ b/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/RepoIndex.java
@@ -66,6 +66,8 @@ public class RepoIndex implements ResourceIndexer {
 	 */
 	private final List<Pair<ResourceAnalyzer, Filter>> analyzers = new LinkedList<Pair<ResourceAnalyzer, Filter>>();
 
+	private URLResolver									resolver;
+
 	/**
 	 * Construct a default instance that uses a console logger.
 	 */
@@ -249,7 +251,7 @@ public class RepoIndex implements ResourceIndexer {
 					rootURL = new File(System.getProperty("user.dir")).toURI().toURL();
 
 				String urlTemplate = config.get(ResourceIndexer.URL_TEMPLATE);
-				bundleAnalyzer.setStateLocal(new GeneratorState(rootURL, urlTemplate));
+				bundleAnalyzer.setStateLocal(new GeneratorState(rootURL, urlTemplate, resolver));
 			} else {
 				bundleAnalyzer.setStateLocal(null);
 			}
@@ -363,4 +365,13 @@ public class RepoIndex implements ResourceIndexer {
 		}
 		return value;
 	}
+
+	/**
+	 * Set a URL resolver that calculates the reference to the file
+	 */
+
+	public void setURLResolver(URLResolver resolver) {
+		this.resolver = resolver;
+	}
+
 }

--- a/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/URLResolver.java
+++ b/org.osgi.impl.bundle.repoindex.lib/src/org/osgi/service/indexer/impl/URLResolver.java
@@ -1,0 +1,22 @@
+package org.osgi.service.indexer.impl;
+
+import java.io.File;
+import java.net.URI;
+
+/**
+ * Override the calculation of the URL with a specific function.
+ */
+public interface URLResolver {
+
+	/**
+	 * Calculate the URL for the given artifact. If this returns null or throws
+	 * an exception, the automatic calculation will be used. Exceptions are
+	 * logged so should not be used for flow control.
+	 * 
+	 * @param artifact
+	 *            The artifact being analyzed
+	 * @return Either a URI to be used in the content capability or null if the
+	 *         default method should be used
+	 */
+	URI resolver(File artifact) throws Exception;
+}


### PR DESCRIPTION
Sometimes the standard template or default URL calculation is not sufficient. When a URI resolver is set, it takes over and it can calculate any URI based on the file under consideration.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>