### PR TITLE
ResolveProcess does not populate optional candidates

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/WireImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/WireImpl.java
@@ -1,0 +1,45 @@
+package aQute.bnd.osgi.resource;
+
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.resource.Wire;
+
+public class WireImpl implements Wire {
+
+	private final Capability	capability;
+	private final Requirement	requirement;
+
+	public WireImpl(Capability capability, Requirement requirement) {
+		this.capability = capability;
+		this.requirement = requirement;
+	}
+
+	@Override
+	public Capability getCapability() {
+		return capability;
+	}
+
+	@Override
+	public Requirement getRequirement() {
+		return requirement;
+	}
+
+	@Override
+	public Resource getProvider() {
+		return capability.getResource();
+	}
+
+	@Override
+	public Resource getRequirer() {
+		return requirement.getResource();
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder builder = new StringBuilder();
+		builder.append("WireImpl [").append(requirement.toString()).append("  -->  ").append(capability).append("]");
+		return builder.toString();
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/WireImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/WireImpl.java
@@ -11,6 +11,11 @@ public class WireImpl implements Wire {
 	private final Requirement	requirement;
 
 	public WireImpl(Capability capability, Requirement requirement) {
+		if (capability == null || requirement == null) {
+			throw new IllegalArgumentException(
+					"Both a capabability and a requirement are required. The following were supplied. Cap: "
+							+ String.valueOf(capability) + " Req: " + String.valueOf(requirement));
+		}
 		this.capability = capability;
 		this.requirement = requirement;
 	}
@@ -40,6 +45,30 @@ public class WireImpl implements Wire {
 		final StringBuilder builder = new StringBuilder();
 		builder.append("WireImpl [").append(requirement.toString()).append("  -->  ").append(capability).append("]");
 		return builder.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return capability.hashCode() + requirement.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this)
+			return true;
+
+		if (obj instanceof Wire) {
+			Wire w = (Wire) obj;
+
+			if (capability.equals(w.getCapability()) && requirement.equals(w.getRequirement())) {
+				Resource provider = getProvider();
+				Resource requirer = getRequirer();
+
+				return (provider == null ? w.getProvider() == null : provider.equals(w.getProvider()))
+						&& (requirer == null ? w.getRequirer() == null : requirer.equals(w.getRequirer()));
+			}
+		}
+		return false;
 	}
 
 }

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ResolveProcessTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ResolveProcessTest.java
@@ -1,0 +1,180 @@
+package biz.aQute.resolve;
+
+import static org.osgi.framework.Version.parseVersion;
+import static org.osgi.framework.namespace.IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE;
+import static org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE;
+import static org.osgi.resource.Namespace.REQUIREMENT_FILTER_DIRECTIVE;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.osgi.framework.Version;
+import org.osgi.resource.Resource;
+import org.osgi.resource.Wire;
+import org.osgi.service.resolver.ResolutionException;
+
+import aQute.bnd.deployer.repository.FixedIndexedRepo;
+import aQute.bnd.osgi.Processor;
+import aQute.lib.io.IO;
+import junit.framework.TestCase;
+import test.lib.MockRegistry;
+
+public class ResolveProcessTest extends TestCase {
+
+	private final class ResourceComparator implements Comparator<Resource> {
+		@Override
+		public int compare(Resource o1, Resource o2) {
+			Map<String,Object> a1 = o1.getCapabilities(IDENTITY_NAMESPACE).get(0).getAttributes();
+			Map<String,Object> a2 = o2.getCapabilities(IDENTITY_NAMESPACE).get(0).getAttributes();
+			String n1 = (String) a1.get(IDENTITY_NAMESPACE);
+			String n2 = (String) a2.get(IDENTITY_NAMESPACE);
+
+			int diff = n1.compareTo(n2);
+			if (diff == 0) {
+				diff = ((Version) a1.get(CAPABILITY_VERSION_ATTRIBUTE))
+						.compareTo((Version) a2.get(CAPABILITY_VERSION_ATTRIBUTE));
+			}
+			return diff;
+		}
+	}
+
+	public void testResolveRequired() throws ResolutionException, MalformedURLException, URISyntaxException {
+		ResolveProcess process = new ResolveProcess();
+		ResolverLogger logger = new ResolverLogger();
+
+		MockRegistry registry = new MockRegistry();
+
+		registry.addPlugin(getIndex("testdata/repo7/index.xml"));
+
+		Processor model = new Processor();
+
+		model.setProperty("-runfw", "org.apache.felix.framework");
+		model.setProperty("-runrequires",
+				"osgi.extender;filter:='(&(osgi.extender=osgi.component)(version>=1.3)(!(version>=2)))'");
+
+		Map<Resource,List<Wire>> requiredResources = process.resolveRequired(model, null, registry,
+				new BndResolver(logger), Collections.<ResolutionCallback> emptyList(), logger);
+
+		Collection<Resource> optionalResources = process.getOptionalResources();
+
+		assertEquals(1, requiredResources.size());
+		assertEquals(3, optionalResources.size());
+
+		SortedSet<Resource> set = new TreeSet<Resource>(new ResourceComparator());
+
+		set.addAll(optionalResources);
+
+		Iterator<Resource> it = set.iterator();
+
+		checkOptionalResource(process, it.next(), "org.apache.felix.configadmin", parseVersion("1.8.8"),
+				"org.osgi.service.cm");
+		checkOptionalResource(process, it.next(), "org.apache.felix.log", parseVersion("1.0.1"),
+				"org.osgi.service.log");
+		checkOptionalResource(process, it.next(), "org.apache.felix.metatype", parseVersion("1.1.0"),
+				"org.osgi.service.metatype");
+	}
+
+	public void testBigNastyResolveRequired() throws ResolutionException, MalformedURLException, URISyntaxException {
+		ResolveProcess process = new ResolveProcess();
+		ResolverLogger logger = new ResolverLogger();
+
+		MockRegistry registry = new MockRegistry();
+
+		registry.addPlugin(getIndex("testdata/repo7/index.xml"));
+		registry.addPlugin(getIndex("testdata/repo7/index-aries.xml"));
+		registry.addPlugin(getIndex("testdata/repo7/index-gemini.xml"));
+		registry.addPlugin(getIndex("testdata/repo7/index-local.xml"));
+
+		Processor model = new Processor();
+
+		model.setProperty("-runfw", "org.apache.felix.framework");
+		model.setProperty("-runrequires", "osgi.extender;filter:='(osgi.extender=osgi.component)'");
+
+		Map<Resource,List<Wire>> requiredResources = process.resolveRequired(model, null, registry,
+				new BndResolver(logger), Collections.<ResolutionCallback> emptyList(), logger);
+
+		Collection<Resource> optionalResources = process.getOptionalResources();
+
+		assertEquals(1, requiredResources.size());
+		assertEquals(13, optionalResources.size());
+
+		SortedSet<Resource> set = new TreeSet<Resource>(new ResourceComparator());
+
+		set.addAll(optionalResources);
+
+		Iterator<Resource> it = set.iterator();
+
+		checkOptionalResource(process, it.next(), "org.apache.felix.configadmin", parseVersion("1.8.2"),
+				"org.osgi.service.cm");
+		checkOptionalResource(process, it.next(), "org.apache.felix.configadmin", parseVersion("1.8.8"),
+				"org.osgi.service.cm");
+		checkOptionalResource(process, it.next(), "org.apache.felix.gogo.command", parseVersion("0.12.0"),
+				"org.osgi.service.log");
+		checkOptionalResource(process, it.next(), "org.apache.felix.gogo.runtime", parseVersion("0.10.0"),
+				"org.apache.felix.service.command");
+		checkOptionalResource(process, it.next(), "org.apache.felix.log", parseVersion("1.0.1"),
+				"org.osgi.service.log");
+		checkOptionalResource(process, it.next(), "org.apache.felix.metatype", parseVersion("1.0.4"),
+				"org.osgi.service.metatype");
+		checkOptionalResource(process, it.next(), "org.apache.felix.metatype", parseVersion("1.1.0"),
+				"org.osgi.service.metatype");
+		checkOptionalResource(process, it.next(), "org.apache.felix.shell", parseVersion("1.4.2"),
+				"org.osgi.service.log", "org.apache.felix.shell");
+		checkOptionalResource(process, it.next(), "org.eclipse.osgi.services", parseVersion("3.1.200.v20070605"),
+				"org.osgi.service.cm", "org.osgi.service.log", "org.osgi.service.metatype");
+		checkOptionalResource(process, it.next(), "org.ops4j.pax.logging.pax-logging-api", parseVersion("1.4.0"),
+				"org.osgi.service.log");
+		checkOptionalResource(process, it.next(), "osgi.cmpn", parseVersion("4.3.1.201210102024"),
+				"org.osgi.service.cm", "org.osgi.service.log", "org.osgi.service.metatype");
+		checkOptionalResource(process, it.next(), "osgi.cmpn", parseVersion("5.0.0.201305092017"),
+				"org.osgi.service.cm", "org.osgi.service.log", "org.osgi.service.metatype");
+		checkOptionalResource(process, it.next(), "osgi.enterprise", parseVersion("4.2.0.201003190513"),
+				"org.osgi.service.cm", "org.osgi.service.log", "org.osgi.service.metatype");
+	}
+
+	protected FixedIndexedRepo getIndex(String location) throws MalformedURLException, URISyntaxException {
+		File index = IO.getFile(location);
+		FixedIndexedRepo fir = new FixedIndexedRepo();
+		fir.setLocations(index.toURI().toString());
+		return fir;
+	}
+
+	private void checkOptionalResource(ResolveProcess process, Resource resource, String bsn, Version version,
+			String packageName, String... morePackages) {
+		Collection<Wire> reasons;
+		Map<String,Object> idAttrs;
+		idAttrs = resource.getCapabilities(IDENTITY_NAMESPACE).get(0).getAttributes();
+		assertEquals(bsn, idAttrs.get(IDENTITY_NAMESPACE));
+		assertEquals(version, idAttrs.get(CAPABILITY_VERSION_ATTRIBUTE));
+		reasons = process.getOptionalReasons(resource);
+		assertEquals(1 + morePackages.length, reasons.size());
+
+		Iterator<Wire> iterator = reasons.iterator();
+
+		Wire wire = iterator.next();
+		assertEquals("org.apache.felix.scr",
+				wire.getRequirer().getCapabilities(IDENTITY_NAMESPACE)
+				.get(0).getAttributes().get(IDENTITY_NAMESPACE));
+		assertTrue(wire.getRequirement().toString(),
+				wire.getRequirement()
+				.getDirectives().get(REQUIREMENT_FILTER_DIRECTIVE).contains(packageName));
+
+		for (String pkg : morePackages) {
+			wire = iterator.next();
+			assertEquals("org.apache.felix.scr", wire.getRequirer().getCapabilities(IDENTITY_NAMESPACE).get(0)
+					.getAttributes().get(IDENTITY_NAMESPACE));
+			assertTrue(wire.getRequirement().toString(),
+					wire.getRequirement().getDirectives().get(REQUIREMENT_FILTER_DIRECTIVE).contains(pkg));
+		}
+	}
+
+}

--- a/biz.aQute.resolve/testdata/repo7/index-aries.xml
+++ b/biz.aQute.resolve/testdata/repo7/index-aries.xml
@@ -1,0 +1,4667 @@
+<?xml version="1.0" encoding="utf-8"?>
+<repository increment="1439912494930" name="Aries" xmlns="http://www.osgi.org/xmlns/repository/v1.0.0">
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="derby"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="eecb3bc5df060a8cb8cd32b85a7a57abdfa9be0ac2b21dce787023ed7532cb6c"/>
+      <attribute name="url" value="derby/derby-10.5.3000000.jar"/>
+      <attribute name="size" type="Long" value="2512189"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.authentication"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.database"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.io"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.jdbc"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.vti"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.3000000.802917"/>
+    </capability>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.api"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="02ac79ea069be7e82a197d468c4fe47354193ed4e75e53d18465fddeb2a90cbf"/>
+      <attribute name="url" value="org.apache.aries.application.api/org.apache.aries.application.api-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="46766"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework,org.apache.aries.application.filesystem,org.apache.aries.application.management"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.filesystem"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.osgi.framework,org.apache.aries.application.filesystem"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.runtime"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.osgi.framework,org.apache.aries.application.management"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.convert"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application.management,org.apache.aries.application.filesystem"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.resolve"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.apache.aries.application.modelling,org.apache.aries.application.management.spi.repository,org.osgi.framework,org.apache.aries.application.management"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.repository"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.osgi.framework,org.apache.aries.application.management.spi.framework,org.apache.aries.application.management,org.apache.aries.application.modelling"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.update"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.apache.aries.application.management.spi.repository,org.osgi.framework,org.apache.aries.application.management.spi.framework,org.apache.aries.application.management"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.management.spi.framework"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application.management.spi.repository,org.osgi.framework,org.apache.aries.application.management,org.apache.aries.application"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.modelling"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application.management,org.apache.aries.application.filesystem,org.apache.aries.application"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.modelling.utils"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.apache.aries.application.modelling"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.default.local.platform"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="68df83566eb69f6d3e4e0ed085d9af48053042202adf2e6b3200a12aa7f292ea"/>
+      <attribute name="url" value="org.apache.aries.application.default.local.platform/org.apache.aries.application.default.local.platform-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="10428"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.default.local.platform"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.default.local.platform"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.runtime.LocalPlatform"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.runtime)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.deployment.management"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="e20ed806232fa4be50c31585de97832215b99a8fce1a2585b88f0da429cd035a"/>
+      <attribute name="url" value="org.apache.aries.application.deployment.management/org.apache.aries.application.deployment.management-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="24203"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.deployment.management"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.deployment.management"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.resolve.DeploymentManifestManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.resolve)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.runtime)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling.utils)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.manifest)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.container)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.resolve.AriesApplicationResolver)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.resolve.PostResolveTransformer)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.runtime.LocalPlatform)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.modelling.ModelledResourceManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.modelling.ModellingManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.modelling.utils.ModellingHelper)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.install"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="ce19165af3f35c000962fdc8d3773c7a860bbe4f3b9177412b75d49f95682e6d"/>
+      <attribute name="url" value="org.apache.aries.application.install/org.apache.aries.application.install-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="11569"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.install"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.install"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.install"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.install"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.felix.fileinstall,org.apache.aries.application.filesystem,org.apache.aries.application,org.apache.aries.application.utils.filesystem,org.osgi.framework,org.slf4j,org.apache.aries.application.management"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.felix.fileinstall.ArtifactInstaller"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.fileinstall)(version&gt;=3.1.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.AriesApplicationManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.management"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f1aac2e5771a7182036c21e21148b573342c575f6c926856357b460bce262107"/>
+      <attribute name="url" value="org.apache.aries.application.management/org.apache.aries.application.management-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="24343"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.management"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.management"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.AriesApplicationManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.convert)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.framework)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.repository)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.resolve)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.runtime)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.manifest)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.ApplicationMetadataFactory)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.DeploymentMetadataFactory)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.convert.BundleConverter)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.resolve.DeploymentManifestManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.runtime.AriesApplicationContextManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.runtime.LocalPlatform)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.modeller"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="0cb95187b0c8718fcaeb9c4071126296979ddf1b13edad6f4d72721894f682e5"/>
+      <attribute name="url" value="org.apache.aries.application.modeller/org.apache.aries.application.modeller-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="60989"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.modeller"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.modeller"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.modelling.ModelledResourceManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.modelling.ModellingManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.modelling.ParserProxy"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.modelling.utils.ModellingHelper"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling.utils)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.manifest)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.blueprint)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.reflect)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.blueprint.ParserService)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.noop.platform.repo"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="52544d0c92f986d5f6d6b46d2eda1acff6fe848c9b18a46e608310047ee02bd3"/>
+      <attribute name="url" value="org.apache.aries.application.noop.platform.repo/org.apache.aries.application.noop.platform.repo-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="10436"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.noop.platform.repo"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.noop.platform.repo"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.repository.PlatformRepository"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.repository)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.noop.postresolve.process"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="1d808ad85399c6008b24c65d236370127ed933d50db72d89e8a1a84531bf251d"/>
+      <attribute name="url" value="org.apache.aries.application.noop.postresolve.process/org.apache.aries.application.noop.postresolve.process-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="10645"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.noop.postresolve.process"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.noop.postresolve.process"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.resolve.PostResolveTransformer"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.resolve)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.resolver.obr"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="d4d1f8fcbbb6eaac72ea2ad0197e3b2b74ee612831a0190624d6c1801422320a"/>
+      <attribute name="url" value="org.apache.aries.application.resolver.obr/org.apache.aries.application.resolver.obr-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="48652"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.resolver.obr"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.resolver.obr"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.resolver.obr.ext"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.resolver.obr"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.felix.bundlerepository,org.apache.aries.application.modelling,org.osgi.framework,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.repository.RepositoryGenerator"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.resolve.AriesApplicationResolver"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.repository)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.resolve)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.modelling.utils)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.filesystem)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.utils.manifest)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.bundlerepository)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.management.spi.repository.PlatformRepository)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.modelling.ModellingManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.modelling.utils.ModellingHelper)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.application.resolver.obr.ext.BundleResourceTransformer)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.felix.bundlerepository.RepositoryAdmin)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.runtime"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="8ebe72249f614e735387ea2178b84e5a25c0f2b6ac16d8095fa523c980f5989a"/>
+      <attribute name="url" value="org.apache.aries.application.runtime/org.apache.aries.application.runtime-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="16001"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.management.spi.runtime.AriesApplicationContextManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.resolve)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management.spi.runtime)(version&gt;=0.3.0)(!(version&gt;=0.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.application.utils"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f5db9e221d8e30e5b8e0fbb1c16b1e2644388bcfddbab412f464f3c881097eb4"/>
+      <attribute name="url" value="org.apache.aries.application.utils/org.apache.aries.application.utils-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="72303"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.utils"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.slf4j,org.apache.aries.application,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.utils.filesystem"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application.filesystem,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.utils.manifest"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application.filesystem,org.apache.aries.application.utils.filesystem,org.osgi.framework,org.slf4j,org.apache.aries.application,org.apache.aries.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.utils.management"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.application,org.osgi.framework,org.apache.aries.application.management,org.apache.aries.application.utils.manifest"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.application.utils.service"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.application.utils"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.ApplicationMetadataFactory"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.application.DeploymentMetadataFactory"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.filesystem)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.application.management)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.blueprint"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="2a67462157a1c2620d5afda12c0afe879c22b7846b8a08f5901ad88575b50989"/>
+      <attribute name="url" value="org.apache.aries.blueprint/org.apache.aries.blueprint-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="370426"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="blueprint.graceperiod" value="false"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.container,org.osgi.service.blueprint.reflect,org.apache.aries.blueprint,org.apache.aries.blueprint.ext,org.apache.aries.blueprint.mutable,org.apache.aries.blueprint.compendium.cm"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.container"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.reflect"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.ext"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.apache.aries.blueprint,org.osgi.service.blueprint.container,org.apache.aries.blueprint.mutable,org.slf4j,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.compendium.cm"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.blueprint,org.osgi.service.blueprint.reflect,org.osgi.framework,org.osgi.service.cm,org.osgi.service.blueprint.container,org.apache.aries.blueprint.utils,org.slf4j,org.apache.aries.blueprint.container,org.apache.aries.blueprint.ext,org.w3c.dom,org.apache.aries.blueprint.mutable"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.namespace"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.blueprint,org.osgi.service.blueprint.reflect,org.apache.aries.blueprint.reflect,org.apache.aries.blueprint.container,org.osgi.framework,javax.xml.validation,org.slf4j,org.xml.sax,javax.xml.transform,org.osgi.util.tracker,javax.xml.transform.stream"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.utils"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework,org.apache.aries.blueprint,org.apache.aries.blueprint.container,org.apache.aries.blueprint.di,org.osgi.service.blueprint.container"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.nls"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.container"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.blueprint,org.osgi.service.blueprint.reflect,org.osgi.framework,org.osgi.service.blueprint.container,org.apache.aries.blueprint.utils,org.slf4j,org.apache.aries.blueprint.di,org.apache.aries.proxy,org.apache.aries.blueprint.proxy,org.apache.aries.blueprint.namespace,org.apache.aries.blueprint.reflect,javax.xml.validation,org.osgi.util.tracker,org.osgi.service.event,org.apache.aries.util,org.apache.aries.util.tracker,org.apache.aries.blueprint.annotation.service,org.apache.aries.quiesce.manager,org.apache.aries.quiesce.participant,org.xml.sax,javax.xml.parsers,javax.xml.transform.dom,org.w3c.dom,javax.xml.transform,org.apache.aries.blueprint.ext,org.apache.aries.blueprint.mutable"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.apache.aries.blueprint.di,org.osgi.framework,org.osgi.service.blueprint.container,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.di"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.blueprint.container,org.osgi.service.blueprint.container,org.apache.aries.blueprint.utils,org.apache.aries.blueprint.ext,org.apache.aries.blueprint,org.osgi.service.blueprint.reflect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.reflect"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.apache.aries.blueprint.mutable,org.apache.aries.blueprint"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.mutable"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.apache.aries.blueprint"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.blueprint.proxy"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.blueprint,org.osgi.service.blueprint.reflect,org.apache.aries.proxy,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.blueprint.NamespaceHandler"/>
+      <attribute name="osgi.service.blueprint.namespace" value=""/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.blueprint.NamespaceHandler"/>
+      <attribute name="osgi.service.blueprint.namespace" value="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.blueprint.ParserService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.extender">
+      <attribute name="osgi.extender" value="osgi.blueprint"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <directive name="uses" value="org.osgi.service.blueprint.container,org.osgi.service.blueprint.reflect"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.validation)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.aries.blueprint.annotation.service)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.proxy)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.manager)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.participant)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util.tracker)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.framework.adaptor)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.framework.internal.core)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.internal.loader)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.event)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.osgi.service.cm.ConfigurationAdmin)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.jndi"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="12ab577a884e17cc67a63218ce258af792f1d685b01e79ee8659478f8d401180"/>
+      <attribute name="url" value="org.apache.aries.jndi/org.apache.aries.jndi-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="102538"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.jndi"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.jndi"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jndi"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jndi"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.naming.directory,javax.naming"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jndi.urls"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jndi"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.naming,javax.naming.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jndi.spi"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jndi"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.directory)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.ldap)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.spi)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jndi.spi)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jndi.urls)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.proxy)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.blueprint.container)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jndi)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.jpa.api"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="4993ad329829fb9dafd8704a1130906402cfc126f2cdc2ad7be21b1f66cef846"/>
+      <attribute name="url" value="org.apache.aries.jpa.api/org.apache.aries.jpa.api-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="13271"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.jpa.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.jpa.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container.parsing"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.persistence.spi,org.apache.aries.jpa.container.parsing,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.api"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.jpa.blueprint.aries"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="d5a98db49c7f0b63073a786a556933b2c9741a1f290ddcf17c4770d9f4aa3a2e"/>
+      <attribute name="url" value="org.apache.aries.jpa.blueprint.aries/org.apache.aries.jpa.blueprint.aries-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="20745"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.jpa.blueprint.aries"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.jpa.blueprint.aries"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.blueprint.NamespaceHandler"/>
+      <attribute name="osgi.service.blueprint.namespace" value="http://aries.apache.org/xmlns/jpa/v1.0.0"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.blueprint)(version&gt;=0.1.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.blueprint.mutable)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jpa.container.context)(version&gt;=0.1.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.reflect)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.aries.jpa.container.context.PersistenceContextProvider)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="62d07ea5316b861c5fb42d12be060010885a422fa955573b24e8dd894663618a"/>
+      <attribute name="url" value="org.apache.aries.jpa.container.context/org.apache.aries.jpa.container.context-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="39647"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jpa.container.context)(version&gt;=0.1.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.manager)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.participant)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.jpa.container"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="ddc2bbf3e9229ac9e89e629809f1ccac3832d8c1e0d660f7f39813e9da38f2c3"/>
+      <attribute name="url" value="org.apache.aries.jpa.container/org.apache.aries.jpa.container-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="86889"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.jpa.container"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.jpa.container"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container.context"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.container"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container.parsing"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.container"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.jpa.container"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.jpa.container"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.persistence.spi,org.apache.aries.jpa.container.parsing,org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.validation)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jpa.container)(version&gt;=0.1.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.jpa.container.parsing)(version&gt;=0.1.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.manager)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.quiesce.participant)(version&gt;=0.2.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util.tracker)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.proxy"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="3d0db549e2e07fe4e0edb0da2af2c086aab9b7b77648f8821f3eeb43a7e07261"/>
+      <attribute name="url" value="org.apache.aries.proxy/org.apache.aries.proxy-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="40726"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.proxy"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.proxy"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.proxy"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.proxy"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.apache.aries.util.nls,org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.util.nls)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.objectweb.asm)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.objectweb.asm.commons)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.samples.ariestrader.derby.ds"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="b19f6c067371fc323706bcaa86a0abafdbe3e3abb4828487e6835c364c615213"/>
+      <attribute name="url" value="org.apache.aries.samples.ariestrader.derby.ds/org.apache.aries.samples.ariestrader.derby.ds-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="9501"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.samples.ariestrader.derby.ds"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.samples.ariestrader.derby.ds"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="javax.sql.DataSource"/>
+      <attribute name="osgi.jndi.service.name" value="jdbc/NoTxTradeDataSource"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="javax.sql.XADataSource"/>
+      <attribute name="osgi.jndi.service.name" value="jdbc/TradeDataSource"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.derby.jdbc)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.transaction.blueprint"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="81c5197aea1f958bf6087fd0e02c2109c5f3b7bbd4126bde7c3dedc79da2070f"/>
+      <attribute name="url" value="org.apache.aries.transaction.blueprint/org.apache.aries.transaction.blueprint-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="37357"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.transaction.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.transaction.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.transaction.exception"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.blueprint"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.aries.blueprint.NamespaceHandler"/>
+      <attribute name="osgi.service.blueprint.namespace" value=""/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.aries.blueprint)(version&gt;=0.3.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.reflect)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=javax.transaction.TransactionManager)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.blueprint)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.transaction.manager"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="96e73ff9269dcb939aec8731956e9049bdd1db92c6ab90f3af4871c198d1ce6d"/>
+      <attribute name="url" value="org.apache.aries.transaction.manager/org.apache.aries.transaction.manager-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="175684"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction.log"/>
+      <attribute name="version" type="Version" value="2.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.transaction.xa,org.apache.geronimo.transaction.manager,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction.manager"/>
+      <attribute name="version" type="Version" value="2.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.transaction,javax.transaction.xa,org.slf4j,javax.resource.spi,org.apache.geronimo.transaction.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction"/>
+      <attribute name="version" type="Version" value="2.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.transaction"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="javax.transaction.xa"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.transaction.xa"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.transaction.manager"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="javax.transaction.TransactionManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="javax.transaction.TransactionSynchronizationRegistry"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="javax.transaction.UserTransaction"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.geronimo.transaction.manager.RecoverableTransactionManager"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.resource.spi)(version&gt;=1.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.springframework.transaction)(version&gt;=2.5.0)(!(version&gt;=4.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.springframework.transaction.jta)(version&gt;=2.5.0)(!(version&gt;=4.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.springframework.transaction.support)(version&gt;=2.5.0)(!(version&gt;=4.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.transaction.wrappers"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="e2233c1f63558ff96218643d0938e341018864e5c42798c61ddd1e6b4d8d2118"/>
+      <attribute name="url" value="org.apache.aries.transaction.wrappers/org.apache.aries.transaction.wrappers-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="18015"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.transaction.wrappers"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.transaction.wrappers"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.aries.util"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="4ebe46b2b15248b628ee1b64c51fc9c3787d28550ec244484386c8c7bd58cd45"/>
+      <attribute name="url" value="org.apache.aries.util/org.apache.aries.util-0.3.0.jar"/>
+      <attribute name="size" type="Long" value="44407"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.aries.util"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.aries.util"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.util"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.util"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.util.tracker"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.util"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.util.tracker,org.osgi.framework,org.osgi.framework.launch,org.osgi.service.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.aries.util.nls"/>
+      <attribute name="version" type="Version" value="0.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.aries.util"/>
+      <attribute name="bundle-version" type="Version" value="0.3.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.framework.adaptor)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.framework.internal.core)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.internal.loader)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.launch)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.commons.collections"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="87363a4c94eaabeefd8b930cb059f66b64c9f7d632862f23de3012da7660047b"/>
+      <attribute name="url" value="org.apache.commons.collections/org.apache.commons.collections-3.2.1.jar"/>
+      <attribute name="size" type="Long" value="575389"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.map"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.buffer"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.comparators"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.collection"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.bag"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.iterators"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.bidimap"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.set"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.functors"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.list"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections.keyvalue"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.collections"/>
+      <attribute name="version" type="Version" value="3.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.collections"/>
+      <attribute name="bundle-version" type="Version" value="3.2.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.bag)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.bidimap)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.buffer)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.collection)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.comparators)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.functors)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.iterators)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.keyvalue)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.list)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.map)(version&gt;=3.2.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.set)(version&gt;=3.2.1))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.commons.lang"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="a64e0c73988fef8d5b73fc29d105a3a6e2dc5d9b90a94fca065cd2439dc56590"/>
+      <attribute name="url" value="org.apache.commons.lang/org.apache.commons.lang-2.5.0.jar"/>
+      <attribute name="size" type="Long" value="279193"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.enum"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.enums"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.builder"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.time"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.exception"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.mutable"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.text"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.reflect"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang.math"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.lang"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.lang"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.builder)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.enum)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.enums)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.exception)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.math)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.mutable)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.reflect)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.text)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.lang.time)(version&gt;=2.5.0))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.commons.pool"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.5.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="22095672ac3ad6503e42ec6d4cbc330cd1318040223f6c5d9605473b6d2aa0fd"/>
+      <attribute name="url" value="org.apache.commons.pool/org.apache.commons.pool-1.5.4.jar"/>
+      <attribute name="size" type="Long" value="96221"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.commons.pool"/>
+      <attribute name="bundle-version" type="Version" value="1.5.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.commons.pool"/>
+      <attribute name="bundle-version" type="Version" value="1.5.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.pool.impl"/>
+      <attribute name="version" type="Version" value="1.5.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.pool"/>
+      <attribute name="bundle-version" type="Version" value="1.5.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.pool"/>
+      <attribute name="version" type="Version" value="1.5.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.commons.pool"/>
+      <attribute name="bundle-version" type="Version" value="1.5.4"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.pool)(version&gt;=1.5.4))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.pool.impl)(version&gt;=1.5.4))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.bundlerepository"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.6.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="cb6704defdbb078e47474f8bbc76632bfa0b90c2f8d6139a8b4bfdb8c477d3b4"/>
+      <attribute name="url" value="org.apache.felix.bundlerepository/org.apache.felix.bundlerepository-1.6.4.jar"/>
+      <attribute name="size" type="Long" value="153005"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.bundlerepository"/>
+      <attribute name="bundle-version" type="Version" value="1.6.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.bundlerepository"/>
+      <attribute name="bundle-version" type="Version" value="1.6.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.bundlerepository"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.bundlerepository"/>
+      <attribute name="bundle-version" type="Version" value="1.6.4"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.felix.bundlerepository.RepositoryAdmin"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.obr.RepositoryAdmin"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.stream)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.bundlerepository)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.obr)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.url)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.fileinstall"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="8226f61717e973d5d51cfe34e1652235f383aed8211c055584c3d0aa93b54e82"/>
+      <attribute name="url" value="org.apache.felix.fileinstall/org.apache.felix.fileinstall-3.1.4.jar"/>
+      <attribute name="size" type="Long" value="71899"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.fileinstall"/>
+      <attribute name="version" type="Version" value="3.1.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.fileinstall)(version&gt;=3.1.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.startlevel)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.url)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.1.3"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="3abba9e7c7fb0c24346f50bcc0999ea1696571d7db595862da11d0092a676779"/>
+      <attribute name="url" value="org.apache.geronimo.components.geronimo-transaction/org.apache.geronimo.components.geronimo-transaction-2.1.3.jar"/>
+      <attribute name="size" type="Long" value="57705"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="bundle-version" type="Version" value="2.1.3"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="bundle-version" type="Version" value="2.1.3"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction.log"/>
+      <attribute name="version" type="Version" value="2.1.3"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="bundle-version" type="Version" value="2.1.3"/>
+      <directive name="uses" value="org.objectweb.howl.log,org.objectweb.howl.log.xa,javax.transaction.xa,org.apache.geronimo.transaction.manager,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction.manager"/>
+      <attribute name="version" type="Version" value="2.1.3"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="bundle-version" type="Version" value="2.1.3"/>
+      <directive name="uses" value="javax.resource.spi,javax.transaction,javax.transaction.xa,org.slf4j,org.apache.geronimo.transaction.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.geronimo.transaction"/>
+      <attribute name="version" type="Version" value="2.1.3"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.components.geronimo-transaction"/>
+      <attribute name="bundle-version" type="Version" value="2.1.3"/>
+      <directive name="uses" value="javax.transaction"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.resource.spi)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.objectweb.howl.log)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.objectweb.howl.log.xa)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="e16e8373d2affd5d4d248aac04ff7389d2d411f8339c94456fc93375a4b7a9b7"/>
+      <attribute name="url" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec/org.apache.geronimo.specs.geronimo-jpa_2.0_spec-1.1.0.jar"/>
+      <attribute name="size" type="Long" value="120194"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <attribute name="singleton" value="true"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <directive name="uses" value="javax.persistence.criteria,javax.persistence.metamodel,javax.persistence.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.criteria"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <directive name="uses" value="javax.persistence.metamodel,javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.metamodel"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.spi"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <directive name="uses" value="javax.persistence,javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.criteria"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.metamodel"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.spi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jpa_2.0_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.geronimo.osgi.registry.api)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.1.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="3a0c3c1bbc2efe8383969574922791959670ef547d6c897496915617025c3023"/>
+      <attribute name="url" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec/org.apache.geronimo.specs.geronimo-jta_1.1_spec-1.1.1.jar"/>
+      <attribute name="size" type="Long" value="16030"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.transaction.xa"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.transaction"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-jta_1.1_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.1.1"/>
+      <directive name="uses" value="javax.transaction.xa"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="74415d1ac556e28ba38f0046ca43bcd32d84a99f8ecbbf7c08ef0d843706a353"/>
+      <attribute name="url" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec/org.apache.geronimo.specs.geronimo-servlet_2.5_spec-1.2.0.jar"/>
+      <attribute name="size" type="Long" value="70593"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.http"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.2.0"/>
+      <directive name="uses" value="javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.resources"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.geronimo.specs.geronimo-servlet_2.5_spec"/>
+      <attribute name="bundle-version" type="Version" value="1.2.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.resources)(version&gt;=2.5.0))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.openjpa"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="ba8286833932b7ea75150bf06556750987d7d3ed16c5abe4201dac4123839e2e"/>
+      <attribute name="url" value="org.apache.openjpa/org.apache.openjpa-2.0.0.jar"/>
+      <attribute name="size" type="Long" value="4068849"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.slice.transaction"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.encryption"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.validation"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="javax.validation,org.apache.openjpa.persistence,javax.persistence.spi,org.apache.openjpa.validation,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.conf,javax.persistence,org.apache.openjpa.lib.util,javax.validation.groups,javax.validation.metadata"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.util"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.conf,org.apache.commons.collections.set,org.apache.commons.collections.iterators,org.apache.openjpa.lib.util,org.apache.commons.collections,org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.enhance,org.apache.commons.lang,org.apache.openjpa.lib.util.concurrent,serp.bytecode,serp.util,org.apache.openjpa.lib.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.log"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.commons.logging,org.apache.log4j,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.criteria"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.kernel.exps,javax.persistence.criteria,org.apache.openjpa.enhance,javax.persistence.metamodel,org.apache.openjpa.kernel,org.apache.openjpa.persistence,javax.persistence,org.apache.openjpa.lib.util,org.apache.openjpa.persistence.meta,org.apache.openjpa.meta,org.apache.openjpa.kernel.jpql,org.apache.openjpa.util,org.apache.openjpa.persistence.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.ant"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.tools.ant.taskdefs,org.apache.tools.ant.types,org.apache.openjpa.lib.conf,org.apache.tools.ant,org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.util"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="serp.bytecode,serp.util,org.apache.commons.lang.exception,org.apache.commons.lang,javax.validation,org.apache.commons.collections.map,org.apache.commons.collections.set,serp.bytecode.lowlevel"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.identifier"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.commons.lang,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.kernel.exps"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.sql,org.apache.openjpa.kernel.exps,org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.jdbc.meta,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.jdbc.schema,org.apache.openjpa.util,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.openjpa.jdbc.conf,org.apache.openjpa.enhance,org.apache.openjpa.jdbc.meta.strats,serp.util,org.apache.commons.lang,org.apache.openjpa.jdbc.identifier"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.slice.jdbc"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util,javax.sql,org.apache.openjpa.lib.jdbc,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.slice,org.apache.openjpa.jdbc.conf,org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.kernel,org.apache.openjpa.jdbc.sql,org.apache.openjpa.util,org.apache.openjpa.lib.log,org.apache.openjpa.jdbc.schema,org.apache.openjpa.meta,org.apache.openjpa.lib.rop,org.apache.openjpa.enhance,org.apache.openjpa.kernel.exps"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.meta"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.sql,org.apache.openjpa.util,org.apache.openjpa.lib.rop,org.apache.openjpa.conf,org.apache.openjpa.lib.log,org.apache.openjpa.enhance,org.apache.openjpa.lib.util,org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.jdbc.meta.strats,org.apache.openjpa.jdbc.schema,org.apache.openjpa.lib.xml,org.apache.openjpa.lib.meta,org.apache.commons.lang,serp.util,org.apache.openjpa.jdbc.conf,org.apache.openjpa.lib.conf,serp.bytecode"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.datacache"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util.concurrent,serp.util,org.apache.openjpa.util,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.commons.lang,org.apache.openjpa.event,org.apache.openjpa.meta,org.apache.openjpa.kernel,serp.bytecode,org.apache.openjpa.enhance,org.apache.openjpa.lib.rop,org.apache.commons.collections.map,org.apache.openjpa.kernel.exps"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.slice"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.kernel,org.apache.openjpa.slice.jdbc,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.util,org.apache.openjpa.enhance,org.apache.openjpa.meta"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.conf"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.jdbc.meta,javax.sql,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.lib.jdbc,org.apache.openjpa.jdbc.sql,org.apache.openjpa.conf,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.kernel,org.apache.openjpa.jdbc.schema,serp.bytecode,serp.bytecode.lowlevel,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.openjpa.meta,org.apache.commons.lang,serp.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.ee"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.util,javax.transaction,org.apache.openjpa.lib.util,org.apache.openjpa.lib.conf,org.apache.openjpa.conf,javax.naming,javax.transaction.xa,com.ibm.websphere.jtaextensions,org.apache.openjpa.lib.log,serp.bytecode,com.ibm.wsspi.uow"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.meta"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="serp.util,org.apache.openjpa.lib.util,org.apache.commons.lang,org.xml.sax,serp.bytecode.lowlevel,org.apache.openjpa.lib.log,org.apache.commons.lang.exception,org.apache.openjpa.lib.xml,javax.xml.parsers,org.xml.sax.ext,org.xml.sax.helpers,javax.xml.transform,javax.xml.transform.stream,javax.xml.transform.sax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.util"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.query"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.util,org.apache.openjpa.persistence,org.apache.openjpa.conf,org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.ant"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.lib.ant,org.apache.openjpa.enhance,org.apache.openjpa.lib.util,org.apache.tools.ant.types,org.apache.openjpa.meta,org.apache.tools.ant"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.identifier"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.commons.lang,org.apache.openjpa.lib.identifier,org.apache.openjpa.jdbc.schema,org.apache.openjpa.jdbc.sql,org.apache.openjpa.jdbc.conf,org.apache.openjpa.lib.conf"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.schema"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.meta,org.apache.openjpa.jdbc.identifier,org.apache.commons.lang,javax.sql,org.apache.openjpa.lib.jdbc,org.apache.openjpa.lib.util,org.apache.openjpa.jdbc.sql,org.apache.openjpa.util,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.jdbc.conf,org.apache.openjpa.kernel,org.apache.openjpa.lib.identifier,org.apache.openjpa.lib.meta,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.lib.xml,org.xml.sax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.meta"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="javax.persistence.metamodel,org.apache.openjpa.kernel,org.apache.openjpa.meta,org.apache.openjpa.lib.util,javax.annotation,javax.lang.model.util,javax.tools,javax.lang.model.type,javax.lang.model,org.apache.openjpa.persistence,javax.lang.model.element,org.apache.openjpa.persistence.util,javax.annotation.processing,org.apache.openjpa.util,org.apache.openjpa.conf,org.apache.openjpa.kernel.exps,javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.xml"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util,org.xml.sax,org.apache.commons.lang.exception,javax.xml.parsers,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.sql"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.kernel.exps,org.apache.openjpa.jdbc.meta,org.apache.openjpa.kernel.exps,org.apache.openjpa.jdbc.schema,org.apache.openjpa.jdbc.kernel,serp.util,org.apache.openjpa.util,org.apache.openjpa.lib.util,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.lib.log,org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.jdbc.conf,org.apache.openjpa.lib.identifier,org.apache.commons.lang,org.apache.openjpa.lib.conf,javax.sql,org.apache.openjpa.lib.jdbc,org.postgresql.largeobject,org.postgresql,org.apache.openjpa.lib.xml,javax.xml.parsers,org.w3c.dom,org.apache.commons.collections.iterators"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.rop"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util,org.apache.commons.lang,org.apache.commons.lang.exception,org.apache.commons.collections"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.conf"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,serp.util,org.apache.commons.lang,javax.naming,org.apache.openjpa.lib.util.concurrent,org.apache.commons.lang.exception"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.kernel.jpql"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.util,org.apache.openjpa.kernel.exps,org.apache.openjpa.lib.util,org.apache.openjpa.kernel,org.apache.openjpa.conf,org.apache.openjpa.lib.log,org.apache.openjpa.meta"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.conf"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.abstractstore,org.apache.openjpa.util,org.apache.openjpa.kernel,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.openjpa.meta,org.apache.openjpa.lib.encryption,org.apache.openjpa.datacache,org.apache.openjpa.ee,org.apache.openjpa.kernel.exps,org.apache.openjpa.event,org.apache.commons.lang,org.apache.openjpa.validation,org.apache.openjpa.lib.util.concurrent"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.enhance"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.lib.util,serp.bytecode,org.apache.openjpa.util,serp.util,org.apache.openjpa.lib.log,org.apache.commons.lang,org.apache.openjpa.meta,org.apache.openjpa.lib.meta,serp.bytecode.lowlevel,org.apache.openjpa.kernel,org.apache.openjpa.lib.util.concurrent"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.kernel"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="javax.transaction,org.apache.openjpa.util,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.conf,org.apache.openjpa.enhance,org.apache.openjpa.lib.util,org.apache.openjpa.meta,org.apache.openjpa.event,org.apache.commons.lang,org.apache.openjpa.lib.util.concurrent,org.apache.openjpa.datacache,org.apache.openjpa.ee,org.apache.commons.collections.set,org.apache.commons.collections.map,org.apache.openjpa.kernel.exps,org.apache.commons.collections.iterators,org.apache.openjpa.lib.rop,org.apache.commons.collections,serp.util,javax.transaction.xa"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.event"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.openjpa.util,org.apache.openjpa.kernel,org.apache.openjpa.lib.util.concurrent,org.apache.openjpa.meta,javax.jms,javax.naming,org.apache.openjpa.conf,org.apache.commons.pool,org.apache.commons.pool.impl,serp.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.meta"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.meta,org.apache.openjpa.util,serp.util,org.apache.openjpa.lib.log,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.commons.lang,org.apache.openjpa.enhance,org.apache.openjpa.lib.xml,org.apache.openjpa.lib.conf,org.apache.openjpa.datacache,org.apache.commons.collections.comparators,org.apache.openjpa.kernel,serp.bytecode,org.apache.openjpa.event,org.apache.commons.collections.bidimap"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.util.concurrent"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util,org.apache.commons.collections.set"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.osgi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.framework,org.apache.openjpa.persistence,javax.persistence.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.xmlstore"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.util,org.apache.openjpa.conf,org.apache.openjpa.event,org.apache.openjpa.meta,org.apache.openjpa.kernel,org.apache.openjpa.lib.conf,org.apache.openjpa.enhance,org.apache.openjpa.lib.util,org.xml.sax,org.xml.sax.helpers,org.apache.openjpa.lib.xml,javax.xml.parsers,org.apache.openjpa.lib.rop,org.apache.openjpa.abstractstore"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.ant"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.meta,org.apache.tools.ant.types,org.apache.openjpa.jdbc.schema,org.apache.openjpa.util,org.apache.openjpa.jdbc.conf,org.apache.openjpa.lib.conf,org.apache.tools.ant,org.apache.openjpa.lib.ant,org.apache.openjpa.lib.util,org.apache.commons.lang"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.validation"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.meta,org.apache.openjpa.event,org.apache.openjpa.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.kernel"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.kernel,org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.jdbc.meta,javax.sql,org.apache.openjpa.jdbc.sql,org.apache.openjpa.util,org.apache.openjpa.jdbc.conf,org.apache.openjpa.jdbc.schema,org.apache.openjpa.meta,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.openjpa.lib.jdbc,org.apache.openjpa.lib.meta,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.lib.graph,org.apache.commons.lang,org.apache.openjpa.lib.rop,org.apache.openjpa.enhance,org.apache.openjpa.event,org.apache.openjpa.datacache,org.apache.openjpa.kernel.exps,org.apache.openjpa.jdbc.meta.strats,org.apache.openjpa.jdbc.kernel.exps,org.apache.openjpa.kernel.jpql,javax.transaction,org.apache.openjpa.ee"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.jdbc"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util,org.apache.openjpa.lib.log,javax.sql,org.apache.commons.lang.exception,org.apache.openjpa.lib.util.concurrent"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.lib.graph"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.lib.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="serp.util,org.apache.commons.lang,javax.persistence,org.apache.openjpa.util,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.log,org.apache.openjpa.conf,org.apache.openjpa.enhance,org.apache.openjpa.lib.util,org.apache.openjpa.event,org.apache.openjpa.meta,org.apache.openjpa.lib.meta,org.apache.openjpa.persistence.meta,org.apache.openjpa.persistence.criteria,javax.persistence.criteria,org.apache.openjpa.kernel,org.apache.openjpa.datacache,javax.persistence.spi,org.apache.openjpa.persistence.query,javax.persistence.metamodel,org.apache.openjpa.persistence.validation,org.apache.openjpa.ee,org.apache.openjpa.kernel.exps,javax.naming,javax.rmi,org.xml.sax,org.apache.openjpa.persistence.osgi,javax.sql,org.apache.openjpa.lib.rop,org.apache.openjpa.lib.xml"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.abstractstore"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.util,org.apache.openjpa.lib.conf,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.openjpa.kernel,org.apache.openjpa.lib.rop,org.apache.openjpa.meta"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.persistence.jdbc"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="javax.persistence,org.apache.openjpa.jdbc.sql,org.apache.openjpa.util,org.apache.openjpa.conf,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.commons.lang,org.apache.openjpa.meta,org.apache.openjpa.jdbc.meta,org.apache.openjpa.persistence,org.apache.openjpa.jdbc.conf,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.jdbc.schema,org.apache.openjpa.jdbc.meta.strats,serp.util,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.kernel,org.apache.openjpa.lib.conf,org.apache.openjpa.lib.xml,org.xml.sax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.kernel.exps"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.kernel,serp.util,org.apache.openjpa.util,org.apache.openjpa.conf,org.apache.openjpa.lib.util,org.apache.openjpa.meta,org.apache.openjpa.enhance,org.apache.commons.lang,org.apache.openjpa.kernel.jpql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.openjpa.jdbc.meta.strats"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.openjpa"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.apache.openjpa.jdbc.meta,org.apache.openjpa.jdbc.kernel,org.apache.openjpa.jdbc.sql,org.apache.openjpa.lib.rop,org.apache.openjpa.kernel,org.apache.openjpa.lib.log,org.apache.openjpa.lib.util,org.apache.openjpa.util,org.apache.openjpa.jdbc.identifier,org.apache.openjpa.jdbc.schema,org.apache.commons.lang,org.apache.openjpa.jdbc.conf,org.apache.openjpa.meta,org.apache.openjpa.enhance,org.apache.openjpa.conf,javax.xml.transform,javax.xml.transform.stream,javax.xml.bind"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=com.ibm.websphere.jtaextensions)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=com.ibm.wsspi.uow)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.annotation)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.annotation.processing)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.jms)(version&gt;=1.1.0)(!(version&gt;=1.2.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.lang.model)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.lang.model.element)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.lang.model.type)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.lang.model.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=2.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=2.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=2.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=2.0.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.rmi)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.tools)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0)(!(version&gt;=1.2.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0)(!(version&gt;=1.2.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.validation)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.validation.groups)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.validation.metadata)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.bind)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.bidimap)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.comparators)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.iterators)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.map)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.collections.set)(version&gt;=3.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.commons.lang)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.commons.lang.exception)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.commons.logging)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.pool)(version&gt;=1.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.pool.impl)(version&gt;=1.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.log4j)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.abstractstore)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.ant)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.conf)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.datacache)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.ee)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.enhance)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.event)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.ant)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.conf)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.identifier)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.kernel)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.kernel.exps)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.meta)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.meta.strats)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.schema)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.jdbc.sql)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.kernel)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.kernel.exps)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.kernel.jpql)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.ant)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.conf)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.encryption)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.graph)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.identifier)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.jdbc)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.log)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.meta)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.rop)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.util)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.util.concurrent)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.lib.xml)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.meta)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.criteria)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.jdbc)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.meta)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.osgi)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.query)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.util)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.persistence.validation)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.slice)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.slice.jdbc)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.slice.transaction)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.util)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.validation)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.openjpa.xmlstore)(version&gt;=2.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.taskdefs)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.postgresql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.postgresql.largeobject)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.ext)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=serp.bytecode)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=serp.bytecode.lowlevel)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=serp.util)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.equinox.cm"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.2.0.v20070116"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="e1e560bc38fba9a96bc86987a945e9c008b25905637ffacd4361d9667edfdae1"/>
+      <attribute name="url" value="org.eclipse.equinox.cm/org.eclipse.equinox.cm-3.2.0.jar"/>
+      <attribute name="size" type="Long" value="43895"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.equinox.cm"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0.v20070116"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.equinox.cm"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0.v20070116"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <directive name="uses" value="org.osgi.service.cm"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.osgi.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.1))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(|(&amp;(osgi.ee=OSGi/Minimum)(version=1.1))(&amp;(osgi.ee=CDC/Foundation)(version=1.0))(&amp;(osgi.ee=JavaSE)(version=1.3)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.osgi.services"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="d7107f65742d05bc06f269fd1a46684ceaca322f1eba3c4c8f2bd0980391ae44"/>
+      <attribute name="url" value="org.eclipse.osgi.services/org.eclipse.osgi.services-3.1.200.jar"/>
+      <attribute name="size" type="Long" value="63704"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.device"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.event"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.io"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.provisioning"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.upnp"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.useradmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.wireadmin"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.osgi.services"/>
+      <attribute name="bundle-version" type="Version" value="3.1.200.v20070605"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=OSGi/Minimum)(version=1.0))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.objectweb.asm.all"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="cd9c594e1bd8793f7318067df25cfc766e2d9809ac200c5cd4bd0daa38d2814e"/>
+      <attribute name="url" value="org.objectweb.asm.all/org.objectweb.asm.all-3.2.0.jar"/>
+      <attribute name="size" type="Long" value="203417"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.signature"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.commons"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.tree"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.tree.analysis"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.util"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objectweb.asm.xml"/>
+      <attribute name="version" type="Version" value="3.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.objectweb.asm.all"/>
+      <attribute name="bundle-version" type="Version" value="3.2.0"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.3))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="991511ce62745a1da7de8c183f1551a437d73a6c22867d8f70368ad7e34f5d57"/>
+      <attribute name="url" value="org.ops4j.pax.logging.pax-logging-api/org.ops4j.pax.logging.pax-logging-api-1.4.0.jar"/>
+      <attribute name="size" type="Long" value="88414"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.juli.logging"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.ops4j.pax.logging,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.knopflerfish.service.log"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.osgi.service.log,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j.spi"/>
+      <attribute name="version" type="Version" value="1.5.6"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.log4j.spi"/>
+      <attribute name="version" type="Version" value="1.2.15"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.apache.log4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.avalon.framework.logger"/>
+      <attribute name="version" type="Version" value="4.3.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.apache.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.log4j.xml"/>
+      <attribute name="version" type="Version" value="1.2.15"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="javax.xml.parsers,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.logging"/>
+      <attribute name="version" type="Version" value="1.1.1"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.ops4j.pax.logging,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ops4j.pax.logging"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.knopflerfish.service.log,org.osgi.framework,org.osgi.util.tracker"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.commons.logging.impl"/>
+      <attribute name="version" type="Version" value="1.1.1"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.apache.commons.logging"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.log4j"/>
+      <attribute name="version" type="Version" value="1.2.15"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.ops4j.pax.logging,org.apache.log4j.spi,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j"/>
+      <attribute name="version" type="Version" value="1.5.6"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.slf4j.spi,org.slf4j.helpers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j.helpers"/>
+      <attribute name="version" type="Version" value="1.5.6"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.slf4j.spi,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ops4j.pax.logging.avalon"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-api"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+      <directive name="uses" value="org.ops4j.pax.logging,org.apache.avalon.framework.logger,org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.avalon.framework.logger)(version&gt;=4.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.logging)(version&gt;=1.1.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.logging.impl)(version&gt;=1.1.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.juli.logging)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.log)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.log4j)(version&gt;=1.2.15))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.log4j.spi)(version&gt;=1.2.15))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.log4j.xml)(version&gt;=1.2.15))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.knopflerfish.service.log)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.logging)(version&gt;=0.9.5)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.logging.avalon)(version&gt;=0.9.5)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.event)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.5.6))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.helpers)(version&gt;=1.5.6))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.spi)(version&gt;=1.5.6))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.ops4j.pax.logging.pax-logging-service"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="205bc97d5c0d0ca704b1da183638d6b00ad1d6512da9f8b08e7f723a0524a1e6"/>
+      <attribute name="url" value="org.ops4j.pax.logging.pax-logging-service/org.ops4j.pax.logging.pax-logging-service-1.4.0.jar"/>
+      <attribute name="size" type="Long" value="427221"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.ops4j.pax.logging.pax-logging-service"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.ops4j.pax.logging.pax-logging-service"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ops4j.pax.logging.spi"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+      <attribute name="provider" value="paxlogging"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.logging.pax-logging-service"/>
+      <attribute name="bundle-version" type="Version" value="1.4.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=com.sun.jdmk.comm)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.jms)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail.internet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing.border)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing.event)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing.table)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing.text)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.swing.tree)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.knopflerfish.service.log)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.logging)(version&gt;=0.9.5)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="provider" value="paxlogging"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.logging.spi)(version&gt;=1.4.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.ops4j.pax.web.pax-web-extender-war"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="bb2773d2169c4709f9dcd8dedd200b5aedf1b730c711ef9928d90f242ef82892"/>
+      <attribute name="url" value="org.ops4j.pax.web.pax-web-extender-war/org.ops4j.pax.web.pax-web-extender-war-0.8.1.jar"/>
+      <attribute name="size" type="Long" value="112655"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.ops4j.pax.web.pax-web-extender-war"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.ops4j.pax.web.pax-web-extender-war"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.logging)(version&gt;=1.0.4))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.web.service)(version&gt;=0.6.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.http)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="58cb8f40d8bd36f762ff748bdf913655bd7c4538661bf9af614f44471ee371cb"/>
+      <attribute name="url" value="org.ops4j.pax.web.pax-web-jetty-bundle/org.ops4j.pax.web.pax-web-jetty-bundle-0.8.1.jar"/>
+      <attribute name="size" type="Long" value="2225198"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ops4j.pax.web.service"/>
+      <attribute name="version" type="Version" value="0.8.1"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.osgi.framework,javax.servlet,org.osgi.service.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet.http,javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.webapp.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.webapp,org.eclipse.jetty.server.handler.jmx"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.security.authentication"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,org.eclipse.jetty.server,org.eclipse.jetty.security,org.eclipse.jetty.http.security,javax.servlet.http,org.eclipse.jetty.util,org.eclipse.jetty.util.log,javax.security.auth"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.continuation"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,org.mortbay.log,org.mortbay.util.ajax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.ssl"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.io,javax.security.cert,javax.net.ssl,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.io.nio,org.eclipse.jetty.http,org.eclipse.jetty.server.nio,org.eclipse.jetty.util.resource,org.eclipse.jetty.http.security,org.eclipse.jetty.server.bio,org.eclipse.jetty.io.bio"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.thread"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.jaas.spi"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.security.auth.callback,org.eclipse.jetty.http.security,javax.security.auth,org.eclipse.jetty.util.log,org.eclipse.jetty.plus.jaas,org.eclipse.jetty.plus.jaas.callback,javax.security.auth.spi,javax.security.auth.login,javax.naming,javax.sql,org.eclipse.jetty.util,javax.naming.directory"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.io.bio"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jsp"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="com.sun.org.apache.commons.logging,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.handler"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.io.nio,org.eclipse.jetty.io,org.eclipse.jetty.util.thread,org.eclipse.jetty.http,javax.servlet,javax.servlet.http,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.statistic,org.eclipse.jetty.continuation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy.util"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jndi"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.naming,org.eclipse.jetty.server.handler,org.eclipse.jetty.util.log,javax.naming.spi,org.eclipse.jetty.jndi.local"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.servlets"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,javax.servlet.http,org.eclipse.jetty.util,javax.servlet,org.eclipse.jetty.server,org.eclipse.jetty.io,org.eclipse.jetty.continuation,org.eclipse.jetty.util.thread,org.eclipse.jetty.http.security,org.eclipse.jetty.client,org.eclipse.jetty.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.servlets.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.servlet.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.servlet,org.eclipse.jetty.jmx"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy.graph"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server.handler,org.eclipse.jetty.util,org.eclipse.jetty.deploy.graph,org.eclipse.jetty.util.log,org.eclipse.jetty.util.component,org.eclipse.jetty.server,org.eclipse.jetty.util.resource,org.eclipse.jetty.xml,org.eclipse.jetty.deploy.bindings,org.eclipse.jetty.webapp"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.resource"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.annotation"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.naming,org.eclipse.jetty.util.log,org.eclipse.jetty.util,javax.servlet,org.eclipse.jetty.servlet,org.eclipse.jetty.servlet.api"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.webapp"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.resource,org.eclipse.jetty.xml,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.server.handler,org.eclipse.jetty.server,org.eclipse.jetty.servlet,org.eclipse.jetty.io,org.eclipse.jetty.security,org.eclipse.jetty.http,javax.servlet,org.eclipse.jetty.http.security,org.eclipse.jetty.server.session,org.eclipse.jetty.servlet.api,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.webapp"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.webapp,javax.naming,org.eclipse.jetty.plus.jndi,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.log,org.eclipse.jetty.xml,org.eclipse.jetty.jndi,org.eclipse.jetty.servlet,javax.servlet,org.eclipse.jetty.plus.annotation,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy.bindings"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.server.handler,org.eclipse.jetty.deploy.graph,org.eclipse.jetty.deploy,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.security.jaspi.callback"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.security.auth.callback,org.eclipse.jetty.http.security,javax.security.auth"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.handler.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server.handler,org.eclipse.jetty.jmx,org.eclipse.jetty.util.resource,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.bio"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.io.bio,org.eclipse.jetty.io,org.eclipse.jetty.http,org.eclipse.jetty.util.thread,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,org.eclipse.jetty.util.thread"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.io"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.http"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.util.component,org.eclipse.jetty.util.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.jaas"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.plus.jaas.callback,org.eclipse.jetty.server,javax.security.auth.callback,org.eclipse.jetty.security,javax.security.auth.login,javax.security.auth,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.deploy.providers"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.server.handler,org.eclipse.jetty.util.resource,org.eclipse.jetty.deploy.util,org.eclipse.jetty.deploy,org.eclipse.jetty.xml,org.eclipse.jetty.util,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.webapp"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.ajp"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.io,org.eclipse.jetty.http,org.eclipse.jetty.util.log,javax.servlet,org.eclipse.jetty.server.bio"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.security.jaspi.modules"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.security.auth.callback,org.eclipse.jetty.security.authentication,javax.security.auth,org.eclipse.jetty.http.security,org.eclipse.jetty.security.jaspi.callback,javax.servlet.http,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.session"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,javax.servlet.http,javax.servlet,org.eclipse.jetty.server.handler,org.eclipse.jetty.util,org.eclipse.jetty.util.statistic,org.eclipse.jetty.http,javax.naming,javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.client"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io,org.eclipse.jetty.http,org.eclipse.jetty.util,org.eclipse.jetty.util.thread,javax.net.ssl,org.eclipse.jetty.util.component,org.eclipse.jetty.client.security,org.eclipse.jetty.util.resource,org.eclipse.jetty.io.nio,org.eclipse.jetty.http.security,org.eclipse.jetty.util.log,org.eclipse.jetty.io.bio,javax.net"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.client.security"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.client,org.eclipse.jetty.io,org.eclipse.jetty.http.security,org.eclipse.jetty.http,org.eclipse.jetty.util,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.security"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,org.eclipse.jetty.server,org.eclipse.jetty.http.security,org.eclipse.jetty.http,org.eclipse.jetty.server.handler,org.eclipse.jetty.server.session,org.eclipse.jetty.util,javax.servlet.http,org.eclipse.jetty.security.authentication,javax.security.auth,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.log,org.eclipse.jetty.util.component"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jndi.factories"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.http.security,javax.naming,javax.naming.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jndi.java"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.naming,org.eclipse.jetty.util.log,org.eclipse.jetty.jndi,javax.naming.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.log.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.nio.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.component"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.component.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.servlet"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.servlet,org.eclipse.jetty.plus.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.jaas.callback"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.security.auth.callback,org.eclipse.jetty.server,org.eclipse.jetty.http.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.websocket"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.io.nio,javax.servlet.http,org.eclipse.jetty.server,org.eclipse.jetty.http,javax.servlet,org.eclipse.jetty.server.handler"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.xml"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.component,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.xml.sax,javax.xml.parsers,org.xml.sax.helpers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.util.statistic,org.eclipse.jetty.http,org.eclipse.jetty.util.thread,org.eclipse.jetty.util.component,javax.servlet,org.eclipse.jetty.continuation,org.eclipse.jetty.server.handler,javax.servlet.http,org.eclipse.jetty.util,org.eclipse.jetty.server.ssl,org.eclipse.jetty.server.nio,org.eclipse.jetty.util.resource,org.eclipse.jetty.io.nio,org.eclipse.jetty.server.session,javax.security.auth"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.servlet"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.io,org.eclipse.jetty.http,org.eclipse.jetty.server.nio,org.eclipse.jetty.server.handler,org.eclipse.jetty.util.resource,javax.servlet,org.eclipse.jetty.server.ssl,org.eclipse.jetty.util.log,javax.servlet.http,org.eclipse.jetty.util,org.eclipse.jetty.servlet.api,org.eclipse.jetty.util.component,org.eclipse.jetty.security,org.eclipse.jetty.server.session,org.eclipse.jetty.continuation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.thread.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.nio"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io.nio,org.eclipse.jetty.server,org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.http,org.eclipse.jetty.util.thread,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.jndi"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.naming,org.eclipse.jetty.util.log,org.eclipse.jetty.jndi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jndi.local"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.naming,org.eclipse.jetty.jndi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.plus.security"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,javax.naming,org.eclipse.jetty.security,org.eclipse.jetty.http.security,javax.sql,org.eclipse.jetty.plus.jndi,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.client.webdav"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.client,org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.client.security,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.io.nio"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.io,org.eclipse.jetty.util.log,org.eclipse.jetty.util.thread,org.eclipse.jetty.util.component,javax.net.ssl"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.statistic"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.annotations"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.webapp,org.eclipse.jetty.servlet,javax.servlet,org.eclipse.jetty.util.resource,org.eclipse.jetty.util.log,org.eclipse.jetty.util,org.eclipse.jetty.security,org.eclipse.jetty.plus.annotation,org.eclipse.jetty.server,javax.naming,org.eclipse.jetty.plus.jndi,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.servlet.api"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.rewrite.handler"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet.http,org.eclipse.jetty.server,org.eclipse.jetty.http,org.eclipse.jetty.util,javax.servlet,org.eclipse.jetty.server.handler,org.eclipse.jetty.util.log"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.session.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.security.jaspi"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,org.eclipse.jetty.server,org.eclipse.jetty.security,org.eclipse.jetty.security.authentication,javax.security.auth,javax.security.auth.callback,org.eclipse.jetty.util.log,org.eclipse.jetty.http.security,org.eclipse.jetty.security.jaspi.callback"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.server.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.server,org.eclipse.jetty.server.handler,org.eclipse.jetty.jmx"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.http.security"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util.log,org.eclipse.jetty.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.jmx"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.management.remote,org.eclipse.jetty.util.thread,javax.management,org.eclipse.jetty.util.component,org.eclipse.jetty.util.log,org.eclipse.jetty.util,javax.management.modelmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.log"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.jetty.util.ajax"/>
+      <attribute name="version" type="Version" value="7.2.0.v20101020"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jetty-bundle"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.eclipse.jetty.util,org.eclipse.jetty.util.log"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=com.sun.org.apache.commons.logging)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management.modelmbean)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management.remote)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.directory)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.spi)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net.ssl)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.auth)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.auth.callback)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.auth.login)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.auth.spi)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.auth.x500)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.cert)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.sasl)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.3.0)(!(version&gt;=2.6.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.3.0)(!(version&gt;=2.6.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.logging)(version&gt;=1.0.4))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.ajp)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.annotations)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.client)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.client.security)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.client.webdav)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.continuation)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy.bindings)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy.graph)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy.providers)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.deploy.util)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.http)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.http.security)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.io)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.io.bio)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.io.nio)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jndi)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jndi.factories)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jndi.java)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jndi.local)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.jsp)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.annotation)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.jaas)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.jaas.callback)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.jaas.spi)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.jndi)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.security)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.servlet)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.plus.webapp)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.rewrite.handler)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.security)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.security.authentication)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.security.jaspi)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.security.jaspi.callback)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.security.jaspi.modules)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.bio)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.handler)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.handler.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.nio)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.nio.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.session)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.session.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.server.ssl)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.servlet)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.servlet.api)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.servlet.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.servlets)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.servlets.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.ajax)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.component)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.component.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.log)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.log.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.resource)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.statistic)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.thread)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.util.thread.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.webapp)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.webapp.jmx)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.websocket)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.jetty.xml)(version&gt;=7.1.0)(!(version&gt;=8.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.mortbay.log)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.mortbay.util.ajax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.web.jsp)(version&gt;=0.8.1))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.web.service)(version&gt;=0.8.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.http)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.4.3))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="4ef728ca309f0a9721313f0b4c4a4a574b34d0adcbcb986c13bf2837ff029593"/>
+      <attribute name="url" value="org.ops4j.pax.web.pax-web-jsp/org.ops4j.pax.web.pax-web-jsp-0.8.1.jar"/>
+      <attribute name="size" type="Long" value="2170895"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ops4j.pax.web.jsp"/>
+      <attribute name="version" type="Version" value="0.8.1"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,org.apache.commons.logging,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.el"/>
+      <attribute name="version" type="Version" value="2.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.jsp"/>
+      <attribute name="version" type="Version" value="2.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,javax.servlet.http,javax.el,javax.servlet.jsp.el,javax.servlet.jsp.tagext"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.jsp.el"/>
+      <attribute name="version" type="Version" value="2.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet,javax.servlet.jsp,javax.servlet.http,javax.el"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.jsp.resources"/>
+      <attribute name="version" type="Version" value="2.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.jsp.tagext"/>
+      <attribute name="version" type="Version" value="2.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.servlet.jsp"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.jasper.compiler"/>
+      <attribute name="version" type="Version" value="6.0.18"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="org.apache.tools.ant,org.apache.juli.logging,org.apache.tools.ant.taskdefs,org.apache.tools.ant.types,javax.servlet.jsp.tagext,org.xml.sax,javax.el,javax.servlet,org.xml.sax.ext,javax.xml.parsers,org.xml.sax.helpers,javax.servlet.jsp,org.apache.jasper.el,javax.servlet.jsp.el,org.apache.el"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.jasper.el"/>
+      <attribute name="version" type="Version" value="6.0.18"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.el,javax.servlet.jsp.el"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.el"/>
+      <attribute name="version" type="Version" value="6.0.18"/>
+      <attribute name="bundle-symbolic-name" value="org.ops4j.pax.web.pax-web-jsp"/>
+      <attribute name="bundle-version" type="Version" value="0.8.1"/>
+      <directive name="uses" value="javax.el"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.el)(version&gt;=2.1.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.3.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.3.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.jsp)(version&gt;=2.1.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.jsp.el)(version&gt;=2.1.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.jsp.resources)(version&gt;=2.1.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.jsp.tagext)(version&gt;=2.1.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.resources)(version&gt;=2.3.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.commons.logging)(version&gt;=1.0.4))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.juli.logging)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.taskdefs)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.util)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.core.resources)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.core.runtime)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.jdt.core)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.jdt.core.dom)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.jdt.internal.compiler.apt.dispatch)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.jdt.internal.core)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.jdt.internal.core.builder)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ops4j.pax.web.jsp)(version&gt;=0.8.1))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.ext)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+</repository>

