### PR TITLE
gradle: bnd plugin cannot set gestalt

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -48,16 +48,6 @@ public class BndPlugin implements Plugin<Project> {
           throw new GradleException("Unable to load bnd workspace ${rootDir}")
         }
       }
-      if (!rootProject.hasProperty('bndWorkspaceInitialized')) {
-        Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
-        bndWorkspace.addGestalt(Constants.GESTALT_BATCH, null)
-        if (rootProject.hasProperty('bnd_gestalt')) {
-          rootProject.bnd_gestalt.trim().split(/\s*,\s*/).each {
-            bndWorkspace.addGestalt(it, null)
-          }
-        }
-        rootProject.ext.bndWorkspaceInitialized = true
-      }
       this.bndProject = bndWorkspace.getProject(name)
       if (bndProject == null) {
         throw new GradleException("Unable to load bnd project ${name} from workspace ${rootDir}")

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@
  */
 
 import aQute.bnd.build.Workspace
+import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
@@ -15,6 +16,8 @@ buildscript {
 }
 
 /* Initialize the bnd workspace */
+Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
+Workspace.addGestalt(Constants.GESTALT_BATCH, null)
 ext.bndWorkspace = Workspace.getWorkspace(rootDir, bnd_cnf)
 if (bndWorkspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@
  */
 
 import aQute.bnd.build.Workspace
+import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
@@ -37,6 +38,8 @@ buildscript {
 }
 
 /* Initialize the bnd workspace */
+Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
+Workspace.addGestalt(Constants.GESTALT_BATCH, null)
 def workspace = Workspace.getWorkspace(rootDir, bnd_cnf)
 if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")


### PR DESCRIPTION
The gradle plugin runs too late to alter the gestalt of the workspace.
So we remove that from the plugin and change the settings.gradle and
build.gradle files to set the gestalt.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>