### PR TITLE
[indexer-maven-plugin] Output artifact type too generic

### DIFF
--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -184,14 +184,15 @@ public class IndexerMojo extends AbstractMojo {
 			throw new MojoExecutionException("Unable to create the gzipped output file");
 		}
 		
-		attach(outputFile, "xml", "xml");
-		attach(gzipOutputFile, "xml", "xml.gz");
+		attach(outputFile, "osgi-index", "xml");
+		attach(gzipOutputFile, "osgi-index", "xml.gz");
     }
     
     private void attach(File file, String type, String extension) {
-    	DefaultArtifact artifact = new DefaultArtifact(project.getGroupId(), 
-        		project.getArtifactId(), project.getVersion(), null, type, null, 
-        		new DefaultArtifactHandler(extension));
+    	DefaultArtifactHandler handler = new DefaultArtifactHandler(type);
+    	handler.setExtension(extension);
+		DefaultArtifact artifact = new DefaultArtifact(project.getGroupId(), 
+        		project.getArtifactId(), project.getVersion(), null, type, null, handler);
         artifact.setFile(file);
 		project.addAttachedArtifact(artifact);
     }


### PR DESCRIPTION
Maven lets you output artifacts with a _type_ which can be different from the file extension. Previously we set both to XML. The output is XML, but lots of things output XML. I am therefore changing the output type to _osgi-index_.

Signed-off-by: Tim Ward <timothyjward@apache.org>