### PR TITLE
Added size limit to base64 macro

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MacroTest.java
@@ -1140,6 +1140,15 @@ public class MacroTest extends TestCase {
 		assertEquals(b64, b.getProperty("b64"));
 	}
 
+	public void testBase64TooBig() {
+		Processor b = new Processor();
+		b.setProperty("b64", "${base64;testresources/macro/base64-test.gif;100}");
+		b.getProperty("b64");
+		assertEquals(1, b.getErrors().size());
+		assertTrue("wrong error message",
+				b.getErrors().get(0).startsWith("base64 encoding exceeds size limit of 100 chars"));
+	}
+
 	public void testDigest() {
 		Processor b = new Processor();
 		b.setProperty("a", "${digest;SHA-256;testresources/macro/digest-test.jar}");

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1016,10 +1016,16 @@ public class Macro {
 	 * @throws IOException
 	 */
 	public String _base64(String... args) throws IOException {
-		verifyCommand(args, "${base64;<in>}, get the Base64 encoding of a file", null, 2, 2);
+		verifyCommand(args, "${base64;<in>;<limit>}, get the Base64 encoding of a file", null, 2, 3);
 		File f = domain.getFile(args[1]);
+		int limit = Integer.MAX_VALUE;
+		if (args.length == 3)
+			limit = Integer.parseInt(args[2]);
 		byte[] bytes = IO.read(f);
-		return Base64.encodeBase64(bytes);
+		String encoding = Base64.encodeBase64(bytes);
+		if (encoding.length() > limit)
+			throw new IllegalArgumentException(String.format("base64 encoding exceeds size limit of %d chars", limit));
+		return encoding;
 	}
 
 	/**


### PR DESCRIPTION
Turned out this macro was pretty dangerous unless you had a way to limit the size...