### PR TITLE
Fix bndtools/bndtools#1177: error resolving EE caps

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -308,6 +308,9 @@ public class ResourceBuilder {
 	public void addExportPackage(String packageName, Attrs attrs) throws Exception {
 		CapReqBuilder capb = new CapReqBuilder(resource, PackageNamespace.PACKAGE_NAMESPACE);
 		capb.addAttributesOrDirectives(attrs);
+		if (!attrs.containsKey(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE)) {
+			capb.addAttribute(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE, Version.emptyVersion);
+		}
 		capb.addAttribute(PackageNamespace.PACKAGE_NAMESPACE, packageName);
 		addCapability(capb);
 	}


### PR DESCRIPTION
The system packages from the EE and `-runsystempackages` omitted any version, so they could not resolve against a filter such as `(&(osgi.wiring.package=javax.xml.parsers)(version>=0.0.0))`.

If this patch works I would like it to be a candidate for inclusion in 3.0.1.