### PR TITLE
embedded repo: Use proper version numbers for embedded bundles

### DIFF
--- a/biz.aQute.bnd.embedded-repo/bnd.bnd
+++ b/biz.aQute.bnd.embedded-repo/bnd.bnd
@@ -5,10 +5,10 @@
 
 Bundle-Description: Embedded Repo for bnd workspace.
 -includeresource: \
-	biz.aQute.launcher/biz.aQute.launcher-latest.jar=${repo;biz.aQute.launcher;snapshot}, \
-	biz.aQute.remote.launcher/biz.aQute.remote.launcher-latest.jar=${repo;biz.aQute.remote.launcher;snapshot}, \
-	biz.aQute.junit/biz.aQute.junit-latest.jar=${repo;biz.aQute.junit;snapshot}, \
-	biz.aQute.tester/biz.aQute.tester-latest.jar=${repo;biz.aQute.tester;snapshot}
+	biz.aQute.launcher/biz.aQute.launcher-${base.version}.jar=${repo;biz.aQute.launcher;snapshot}, \
+	biz.aQute.remote.launcher/biz.aQute.remote.launcher-${base.version}.jar=${repo;biz.aQute.remote.launcher;snapshot}, \
+	biz.aQute.junit/biz.aQute.junit-${base.version}.jar=${repo;biz.aQute.junit;snapshot}, \
+	biz.aQute.tester/biz.aQute.tester-${base.version}.jar=${repo;biz.aQute.tester;snapshot}
 	
 
 -dependson: \


### PR DESCRIPTION
Using latest cause these bundles to be used over the bundles in the
workspace we wanted to test.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>