### PR TITLE
better offline support for JPM repo

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
+++ b/biz.aQute.repository/src/aQute/bnd/jpm/Repository.java
@@ -271,10 +271,6 @@ public class Repository implements Plugin, RepositoryPlugin, Closeable, Refresha
 			}
 		}
 
-		if (!isConnected()) {
-			failure(listeners, file, "Not online");
-		}
-
 		if (file.isFile()) {
 			if (file.length() == size) {
 				// Already exists, done
@@ -285,6 +281,10 @@ public class Repository implements Plugin, RepositoryPlugin, Closeable, Refresha
 			reporter.error("found file but of different length %s, will refetch", file);
 		} else {
 			reporter.trace("not in cache %s", file + " " + queues);
+		}
+
+		if (!isConnected()) {
+			failure(listeners, file, "Not online");
 		}
 
 		// Check if we need synchronous


### PR DESCRIPTION
While working on a bndtools style workspace on a recent plane trip, JPM was complaining about not being online and killing the project builder even though all of the bundles were there locally and already cached.  With this small change it lets cached files be return successfully before trying for online connectivity.