### PR TITLE
repository: Revert to being a bundle

### DIFF
--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -23,9 +23,6 @@ jetty.libs: lib/javax.servlet-2.5.0.jar;version=file,\
 -testpath: \
 	junit.osgi,\
 	org.mockito.mockito-all
-	
-bndlib-range: [${version;==;${build.version}},${version;=+;${build.version}})
-Fragment-Host: biz.aQute.bndlib; bundle-version="${bndlib-range}"
 
 Bnd-Plugins:
 	aQute.bnd.deployer.repository.FixedIndexedRepo,\
@@ -48,32 +45,30 @@ repoindex-pkgs: \
 	org.osgi.service.indexer.impl.util,\
 	aQute.bnd.osgi.resource,\
 	org.osgi.resource;-split-package:=first
-	
+
 Export-Package:\
-	aQute.bnd.deployer.repository,\
+	aQute.bnd.deployer.http;bnd-plugins=true,\
+	aQute.bnd.deployer.obr;bnd-plugins=true,\
+	aQute.bnd.deployer.repository;bnd-plugins=true,\
 	aQute.bnd.deployer.repository.api,\
-	aQute.bnd.deployer.repository.providers,\
-	org.osgi.service.coordinator;-split-package:=merge-first,\
+	aQute.bnd.deployer.repository.providers;bnd-plugins=true,\
+	aQute.bnd.deployer.repository.wrapper;bnd-plugins=true,\
+	aQute.bnd.jpm;bnd-plugins=true,\
+	org.osgi.service.coordinator,\
 	org.osgi.service.indexer
 
-# NB: `org.osgi.framework` API is included in Private-Package for running outside of OSGi.
+# NB: `org.osgi.*` API is included in Private-Package for running outside of OSGi.
 Private-Package:  \
 	${bindex-pkgs},\
 	${repoindex-pkgs},\
-	aQute.bnd.deployer.http,\
-	aQute.bnd.deployer.obr,\
-	org.osgi.service.log;provide:=true;-split-package:=merge-first,\
-	aQute.bnd.deployer.repository.wrapper,\
-	aQute.bnd.jpm,\
+	org.osgi.service.log;-split-package:=first,\
 	org.osgi.framework;-split-package:=first,\
-	aQute.bnd.jpm,\
 	aQute.jpm.facade.repo,\
 	aQute.jsonrpc.proxy,\
 	aQute.rest.urlclient,\
 	aQute.service.library,\
 	aQute.jsonrpc.domain,\
 	aQute.struct
-	
 
 Conditional-Package:\
 	aQute.lib.*;-split-package:=first,\
@@ -88,5 +83,3 @@ Import-Package:\
 	aQute.bnd.osgi.resource,\
 	org.osgi.service.coordinator; resolution:=optional,\
 	*
-
--fixupmessages: "Export aQute.bnd.deployer.*.impl"

--- a/biz.aQute.resolve/bnd.bnd
+++ b/biz.aQute.resolve/bnd.bnd
@@ -17,17 +17,8 @@ Export-Package:  \
 	org.osgi.service.log;-split-package:=first,\
 	org.osgi.service.resolver;-split-package:=first
 
-#
-# We include the DTO packages so we do not force
-# Eclipse to run the latest & greatest OSGi
-# and we do not use these classes for interchange
-#
-
 Private-Package: \
 	biz.aQute.resolve.*,\
 	org.apache.felix.resolver.*
-	org.osgi.resource.dto,\
-	org.osgi.dto
 
 Conditional-Package: aQute.lib*
-


### PR DESCRIPTION
This was changed to a fragment while having issues with the Kepler resolver. Since we have updated now to Luna for 3.1, we should revert this to be a normal bundle.