--- a/biz.aQute.resolve/testdata/repo7/index-gemini.xml
+++ b/biz.aQute.resolve/testdata/repo7/index-gemini.xml
@@ -1,0 +1,2432 @@
+<?xml version="1.0" encoding="utf-8"?>
+<repository increment="1439912495173" name="GeminiJPA" xmlns="http://www.osgi.org/xmlns/repository/v1.0.0">
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="javax.persistence"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.0.v200905011740"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="a8b12b78fe3d12eb65829136d2f3641533a27d4ee621c23e5f9cf1e64b79d2ad"/>
+      <attribute name="url" value="javax.persistence/javax.persistence-1.0.0.jar"/>
+      <attribute name="size" type="Long" value="71575"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.v200905011740"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.v200905011740"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.v200905011740"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.spi"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.v200905011740"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="javax.persistence"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.3.v201010191057"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="123cb78b6851f8d87e2350cf3a9cf6c0543f510a632d5e45fefdc0008ad1997a"/>
+      <attribute name="url" value="javax.persistence/javax.persistence-2.0.3.jar"/>
+      <attribute name="size" type="Long" value="126968"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.spi"/>
+      <attribute name="version" type="Version" value="2.0.3"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+      <directive name="uses" value="javax.persistence,javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence"/>
+      <attribute name="version" type="Version" value="2.0.3"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+      <directive name="uses" value="javax.persistence.criteria,javax.persistence.metamodel,javax.persistence.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.criteria"/>
+      <attribute name="version" type="Version" value="2.0.3"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+      <directive name="uses" value="javax.persistence.metamodel,javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.persistence.metamodel"/>
+      <attribute name="version" type="Version" value="2.0.3"/>
+      <attribute name="jpa" value="2.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jpa"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.persistence"/>
+      <attribute name="bundle-version" type="Version" value="2.0.3.v201010191057"/>
+      <directive name="uses" value="javax.persistence"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jpa)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.derby"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="fc73efe42c5b4bec7d7c4cfd66308af18e2315aa7ac5df449a78a2620afe9d93"/>
+      <attribute name="url" value="org.apache.derby/org.apache.derby-10.5.1.jar"/>
+      <attribute name="size" type="Long" value="2804415"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.authentication"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.client"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.client.am"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.database"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.io"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.jdbc"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.derby.vti"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.derby"/>
+      <attribute name="bundle-version" type="Version" value="10.5.1.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.spi)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto.spec)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.transaction)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.transaction.xa)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.gemini.dbaccess.derby"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f12eb44db860c82e690c824b67e70c23ed584594dbbd9307d1835035cf706deb"/>
+      <attribute name="url" value="org.eclipse.gemini.dbaccess.derby/org.eclipse.gemini.dbaccess.derby-1.0.0.jar"/>
+      <attribute name="size" type="Long" value="23211"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.gemini.dbaccess.derby"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.gemini.dbaccess.derby"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.derby.client.am)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.derby.jdbc)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jdbc)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.gemini.jpa"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="ed83ec8422d2654a0354fd512a44c934db8510b065bef8f99d35553278419881"/>
+      <attribute name="url" value="org.eclipse.gemini.jpa/org.eclipse.gemini.jpa-1.0.0.jar"/>
+      <attribute name="size" type="Long" value="128025"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.gemini.jpa"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.gemini.jpa"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.gemini.jpa.provider"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.gemini.jpa"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0.RELEASE"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.6.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.hooks.weaving)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.wiring)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.jdbc)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.jpa)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.asm)(bundle-version&gt;=2.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.antlr)(bundle-version&gt;=2.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.core)(bundle-version&gt;=2.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.jpa)(bundle-version&gt;=2.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.6))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.persistence.antlr"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="bfca0d85c00f44bd67b43a860e86c72ff0db64bf527567d5a689c3b0282cfba2"/>
+      <attribute name="url" value="org.eclipse.persistence.antlr/org.eclipse.persistence.antlr-2.3.2.jar"/>
+      <attribute name="size" type="Long" value="191919"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.antlr.runtime"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.antlr.runtime.tree"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.antlr.runtime.debug"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.antlr.runtime,org.eclipse.persistence.internal.libraries.antlr.runtime.tree,org.eclipse.persistence.internal.libraries.antlr.runtime.misc"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.antlr.runtime.misc"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.antlr.runtime.tree"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.antlr"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.antlr.runtime,org.eclipse.persistence.internal.libraries.antlr.runtime.misc,org.antlr.stringtemplate"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.antlr.stringtemplate)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.persistence.asm"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="253a6e65692462058eacc03ccf3fb52fb3072ca55c5aaf9b5cb623900590a363"/>
+      <attribute name="url" value="org.eclipse.persistence.asm/org.eclipse.persistence.asm-2.3.2.jar"/>
+      <attribute name="size" type="Long" value="272928"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.signature"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.commons"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.asm,org.eclipse.persistence.internal.libraries.asm.tree,org.eclipse.persistence.internal.libraries.asm.signature"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.tree"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.asm"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.tree.analysis"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.asm.tree,org.eclipse.persistence.internal.libraries.asm"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.xml"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.asm,org.xml.sax,org.xml.sax.helpers,org.xml.sax.ext,javax.xml.transform,javax.xml.transform.sax,javax.xml.transform.stream,org.eclipse.persistence.internal.libraries.asm.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.libraries.asm.util"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.asm"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.asm,org.eclipse.persistence.internal.libraries.asm.tree.analysis,org.eclipse.persistence.internal.libraries.asm.tree,org.eclipse.persistence.internal.libraries.asm.signature"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.ext)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.persistence.core"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="0f3ef6a8705bb4a021ca29e1f611f4eaa5f8aa046726d1cf0110d72d2488563d"/>
+      <attribute name="url" value="org.eclipse.persistence.core/org.eclipse.persistence.core-2.3.2.jar"/>
+      <attribute name="size" type="Long" value="4320298"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.tools.schemaframework"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.sequencing,org.eclipse.persistence.logging,org.eclipse.persistence.sessions.server,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings.structures,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.eis,org.eclipse.persistence.dynamic,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.expressions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.unmapped"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.oxm.record,org.xml.sax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.oracle.annotations"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.persistence,org.eclipse.persistence.annotations"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination.jms"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination.jms,javax.jms,org.eclipse.persistence.internal.sessions.coordination,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions.coordination,javax.naming,org.eclipse.persistence.sessions.coordination.broadcast,org.eclipse.persistence.platform.server"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.weaving"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.server"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sequencing,org.eclipse.persistence.history"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.expressions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.localization,org.eclipse.persistence.history,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.xml"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.xml.sax,org.eclipse.persistence.internal.oxm.record,org.eclipse.persistence.internal.oxm,org.w3c.dom,javax.xml.transform,javax.xml.validation,org.eclipse.persistence.oxm,org.eclipse.persistence.exceptions,org.eclipse.persistence.exceptions.i18n,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.history,org.eclipse.persistence.sessions.server,org.eclipse.persistence.expressions,org.eclipse.persistence.indirection,org.eclipse.persistence.platform.database,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.history,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.logging,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.config,org.eclipse.persistence.internal.helper.linkedlist,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.localization,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.descriptors.copying,javax.persistence,org.eclipse.persistence.annotations,org.eclipse.persistence.sessions.broker"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.parsing"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.expressions,org.eclipse.persistence.queries,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.converters"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.schema.model"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.xml.transform,org.eclipse.persistence.oxm,javax.xml.namespace"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.oracle.plsql"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.database.jdbc,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.mappings.structures"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.sap"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.platform.server,org.eclipse.persistence.transaction.sap,org.eclipse.persistence.sessions,javax.persistence.spi,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.codegen"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper,org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.login"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.sequencing,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.queries"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.mappings,org.eclipse.persistence.expressions,org.eclipse.persistence.descriptors,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.sessions,org.eclipse.persistence.indirection,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.history,org.eclipse.persistence.tools.profiler,org.eclipse.persistence.sequencing,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.localization,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.mappings.converters"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.history"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.expressions,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.history,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.eis.interactions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.resource.cci,javax.resource,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.eis,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.oxm,org.w3c.dom,org.eclipse.persistence.oxm.record,org.eclipse.persistence.internal.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.wls"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.transaction.wls,org.eclipse.persistence.internal.helper,javax.naming,org.eclipse.persistence.services.mbean,org.eclipse.persistence.internal.sessions,javax.management,org.eclipse.persistence.services.weblogic"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.was"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.transaction.was,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.security,org.eclipse.persistence.platform.database,org.eclipse.persistence.sessions,org.eclipse.persistence.services.websphere,org.eclipse.persistence.services.mbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.tools.profiler"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.helper"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.descriptors,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.weaving,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.indirection,org.eclipse.persistence.sessions,org.w3c.dom,javax.xml.namespace,javax.xml.datatype,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.tools.profiler,org.eclipse.persistence.exceptions,org.eclipse.persistence.platform.database,org.eclipse.persistence.platform.database.oracle.plsql,org.eclipse.persistence.logging,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.security,org.eclipse.persistence.tools.schemaframework,org.eclipse.persistence,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.helper.linkedlist"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.logging"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.jms"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.jms,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination.broadcast,org.eclipse.persistence.sessions.coordination.jms,org.eclipse.persistence.platform.server,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.sunas"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.platform.server,org.eclipse.persistence.transaction.sunas,org.eclipse.persistence.services.mbean,org.eclipse.persistence.internal.security,org.eclipse.persistence.services.glassfish,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.sequenced"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination.broadcast"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.coordination,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.session"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.project,org.eclipse.persistence.internal.sessions.factories.model.login,org.eclipse.persistence.internal.sessions.factories.model.pool,org.eclipse.persistence.internal.sessions.factories.model.platform,org.eclipse.persistence.internal.sessions.factories.model.log,org.eclipse.persistence.internal.sessions.factories.model.rcm,org.eclipse.persistence.internal.sessions.factories.model.event"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.xml.jaxp"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.platform.xml,javax.xml.namespace,javax.xml.transform,javax.xml.parsers,javax.xml.validation,javax.xml.transform.sax,org.w3c.dom,org.xml.sax,org.eclipse.persistence.oxm,javax.xml.transform.dom,javax.xml.xpath,javax.xml.transform.stream"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.jboss"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.codegen,org.eclipse.persistence.internal.security,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.oxm.schema,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.mappings.transformers,org.eclipse.persistence.queries,org.eclipse.persistence.oxm.mappings.converters,org.eclipse.persistence.platform.database.jdbc,org.eclipse.persistence.exceptions,org.eclipse.persistence.eis,org.eclipse.persistence.internal.oxm,javax.xml.namespace,org.w3c.dom,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.expressions,org.eclipse.persistence.eis.mappings,org.eclipse.persistence.internal.history,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.history,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.queries,org.eclipse.persistence.eis.adapters.xmlfile,org.eclipse.persistence.sequencing,org.eclipse.persistence.mappings.structures,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.platform.database.oracle.plsql,org.eclipse.persistence.internal.oxm.documentpreservation,org.eclipse.persistence.oxm.documentpreservation,org.xml.sax,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.internal.sessions.factories.model.project,org.eclipse.persistence.internal.sessions.factories.model.rcm.command,org.eclipse.persistence.internal.sessions.factories.model.log,org.eclipse.persistence.sessions.coordination.jms,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.sessions.factories.model.transport,org.eclipse.persistence.internal.sessions.factories.model,org.eclipse.persistence.internal.sessions.factories.model.transport.naming,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.sessions.factories.model.login,org.eclipse.persistence.tools.profiler,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.logging,javax.naming,org.eclipse.persistence.internal.sessions.factories.model.platform,org.eclipse.persistence.internal.sessions.factories.model.transport.discovery,org.eclipse.persistence.sessions.coordination.rmi,org.eclipse.persistence.internal.sessions.factories.model.session,org.eclipse.persistence.sessions.coordination.corba.sun,org.eclipse.persistence.internal.sessions.factories.model.pool,org.eclipse.persistence.internal.sessions.factories.model.sequencing,org.eclipse.persistence.internal.sessions.factories.model.rcm,org.eclipse.persistence.internal.sessions.factories.model.event,org.eclipse.persistence.internal.sessions.factories.model.property,org.eclipse.persistence.config,org.eclipse.persistence.sessions.factories,org.eclipse.persistence.platform.database.converters,org.eclipse.persistence.oxm.platform"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.corba.sun"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.omg.CORBA_2_3.portable,org.omg.CORBA,org.omg.CORBA.portable,org.eclipse.persistence.internal.sessions.coordination.corba,org.eclipse.persistence.sessions.coordination.corba,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.remote"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.history,org.eclipse.persistence.config,org.eclipse.persistence.internal.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.record.namespaces"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.xml.stream,javax.xml.namespace"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.foundation"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.oxm,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.indirection,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.mappings.transformers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.expressions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.expressions,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.history,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.history,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.platform.database,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.identitymaps"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.event"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.oracle.jdbc"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.helper.linkedlist"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.remote.corba.sun"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.remote,org.omg.CORBA,org.omg.CORBA.portable,org.omg.CORBA_2_3.portable"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.conversion"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.expressions,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.indirection,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.descriptors.changetracking,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.config,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.history"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.project"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.mappings.nullpolicy"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.internal.helper,org.w3c.dom,org.eclipse.persistence.oxm.record,org.xml.sax,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.eis.mappings"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.oxm.record,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.eis,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.expressions,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.indirection,org.w3c.dom,org.eclipse.persistence.annotations"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.history"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.history,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.exceptions,org.eclipse.persistence.logging,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.expressions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.documentpreservation"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.w3c.dom,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.oxm"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services.mbean"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.remote.rmi"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.sessions.remote"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.platform.xml,org.eclipse.persistence.internal.descriptors,org.w3c.dom,org.eclipse.persistence.internal.oxm.documentpreservation,org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.oxm,javax.xml.transform.dom,org.eclipse.persistence.oxm.record,org.xml.sax,org.eclipse.persistence.exceptions,javax.xml.transform,org.eclipse.persistence.internal.oxm.record,javax.xml.validation,javax.xml.namespace,org.eclipse.persistence.internal.security,org.eclipse.persistence.oxm.platform,org.eclipse.persistence.oxm.schema,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sessions.factories,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.oxm.accessor,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.queries,org.eclipse.persistence.annotations,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.config,org.xml.sax.ext,javax.xml.transform.sax,org.eclipse.persistence.oxm.attachment,javax.xml.transform.stream"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.indirection"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.descriptors.changetracking,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.localization"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.schema"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.xml,org.eclipse.persistence.oxm,org.w3c.dom,org.xml.sax,javax.xml.namespace"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.record.deferred"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.oxm.unmapped,org.eclipse.persistence.internal.security,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.oxm.record,org.eclipse.persistence.oxm.record,org.xml.sax,org.eclipse.persistence.mappings,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.internal.helper,javax.xml.namespace,org.eclipse.persistence.sessions,org.xml.sax.ext"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.eis.adapters.jms"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.eis.adapters.jms,javax.resource.cci,javax.jms,org.eclipse.persistence.eis,javax.resource,org.eclipse.persistence.eis.interactions,org.eclipse.persistence.internal.sessions,org.w3c.dom,org.eclipse.persistence.oxm.record"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.localization.i18n"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services.weblogic"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.services.mbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.session"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.was"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,org.eclipse.persistence.internal.security,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.descriptors.partitioning"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.database.partitioning,org.eclipse.persistence.platform.database"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.logging,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,javax.naming,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.transformers"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.security,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.dynamic"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.descriptors,org.eclipse.persistence.indirection,org.eclipse.persistence.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.dynamic,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.indirection"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.platform.database"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.eis.adapters.xmlfile"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,javax.resource.cci,org.eclipse.persistence.internal.eis.adapters.xmlfile,org.eclipse.persistence.eis,org.eclipse.persistence.sequencing,org.eclipse.persistence.eis.interactions,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.queries,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.sessions.coordination,org.eclipse.persistence.internal.localization,org.eclipse.persistence.sessions.coordination.rmi,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,javax.naming,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.broadcast"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions.coordination.broadcast,org.eclipse.persistence.internal.sessions.coordination,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sequencing"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions,org.eclipse.persistence.sessions.server"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services.websphere"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.services.mbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.security"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.crypto.spec,org.eclipse.persistence.internal.helper,javax.crypto,org.eclipse.persistence.exceptions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.indirection"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.indirection,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.mappings.transformers,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.localization,org.eclipse.persistence.eis.mappings,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors.changetracking"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.activation,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.oxm.record,org.eclipse.persistence.oxm.mappings.converters,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.oxm.record,org.eclipse.persistence.internal.queries,org.eclipse.persistence.mappings.transformers,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.helper,javax.xml.namespace,org.xml.sax,org.eclipse.persistence.descriptors,org.eclipse.persistence.oxm.schema,org.eclipse.persistence.exceptions,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.sessions.factories,org.eclipse.persistence.oxm.sequenced,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.platform.xml,org.w3c.dom,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.queries,org.eclipse.persistence.logging,org.eclipse.persistence.internal.oxm.record.deferred,org.xml.sax.ext,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.oxm.attachment,javax.mail.internet,javax.imageio.stream,javax.imageio,javax.xml.transform,javax.xml.transform.stream,javax.xml.datatype,org.eclipse.persistence.internal.oxm.conversion,org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.expressions,org.eclipse.persistence.eis,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.oxm.documentpreservation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination.corba.sun"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination.corba,org.omg.CORBA,org.eclipse.persistence.sessions.coordination.corba,org.eclipse.persistence.internal.sessions.coordination.corba.sun,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.exceptions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions.i18n,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.mappings,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.dynamic,org.eclipse.persistence.platform.database,javax.xml.namespace,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.oxm"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.mappings"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.xml,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.oxm.record,org.w3c.dom,javax.xml.namespace,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.oxm.mappings.converters,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.oxm.attachment,org.eclipse.persistence.mappings.converters,javax.activation,org.eclipse.persistence.internal.security,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.mappings.transformers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.dynamic"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.dynamic,org.eclipse.persistence.internal.libraries.asm,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.config,org.eclipse.persistence.descriptors,org.eclipse.persistence.tools.schemaframework,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.mappings,org.eclipse.persistence.sequencing,org.eclipse.persistence.platform.xml,org.eclipse.persistence.internal.sessions.factories,org.w3c.dom,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sessions.factories"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.corba"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination,org.omg.CORBA,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.platform.server,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.internal.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.factories"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.config,org.eclipse.persistence.mappings,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.codegen,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.sessions.factories,org.eclipse.persistence.mappings.xdb,org.eclipse.persistence.internal.history,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.expressions,org.eclipse.persistence.platform.database,org.eclipse.persistence.indirection,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.internal.queries,org.eclipse.persistence.history,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.eis.interactions,org.eclipse.persistence.eis,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sequencing,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.sessions.server,org.eclipse.persistence.logging,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions.factories.model,org.eclipse.persistence.tools.schemaframework,org.xml.sax,org.eclipse.persistence.platform.xml,org.eclipse.persistence.oxm.platform,org.w3c.dom,org.eclipse.persistence.internal.localization"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.interceptors"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.documentpreservation"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.oxm,org.w3c.dom,org.eclipse.persistence.oxm.record,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services.jboss"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.services.mbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.rcm.command"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services.websphere,javax.management.openmbean,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions.factories,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.helper,org.eclipse.persistence.logging,org.eclipse.persistence.sessions.server,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.helper.linkedlist,org.eclipse.persistence.tools.profiler"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.annotations"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.persistence,org.eclipse.persistence.config,org.eclipse.persistence.descriptors.partitioning"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.sunas"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination.corba"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,javax.naming,org.eclipse.persistence.internal.sessions.coordination.corba,org.eclipse.persistence.internal.sessions.coordination,org.omg.CORBA,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.sap"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.platform"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.oxm,org.eclipse.persistence.internal.oxm.record,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.descriptors"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.expressions,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.internal.weaving,org.eclipse.persistence.platform.database,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.history,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.config,org.eclipse.persistence.internal.queries,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.jpa.parsing,org.eclipse.persistence.internal.jpa.parsing.jpql,org.eclipse.persistence.tools.schemaframework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.transport"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.transport.naming,org.eclipse.persistence.internal.sessions.factories.model.transport.discovery"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.eis.cobol.helper"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.eis.cobol"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.transport.naming"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.eis.cobol"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.eis.cobol.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.localization"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.identitymaps"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.helper.linkedlist,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.security,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.localization,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.config,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.record"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.internal.oxm.record.deferred,org.eclipse.persistence.oxm.record,org.xml.sax,org.w3c.dom,org.xml.sax.ext,org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.oxm.record.namespaces,org.eclipse.persistence.platform.xml,org.eclipse.persistence.descriptors,javax.xml.namespace,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.helper,org.eclipse.persistence.exceptions,javax.xml.transform,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,javax.xml.validation,javax.xml.stream,javax.xml.stream.events,org.eclipse.persistence.mappings,javax.xml.transform.dom,javax.xml.transform.sax,javax.xml.parsers,javax.xml.transform.stream,org.eclipse.persistence.oxm.unmapped,org.eclipse.persistence.oxm.sequenced"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.wls"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.attachment"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.activation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.tools.file"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.platform"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.transport.discovery"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sequencing"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.helper,org.eclipse.persistence.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.changesets"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.exceptions,org.eclipse.persistence.platform.database.partitioning,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.platform.database,org.eclipse.persistence.platform.database.converters,org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.server,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.internal.security,org.eclipse.persistence,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.expressions,javax.naming,javax.sql,org.eclipse.persistence.sessions.server,org.eclipse.persistence.annotations,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.config,org.eclipse.persistence.logging,org.eclipse.persistence.history,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.sessions.changesets"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.rmi.iiop"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.rmi,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.sessions.coordination.rmi,org.eclipse.persistence.sessions.coordination,org.omg.CORBA,org.omg.CORBA_2_3.portable,org.omg.CORBA.portable,javax.rmi.CORBA"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.pool"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.login"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.jboss"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services.jboss,org.eclipse.persistence.logging,org.eclipse.persistence.platform.server,org.eclipse.persistence.services.mbean,org.eclipse.persistence.transaction.jboss,org.eclipse.persistence.sessions,javax.persistence.spi,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.descriptors"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.indirection,org.eclipse.persistence.mappings.transformers,org.eclipse.persistence.internal.security,org.eclipse.persistence.logging,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.annotations,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.descriptors.changetracking"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.jdbc"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper,org.eclipse.persistence.platform.database.oracle.plsql,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.sessions,org.eclipse.persistence.queries"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.converters"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.parsing.jpql.antlr"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.antlr.runtime,org.eclipse.persistence.internal.jpa.parsing.jpql,org.eclipse.persistence.internal.jpa.parsing"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.log"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.querykeys"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.expressions,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.security"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.annotations"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.descriptors,org.eclipse.persistence.config,org.eclipse.persistence.oxm,org.eclipse.persistence.mappings.transformers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.tools.schemaframework,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.exceptions.i18n"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.xdb"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings,org.eclipse.persistence.platform.xml,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.internal.platform.database,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.record"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.xml.sax.ext,org.eclipse.persistence.oxm,org.eclipse.persistence.internal.oxm.record,org.eclipse.persistence.internal.oxm,org.w3c.dom,org.xml.sax.helpers,org.xml.sax,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.oxm.documentpreservation,org.eclipse.persistence.platform.xml,org.eclipse.persistence.internal.sessions,javax.xml.namespace,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.oxm.unmapped,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.oxm.record.namespaces,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,javax.xml.validation,javax.xml.stream,javax.xml.stream.events"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.coordination.rmi"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.internal.helper,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.parsing.jpql"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.libraries.antlr.runtime,org.eclipse.persistence.internal.jpa.parsing.jpql.antlr,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.parsing,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.oc4j"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sessions,javax.management,javax.naming,org.eclipse.persistence.services.mbean,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.helper,org.eclipse.persistence.logging,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.databaseaccess,javax.persistence.spi,org.eclipse.persistence.internal.localization"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.databaseaccess"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,org.eclipse.persistence.platform.database,org.eclipse.persistence.mappings.structures,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.localization,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.queries,org.eclipse.persistence.platform.database.partitioning,org.eclipse.persistence.sequencing,org.eclipse.persistence.tools.schemaframework,org.eclipse.persistence.expressions,org.eclipse.persistence.platform.database.converters"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.transaction.jotm"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction,org.eclipse.persistence.internal.security,javax.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.eis"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.resource.cci,org.w3c.dom,org.eclipse.persistence.exceptions,javax.resource,org.eclipse.persistence.eis.interactions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.sessions.changesets,javax.naming,org.eclipse.persistence.internal.security,org.eclipse.persistence.oxm.record,org.eclipse.persistence.eis.mappings,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.exceptions.i18n,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.sessions.factories,org.eclipse.persistence.mappings.converters,javax.xml.namespace,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.queries,org.eclipse.persistence.sequencing"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.database.partitioning"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.sql,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.tools"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.eis.adapters.jms"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.resource.cci,org.eclipse.persistence,org.eclipse.persistence.exceptions,javax.jms,org.eclipse.persistence.eis,javax.naming"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.coordination.rmi"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.naming,org.eclipse.persistence.internal.sessions.coordination.rmi.iiop,org.eclipse.persistence.internal.sessions.coordination.rmi,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.coordination,javax.rmi,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.eis.adapters.xmlfile"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.resource.cci,org.eclipse.persistence,org.eclipse.persistence.exceptions,javax.naming,javax.resource,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.oxm,org.eclipse.persistence.eis,org.eclipse.persistence.internal.helper,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.services.glassfish"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.services,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.services.mbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.mappings.structures"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.eis,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.helper,org.eclipse.persistence.expressions,org.eclipse.persistence.descriptors,org.eclipse.persistence.platform.database,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.sessions,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.indirection"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.accessor"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.indirection"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.descriptors.changetracking"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.expressions.spatial"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.expressions,org.eclipse.persistence.expressions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.descriptors.invalidation"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.identitymaps"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.descriptors.copying"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.queries,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.remote"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.logging,org.eclipse.persistence.sessions.server,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.platform.database,org.eclipse.persistence.config,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.sequencing"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.platform.server.oc4j"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.transaction.oc4j,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.platform.database,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.broker"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sequencing,org.eclipse.persistence.logging,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.sequencing,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.exceptions,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.platform.server,org.eclipse.persistence.history,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.sessions.coordination"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.sequencing"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.oxm.schema"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.oxm,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.oxm.schema,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.internal.oxm.schema.model,javax.xml.namespace,org.eclipse.persistence.exceptions,org.eclipse.persistence.oxm.mappings,javax.xml.transform,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.sessions.remote.rmi.iiop"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.sessions.remote,javax.rmi,org.omg.CORBA,org.omg.CORBA_2_3.portable,org.omg.CORBA.portable,javax.rmi.CORBA"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.rcm"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.sessions.factories.model.rcm.command,org.eclipse.persistence.internal.sessions.factories.model.transport"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.descriptors.changetracking"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.sessions.changesets,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.descriptors.changetracking,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.queries"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.sessions.factories.model.property"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.config"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.queries"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.queries,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.annotations,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security,org.eclipse.persistence.exceptions,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.internal.sessions.remote,org.eclipse.persistence.sessions.remote,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.history,org.eclipse.persistence.tools.profiler,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.internal.jpa.parsing.jpql,org.eclipse.persistence.internal.history,org.eclipse.persistence.mappings.querykeys,org.eclipse.persistence.platform.database,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.mappings.structures"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.oxm.mappings.converters"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.core"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.oxm,org.eclipse.persistence.sessions,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.oxm,org.eclipse.persistence.exceptions,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.helper,org.eclipse.persistence.descriptors"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.activation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto.spec)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.imageio)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.imageio.stream)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.jms)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail.internet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management.openmbean)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.resource)(version&gt;=1.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.resource.cci)(version&gt;=1.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.rmi)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.rmi.CORBA)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.datatype)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.stream)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.stream.events)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.dom)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.validation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.xpath)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.persistence.internal.libraries.antlr.runtime)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.persistence.internal.libraries.asm)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.omg.CORBA)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.omg.CORBA.portable)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.omg.CORBA_2_3.portable)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.ext)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.antlr)(bundle-version&gt;=2.3.2))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.asm)(bundle-version&gt;=2.3.2))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.persistence.jpa"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="896f40be45ccb07d8d66914eba4dc5158d5f3cc5d29e09246b18a12cf9c89dfe"/>
+      <attribute name="url" value="org.eclipse.persistence.jpa/org.eclipse.persistence.jpa-2.3.2.jar"/>
+      <attribute name="size" type="Long" value="959339"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.queries"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.queries,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.platform.database.oracle.plsql,org.eclipse.persistence.internal.helper,org.eclipse.persistence.annotations,org.eclipse.persistence.platform.database.jdbc"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.jdbc"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.sql,org.eclipse.persistence.internal.jpa.transaction"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.structures"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.mappings.structures,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.helper,javax.persistence,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.descriptors,org.eclipse.persistence.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.copypolicy"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.descriptors.copying,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.xml"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.accessors.mappings"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.sequencing,org.eclipse.persistence.internal.jpa.metadata.mappings,org.eclipse.persistence.internal.jpa.metadata.converters,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.helper,javax.persistence,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.jpa.metadata.transformers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.deployment"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.helper,org.eclipse.persistence.jpa,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.listeners,javax.validation,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.logging,javax.persistence.spi,javax.persistence,javax.xml.parsers,org.xml.sax,org.eclipse.persistence.internal.jpa.deployment.xml.parser,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,javax.persistence.metamodel,javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.tables"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.tools.schemaframework,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.exceptions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.helper,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.internal.localization,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.sessions,org.eclipse.persistence.jpa,org.eclipse.persistence.descriptors.invalidation,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.jpa.parsing,org.eclipse.persistence.platform.database,org.eclipse.persistence.platform.database.oracle.plsql,org.eclipse.persistence.internal.jpa.parsing.jpql,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.queries,org.eclipse.persistence.internal.jpa.querydef,javax.persistence,javax.persistence.metamodel,org.eclipse.persistence.sessions.server,org.eclipse.persistence.internal.jpa.deployment,javax.persistence.criteria,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.config,javax.persistence.spi,org.eclipse.persistence.sessions.factories,org.eclipse.persistence.tools.schemaframework,javax.sql,org.eclipse.persistence.internal.jpa.transaction,org.eclipse.persistence.internal.jpa.jdbc,org.eclipse.persistence.sessions.coordination.jms,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.platform.server,org.eclipse.persistence.internal.jpa.metamodel,org.eclipse.persistence.tools.profiler,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.sessions.coordination,org.eclipse.persistence.sequencing,org.eclipse.persistence.platform.database.partitioning,org.eclipse.persistence.logging,org.eclipse.persistence.sessions.coordination.rmi,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.jpa.metadata,org.eclipse.persistence.internal.jpa.weaving,org.eclipse.persistence.platform.database.converters,javax.transaction,org.eclipse.persistence.history"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.accessors"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.partitioning,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.jpa.metadata.mappings,org.eclipse.persistence.internal.jpa.metadata.converters,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.transformers"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.mappings.transformers,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.sequencing"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.sequencing,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.sessions,javax.persistence,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.jpa.metadata.tables"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.listeners"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,javax.validation,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.indirection,javax.validation.groups,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.jpa.metadata.xml,javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.deployment.xml.parser"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.jdbc,javax.sql,org.eclipse.persistence.internal.jpa.deployment,javax.persistence.spi,org.xml.sax,org.eclipse.persistence.internal.helper,org.w3c.dom"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.mappings"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,javax.persistence,org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.helper"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metamodel"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.logging,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,javax.persistence.metamodel,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.localization,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.queries,org.eclipse.persistence.internal.dynamic,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.jpa,javax.persistence,org.eclipse.persistence.mappings.structures"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.accessors.classes"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.queries,org.eclipse.persistence.platform.database.oracle.annotations,org.eclipse.persistence.internal.jpa.metadata.structures,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata.copypolicy,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.mappings,org.eclipse.persistence.internal.jpa.metadata.changetracking,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,javax.persistence,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.internal.jpa.metadata.inheritance,org.eclipse.persistence.internal.jpa.metadata.listeners,org.eclipse.persistence.internal.jpa.metadata.locking,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.jpa.metadata.cache,org.eclipse.persistence.internal.jpa.metadata.additionalcriteria,org.eclipse.persistence.internal.jpa.metadata.multitenant,org.eclipse.persistence.internal.jpa.metadata.sequencing,org.eclipse.persistence.queries"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.exceptions,org.eclipse.persistence.annotations,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,javax.persistence,org.eclipse.persistence.internal.libraries.asm,org.eclipse.persistence.internal.libraries.asm.commons,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.jpa.metadata.xml"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.locking"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.inheritance,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.listeners,org.eclipse.persistence.config,org.eclipse.persistence.internal.jpa.metadata.mappings,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.helper,javax.persistence,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.internal.jpa.modelgen,org.eclipse.persistence.logging,org.eclipse.persistence.jpa.metadata,org.eclipse.persistence.internal.jpa.deployment,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.jpa,org.eclipse.persistence.internal.jpa.metadata.converters,javax.persistence.spi,org.eclipse.persistence.platform.database.converters,org.eclipse.persistence.internal.jpa.metadata.queries,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.jpa.metadata.sequencing,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sequencing,org.eclipse.persistence.sessions,org.eclipse.persistence.jpa.dynamic,org.eclipse.persistence.internal.jpa.metadata.partitioning,org.eclipse.persistence.dynamic"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.weaving"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.libraries.asm,org.eclipse.persistence.internal.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.libraries.asm.commons,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,javax.persistence.spi,org.eclipse.persistence.internal.weaving,org.eclipse.persistence.descriptors,org.eclipse.persistence.indirection,org.eclipse.persistence.internal.indirection,org.eclipse.persistence.mappings.foundation,org.eclipse.persistence.descriptors.changetracking"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.jpa.metadata"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.logging,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.xml"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.mappings,org.eclipse.persistence.internal.databaseaccess,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings.converters,org.xml.sax,org.eclipse.persistence.internal.jpa.metadata.queries,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.partitioning,org.eclipse.persistence.internal.jpa.metadata.sequencing,org.eclipse.persistence.internal.jpa.metadata.listeners,org.eclipse.persistence.internal.jpa.metadata.mappings,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.jpa.metadata.converters,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.oxm.mappings.nullpolicy,org.eclipse.persistence.internal.jpa.metadata.structures,org.eclipse.persistence.internal.jpa.metadata.copypolicy,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.oxm,org.eclipse.persistence.descriptors,org.eclipse.persistence.oxm.platform,org.eclipse.persistence.oxm.schema,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.transformers,org.eclipse.persistence.internal.jpa.metadata.locking,org.eclipse.persistence.internal.jpa.metadata.cache,org.eclipse.persistence.internal.jpa.metadata.inheritance,org.eclipse.persistence.internal.jpa.metadata.additionalcriteria,org.eclipse.persistence.oxm.mappings,org.eclipse.persistence.internal.jpa.metadata.multitenant,org.eclipse.persistence.internal.jpa.metadata.changetracking,javax.xml.parsers,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa,javax.xml.transform,javax.xml.transform.stream,javax.xml.validation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.cache"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.exceptions,org.eclipse.persistence.annotations,org.eclipse.persistence.config,org.eclipse.persistence.descriptors.invalidation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.inheritance"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.jpa.dynamic"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.identitymaps,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.dynamic,org.eclipse.persistence.sessions.server,org.eclipse.persistence.sessions,javax.persistence,org.eclipse.persistence.jpa"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.jpa"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="javax.persistence,org.eclipse.persistence.sessions.broker,org.eclipse.persistence.sessions.server,org.eclipse.persistence.expressions,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.sessions,org.eclipse.persistence.queries,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.localization,org.eclipse.persistence.sessions.factories,org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.weaving,org.eclipse.persistence.internal.jpa.deployment,javax.persistence.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.partitioning"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.descriptors.partitioning,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.security,org.eclipse.persistence.exceptions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.additionalcriteria"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.multitenant"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.sessions.server,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.inheritance,org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.config,org.eclipse.persistence.internal.jpa.metadata.columns,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.tools.weaving.jpa"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.logging,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper,org.apache.tools.ant.types,org.apache.tools.ant,org.eclipse.persistence.internal.jpa.deployment,org.eclipse.persistence.jpa,org.eclipse.persistence.internal.jpa,javax.persistence.spi,org.eclipse.persistence.internal.jpa.weaving"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.changetracking"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.descriptors.changetracking,org.eclipse.persistence.annotations,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.jpa.metadata.accessors.objects"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.querydef"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.expressions,javax.persistence.criteria,javax.persistence.metamodel,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.helper,org.eclipse.persistence.internal.queries,org.eclipse.persistence.queries,org.eclipse.persistence.internal.expressions,org.eclipse.persistence.internal.jpa.metamodel,javax.persistence,org.eclipse.persistence.internal.security,org.eclipse.persistence.sessions,org.eclipse.persistence.descriptors,org.eclipse.persistence.internal.sessions"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.converters"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.mappings,org.eclipse.persistence.internal.jpa.metadata.accessors.mappings,org.eclipse.persistence.mappings.converters,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.exceptions,javax.persistence,org.eclipse.persistence.internal.security,org.eclipse.persistence.internal.jpa.metadata.accessors.classes,org.eclipse.persistence.mappings.foundation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.metadata.columns"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.internal.jpa.metadata.accessors,org.eclipse.persistence.internal.jpa.metadata,org.eclipse.persistence.internal.jpa.metadata.xml,org.eclipse.persistence.internal.jpa.metadata.tables,org.eclipse.persistence.internal.jpa.metadata.accessors.objects,org.eclipse.persistence.internal.helper,org.eclipse.persistence.mappings,org.eclipse.persistence.exceptions,javax.persistence,org.eclipse.persistence.annotations,org.eclipse.persistence.descriptors"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.modelgen"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.persistence.internal.jpa.transaction"/>
+      <attribute name="version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.persistence.jpa"/>
+      <attribute name="bundle-version" type="Version" value="2.3.2.v20111125-r10461"/>
+      <directive name="uses" value="org.eclipse.persistence.exceptions,org.eclipse.persistence.internal.jpa,org.eclipse.persistence.internal.localization,org.eclipse.persistence.internal.sessions,javax.persistence,org.eclipse.persistence.transaction,org.eclipse.persistence.sessions,org.eclipse.persistence.internal.jpa.jdbc,javax.transaction,javax.transaction.xa"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.criteria)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.metamodel)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="jpa" value="2.0"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.persistence.spi)(version&gt;=1.1.0)(!(version&gt;=2.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.transaction.xa)(version&gt;=1.1.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.validation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.validation.groups)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.validation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.annotations)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.config)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.descriptors)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.descriptors.changetracking)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.descriptors.copying)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.descriptors.invalidation)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.descriptors.partitioning)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.dynamic)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.exceptions)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.expressions)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.history)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.indirection)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.databaseaccess)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.descriptors)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.dynamic)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.expressions)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.helper)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.identitymaps)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.indirection)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.jpa.parsing)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.jpa.parsing.jpql)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.persistence.internal.libraries.asm)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.persistence.internal.libraries.asm.commons)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.localization)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.queries)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.security)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.sessions)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.internal.weaving)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.logging)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.mappings)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.mappings.converters)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.mappings.foundation)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.mappings.structures)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.mappings.transformers)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.oxm)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.oxm.mappings)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.oxm.mappings.nullpolicy)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.oxm.platform)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.oxm.schema)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database.converters)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database.jdbc)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database.oracle.annotations)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database.oracle.plsql)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.database.partitioning)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.platform.server)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.queries)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sequencing)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.broker)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.coordination)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.coordination.jms)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.coordination.rmi)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.factories)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.sessions.server)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.tools.profiler)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.tools.schemaframework)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.persistence.transaction)(version&gt;=2.3.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.core)(bundle-version&gt;=2.3.2))"/>
+      <directive name="visibility" value="reexport"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.persistence.asm)(bundle-version&gt;=2.3.2))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.h2"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="990b94cdfc89987281af4168fc2f6c9067be96a8533f5a6eb0f33da4d30d3e4b"/>
+      <attribute name="url" value="org.h2/org.h2-1.3.174.jar"/>
+      <attribute name="size" type="Long" value="1605870"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.api"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.constant"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.fulltext"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.jdbc"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.jdbcx"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.tools"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.util"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.value"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.bnf"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.h2.bnf.context"/>
+      <attribute name="version" type="Version" value="1.3.174"/>
+      <attribute name="bundle-symbolic-name" value="org.h2"/>
+      <attribute name="bundle-version" type="Version" value="1.3.174"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.spi)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net.ssl)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.transaction.xa)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.analysis)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.analysis.standard)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.document)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.index)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.queryParser)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.search)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.store)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.lucene.util)(version&gt;=3.0.0)(!(version&gt;=3.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.vividsolutions.jts.geom)(version&gt;=1.13.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.vividsolutions.jts.io)(version&gt;=1.13.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.api)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.fulltext)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.jdbcx)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.tools)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.util)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.h2.value)(version&gt;=1.3.174)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jdbc)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.6.0)(!(version&gt;=1.7.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+</repository>

--- a/biz.aQute.resolve/testdata/repo7/index-local.xml
+++ b/biz.aQute.resolve/testdata/repo7/index-local.xml
@@ -1,0 +1,4659 @@
+<?xml version="1.0" encoding="utf-8"?>
+<repository increment="1439912495357" name="Local" xmlns="http://www.osgi.org/xmlns/repository/v1.0.0">
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="biz.aQute.bnd.annotation"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="1e9d608b25fe781bfc8d40d66b6fee4dfb394a491b895d9024db3c0f82f46607"/>
+      <attribute name="url" value="biz.aQute.bnd.annotation/biz.aQute.bnd.annotation-1.51.1.jar"/>
+      <attribute name="size" type="Long" value="35534"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation.component"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation.metatype"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.test"/>
+      <attribute name="version" type="Version" value="1.51.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd.annotation"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+      <directive name="uses" value="aQute.libg.reporter,junit.framework,javax.xml.namespace,javax.xml.xpath,javax.xml.parsers,org.w3c.dom"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.libg.reporter)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.xpath)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=junit.framework)(version&gt;=3.8.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="biz.aQute.bnd"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.51.1"/>
+      <directive name="singleton" value="true"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="1043c7ef2aec4eb3f010affde714f4af3691f41860e1eb860dbd32ff8515738e"/>
+      <attribute name="url" value="biz.aQute.bnd/biz.aQute.bnd-1.51.1.jar"/>
+      <attribute name="size" type="Long" value="1252615"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service"/>
+      <attribute name="version" type="Version" value="1.44.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service.url"/>
+      <attribute name="version" type="Version" value="1.51.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service.action"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.bindex"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.coordinator"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bnd"/>
+      <attribute name="bundle-version" type="Version" value="1.51.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=aQute.bnd.service.url)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.xpath)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=junit.framework)(version&gt;=3.8.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.bindex)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component.annotations)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.coordinator)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.ui.ide)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jface.text)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.ui.workbench.texteditor)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.ui.editors)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.ui)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.debug.ui)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jdt.core)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jdt.ui)(bundle-version&gt;=3.3.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.core.runtime)(bundle-version&gt;=3.2.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jdt.launching)(bundle-version&gt;=3.2.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jdt.debug.ui)(bundle-version&gt;=3.2.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(&amp;(osgi.wiring.bundle=org.eclipse.jdt.junit)(bundle-version&gt;=3.2.0)(!(bundle-version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(osgi.wiring.bundle=org.junit)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(osgi.wiring.bundle=org.eclipse.osgi.services)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(osgi.wiring.bundle=org.apache.ant)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.bundle">
+      <directive name="filter" value="(osgi.wiring.bundle=org.eclipse.ui.console)"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="biz.aQute.bndlib"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="a2b831780c4416bcd48e0d3330e23eafa1fc6540263f51e7420662c5fb038a98"/>
+      <attribute name="url" value="biz.aQute.bndlib/biz.aQute.bndlib-1.51.0.jar"/>
+      <attribute name="size" type="Long" value="931471"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation.metatype"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.annotation.component"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.lib.osgi"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.bnd.annotation,aQute.libg.version,aQute.bnd.service,aQute.libg.header,aQute.bnd.annotation.metatype,aQute.libg.reporter,aQute.libg.sed,aQute.libg.qtokens"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.build"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.bnd.service,aQute.lib.osgi,aQute.libg.reporter,aQute.libg.version,aQute.bnd.help,aQute.libg.header,aQute.bnd.service.action,aQute.libg.sed,javax.naming"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service"/>
+      <attribute name="version" type="Version" value="1.44.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.lib.osgi,aQute.libg.reporter,aQute.bnd.build,aQute.libg.version"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service.url"/>
+      <attribute name="version" type="Version" value="1.51.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.service.action"/>
+      <attribute name="version" type="Version" value="1.43.1"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.bnd.build"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.bnd.help"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.lib.osgi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.reporter"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.version"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.sed"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.header"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="aQute.libg.reporter,aQute.libg.qtokens"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.qtokens"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="aQute.libg.sax"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="org.xml.sax,javax.xml.transform,javax.xml.parsers,javax.xml.transform.sax"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.bindex"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.coordinator"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.bndlib"/>
+      <attribute name="bundle-version" type="Version" value="1.51.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.libg.sax)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.transform.stream)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.xpath)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=junit.framework)(version&gt;=3.8.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.bindex)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="biz.aQute.junit"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="d1e25e32acfac0ec000d439c1d564201d02e130eabfa9099d556d6732b25eb66"/>
+      <attribute name="url" value="biz.aQute.junit/biz.aQute.junit-1.0.0.jar"/>
+      <attribute name="size" type="Long" value="67008"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="biz.aQute.junit"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="biz.aQute.junit"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="junit.framework"/>
+      <attribute name="version" type="Version" value="3.8.0"/>
+      <attribute name="bundle-symbolic-name" value="biz.aQute.junit"/>
+      <attribute name="bundle-version" type="Version" value="1.0.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=junit.framework)(version&gt;=3.8.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="biz.aQute.launcher"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="0428404be25dbad3647b7db55785d3da29c291abc5c93c00b7ab43f51d365b65"/>
+      <attribute name="url" value="biz.aQute.launcher/biz.aQute.launcher-1.0.1.jar"/>
+      <attribute name="size" type="Long" value="56566"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="biz.aQute.launcher"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="biz.aQute.launcher"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.bnd.build)(version&gt;=1.43.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.bnd.service)(version&gt;=1.44.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.lib.io)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.lib.osgi)(version&gt;=1.43.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.libg.generics)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.launch)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.permissionadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="bndtools.runtime.eclipse.applaunch"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.1.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="9d35ca2e088cdcdd09a3c45099352477b635dda5959b4a5f6d406e8763ed3f7f"/>
+      <attribute name="url" value="bndtools.runtime.eclipse.applaunch/bndtools.runtime.eclipse.applaunch-0.1.0.jar"/>
+      <attribute name="size" type="Long" value="14079"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="bndtools.runtime.eclipse.applaunch"/>
+      <attribute name="bundle-version" type="Version" value="0.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="bndtools.runtime.eclipse.applaunch"/>
+      <attribute name="bundle-version" type="Version" value="0.1.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.eclipse.osgi.service.runnable)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="ch.qos.logback.classic"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="5d1111b872a8be8ac8f9e9876b70afcd0d6967dc6a1d4be4087cd6eb5c88cf6b"/>
+      <attribute name="url" value="ch.qos.logback.classic/ch.qos.logback.classic-1.0.13.jar"/>
+      <attribute name="size" type="Long" value="264595"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.util"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.classic,ch.qos.logback.core,ch.qos.logback.classic.gaffer,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util,ch.qos.logback.classic.joran,ch.qos.logback.classic.selector,ch.qos.logback.core.filter,ch.qos.logback.core.net.ssl,ch.qos.logback.classic.boolex,ch.qos.logback.classic.encoder,javax.naming,ch.qos.logback.classic.spi,org.slf4j.spi,ch.qos.logback.core.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.jul"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.classic,ch.qos.logback.core.spi,ch.qos.logback.core,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.joran.action"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.classic.turbo,ch.qos.logback.classic.util,ch.qos.logback.classic,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.joran.action,ch.qos.logback.core.util,org.xml.sax,ch.qos.logback.classic.net,ch.qos.logback.classic.boolex,javax.naming,ch.qos.logback.classic.jmx,javax.management,ch.qos.logback.core.spi,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.html"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.html,ch.qos.logback.core,ch.qos.logback.core.helpers,ch.qos.logback.classic.spi,ch.qos.logback.classic,ch.qos.logback.core.pattern,ch.qos.logback.classic.pattern"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.gaffer"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core.spi,groovy.lang,org.codehaus.groovy.reflection,org.codehaus.groovy.runtime,ch.qos.logback.core,org.codehaus.groovy.runtime.callsite,ch.qos.logback.core.joran.spi,org.codehaus.groovy.runtime.typehandling,ch.qos.logback.classic,ch.qos.logback.classic.turbo,ch.qos.logback.classic.jmx,javax.management,org.slf4j,ch.qos.logback.classic.net,org.codehaus.groovy.runtime.wrappers,ch.qos.logback.core.util,org.codehaus.groovy.control.customizers,ch.qos.logback.classic.encoder,org.codehaus.groovy.control,ch.qos.logback.core.joran.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.helpers"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="javax.servlet,org.slf4j,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.pattern"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core,ch.qos.logback.core.boolex,ch.qos.logback.classic.spi,ch.qos.logback.core.pattern,ch.qos.logback.core.util,ch.qos.logback.classic,org.slf4j,ch.qos.logback.classic.util,ch.qos.logback.core.net"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.encoder"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.classic,ch.qos.logback.core.pattern,ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.net"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,javax.naming,javax.jms,ch.qos.logback.core.net,ch.qos.logback.classic.spi,ch.qos.logback.classic.util,ch.qos.logback.classic,org.slf4j,ch.qos.logback.core,ch.qos.logback.core.helpers,ch.qos.logback.core.pattern,ch.qos.logback.core.boolex,ch.qos.logback.classic.boolex,javax.net,ch.qos.logback.core.net.ssl,javax.net.ssl,ch.qos.logback.core.joran.spi,ch.qos.logback.classic.joran,ch.qos.logback.core.util,ch.qos.logback.classic.pattern"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.log4j"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.helpers,ch.qos.logback.classic,ch.qos.logback.core,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.turbo"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.classic,org.slf4j,ch.qos.logback.core.status,ch.qos.logback.classic.util,ch.qos.logback.core,ch.qos.logback.classic.gaffer,ch.qos.logback.core.joran.spi,ch.qos.logback.classic.joran,ch.qos.logback.core.joran.event,ch.qos.logback.core.joran.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.db.names"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.jmx"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.status,ch.qos.logback.classic.util,ch.qos.logback.classic,ch.qos.logback.core,javax.management,ch.qos.logback.core.joran.spi,ch.qos.logback.classic.joran,ch.qos.logback.core.util,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.classic.spi,ch.qos.logback.core.status,ch.qos.logback.core.encoder,ch.qos.logback.classic.encoder,org.slf4j,org.slf4j.spi,ch.qos.logback.core.spi,ch.qos.logback.classic.util,ch.qos.logback.classic.turbo,ch.qos.logback.core.pattern,ch.qos.logback.classic.pattern.color,ch.qos.logback.core.pattern.parser,ch.qos.logback.classic.pattern,ch.qos.logback.core.pattern.color,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.selector"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,javax.naming,ch.qos.logback.classic.util,ch.qos.logback.classic,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util,ch.qos.logback.classic.joran"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.pattern.color"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.classic,ch.qos.logback.classic.spi,ch.qos.logback.core.pattern.color"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.boolex"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="groovy.lang,org.codehaus.groovy.runtime.typehandling,org.codehaus.groovy.reflection,org.codehaus.groovy.runtime,ch.qos.logback.classic.spi,org.codehaus.groovy.runtime.callsite,ch.qos.logback.core,ch.qos.logback.core.boolex,ch.qos.logback.core.util,org.codehaus.groovy.control,ch.qos.logback.classic,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.filter"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.filter,ch.qos.logback.classic,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.net.server"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.classic,ch.qos.logback.core.net.server,ch.qos.logback.core,ch.qos.logback.classic.spi,ch.qos.logback.core.util,ch.qos.logback.classic.net,ch.qos.logback.core.spi,javax.net,ch.qos.logback.core.net.ssl,javax.net.ssl"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.joran"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.joran.conditional,ch.qos.logback.classic.util,ch.qos.logback.classic.sift,ch.qos.logback.classic.joran.action,ch.qos.logback.core.joran,ch.qos.logback.core.joran.action,ch.qos.logback.core.joran.spi,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.db"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.classic.db.names,ch.qos.logback.core.db,ch.qos.logback.classic,ch.qos.logback.classic.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.sift"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.joran.event,ch.qos.logback.core.sift,ch.qos.logback.classic.spi,ch.qos.logback.classic.util,ch.qos.logback.classic,ch.qos.logback.classic.selector,ch.qos.logback.core.util,ch.qos.logback.core.joran.spi,ch.qos.logback.core.joran.action,org.xml.sax,org.slf4j,ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.selector.servlet"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="javax.servlet,javax.naming,ch.qos.logback.classic.util,ch.qos.logback.classic,ch.qos.logback.classic.selector,org.slf4j"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.classic.spi"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.spi,ch.qos.logback.classic,org.slf4j,org.slf4j.spi,ch.qos.logback.classic.util,org.slf4j.helpers,sun.reflect,ch.qos.logback.classic.turbo"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j.impl"/>
+      <attribute name="version" type="Version" value="1.7.5"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.classic"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="org.slf4j.spi,ch.qos.logback.core.status,ch.qos.logback.classic.util,org.slf4j.helpers,ch.qos.logback.classic,ch.qos.logback.core,ch.qos.logback.classic.selector,ch.qos.logback.core.joran.spi,org.slf4j,ch.qos.logback.core.util"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.boolex)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.db)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.db.names)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.encoder)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.filter)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.gaffer)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.helpers)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.html)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.jmx)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.joran)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.joran.action)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.jul)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.log4j)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.net)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.net.server)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.pattern)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.pattern.color)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.selector)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.selector.servlet)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.sift)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.spi)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.turbo)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.classic.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.boolex)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.db)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.encoder)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.filter)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.helpers)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.html)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.action)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.conditional)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.event)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.spi)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net.server)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net.ssl)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern.color)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern.parser)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.read)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.rolling)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.rolling.helper)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.sift)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.spi)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.status)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=groovy.lang)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.jms)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net.ssl)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.control)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.control.customizers)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.reflection)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.runtime)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.runtime.callsite)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.runtime.typehandling)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.codehaus.groovy.runtime.wrappers)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j)(version&gt;=1.7.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.helpers)(version&gt;=1.7.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.impl)(version&gt;=1.7.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.spi)(version&gt;=1.7.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=sun.reflect)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="ch.qos.logback.core"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="826346f654c9f5fa5a47301310c4eaf71ab2311f6a4205b5fdb4e91a6f8091ed"/>
+      <attribute name="url" value="ch.qos.logback.core/ch.qos.logback.core-1.0.13.jar"/>
+      <attribute name="size" type="Long" value="418870"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.spi"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.status,ch.qos.logback.core.helpers,ch.qos.logback.core.filter"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.status"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.spi,ch.qos.logback.core.util,ch.qos.logback.core.helpers,javax.servlet,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.db.dialect"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.property"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.status,ch.qos.logback.core.filter,ch.qos.logback.core.helpers,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util,ch.qos.logback.core.recovery,ch.qos.logback.core.encoder"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.encoder"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran.action"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core,ch.qos.logback.core.boolex,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util,org.xml.sax,ch.qos.logback.core.joran.util,ch.qos.logback.core.joran.event,ch.qos.logback.core.pattern.util,ch.qos.logback.core.status"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran.spi"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core,org.xml.sax,ch.qos.logback.core.joran.event,ch.qos.logback.core.util,ch.qos.logback.core.joran.action,ch.qos.logback.core.status"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran.event"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="org.xml.sax,org.xml.sax.helpers,ch.qos.logback.core.status,ch.qos.logback.core.spi,javax.xml.parsers,ch.qos.logback.core,ch.qos.logback.core.joran.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.net"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,javax.net,ch.qos.logback.core.net.ssl,ch.qos.logback.core,javax.net.ssl,ch.qos.logback.core.util,javax.naming,javax.mail,ch.qos.logback.core.helpers,ch.qos.logback.core.sift,javax.mail.internet,ch.qos.logback.core.pattern,ch.qos.logback.core.boolex"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core.spi,ch.qos.logback.core.joran.event,ch.qos.logback.core,ch.qos.logback.core.joran.util,ch.qos.logback.core.joran.spi,org.xml.sax,ch.qos.logback.core.joran.action"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.boolex"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,org.codehaus.janino,ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.rolling"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core,ch.qos.logback.core.rolling.helper,ch.qos.logback.core.spi,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.subst"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.util,ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.recovery"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core,ch.qos.logback.core.net"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.db"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="javax.naming,javax.sql,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.joran.util,ch.qos.logback.core.joran.action,ch.qos.logback.core.util,org.xml.sax,ch.qos.logback.core.spi,ch.qos.logback.core.db.dialect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.sift"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.joran.event,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.spi,ch.qos.logback.core.helpers,ch.qos.logback.core.util,ch.qos.logback.core.joran,ch.qos.logback.core.joran.action"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.read"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.helpers,ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.pattern"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core,ch.qos.logback.core.status,ch.qos.logback.core.pattern.parser,ch.qos.logback.core.encoder"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.pattern.parser"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core.spi,ch.qos.logback.core.pattern,ch.qos.logback.core,ch.qos.logback.core.util,ch.qos.logback.core.pattern.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.html"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.pattern,ch.qos.logback.core,ch.qos.logback.core.pattern.parser"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran.conditional"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.joran.event,ch.qos.logback.core.spi,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.joran.action,ch.qos.logback.core.util,org.xml.sax,org.codehaus.janino,org.codehaus.commons.compiler"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.helpers"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.filter"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.boolex"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.layout"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.pattern.util"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.net.ssl"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="javax.net,javax.net.ssl,ch.qos.logback.core.util,ch.qos.logback.core.spi,ch.qos.logback.core.joran.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.net.server"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,javax.net,ch.qos.logback.core,ch.qos.logback.core.util,ch.qos.logback.core.net.ssl,javax.net.ssl"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.joran.util"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.status,ch.qos.logback.core,ch.qos.logback.core.joran.spi,ch.qos.logback.core.util,ch.qos.logback.core.spi"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.util"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core,ch.qos.logback.core.rolling,ch.qos.logback.core.subst,ch.qos.logback.core.status,ch.qos.logback.core.helpers"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.pattern.color"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.pattern"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="ch.qos.logback.core.rolling.helper"/>
+      <attribute name="version" type="Version" value="1.0.13"/>
+      <attribute name="bundle-symbolic-name" value="ch.qos.logback.core"/>
+      <attribute name="bundle-version" type="Version" value="1.0.13"/>
+      <directive name="uses" value="ch.qos.logback.core.spi,ch.qos.logback.core.status,ch.qos.logback.core.util,ch.qos.logback.core.pattern,ch.qos.logback.core.pattern.util,ch.qos.logback.core,ch.qos.logback.core.pattern.parser,ch.qos.logback.core.rolling"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.boolex)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.db)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.db.dialect)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.encoder)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.filter)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.helpers)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.html)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.action)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.conditional)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.event)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.spi)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.joran.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.layout)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net.server)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.net.ssl)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern.color)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern.parser)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.pattern.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.property)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.read)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.recovery)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.rolling)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.rolling.helper)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.sift)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.spi)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.status)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.subst)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=ch.qos.logback.core.util)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.mail.internet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net.ssl)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.codehaus.commons.compiler)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.codehaus.janino)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.fusesource.jansi)(version&gt;=1.9.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="com.google.guava"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="3351ddb25f28f848318bfac44fbcbbe4a804b615466098cb85cc0e85c0f9622c"/>
+      <attribute name="url" value="com.google.guava/com.google.guava-11.0.1.jar"/>
+      <attribute name="size" type="Long" value="1675518"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.annotations"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.base"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.cache"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.collect"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.eventbus"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.hash"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.io"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.math"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.net"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.primitives"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.util.concurrent"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.base.internal"/>
+      <attribute name="version" type="Version" value="11.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="11.0.1"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="com.google.guava"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="ec7f9928bc0cd5ca36b32bc3965055c49843d69ac1a9ccf380fdcc3f686af7fc"/>
+      <attribute name="url" value="com.google.guava/com.google.guava-12.0.1.jar"/>
+      <attribute name="size" type="Long" value="1795932"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.net"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.base,javax.annotation,com.google.common.hash,com.google.common.io,com.google.common.primitives,com.google.common.collect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.collect"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.base,javax.annotation,com.google.common.primitives,com.google.common.math"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.primitives"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="javax.annotation,com.google.common.base,sun.misc"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.base"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="javax.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.cache"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.collect,com.google.common.util.concurrent,javax.annotation,com.google.common.base,com.google.common.primitives"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.eventbus"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.collect,com.google.common.base,com.google.common.cache"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.util.concurrent"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.base,javax.annotation,com.google.common.collect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.hash"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.base,com.google.common.math,com.google.common.primitives,javax.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.io"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.hash,com.google.common.base,javax.annotation,com.google.common.primitives"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.reflect"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="javax.annotation,com.google.common.base,com.google.common.collect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.math"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+      <directive name="uses" value="com.google.common.base,javax.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.google.common.annotations"/>
+      <attribute name="version" type="Version" value="12.0.1"/>
+      <attribute name="bundle-symbolic-name" value="com.google.guava"/>
+      <attribute name="bundle-version" type="Version" value="12.0.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.annotation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=sun.misc)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="jackson-annotations"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="fa5bbab0835edaf7ab4db5b7b5084e93fb1946e4de7244ef5bcc95064027b7eb"/>
+      <attribute name="url" value="jackson-annotations/jackson-annotations-2.0.0.jar"/>
+      <attribute name="size" type="Long" value="35131"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="jackson-annotations"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="jackson-annotations"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.annotation"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-annotations"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="jackson-core"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="b6808cd4a8e6ad1da7ca4e432eb1d77092d3cb7807259431df91e22c2187edd3"/>
+      <attribute name="url" value="jackson-core/jackson-core-2.0.0.jar"/>
+      <attribute name="size" type="Long" value="200799"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core.io,com.fasterxml.jackson.core.json,com.fasterxml.jackson.core.util,com.fasterxml.jackson.core.sym,com.fasterxml.jackson.core.format,com.fasterxml.jackson.core.type"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.base"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.core.json,com.fasterxml.jackson.core.util,com.fasterxml.jackson.core.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.format"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.core.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.io"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.core.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.json"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.core.io,com.fasterxml.jackson.core.sym,com.fasterxml.jackson.core.format,com.fasterxml.jackson.core.util,com.fasterxml.jackson.core.base"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.sym"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.type"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.core.util"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-core"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.core.io"/>
+    </capability>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="jackson-databind"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="842f75400fa78034f6eddd931c08104366b90ef68ef4d0e410632828d22678d7"/>
+      <attribute name="url" value="jackson-databind/jackson-databind-2.0.0.jar"/>
+      <attribute name="size" type="Long" value="872810"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.databind.deser,com.fasterxml.jackson.databind.deser.impl,com.fasterxml.jackson.databind.exc,com.fasterxml.jackson.core.type,com.fasterxml.jackson.core.format,com.fasterxml.jackson.databind.ser,com.fasterxml.jackson.databind.jsontype.impl,com.fasterxml.jackson.core.io,com.fasterxml.jackson.databind.jsonschema,com.fasterxml.jackson.core.util,com.fasterxml.jackson.databind.ser.impl,com.fasterxml.jackson.databind.ser.std"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.annotation"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.deser"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.cfg"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.core.util,com.fasterxml.jackson.databind.deser,com.fasterxml.jackson.core.type,com.fasterxml.jackson.databind.ser"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.deser"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.deser.impl,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.deser.std,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.databind.ext,com.fasterxml.jackson.core.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.deser.impl"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind.deser,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.deser.std,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.core,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.deser.std"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.deser,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.deser.impl,com.fasterxml.jackson.core.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.exc"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.ext"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.deser.std,javax.xml.datatype,javax.xml.namespace,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.ser.std,org.w3c.dom,javax.xml.parsers,org.xml.sax,org.w3c.dom.ls,com.fasterxml.jackson.databind.node,org.w3c.dom.bootstrap"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.introspect"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.jsontype.impl,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.core,com.fasterxml.jackson.databind.ser.std"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.jsonschema"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.jsontype"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.core,com.fasterxml.jackson.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.jsontype.impl"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind.util,com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.core.util,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.databind.introspect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.module"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.deser,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.core,com.fasterxml.jackson.databind.ser"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.node"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.core.io,com.fasterxml.jackson.core.util,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.core.base"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.ser"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.ser.std,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.ser.impl,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.databind.ext,com.fasterxml.jackson.core.io,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.databind.jsonschema"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.ser.impl"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.ser.std,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.databind.ser,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.core.io,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.type"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.ser.std"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.ser,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.jsonschema,com.fasterxml.jackson.databind.ser.impl,com.fasterxml.jackson.databind.node,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.core.io,com.fasterxml.jackson.databind.util,com.fasterxml.jackson.annotation,com.fasterxml.jackson.databind.annotation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.type"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind,com.fasterxml.jackson.core.type,com.fasterxml.jackson.core,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="com.fasterxml.jackson.databind.util"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="jackson-databind"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.databind.annotation,com.fasterxml.jackson.databind,com.fasterxml.jackson.core.io,com.fasterxml.jackson.core,com.fasterxml.jackson.databind.jsontype,com.fasterxml.jackson.databind.cfg,com.fasterxml.jackson.databind.type,com.fasterxml.jackson.core.json,com.fasterxml.jackson.core.util,com.fasterxml.jackson.core.base"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.annotation)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.base)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.format)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.io)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.json)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.type)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=com.fasterxml.jackson.core.util)(version&gt;=2.0.0)(!(version&gt;=3.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.datatype)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom.bootstrap)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom.ls)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="javax.servlet"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="7df78279335208cde04f98a29494aa59eef1d58f6e8ad684d0b70dec9a6baf0e"/>
+      <attribute name="url" value="javax.servlet/javax.servlet-2.5.0.jar"/>
+      <attribute name="size" type="Long" value="118865"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="javax.servlet"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="javax.servlet"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.servlet"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.http"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.servlet"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.resources"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="javax.servlet"/>
+      <attribute name="bundle-version" type="Version" value="2.5.0.v200910301333"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(|(&amp;(osgi.ee=CDC/Foundation)(version=1.1))(&amp;(osgi.ee=JavaSE)(version=1.4)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="c08c6470590873bb1cd955fb39e8657b51d2bba5d1ecd7eaa5f35f05a088b354"/>
+      <attribute name="url" value="name.njbartlett.osgi.emf.minimal/name.njbartlett.osgi.emf.minimal-2.7.0.jar"/>
+      <attribute name="size" type="Long" value="1192662"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.common"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.core.runtime,org.eclipse.emf.common.util,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.common.notify"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.common.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.common.notify.impl"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.common.util,org.eclipse.emf.common.notify"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.common.util"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.core.runtime,org.eclipse.emf.common"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.common.util,org.eclipse.emf.ecore.resource,org.eclipse.emf.common.notify,org.eclipse.emf.ecore.impl,org.eclipse.emf.ecore.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.impl"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.util,org.eclipse.emf.ecore,org.eclipse.emf.common.util,org.eclipse.emf.ecore.resource,org.eclipse.emf.common.notify.impl,org.eclipse.emf.common.notify,org.eclipse.emf.ecore.xml.type.util,org.eclipse.emf.common,org.eclipse.emf.ecore.resource.impl,org.eclipse.emf.ecore.plugin,org.eclipse.emf.ecore.xml.type"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.plugin"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.resource,org.eclipse.core.runtime,org.osgi.framework,org.eclipse.emf.ecore,org.xml.sax.helpers,org.xml.sax,org.eclipse.emf.ecore.impl,org.eclipse.core.resources,org.eclipse.emf.common,org.eclipse.emf.common.util,javax.xml.parsers,org.eclipse.emf.ecore.util,org.eclipse.emf.ecore.resource.impl"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.resource"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.core.runtime.content,org.eclipse.emf.ecore.resource.impl,org.eclipse.emf.common.util,org.eclipse.emf.ecore,org.eclipse.emf.common.notify"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.resource.impl"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.resource,javax.crypto.spec,javax.crypto,org.eclipse.emf.common.util,org.eclipse.emf.ecore,org.eclipse.emf.ecore.util,org.eclipse.core.runtime,org.eclipse.core.runtime.content,org.eclipse.emf.common,org.eclipse.emf.ecore.plugin,org.eclipse.core.resources,org.eclipse.emf.common.notify.impl,org.eclipse.emf.common.notify,org.eclipse.emf.ecore.impl"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xml.namespace"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.common.util,org.eclipse.emf.ecore.util,org.eclipse.emf.ecore"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xml.type"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.util,org.eclipse.emf.ecore,org.eclipse.emf.common.util,javax.xml.datatype,javax.xml.namespace"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xml.type.internal"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.xml.type,javax.xml.namespace,org.eclipse.emf.ecore.plugin,org.eclipse.emf.common.util,org.eclipse.emf.ecore.xml.type.util,javax.xml.datatype"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xml.type.util"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.xml.sax,org.eclipse.emf.ecore.xml.type,javax.xml.datatype,javax.xml.namespace,org.xml.sax.helpers,org.eclipse.emf.common.util,org.eclipse.emf.ecore.resource.impl,org.eclipse.emf.ecore,org.eclipse.emf.ecore.xml.type.internal,org.eclipse.emf.ecore.plugin,org.eclipse.emf.ecore.util"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.util"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110912-0920"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.minimal"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110912-0920"/>
+      <directive name="uses" value="org.eclipse.emf.common.notify,org.eclipse.emf.ecore,org.eclipse.emf.common.util,org.eclipse.emf.ecore.xml.type,org.eclipse.emf.ecore.xml.type.util,org.eclipse.emf.ecore.impl,org.eclipse.emf.common.notify.impl,org.eclipse.emf.ecore.resource,org.eclipse.emf.ecore.plugin,org.eclipse.emf.ecore.xml.namespace"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.crypto.spec)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.datatype)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.core.resources)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.core.runtime)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.core.runtime.content)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.common.notify)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.common.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.impl)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.plugin)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.resource)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.type.internal)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.type.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.6.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110520-1406"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="2d8a1e523e4d5e724bb597cd62f2654da74c37bc4712179254310ef21cd10ad8"/>
+      <attribute name="url" value="name.njbartlett.osgi.emf.xmi/name.njbartlett.osgi.emf.xmi-2.7.0.jar"/>
+      <attribute name="size" type="Long" value="208921"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110520-1406"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110520-1406"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xmi"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110520-1406"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110520-1406"/>
+      <directive name="uses" value="org.eclipse.emf.ecore,org.w3c.dom,org.eclipse.emf.ecore.resource,org.eclipse.emf.ecore.util,org.eclipse.emf.common.util,org.eclipse.emf.common,org.xml.sax.ext,org.xml.sax,javax.xml.parsers,org.eclipse.emf.ecore.xml.type"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xmi.impl"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110520-1406"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110520-1406"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.xmi,org.eclipse.emf.ecore,org.eclipse.emf.ecore.util,org.w3c.dom,org.eclipse.emf.common.util,org.xml.sax,org.xml.sax.helpers,org.eclipse.emf.ecore.resource,org.eclipse.emf.ecore.resource.impl,org.eclipse.emf.ecore.xml.type,org.eclipse.emf.common,org.eclipse.emf.ecore.impl,org.eclipse.emf.ecore.xml.type.util,org.eclipse.emf.ecore.xmi.util,org.eclipse.emf.ecore.xml.type.internal,javax.xml.namespace,org.xml.sax.ext,javax.xml.parsers,org.eclipse.emf.common.notify,org.eclipse.emf.ecore.xml.namespace"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.emf.ecore.xmi.util"/>
+      <attribute name="version" type="Version" value="2.7.0.v20110520-1406"/>
+      <attribute name="bundle-symbolic-name" value="name.njbartlett.osgi.emf.xmi"/>
+      <attribute name="bundle-version" type="Version" value="2.7.0.v20110520-1406"/>
+      <directive name="uses" value="org.eclipse.emf.ecore.resource,org.eclipse.emf.ecore.util,org.eclipse.emf.ecore.xmi,org.eclipse.emf.common.util,org.eclipse.emf.common,org.eclipse.emf.ecore.xmi.impl,org.eclipse.emf.ecore.resource.impl,org.w3c.dom,org.xml.sax,org.eclipse.emf.ecore,org.eclipse.emf.ecore.impl"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.common)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.common.notify)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.common.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.impl)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.resource)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.resource.impl)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.namespace)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.type)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.type.internal)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.emf.ecore.xml.type.util)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.w3c.dom)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.ext)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.configadmin"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="58a8e2c2367d2e9448929d86027458c88da5c56c79ab0242dde1be2d9822043b"/>
+      <attribute name="url" value="org.apache.felix.configadmin/org.apache.felix.configadmin-1.8.2.jar"/>
+      <attribute name="size" type="Long" value="128686"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.cm"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.cm.file"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+      <directive name="uses" value="org.apache.felix.cm,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <attribute name="service.description" value="Configuration Admin Service Specification 1.5 Implementation"/>
+      <attribute name="service.pid" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <attribute name="service.vendor" value="Apache Software Foundation"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.felix.cm.PersistenceManager"/>
+      <attribute name="service.description" value="Platform Filesystem Persistence Manager"/>
+      <attribute name="service.pid" value="org.apache.felix.cm.file.FilePersistenceManager"/>
+      <attribute name="service.vendor" value="Apache Software Foundation"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <directive name="uses" value="org.osgi.service.cm"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.cm)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.cm.file)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.5.0)(!(version&gt;=1.6.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.osgi.service.log.LogService)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.eventadmin"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.2.14"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="9b91a6e582c29f2060bb1a892705d3f4937307abdee7fefd2b40232cf88cfd55"/>
+      <attribute name="url" value="org.apache.felix.eventadmin/org.apache.felix.eventadmin-1.2.14.jar"/>
+      <attribute name="size" type="Long" value="205242"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.eventadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.2.14"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.eventadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.2.14"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.event"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.eventadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.2.14"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.event.EventAdmin"/>
+      <directive name="uses" value="org.osgi.service.event"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.event)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.fileinstall"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="88376f34f2e3c201ddd30f32283e8d58973cc59d034ec6050d7450ed0c7fb16e"/>
+      <attribute name="url" value="org.apache.felix.fileinstall/org.apache.felix.fileinstall-3.1.4.jar"/>
+      <attribute name="size" type="Long" value="71899"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.fileinstall"/>
+      <attribute name="version" type="Version" value="3.1.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.fileinstall"/>
+      <attribute name="bundle-version" type="Version" value="3.1.4"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.fileinstall)(version&gt;=3.1.0)(!(version&gt;=4.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.startlevel)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.url)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.gogo.command"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.12.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="5799c75d81dd5682ff79f3e440b9ba77c5511fe683b5b7d5a322059ce4d39800"/>
+      <attribute name="url" value="org.apache.felix.gogo.command/org.apache.felix.gogo.command-0.12.0.jar"/>
+      <attribute name="size" type="Long" value="51746"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.gogo.command"/>
+      <attribute name="bundle-version" type="Version" value="0.12.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.gogo.command"/>
+      <attribute name="bundle-version" type="Version" value="0.12.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.gogo.command"/>
+      <attribute name="bundle-version" type="Version" value="0.12.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.command)(version&gt;=0.10.0)(!(version&gt;=1.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.wiring)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.startlevel)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.10.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="15e94961ae2d0046278686965fe6a34ad43d8d18719f5bc2304e725cdb57a379"/>
+      <attribute name="url" value="org.apache.felix.gogo.runtime/org.apache.felix.gogo.runtime-0.10.0.jar"/>
+      <attribute name="size" type="Long" value="66965"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.service.command"/>
+      <attribute name="version" type="Version" value="0.10.0"/>
+      <attribute name="status" value="provisional"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+      <directive name="mandatory" value="status"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.gogo.api"/>
+      <attribute name="version" type="Version" value="0.10.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+      <directive name="uses" value="org.apache.felix.service.command"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.service.threadio"/>
+      <attribute name="version" type="Version" value="0.10.0"/>
+      <attribute name="status" value="provisional"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+      <directive name="mandatory" value="status"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.gogo.api)(version&gt;=0.10.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.command)(version&gt;=0.10.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.threadio)(version&gt;=0.10.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.event)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.gogo.shell"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="0.10.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="5a625f772d7c03443229d9a1e9f9b851892ee363c2e88ef1d5b55ed0979431a2"/>
+      <attribute name="url" value="org.apache.felix.gogo.shell/org.apache.felix.gogo.shell-0.10.0.jar"/>
+      <attribute name="size" type="Long" value="49004"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.gogo.shell"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.gogo.shell"/>
+      <attribute name="bundle-version" type="Version" value="0.10.0"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.command)(version&gt;=0.10.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.startlevel)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.http.jetty"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="e4d019c20015b7b36ff6480730255dfbd6c9091615a99353ee4c1cc815ab2cf3"/>
+      <attribute name="url" value="org.apache.felix.http.jetty/org.apache.felix.http.jetty-2.2.0.jar"/>
+      <attribute name="size" type="Long" value="941716"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.http.api"/>
+      <attribute name="version" type="Version" value="2.0.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+      <directive name="uses" value="javax.servlet,org.osgi.service.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+      <directive name="uses" value="javax.servlet.http,javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.resources"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.jsp.resources"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="javax.servlet.http"/>
+      <attribute name="version" type="Version" value="2.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.http.jetty"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+      <directive name="uses" value="javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.http.HttpService"/>
+      <directive name="uses" value="org.osgi.service.http,javax.servlet,javax.servlet.http"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.net.ssl)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.security.cert)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.jsp.resources)(version&gt;=2.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.resources)(version&gt;=2.5.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.http.api)(version&gt;=2.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.http)(version&gt;=1.2.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.slf4j)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.xml.sax.helpers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.log"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="99e720ade46420b2e4c554f6e90823e61d92730e7bd8325337b7b6b228a7d290"/>
+      <attribute name="url" value="org.apache.felix.log/org.apache.felix.log-1.0.1.jar"/>
+      <attribute name="size" type="Long" value="22243"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogReaderService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogService"/>
+      <directive name="uses" value="org.osgi.service.log"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.main"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="c9164aebf1aad96e3619fc04ed25a7123a84cbf1d25c26d944479df58ff2bd62"/>
+      <attribute name="url" value="org.apache.felix.main/org.apache.felix.main-4.6.1.jar"/>
+      <attribute name="size" type="Long" value="589673"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework"/>
+      <attribute name="version" type="Version" value="1.8.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.dto"/>
+      <attribute name="version" type="Version" value="1.8.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.bundle"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.resolver"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework.wiring"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.service"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.weaving"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework.wiring"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.launch"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.namespace"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.startlevel"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.startlevel.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.wiring"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.wiring.dto"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.dto,org.osgi.resource.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.resource"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.resource.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.packageadmin"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.startlevel"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.url"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.tracker"/>
+      <attribute name="version" type="Version" value="1.5.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.main"/>
+      <attribute name="bundle-version" type="Version" value="4.6.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.contract">
+      <attribute name="osgi.contract" value="OSGiFramework"/>
+      <directive name="uses" value="org.osgi.dto,org.osgi.framework,org.osgi.framework.dto,org.osgi.framework.hooks.bundle,org.osgi.framework.hooks.resolver,org.osgi.framework.hooks.service,org.osgi.framework.hooks.weaving,org.osgi.framework.launch,org.osgi.framework.namespace,org.osgi.framework.startlevel,org.osgi.framework.startlevel.dto,org.osgi.framework.wiring,org.osgi.framework.wiring.dto,org.osgi.resource,org.osgi.resource.dto,org.osgi.service.packageadmin,org.osgi.service.startlevel,org.osgi.service.url,org.osgi.util.tracker"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.metatype"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="3909892c3b73d6833c67d2aabc27fc00f90aa132f0a4342d822a752e163ccf93"/>
+      <attribute name="url" value="org.apache.felix.metatype/org.apache.felix.metatype-1.0.4.jar"/>
+      <attribute name="size" type="Long" value="93990"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.0.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.0.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.metatype"/>
+      <attribute name="version" type="Version" value="1.0.4"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.0.4"/>
+      <directive name="uses" value="org.osgi.service.metatype,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.0.4"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.metatype.MetaTypeService"/>
+      <directive name="uses" value="org.osgi.service.metatype"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.metatype)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1.0))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.scr"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="19d395d8800d5546397211edc209e2e42d0ee500c93aca9d04ce69e4288f41d9"/>
+      <attribute name="url" value="org.apache.felix.scr/org.apache.felix.scr-1.8.2.jar"/>
+      <attribute name="size" type="Long" value="267629"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.scr"/>
+      <attribute name="version" type="Version" value="1.8.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.service.component"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.scr.component"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="status" value="provisional"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+      <directive name="mandatory" value="status"/>
+      <directive name="uses" value="org.osgi.service.component"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.2.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="1.8.2"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.extender">
+      <attribute name="osgi.extender" value="osgi.component"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <directive name="uses" value="org.osgi.service.component"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.scr)(version&gt;=1.8.0)(!(version&gt;=1.9.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.command)(version&gt;=0.6.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.shell)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component)(version&gt;=1.2.0)(!(version&gt;=1.3.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.shell.tui"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.4.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="87c42aea8a6b6e2fd7ece9eaea855f83c51eba76f6636a9602ca94b20045c69a"/>
+      <attribute name="url" value="org.apache.felix.shell.tui/org.apache.felix.shell.tui-1.4.1.jar"/>
+      <attribute name="size" type="Long" value="12748"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.shell.tui"/>
+      <attribute name="bundle-version" type="Version" value="1.4.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.shell.tui"/>
+      <attribute name="bundle-version" type="Version" value="1.4.1"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.shell)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.apache.felix.shell.ShellService)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.shell"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.4.2"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="7ef27401da970a30d88ab2df9142d0a698933b97abd025d89d3d6fa14620b966"/>
+      <attribute name="url" value="org.apache.felix.shell/org.apache.felix.shell-1.4.2.jar"/>
+      <attribute name="size" type="Long" value="62727"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.shell"/>
+      <attribute name="bundle-version" type="Version" value="1.4.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.shell"/>
+      <attribute name="bundle-version" type="Version" value="1.4.2"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.ungoverned.osgi.service.shell"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.shell"/>
+      <attribute name="bundle-version" type="Version" value="1.4.2"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.shell"/>
+      <attribute name="bundle-version" type="Version" value="1.4.2"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.shell"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.shell"/>
+      <attribute name="bundle-version" type="Version" value="1.4.2"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.felix.shell.ShellService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.ungoverned.osgi.service.shell.ShellService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.shell)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.startlevel)(version&gt;=1.1.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.ungoverned.osgi.service.shell)(version&gt;=1.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.osgi.service.startlevel.StartLevel)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.osgi.service.packageadmin.PackageAdmin)"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.webconsole"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.1.8"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="b4bf9813e918a140a8c7cd7b3162b0b13d80b3b79d4d254e2bd226530feefca5"/>
+      <attribute name="url" value="org.apache.felix.webconsole/org.apache.felix.webconsole-3.1.8.jar"/>
+      <attribute name="size" type="Long" value="637792"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.webconsole"/>
+      <attribute name="bundle-version" type="Version" value="3.1.8"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.webconsole"/>
+      <attribute name="bundle-version" type="Version" value="3.1.8"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.webconsole"/>
+      <attribute name="version" type="Version" value="3.1.2"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.webconsole"/>
+      <attribute name="bundle-version" type="Version" value="3.1.8"/>
+      <directive name="uses" value="javax.servlet,org.osgi.framework,javax.servlet.http"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.portlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet)(version&gt;=2.4.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=javax.servlet.http)(version&gt;=2.4.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.scr)(version&gt;=1.0.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.felix.shell)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.webconsole)(version&gt;=3.1.2))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.cm)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.condpermadmin)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.deploymentadmin)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.http)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.log)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.metatype)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.packageadmin)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.permissionadmin)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.prefs)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.startlevel)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.service.wireadmin)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.easymock"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="3.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="9a1b4365c936d8cf38744a677bb4972c02792b24374c15b97f7abed32aac8c97"/>
+      <attribute name="url" value="org.easymock/org.easymock-3.0.0.jar"/>
+      <attribute name="size" type="Long" value="210829"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.easymock"/>
+      <attribute name="bundle-version" type="Version" value="3.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.easymock"/>
+      <attribute name="bundle-version" type="Version" value="3.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.easymock.internal"/>
+      <attribute name="version" type="Version" value="3.0.0"/>
+      <attribute name="poweruser" value="true"/>
+      <attribute name="bundle-symbolic-name" value="org.easymock"/>
+      <attribute name="bundle-version" type="Version" value="3.0.0"/>
+      <directive name="mandatory" value="poweruser"/>
+      <directive name="uses" value="org.easymock,net.sf.cglib.proxy,net.sf.cglib.core,org.easymock.internal.matchers,org.objenesis"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.easymock.internal.matchers"/>
+      <attribute name="version" type="Version" value="3.0.0"/>
+      <attribute name="poweruser" value="true"/>
+      <attribute name="bundle-symbolic-name" value="org.easymock"/>
+      <attribute name="bundle-version" type="Version" value="3.0.0"/>
+      <directive name="mandatory" value="poweruser"/>
+      <directive name="uses" value="org.easymock,org.easymock.internal"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.easymock"/>
+      <attribute name="version" type="Version" value="3.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.easymock"/>
+      <attribute name="bundle-version" type="Version" value="3.0.0"/>
+      <directive name="uses" value="org.easymock.internal,org.easymock.internal.matchers"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=net.sf.cglib.core)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=net.sf.cglib.proxy)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=net.sf.cglib.reflect)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.easymock)(version&gt;=3.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="poweruser" value="true"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.easymock.internal)(version&gt;=3.0.0))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.objenesis)(version&gt;=1.2.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.eclipse.equinox.supplement"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="6225757d3a326a80ffbdb1ad076b38afeb4fd7bd7cff4448c7f895ff5c5ba290"/>
+      <attribute name="url" value="org.eclipse.equinox.supplement/org.eclipse.equinox.supplement-1.3.0.jar"/>
+      <attribute name="size" type="Long" value="113255"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.framework.log"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.datalocation"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.debug"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.environment"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.localization"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.runnable"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.service.urlconversion"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.storagemanager"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.util"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.framework.debug"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.framework.util"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.framework.internal.core"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.osgi.framework.internal.reliablefile"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.eclipse.core.runtime.internal.adaptor"/>
+      <attribute name="version" type="Version" value="0.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.eclipse.equinox.supplement"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.v20100503"/>
+      <directive name="x-internal" value="true"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.util.tracker)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.framework.log)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.datalocation)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.debug)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.environment)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.localization)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.runnable)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.service.urlconversion)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.storagemanager)"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.eclipse.osgi.util)"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(|(&amp;(osgi.ee=JavaSE)(version=1.4))(&amp;(osgi.ee=CDC/Foundation)(version=1.0))(&amp;(osgi.ee=JavaSE)(version=1.3)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.mockito.mockito-all"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="9c774466a0aa16d52aa76ecc7593524b6472c25b8fb0565592fdeec6cb316d9e"/>
+      <attribute name="url" value="org.mockito.mockito-all/org.mockito.mockito-all-1.8.5.jar"/>
+      <attribute name="size" type="Long" value="1439455"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.exceptions.base"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.stubbing"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito.invocation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.exceptions.verification.junit"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="junit.framework,org.mockito.exceptions.verification"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.exceptions.misusing"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito.exceptions.base"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.invocation"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.runners"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.junit.runner,org.junit.runner.notification,org.junit.runner.manipulation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.verification"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.hamcrest,org.mockito.stubbing,org.mockito.verification,org.mockito.exceptions.base,org.mockito.exceptions,org.mockito.configuration,org.mockito.invocation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.exceptions"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito.exceptions.verification.junit,org.mockito.exceptions.base,org.mockito.exceptions.verification,org.mockito.exceptions.misusing"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.configuration"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito,org.mockito.stubbing"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.stubbing.answers"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito.exceptions.base,org.mockito.stubbing,org.mockito.invocation"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.mockito.exceptions.verification"/>
+      <attribute name="version" type="Version" value="1.8.5"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.mockito.exceptions.base"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.hamcrest"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.hamcrest.core"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.hamcrest.core"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+      <directive name="uses" value="org.hamcrest"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.objenesis"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.mockito.mockito-all"/>
+      <attribute name="bundle-version" type="Version" value="1.8.5"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=COM.jrockit.reflect)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=jrockit.vm)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=junit.framework)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.hamcrest)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.internal.runners)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.runner)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.runner.manipulation)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.runner.notification)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.runners)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.junit.runners.model)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.configuration)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.exceptions)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.exceptions.base)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.exceptions.misusing)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.exceptions.verification)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.exceptions.verification.junit)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.invocation)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.runners)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.stubbing)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.stubbing.answers)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.mockito.verification)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.objenesis)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=sun.reflect)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.osgi.impl.bundle.bindex"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="8d93c6f99983c16688e0773be5862470b53008a6a49c95a10afce496cbd3658b"/>
+      <attribute name="url" value="org.osgi.impl.bundle.bindex/org.osgi.impl.bundle.bindex-2.2.0.jar"/>
+      <attribute name="size" type="Long" value="154617"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.osgi.impl.bundle.bindex"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.osgi.impl.bundle.bindex"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.bindex"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.osgi.impl.bundle.bindex"/>
+      <attribute name="bundle-version" type="Version" value="2.2.0"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" type="List&lt;String&gt;" value="org.osgi.service.bindex.BundleIndexer"/>
+      <directive name="uses" value="org.osgi.service.bindex"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.apache.tools.ant.types)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.bindex)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.extender">
+      <directive name="filter" value="(&amp;(osgi.extender=osgi.component)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="effective" value="active"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.osgi.service.component.annotations"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.3.0.201501170150"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f606390be512dd62316a3a9541bf539dfb14fbcdf85e3541b487d63f71ddcefe"/>
+      <attribute name="url" value="org.osgi.service.component.annotations/org.osgi.service.component.annotations-1.3.0.jar"/>
+      <attribute name="size" type="Long" value="35750"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.osgi.service.component.annotations"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.201501170150"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.osgi.service.component.annotations"/>
+      <attribute name="bundle-version" type="Version" value="1.3.0.201501170150"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="osgi.cmpn"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="8a6464bc7e1bb4f65c27c62f7d9cf7578ba6de7f35c75314a9c38fc20b2f8978"/>
+      <attribute name="url" value="osgi.cmpn/osgi.cmpn-4.3.1.jar"/>
+      <attribute name="size" type="Long" value="767142"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.application"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.application"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.reflect"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.container"/>
+      <attribute name="version" type="Version" value="1.0.2"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component.annotations"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.coordinator"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.deploymentadmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.deploymentadmin.spi"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.service.deploymentadmin"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.device"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.notification"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.service.dmt"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt"/>
+      <attribute name="version" type="Version" value="2.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.security"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.service.dmt"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.spi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.service.dmt"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.notification.spi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.service.dmt.notification"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.event"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="javax.servlet.http,javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.io"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="javax.microedition.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jdbc"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jndi"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="javax.naming.directory,javax.naming"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jpa"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.monitor"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.prefs"/>
+      <attribute name="version" type="Version" value="1.1.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.provisioning"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.remoteserviceadmin"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.upnp"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.useradmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.wireadmin"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.measurement"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.position"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.util.measurement"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.tracker"/>
+      <attribute name="version" type="Version" value="1.5.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.xml"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="4.3.1.201210102024"/>
+      <directive name="uses" value="org.osgi.framework,javax.xml.parsers"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.microedition.io)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.directory)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.persistence)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="osgi.cmpn"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f1ef32cc1530f4e66aac606c24363b627ace4780a7737b045bfb3b908d801bcd"/>
+      <attribute name="url" value="osgi.cmpn/osgi.cmpn-5.0.0.jar"/>
+      <attribute name="size" type="Long" value="771157"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.application"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.namespace.contract"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.namespace.extender"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.namespace.service"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.application"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.container"/>
+      <attribute name="version" type="Version" value="1.0.2"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.service.blueprint.reflect"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.reflect"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.5.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.2.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component.annotations"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.coordinator"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.deploymentadmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.deploymentadmin.spi"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.service.deploymentadmin"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.device"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt"/>
+      <attribute name="version" type="Version" value="2.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.notification"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.service.dmt"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.notification.spi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.service.dmt.notification"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.security"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.dmt.spi"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.service.dmt"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.event"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.servlet,javax.servlet.http"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.io"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.microedition.io"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jdbc"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jndi"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.naming,javax.naming.directory"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jpa"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.monitor"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.prefs"/>
+      <attribute name="version" type="Version" value="1.1.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.provisioning"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.remoteserviceadmin"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.repository"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.resolver"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.serviceloader"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.subsystem"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.upnp"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.useradmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.wireadmin"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.measurement"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.position"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="org.osgi.util.measurement"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.xml"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.cmpn"/>
+      <attribute name="bundle-version" type="Version" value="5.0.0.201305092017"/>
+      <directive name="uses" value="javax.xml.parsers,org.osgi.framework"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.microedition.io)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.directory)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.persistence)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.framework)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=org.osgi.resource)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="osgi.enterprise"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="15f369fce782de0594b3c8719793d9ea09a915bbde42bb6e96bc1df5c7c34452"/>
+      <attribute name="url" value="osgi.enterprise/osgi.enterprise-4.2.0.jar"/>
+      <attribute name="size" type="Long" value="354544"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx.service.cm"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.management.openmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx.framework"/>
+      <attribute name="version" type="Version" value="1.5.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.jmx,javax.management.openmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx.service.permissionadmin"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx.service.provisioning"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.management.openmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx.service.useradmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.jmx,javax.management.openmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.jmx"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.management.openmbean"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.reflect"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.blueprint.container"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.service.blueprint.reflect,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.event"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.http"/>
+      <attribute name="version" type="Version" value="1.2.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.servlet.http,javax.servlet"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.provisioning"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.remoteserviceadmin"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jdbc"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.sql"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jndi"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.naming.directory,javax.naming"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.jpa"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="javax.persistence"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.useradmin"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.tracker"/>
+      <attribute name="version" type="Version" value="1.4.0"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.xml"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+      <attribute name="bundle-symbolic-name" value="osgi.enterprise"/>
+      <attribute name="bundle-version" type="Version" value="4.2.0.201003190513"/>
+      <directive name="uses" value="org.osgi.framework,javax.xml.parsers"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.management.openmbean)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.naming.directory)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.persistence)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.servlet.http)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.sql)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(osgi.wiring.package=javax.xml.parsers)"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx.framework)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx.service.cm)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx.service.permissionadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx.service.provisioning)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.jmx.service.useradmin)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.container)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.blueprint.reflect)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.event)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.http)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jdbc)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jndi)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.jpa)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.provisioning)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.remoteserviceadmin)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.useradmin)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.xml)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="slf4j.api"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.7.4"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="998feb486b31503f844e8543d6249560252732ee615f2031f542778d30034d74"/>
+      <attribute name="url" value="slf4j.api/slf4j.api-1.7.4.jar"/>
+      <attribute name="size" type="Long" value="26083"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="slf4j.api"/>
+      <attribute name="bundle-version" type="Version" value="1.7.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="slf4j.api"/>
+      <attribute name="bundle-version" type="Version" value="1.7.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j"/>
+      <attribute name="version" type="Version" value="1.7.4"/>
+      <attribute name="bundle-symbolic-name" value="slf4j.api"/>
+      <attribute name="bundle-version" type="Version" value="1.7.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j.spi"/>
+      <attribute name="version" type="Version" value="1.7.4"/>
+      <attribute name="bundle-symbolic-name" value="slf4j.api"/>
+      <attribute name="bundle-version" type="Version" value="1.7.4"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.slf4j.helpers"/>
+      <attribute name="version" type="Version" value="1.7.4"/>
+      <attribute name="bundle-symbolic-name" value="slf4j.api"/>
+      <attribute name="bundle-version" type="Version" value="1.7.4"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.slf4j.impl)(version&gt;=1.6.0))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.3))"/>
+    </requirement>
+  </resource>
+</repository>

