### PR TITLE
Wildcard BSN in buildpath with repository filter

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.jar.Manifest;
 
-import junit.framework.TestCase;
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
@@ -23,6 +22,7 @@ import aQute.bnd.service.Strategy;
 import aQute.bnd.version.Version;
 import aQute.lib.deployer.FileRepo;
 import aQute.lib.io.IO;
+import junit.framework.TestCase;
 
 @SuppressWarnings({
 		"resource", "restriction"
@@ -104,7 +104,20 @@ public class ProjectTest extends TestCase {
 		List<Container> testpath = new ArrayList<Container>(project.getTestpath());
 		assertEquals( 3, testpath.size());
 	}
-	
+
+	public void testRepoFilterBuildPath() throws Exception {
+		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
+		Project project = ws.getProject("repofilter");
+		assertNotNull(project);
+		project.setProperty("-buildpath", "p3; version='[1,2)'; repos=Relea*");
+
+		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
+		assertEquals(2, buildpath.size());
+		// Without repos filter we would get lowest version, i.e. 1.0.0 from the
+		// repo named "Repo".
+		assertEquals("1.1.0", buildpath.get(1).getVersion());
+	}
+
 	/**
 	 * Check if a project=version, which is illegal on -runbundles, is actually
 	 * reported as an error.
@@ -694,13 +707,13 @@ public class ProjectTest extends TestCase {
 	}
 
 	public void testBuildAll() throws Exception {
-		assertTrue(testBuildAll("*", 18).check()); // there are 14 projects
+		assertTrue(testBuildAll("*", 19).check()); // there are 14 projects
 		assertTrue(testBuildAll("p*", 11).check()); // 7 begin with p
-		assertTrue(testBuildAll("!p*, *", 7).check()); // negation: 6 don't
+		assertTrue(testBuildAll("!p*, *", 8).check()); // negation: 6 don't
 														// begin with p
 		assertTrue(testBuildAll("*-*", 6).check()); // more than one wildcard: 7
 													// have a dash
-		assertTrue(testBuildAll("!p*, p1, *", 7).check("Missing dependson p1")); // check
+		assertTrue(testBuildAll("!p*, p1, *", 8).check("Missing dependson p1")); // check
 																					// that
 																					// an
 																					// unused
@@ -708,7 +721,7 @@ public class ProjectTest extends TestCase {
 																					// is
 																					// an
 																					// error
-		assertTrue(testBuildAll("p*, !*-*, *", 16).check()); // check that
+		assertTrue(testBuildAll("p*, !*-*, *", 17).check()); // check that
 																// negation
 																// works after
 																// some projects

--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -117,6 +117,37 @@ public class ProjectTest extends TestCase {
 		// repo named "Repo".
 		assertEquals("1.1.0", buildpath.get(1).getVersion());
 	}
+	
+	public void testWildcardBuildPath() throws Exception {
+		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
+		Project project = ws.getProject("repofilter");
+		assertNotNull(project);
+		project.setProperty("-buildpath", "lib*");
+
+		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
+		// assertEquals(7, buildpath.size());
+
+		for (int i = 1; i < buildpath.size(); i++) {
+			Container c = buildpath.get(i);
+			assertEquals(Container.TYPE.REPO, c.getType());
+		}
+	}
+
+	public void testWildcardBuildPathWithRepoFilter() throws Exception {
+		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
+		Project project = ws.getProject("repofilter");
+		assertNotNull(project);
+		project.setProperty("-buildpath", "*; repos=Relea*");
+
+		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
+		assertEquals(3, buildpath.size());
+
+		assertEquals(Container.TYPE.REPO, buildpath.get(1).getType());
+		assertEquals("org.apache.felix.configadmin", buildpath.get(1).getBundleSymbolicName());
+
+		assertEquals(Container.TYPE.REPO, buildpath.get(2).getType());
+		assertEquals("p3", buildpath.get(2).getBundleSymbolicName());
+	}
 
 	/**
 	 * Check if a project=version, which is illegal on -runbundles, is actually

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -38,6 +38,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
+import aQute.bnd.build.Container.TYPE;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
@@ -79,6 +80,7 @@ import aQute.libg.glob.Glob;
 import aQute.libg.reporter.ReporterMessages;
 import aQute.libg.sed.Replacer;
 import aQute.libg.sed.Sed;
+import aQute.libg.tuple.Pair;
 
 /**
  * This class is NOT threadsafe
@@ -548,6 +550,10 @@ public class Project extends Processor {
 				String versionRange = attrs.get("version");
 				boolean triedGetBundle = false;
 
+				if (bsn.indexOf('*') >= 0) {
+					return getBundlesWildcard(bsn, versionRange, strategyx, attrs);
+				}
+
 				if (versionRange != null) {
 					if (versionRange.equals(VERSION_ATTR_LATEST) || versionRange.equals(VERSION_ATTR_SNAPSHOT)) {
 						found = getBundle(bsn, versionRange, strategyx, attrs);
@@ -631,6 +637,105 @@ public class Project extends Processor {
 	 */
 	Collection<Container> getBundles(Strategy strategy, String spec) throws Exception {
 		return getBundles(strategy, spec, null);
+	}
+
+	/**
+	 * Get all bundles matching a wildcard expression.
+	 * 
+	 * @param bsnPattern
+	 *            A bsn wildcard, e.g. "osgi*" or just "*".
+	 * @param range
+	 *            A range to narrow the versions of bundles found, or null to
+	 *            return any version.
+	 * @param strategyx
+	 *            The version selection strategy, which may be 'HIGHEST' or
+	 *            'LOWEST' only -- 'EXACT' is not permitted.
+	 * @param attrs
+	 *            Additional search attributes.
+	 * @return
+	 * @throws Exception
+	 */
+	public List<Container> getBundlesWildcard(String bsnPattern, String range, Strategy strategyx,
+			Map<String,String> attrs) throws Exception {
+
+		if (VERSION_ATTR_SNAPSHOT.equals(range) || VERSION_ATTR_PROJECT.equals(range))
+			return Collections.singletonList(new Container(this, bsnPattern, range, TYPE.ERROR, null,
+					"Cannot use snapshot or project version with wildcard matches", null, null));
+		if (strategyx == Strategy.EXACT)
+			return Collections.singletonList(new Container(this, bsnPattern, range, TYPE.ERROR, null,
+					"Cannot use exact version strategy with wildcard matches", null, null));
+
+		VersionRange versionRange;
+		if (range == null || VERSION_ATTR_LATEST.equals(range))
+			versionRange = new VersionRange("0");
+		else
+			versionRange = new VersionRange(range);
+
+		Pattern repoFilter = repoNameFilter(attrs);
+
+		if (bsnPattern != null)
+			bsnPattern = bsnPattern.trim();
+		if (bsnPattern.length() == 0 || bsnPattern.equals("*"))
+			bsnPattern = null;
+
+		SortedMap<String,Pair<Version,RepositoryPlugin>> providerMap = new TreeMap<String,Pair<Version,RepositoryPlugin>>();
+
+		List<RepositoryPlugin> plugins = workspace.getRepositories();
+		for (RepositoryPlugin plugin : plugins) {
+			if (repoFilter != null) {
+				boolean matches = repoFilter.matcher(plugin.getName()).matches();
+				if (!matches)
+					continue;
+			}
+
+			List<String> bsns = plugin.list(bsnPattern);
+			if (bsns != null)
+				for (String bsn : bsns) {
+					SortedSet<Version> versions = plugin.versions(bsn);
+					if (versions != null && !versions.isEmpty()) {
+						Pair<Version,RepositoryPlugin> currentProvider = providerMap.get(bsn);
+
+						Version candidate;
+						switch (strategyx) {
+							case HIGHEST :
+								candidate = versions.last();
+								if (currentProvider == null || candidate.compareTo(currentProvider.getFirst()) > 0) {
+									providerMap.put(bsn, new Pair<Version,RepositoryPlugin>(candidate, plugin));
+								}
+								break;
+
+							case LOWEST :
+								candidate = versions.first();
+								if (currentProvider == null || candidate.compareTo(currentProvider.getFirst()) < 0) {
+									providerMap.put(bsn, new Pair<Version,RepositoryPlugin>(candidate, plugin));
+								}
+								break;
+							default :
+								// we shouldn't have reached this point!
+								throw new IllegalStateException(
+										"Cannot use exact version strategy with wildcard matches");
+						}
+					}
+				}
+
+		}
+
+		List<Container> containers = new ArrayList<Container>(providerMap.size());
+
+		for (Entry<String, Pair<Version, RepositoryPlugin>> entry : providerMap.entrySet()) {
+			String bsn = entry.getKey();
+			Version version = entry.getValue().getFirst();
+			RepositoryPlugin repo = entry.getValue().getSecond();
+			
+			DownloadBlocker downloadBlocker = new DownloadBlocker(this);
+			File bundle = repo.get(bsn, version, attrs, downloadBlocker);
+			if (bundle != null && !bundle.getName().endsWith(".lib")) {
+				containers.add(new Container(this, bsn, range, Container.TYPE.REPO, bundle, null, attrs,
+						downloadBlocker));
+			}
+		}
+
+		return containers;
 	}
 
 	static void mergeNames(String names, Set<String> set) {


### PR DESCRIPTION
NB: restoring this work from a private branch that was lost some time ago. The work was done on behalf of a client.

The purpose of this is to allow for a buildpath to be set on the cnf project containing all of the content of one or more repositories. This then enables type-level searches over those repository contents in Eclipse.

For example:

    -buildpath: org.apache.*

    -buildpath: *; repos='Build Repo*'

Peter is aware of this work and the implementation corresponds with his specification.