### PR TITLE
gradle: Use MavenVersion class to parse gradle project version property

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -22,7 +22,7 @@ package aQute.bnd.gradle
 import aQute.bnd.osgi.Builder
 import aQute.bnd.osgi.Constants
 import aQute.bnd.osgi.Jar
-import aQute.bnd.version.Version
+import aQute.bnd.version.MavenVersion
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.SourceSet
@@ -160,7 +160,7 @@ class BundleTaskConvention {
         // set bundle version from task's version if necessary
         def String bundleVersion = builder.getProperty(Constants.BUNDLE_VERSION)
         if (isEmpty(bundleVersion)) {
-          builder.setProperty(Constants.BUNDLE_VERSION, Version.parseVersion(version).toString())
+          builder.setProperty(Constants.BUNDLE_VERSION, MavenVersion.parseString(version).getOSGiVersion().toString())
         }
 
         logger.debug 'builder properties: {}', builder.getProperties()

--- a/biz.aQute.bndlib.tests/src/test/MavenVersionTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MavenVersionTest.java
@@ -1,95 +1,96 @@
-package aQute.bnd.deployer.repository.aether;
+package test;
 
-import junit.framework.*;
-import aQute.bnd.version.*;
+import aQute.bnd.version.MavenVersion;
+import aQute.bnd.version.Version;
+import junit.framework.TestCase;
 
-public class MvnVersionTest extends TestCase {
+public class MavenVersionTest extends TestCase {
 
 	public void testMajorMinorMicro() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3");
+		MavenVersion mv = MavenVersion.parseString("1.2.3");
 		assertEquals(new Version(1, 2, 3), mv.getOSGiVersion());
 	}
 
 	public void testMajorMinor() {
-		MvnVersion mv = MvnVersion.parseString("1.2");
+		MavenVersion mv = MavenVersion.parseString("1.2");
 		assertEquals(new Version(1, 2), mv.getOSGiVersion());
 	}
 
 	public void testMajor() {
-		MvnVersion mv = MvnVersion.parseString("1");
+		MavenVersion mv = MavenVersion.parseString("1");
 		assertEquals(new Version(1), mv.getOSGiVersion());
 	}
 
 	public void testSnapshot() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3-SNAPSHOT");
+		MavenVersion mv = MavenVersion.parseString("1.2.3-SNAPSHOT");
 		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2-SNAPSHOT");
+		mv = MavenVersion.parseString("1.2-SNAPSHOT");
 		assertEquals(new Version(1, 2, 0, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
-		mv = MvnVersion.parseString("1-SNAPSHOT");
+		mv = MavenVersion.parseString("1-SNAPSHOT");
 		assertEquals(new Version(1, 0, 0, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2.3.SNAPSHOT");
+		mv = MavenVersion.parseString("1.2.3.SNAPSHOT");
 		assertEquals(new Version(1, 2, 3, "SNAPSHOT"), mv.getOSGiVersion());
 		assertTrue(mv.isSnapshot());
 	}
 
 	public void testNumericQualifier() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3-01");
+		MavenVersion mv = MavenVersion.parseString("1.2.3-01");
 		assertEquals(new Version(1, 2, 3, "01"), mv.getOSGiVersion());
-		mv = MvnVersion.parseString("1.2.3.01");
+		mv = MavenVersion.parseString("1.2.3.01");
 		assertEquals(new Version(1, 2, 3, "01"), mv.getOSGiVersion());
 	}
 
 	public void testQualifierWithDashSeparator() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3-beta-1");
+		MavenVersion mv = MavenVersion.parseString("1.2.3-beta-1");
 		assertEquals(new Version(1, 2, 3, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}
 
 	public void testQualifierWithoutSeparator() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3rc1");
+		MavenVersion mv = MavenVersion.parseString("1.2.3rc1");
 		assertEquals(new Version(1, 2, 3, "rc1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2rc1");
+		mv = MavenVersion.parseString("1.2rc1");
 		assertEquals(new Version(1, 2, 0, "rc1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1rc1");
+		mv = MavenVersion.parseString("1rc1");
 		assertEquals(new Version(1, 0, 0, "rc1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}	
 	
 	public void testQualifierWithDotSeparator() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3.beta-1");
+		MavenVersion mv = MavenVersion.parseString("1.2.3.beta-1");
 		assertEquals(new Version(1, 2, 3, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2.beta-1");
+		mv = MavenVersion.parseString("1.2.beta-1");
 		assertEquals(new Version(1, 2, 0, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.beta-1");
+		mv = MavenVersion.parseString("1.beta-1");
 		assertEquals(new Version(1, 0, 0, "beta-1"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}
 	
 	public void testDotsInQualifier() {
-		MvnVersion mv = MvnVersion.parseString("1.2.3.4.5");
+		MavenVersion mv = MavenVersion.parseString("1.2.3.4.5");
 		assertEquals(new Version(1, 2, 3, "4.5"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2.3-4.5");
+		mv = MavenVersion.parseString("1.2.3-4.5");
 		assertEquals(new Version(1, 2, 3, "4.5"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1.2-4.5");
+		mv = MavenVersion.parseString("1.2-4.5");
 		assertEquals(new Version(1, 2, 0, "4.5"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
-		mv = MvnVersion.parseString("1-4.5");
+		mv = MavenVersion.parseString("1-4.5");
 		assertEquals(new Version(1, 0, 0, "4.5"), mv.getOSGiVersion());
 		assertFalse(mv.isSnapshot());
 	}
 
 	public void testInvalidVersion() {
 		try {
-			MvnVersion mv = MvnVersion.parseString("Not a number");
+			MavenVersion mv = MavenVersion.parseString("Not a number");
 			fail();
 		}
 		catch (IllegalArgumentException e) {

--- a/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
@@ -1,10 +1,9 @@
-package aQute.bnd.deployer.repository.aether;
+package aQute.bnd.version;
 
-import java.util.regex.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.bnd.version.*;
-
-public class MvnVersion implements Comparable<MvnVersion> {
+public class MavenVersion implements Comparable<MavenVersion> {
 
 	public static final String		VERSION_STRING		= "(\\d{1,9})(\\.(\\d{1,9})(\\.(\\d{1,9}))?)?([-\\.]?([-_\\.\\da-zA-Z]+))?";
 
@@ -14,11 +13,11 @@ public class MvnVersion implements Comparable<MvnVersion> {
 
 	private final Version			osgiVersion;
 
-	public MvnVersion(Version osgiVersion) {
+	public MavenVersion(Version osgiVersion) {
 		this.osgiVersion = osgiVersion;
 	}
 
-	public static final MvnVersion parseString(String versionStr) {
+	public static final MavenVersion parseString(String versionStr) {
 		versionStr = versionStr.trim();
 		Matcher m = VERSION.matcher(versionStr);
 		if (!m.matches())
@@ -29,7 +28,7 @@ public class MvnVersion implements Comparable<MvnVersion> {
 		int micro = (m.group(5) != null) ? Integer.parseInt(m.group(5)) : 0;
 		String qualifier = m.group(7);
 		Version version = new Version(major, minor, micro, qualifier);
-		return new MvnVersion(version);
+		return new MavenVersion(version);
 	}
 
 	public Version getOSGiVersion() {
@@ -40,7 +39,7 @@ public class MvnVersion implements Comparable<MvnVersion> {
 		return QUALIFIER_SNAPSHOT.equals(osgiVersion.getQualifier());
 	}
 
-	public int compareTo(MvnVersion other) {
+	public int compareTo(MavenVersion other) {
 		return this.osgiVersion.compareTo(other.osgiVersion);
 	}
 
@@ -71,7 +70,7 @@ public class MvnVersion implements Comparable<MvnVersion> {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		MvnVersion other = (MvnVersion) obj;
+		MavenVersion other = (MavenVersion) obj;
 		if (osgiVersion == null) {
 			if (other.osgiVersion != null)
 				return false;

--- a/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/ConversionUtils.java
+++ b/biz.aQute.repository.aether/src/aQute/bnd/deployer/repository/aether/ConversionUtils.java
@@ -5,6 +5,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Verifier;
+import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
 
 final class ConversionUtils {
@@ -49,7 +50,7 @@ final class ConversionUtils {
 			throw new IllegalArgumentException("Invalid version " + versionString);
 		Version version = Version.parseVersion(versionString);
 		
-		return new DefaultArtifact(groupId, artifactId, JAR_EXTENSION, new MvnVersion(version).toString());
+		return new DefaultArtifact(groupId, artifactId, JAR_EXTENSION, new MavenVersion(version).toString());
 	}
 
 	public static String maybeMavenCoordsToBsn(String coords) throws IllegalArgumentException {


### PR DESCRIPTION
Since gradle users will use the standard gradle project version property and that property will likely be in maven "format", we use the MavenVersion class to parse it into a form suitable for use on the Bundle-Version manifest header.