--- a/biz.aQute.resolve/testdata/repo7/index.xml
+++ b/biz.aQute.resolve/testdata/repo7/index.xml
@@ -1,0 +1,502 @@
+<?xml version="1.0" encoding="utf-8"?>
+<repository increment="1439898091622" name="test-repo" xmlns="http://www.osgi.org/xmlns/repository/v1.0.0">
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.configadmin"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.8.8"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="180f1ceee1b4786d1d29b8bc6e75d10706e84a3bbc0eaa0e41f38c45b1f58a7d"/>
+      <attribute name="url" value="org.apache.felix.configadmin/org.apache.felix.configadmin-1.8.8.jar"/>
+      <attribute name="size" type="Long" value="130990"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.8"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.8"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.cm"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.8"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.cm.file"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.8"/>
+      <directive name="uses" value="org.apache.felix.cm,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.cm"/>
+      <attribute name="version" type="Version" value="1.5.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.configadmin"/>
+      <attribute name="bundle-version" type="Version" value="1.8.8"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <attribute name="service.description" value="Configuration Admin Service Specification 1.5 Implementation"/>
+      <attribute name="service.pid" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <attribute name="service.vendor" value="Apache Software Foundation"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.apache.felix.cm.PersistenceManager"/>
+      <attribute name="service.description" value="Platform Filesystem Persistence Manager"/>
+      <attribute name="service.pid" value="org.apache.felix.cm.file.FilePersistenceManager"/>
+      <attribute name="service.vendor" value="Apache Software Foundation"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.cm.ConfigurationAdmin"/>
+      <directive name="uses" value="org.osgi.service.cm"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.cm)(version&gt;=1.1.0)(!(version&gt;=1.2.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.cm.file)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.5.0)(!(version&gt;=1.6.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.service">
+      <directive name="filter" value="(objectClass=org.osgi.service.log.LogService)"/>
+      <directive name="effective" value="active"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.framework"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="b4c23349d770e5d94591187801083dae366d730c52f04166805f44eebeb33a71"/>
+      <attribute name="url" value="org.apache.felix.framework/org.apache.felix.framework-5.0.1.jar"/>
+      <attribute name="size" type="Long" value="601333"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework"/>
+      <attribute name="version" type="Version" value="1.8.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.dto"/>
+      <attribute name="version" type="Version" value="1.8.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.bundle"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.resolver"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework.wiring"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.service"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.hooks.weaving"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework.wiring"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.launch"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.namespace"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.startlevel"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.startlevel.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.wiring"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.framework.wiring.dto"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.dto,org.osgi.resource.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.resource"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.resource.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.packageadmin"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.startlevel"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.url"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.resolver"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.resource"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.tracker"/>
+      <attribute name="version" type="Version" value="1.5.1"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.dto"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.framework"/>
+      <attribute name="bundle-version" type="Version" value="5.0.1"/>
+    </capability>
+    <capability namespace="osgi.contract">
+      <attribute name="osgi.contract" value="OSGiFramework"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.framework.dto,org.osgi.framework.hooks.bundle,org.osgi.framework.hooks.resolver,org.osgi.framework.hooks.service,org.osgi.framework.hooks.weaving,org.osgi.framework.launch,org.osgi.framework.namespace,org.osgi.framework.startlevel,org.osgi.framework.startlevel.dto,org.osgi.framework.wiring,org.osgi.framework.wiring.dto,org.osgi.resource,org.osgi.resource.dto,org.osgi.service.packageadmin,org.osgi.service.startlevel,org.osgi.service.url,org.osgi.service.resolver,org.osgi.util.tracker,org.osgi.dto"/>
+    </capability>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.log"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="99e720ade46420b2e4c554f6e90823e61d92730e7bd8325337b7b6b228a7d290"/>
+      <attribute name="url" value="org.apache.felix.log/org.apache.felix.log-1.0.1.jar"/>
+      <attribute name="size" type="Long" value="22243"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.log"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.log"/>
+      <attribute name="bundle-version" type="Version" value="1.0.1"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogReaderService"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.log.LogService"/>
+      <directive name="uses" value="org.osgi.service.log"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.4.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.metatype"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="22ec64ee501f9bdb2396aff55f5894746173a4e7c91cd8b09f76563abe984d22"/>
+      <attribute name="url" value="org.apache.felix.metatype/org.apache.felix.metatype-1.1.0.jar"/>
+      <attribute name="size" type="Long" value="73794"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.metatype"/>
+      <attribute name="version" type="Version" value="1.2.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <directive name="uses" value="org.osgi.service.metatype,org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.metatype"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.metatype"/>
+      <attribute name="bundle-version" type="Version" value="1.1.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.implementation">
+      <attribute name="osgi.implementation" value="osgi.metatype"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <directive name="uses" value="org.osgi.service.metatype"/>
+    </capability>
+    <capability namespace="osgi.extender">
+      <attribute name="osgi.extender" value="osgi.metatype"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <directive name="uses" value="org.osgi.service.metatype"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" type="List&lt;String&gt;" value="org.osgi.service.metatype.MetaTypeService"/>
+      <directive name="uses" value="org.osgi.service.metatype"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" value="org.osgi.service.metatype.MetaTypeService"/>
+      <directive name="uses" value="org.osgi.service.metatype"/>
+      <directive name="effective" value="active"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.3.0)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+  </resource>
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.scr"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="f5671487e0a7d98d08c6a81329624e23f9b9d59cf831e4d828bc2df7dcf35960"/>
+      <attribute name="url" value="org.apache.felix.scr/org.apache.felix.scr-2.0.0.jar"/>
+      <attribute name="size" type="Long" value="352854"/>
+      <attribute name="mime" value="application/vnd.osgi.bundle"/>
+    </capability>
+    <capability namespace="osgi.wiring.bundle">
+      <attribute name="osgi.wiring.bundle" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.host">
+      <attribute name="osgi.wiring.host" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.scr.component"/>
+      <attribute name="version" type="Version" value="1.1.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.service.component"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.apache.felix.scr.info"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.framework"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component.runtime"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.framework,org.osgi.service.component.runtime.dto,org.osgi.util.promise"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.service.component.runtime.dto"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.dto,org.osgi.framework.dto"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.function"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+    </capability>
+    <capability namespace="osgi.wiring.package">
+      <attribute name="osgi.wiring.package" value="org.osgi.util.promise"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+      <attribute name="bundle-symbolic-name" value="org.apache.felix.scr"/>
+      <attribute name="bundle-version" type="Version" value="2.0.0"/>
+      <directive name="uses" value="org.osgi.util.function"/>
+    </capability>
+    <capability namespace="osgi.extender">
+      <attribute name="osgi.extender" value="osgi.component"/>
+      <attribute name="version" type="Version" value="1.3.0"/>
+      <directive name="uses" value="org.osgi.service.component"/>
+    </capability>
+    <capability namespace="osgi.service">
+      <attribute name="objectClass" type="List&lt;String&gt;" value="org.osgi.service.component.runtime.ServiceComponentRuntime"/>
+      <directive name="uses" value="org.osgi.service.component.runtime"/>
+    </capability>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.cm)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.log)(version&gt;=1.3.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.metatype)(version&gt;=1.1.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.packageadmin)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <attribute name="status" value="provisional"/>
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.service.command)(version&gt;=0.6.0)(!(version&gt;=1.0.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.shell)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+      <directive name="resolution" value="optional"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.scr.component)(version&gt;=1.1.0)(!(version&gt;=1.2.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.apache.felix.scr.info)(version&gt;=1.0.0)(!(version&gt;=1.1.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.dto)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.dto)(version&gt;=1.8.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.framework.wiring)(version&gt;=1.2.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component)(version&gt;=1.3.0)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component.runtime)(version&gt;=1.3.0)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.service.component.runtime.dto)(version&gt;=1.3.0)(!(version&gt;=1.4.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.promise)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.tracker)(version&gt;=1.5.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.wiring.package">
+      <directive name="filter" value="(&amp;(osgi.wiring.package=org.osgi.util.function)(version&gt;=1.0.0)(!(version&gt;=2.0.0)))"/>
+    </requirement>
+    <requirement namespace="osgi.ee">
+      <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
+    </requirement>
+  </resource>
+</repository>


### PR DESCRIPTION
When doing a _required_ resolve the ResolveProcess should still populate the optional candidates so that other tools can decide whether to pull them in.

Signed-off-by: Tim Ward <timothyjward@apache.org>