### PR TITLE
bnd-indexer-maven-plugin improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
 
 script:
   - ./gradlew --continue
-  - mvn --batch-mode --quiet -Dmaven.repo.local=bnd-maven-plugin/target/m2 -Dfile=dist/bundles/org.osgi.impl.bundle.repoindex.cli/org.osgi.impl.bundle.repoindex.cli-latest.jar org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file
-  - mvn --batch-mode --quiet -Dmaven.repo.local=bnd-maven-plugin/target/m2 -Dfile=dist/bundles/biz.aQute.bndlib/biz.aQute.bndlib-latest.jar org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file
-  - mvn -f maven --batch-mode --quiet -Dmaven.repo.local=bnd-maven-plugin/target/m2 install
+  - mvn --batch-mode --quiet -Dmaven.repo.local=maven/target/m2 -Dfile=dist/bundles/org.osgi.impl.bundle.repoindex.cli/org.osgi.impl.bundle.repoindex.cli-latest.jar org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file
+  - mvn --batch-mode --quiet -Dmaven.repo.local=maven/target/m2 -Dfile=dist/bundles/biz.aQute.bndlib/biz.aQute.bndlib-latest.jar org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file
+  - mvn -f maven --batch-mode --quiet -Dmaven.repo.local=maven/target/m2 install
 
 cache:
   directories:

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -17,17 +17,22 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.aether</groupId>
+			<artifactId>aether-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.aether</groupId>
+			<artifactId>aether-util</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
@@ -53,6 +55,9 @@ public class IndexerMojo extends AbstractMojo {
 
     @Parameter( property = "bnd.indexer.allowLocal", defaultValue = "false", readonly = true )
     private boolean allowLocal;
+
+    @Parameter( property = "bnd.indexer.scopes", readonly = true, required=false )
+    private List<String> scopes;
     
     @Component
     private RepositorySystem system;
@@ -62,8 +67,14 @@ public class IndexerMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
+    	if(scopes == null || scopes.isEmpty()) {
+    		scopes = Arrays.asList("compile", "runtime");
+    	}
+    	
         DependencyResolutionRequest request = new DefaultDependencyResolutionRequest(project, session);
 
+        request.setResolutionFilter(new ScopeDependencyFilter(scopes, null));
+        
         DependencyResolutionResult result;
         try {
             result = resolver.resolve(request);

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.RepositoryUtils;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,6 +25,7 @@ import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -64,6 +67,9 @@ public class IndexerMojo extends AbstractMojo {
 
     @Component
     private ProjectDependenciesResolver resolver;
+    
+    @Component
+    private MavenProjectHelper projectHelper;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -109,10 +115,11 @@ public class IndexerMojo extends AbstractMojo {
         Map<String, String> config = new HashMap<String, String>();
         config.put(ResourceIndexer.PRETTY, "true");
 
+        File outputFile = new File(targetDir, "index.xml");
         OutputStream output;
         try {
         	targetDir.mkdirs();
-            output = new FileOutputStream(new File(targetDir, "index.xml"));
+			output = new FileOutputStream(outputFile);
         } catch (FileNotFoundException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
@@ -122,6 +129,12 @@ public class IndexerMojo extends AbstractMojo {
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
+        
+        DefaultArtifact defaultArtifact = new DefaultArtifact(project.getGroupId(), 
+        		project.getArtifactId(), project.getVersion(), null, "xml", null, 
+        		new DefaultArtifactHandler("xml"));
+        defaultArtifact.setFile(outputFile);
+		project.addAttachedArtifact(defaultArtifact);
     }
 
     class MavenURLResolver implements URLResolver {

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -11,6 +11,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.version>3.1.1</maven.version>
+		<aether.version>0.9.0.M2</aether.version>
 		<bnd.version>3.1.0</bnd.version>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.source>1.7</maven.compiler.source>
@@ -79,6 +80,18 @@
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
 				<version>3.4</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.aether</groupId>
+				<artifactId>aether-api</artifactId>
+				<version>${aether.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.aether</groupId>
+				<artifactId>aether-util</artifactId>
+				<version>${aether.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
* The indexer should only index compile and runtime dependencies by default. Other scopes may be added using configuration if desired
* The output index should be attached to the project so that it can be installed and deployed
* The output index should also include a .gz version for more efficient file serving from remote repositories