### PR TITLE
isNoBundles: Use boolean test rather than presence test

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1549,7 +1549,7 @@ public class Project extends Processor {
 	 * @return
 	 */
 	public boolean isNoBundles() {
-		return getProperty(NOBUNDLES) != null;
+		return isTrue(getProperty(NOBUNDLES));
 	}
 
 	public File saveBuild(Jar jar) throws Exception {


### PR DESCRIPTION
This is now consistent with how Builder tests -nobundles.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>