### PR TITLE
bndrun: export must not reference project properties

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/LauncherTest.java
+++ b/biz.aQute.bndlib.tests/src/test/LauncherTest.java
@@ -96,9 +96,9 @@ public class LauncherTest extends TestCase {
 
 			p.load(resource.openInputStream());
 
-			assertEquals("1", p.getProperty("in.workspace"));
-			assertEquals("2", p.getProperty("in.project"));
-			assertEquals(null, p.getProperty("in.x"));
+			assertEquals("workspace", p.getProperty("in.workspace"));
+			assertEquals("project", p.getProperty("in.project"));
+			assertEquals("project", p.getProperty("in.bndrun"));
 		}
 
 		//
@@ -121,9 +121,9 @@ public class LauncherTest extends TestCase {
 
 				p.load(resource.openInputStream());
 
-				assertEquals("1", p.getProperty("in.workspace"));
-				assertEquals("3", p.getProperty("in.x"));
-				assertEquals(null, p.getProperty("in.project"));
+				assertEquals("workspace", p.getProperty("in.workspace"));
+				assertEquals("workspace", p.getProperty("in.project"));
+				assertEquals("bndrun", p.getProperty("in.bndrun"));
 			}
 		}
 
@@ -132,10 +132,9 @@ public class LauncherTest extends TestCase {
 		{
 
 			Project project = getProject();
-			project.getWorkspace().setProperty("-runproperties.x", "bar=2");
 			project.clear();
 			File f = new File("generated/test.jar");
-			project.export(null, true, f);
+			project.export(null, false, f);
 
 			try (Jar executable = new Jar(f);) {
 
@@ -144,9 +143,9 @@ public class LauncherTest extends TestCase {
 
 				p.load(resource.openInputStream());
 
-				assertEquals("1", p.getProperty("in.workspace"));
-				assertEquals("2", p.getProperty("in.project"));
-				assertEquals(null, p.getProperty("in.x"));
+				assertEquals("workspace", p.getProperty("in.workspace"));
+				assertEquals("project", p.getProperty("in.project"));
+				assertEquals("project", p.getProperty("in.bndrun"));
 			}
 		}
 
@@ -155,10 +154,9 @@ public class LauncherTest extends TestCase {
 		{
 
 			Project project = getProject();
-			project.getWorkspace().setProperty("-runproperties.x", "bar=2");
 			project.clear();
 			File f = new File("generated/test.jar");
-			project.export("x.bndrun", true, f);
+			project.export("x.bndrun", false, f);
 
 			try (Jar executable = new Jar(f);) {
 
@@ -167,9 +165,9 @@ public class LauncherTest extends TestCase {
 
 				p.load(resource.openInputStream());
 
-				assertEquals("1", p.getProperty("in.workspace"));
-				assertEquals(null, p.getProperty("in.project"));
-				assertEquals("3", p.getProperty("in.x"));
+				assertEquals("workspace", p.getProperty("in.workspace"));
+				assertEquals("workspace", p.getProperty("in.project"));
+				assertEquals("bndrun", p.getProperty("in.bndrun"));
 			}
 		}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1884,8 +1884,7 @@ public class Project extends Processor {
 				if (!runFile.isFile())
 					throw new IOException(String.format("Run file %s does not exist (or is not a file).",
 							runFile.getAbsolutePath()));
-				packageProject = new Project(getWorkspace(), getBase(), runFile);
-				packageProject.setParent(this);
+				packageProject = new Run(getWorkspace(), getBase(), runFile);
 			}
 
 			packageProject.clear();
@@ -1916,8 +1915,7 @@ public class Project extends Processor {
 			if (!runFile.isFile())
 				throw new IOException(String.format("Run file %s does not exist (or is not a file).",
 						runFile.getAbsolutePath()));
-			packageProject = new Project(getWorkspace(), getBase(), runFile);
-			packageProject.setParent(this);
+			packageProject = new Run(getWorkspace(), getBase(), runFile);
 		}
 
 		packageProject.clear();

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -105,4 +105,6 @@ Bundle-Developers: \
 	org.eclipse.osgi;version=3.5,\
 	com.springsource.junit;export="junit.framework;version=3.8"
 
--runproperties.testsuite: in.workspace=1
+-runproperties.testlauncher0: in.workspace=workspace
+-runproperties.testlauncher1: in.project=workspace
+-runproperties.testlauncher2: in.bndrun=workspace

--- a/demo/bnd.bnd
+++ b/demo/bnd.bnd
@@ -42,6 +42,6 @@ base.version:   1.1.0
 Export-Package: \
 	test.api
 
-
--runproperties: in.project=2
+-runproperties.testlauncher1: in.project=project
+-runproperties.testlauncher2: in.bndrun=project
 #-export: x.bndrun

--- a/demo/x.bndrun
+++ b/demo/x.bndrun
@@ -14,4 +14,4 @@ Bundle-Version: 1.0.0
 -runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)',\
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
 
--runproperties: in.x=3
+-runproperties.testlauncher2: in.bndrun=bndrun


### PR DESCRIPTION
bndrun files must not depend upon the project (bnd.bnd). They only
inherit from the workspace.

Fixes https://github.com/bndtools/bnd/issues/980

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>