### PR TITLE
gradle: Create a new Workspace object each build

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -43,7 +43,7 @@ public class BndPlugin implements Plugin<Project> {
           throw new GradleException("Project already has '${BndBuilderPlugin.PLUGINID}' plugin applied.")
       }
       if (!rootProject.hasProperty('bndWorkspace')) {
-        rootProject.ext.bndWorkspace = Workspace.getWorkspace(rootDir)
+        rootProject.ext.bndWorkspace = new Workspace(rootDir)
         if (bndWorkspace == null) {
           throw new GradleException("Unable to load bnd workspace ${rootDir}")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-ext.bndWorkspace = Workspace.getWorkspace(rootDir, bnd_cnf)
+ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
 if (bndWorkspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,7 +40,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-def workspace = Workspace.getWorkspace(rootDir, bnd_cnf)
+def workspace = new Workspace(rootDir, bnd_cnf)
 if (workspace == null) {
   throw new GradleException("Unable to load workspace ${rootDir}/${bnd_cnf}")
 }


### PR DESCRIPTION
The static getWorkspace method caches the Workspace. When using the
gradle daemon, the daemon process never notices updates to bnd files
since the Workspace and thus all Projects are cached.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>