### PR TITLE
maven: Use @project.version@ in integration tests

### DIFF
--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>org.osgi.impl.bundle.repoindex.cli</artifactId>
-			<version>${bnd.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 	
@@ -46,7 +46,7 @@
 					<dependency>
 						<groupId>biz.aQute.bnd</groupId>
 						<artifactId>biz.aQute.bndlib</artifactId>
-						<version>${bnd.version}</version>
+						<version>${project.version}</version>
 						<scope>runtime</scope>
 					</dependency>
 					<dependency>
@@ -63,9 +63,6 @@
 					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
 					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
 					<postBuildHookScript>verify.groovy</postBuildHookScript>
-                    <properties>
-                        <bnd.version>${bnd.version}</bnd.version>
-                    </properties>
 					<goals>
 						<goal>package</goal>
 					</goals>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -43,7 +43,7 @@
 				<plugin>
 					<groupId>biz.aQute.bnd</groupId>
 					<artifactId>bnd-indexer-maven-plugin</artifactId>
-					<version>${bnd.version}</version>
+					<version>@project.version@</version>
 					<executions>
 						<execution>
 							<id>index</id>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -12,7 +12,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.version>3.1.1</maven.version>
 		<aether.version>0.9.0.M2</aether.version>
-		<bnd.version>3.1.0</bnd.version>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.source>1.7</maven.compiler.source>
 	</properties>
@@ -97,7 +96,7 @@
 			<dependency>
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>biz.aQute.bndlib</artifactId>
-				<version>${bnd.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
This avoids the need to pass a version property to the integration
pom.

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>