### PR TITLE
[indexer-maven-plugin] Make sure we use remote URLs when we say we will

### DIFF
--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -201,7 +201,20 @@ public class IndexerMojo extends AbstractMojo {
 				return file.toURI();
 			}
 			
-			ArtifactRepository repo = repositories.get(artifact.getRepository().getId());
+			
+			String id = artifact.getRepository().getId();
+
+			if("workspace".equals(id) || "local".equals(id)) {
+				for (ArtifactRepository repository : project.getRemoteArtifactRepositories()) {
+					if(repository.find(RepositoryUtils.toArtifact(artifact.getArtifact())) != null) {
+						id = repository.getId();
+						break;
+					}
+				}
+			}
+			
+			ArtifactRepository repo = repositories.get(id);
+			
 			if(repo == null) {
 				if(localURLs == ALLOWED) {
 					getLog().info("The Artifact " + artifact.getArtifact().toString() + 

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/in-build/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/in-build/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<artifactId>in-build</artifactId>
+	<packaging>pom</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.scr</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute</groupId>
+			<artifactId>bnd</artifactId>
+			<version>1.50.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-indexer-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -11,6 +11,8 @@
 		<module>transitive</module>
 		<module>scoped</module>
 		<module>require-local</module>
+		<module>test-bnd</module>
+		<module>in-build</module>
 	</modules>
 
 	<dependencyManagement>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<!-- This is a fake up of an old bnd! -->
+	<groupId>biz.aQute</groupId>
+	<artifactId>bnd</artifactId>
+	<version>1.50.0</version>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<useDefaultManifestFile>true</useDefaultManifestFile>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/src/main/resources/META-INF/MANIFEST.MF
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: biz.aQute.bnd
+Bundle-Version: 1.50.0


### PR DESCRIPTION
If the bundle is part of the current build then resolve will resolve to the target directory, not the remote location it was just deployed to. This was wrong!

Signed-off-by: Tim Ward <timothyjward@apache.org>