### PR TITLE
Add capability to override spec attributes with extensions.

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
@@ -2860,6 +2860,49 @@ public class DSAnnotationTest extends BndTestCase {
 
 	}
 
+	@XMLAttribute(namespace = "override", prefix = "", embedIn = "http://www.osgi.org/xmlns/scr/*")
+	@Retention(RetentionPolicy.CLASS)
+	@Target({
+		ElementType.TYPE
+	})
+	@interface TestSpecReplace {
+		boolean immediate() default false;
+
+		boolean enabled() default true;
+	}
+
+	@TestSpecReplace
+	@Component(immediate = true, enabled = false)
+	public static class ReplacedAttributes implements Serializable, Runnable {
+		private static final long	serialVersionUID	= 1L;
+
+		@Override
+		public void run() {}
+	}
+
+	public void testReplaceSpecAttribute() throws Exception {
+		Builder b = new Builder();
+		b.setProperty(Constants.DSANNOTATIONS, "test.component.DSAnnotationTest$ReplacedAttributes*");
+		b.setProperty("Private-Package", "test.component");
+		b.addClasspath(new File("bin"));
+
+		Jar jar = b.build();
+		assertOk(b);
+
+		String name = ReplacedAttributes.class.getName();
+		Resource r = jar.getResource("OSGI-INF/" + name + ".xml");
+		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+		assertNotNull(r);
+		r.write(System.err);
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.1.0");
+		// Test the defaults
+		xt.assertAttribute(name, "scr:component/implementation/@class");
+
+		// check that we replaced it
+		xt.assertAttribute("false", "scr:component/@immediate");
+		xt.assertAttribute("true", "scr:component/@enabled");
+	}
+
 	@Component(name = "mixed-std-bnd")
 	static class MixedStdBnd {
 

--- a/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
+++ b/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
@@ -1489,6 +1489,53 @@ public class SpecMetatypeTest extends TestCase {
 		xt.assertExactAttribute("two", "metatype:MetaData/OCD/AD[@id='property']/@foo:second");
 	}
 
+	@XMLAttribute(namespace = "spec.override", prefix = "", embedIn = "*")
+	@Retention(RetentionPolicy.CLASS)
+	@Target({
+			ElementType.TYPE, ElementType.METHOD
+	})
+	@interface SpecOverride {
+		String name() default "replacement name";
+
+		String description() default "replacement description";
+	}
+
+	@SpecOverride
+	@ObjectClassDefinition(name = "default name", description = "default description")
+	@interface SpecReplacementConfig {
+		@SpecOverride(name = "one", description = "two")
+		@AttributeDefinition(name = "default name", description = "default description")
+		String[] property();
+	}
+
+	public void testSpecReplacementExtension() throws Exception {
+		MetatypeVersion version = MetatypeVersion.VERSION_1_3;
+		Builder b = new Builder();
+		b.addClasspath(new File("bin"));
+		b.setProperty("Export-Package", "test.metatype");
+		b.setProperty(Constants.METATYPE_ANNOTATIONS, SpecReplacementConfig.class.getName());
+		b.build();
+		Resource r = b.getJar().getResource(
+				"OSGI-INF/metatype/test.metatype.SpecMetatypeTest$SpecReplacementConfig.xml");
+		assertEquals(0, b.getErrors().size());
+		assertEquals("warnings: " + b.getWarnings(), 0, b.getWarnings().size());
+
+		System.err.println(b.getJar().getResources().keySet());
+		assertNotNull(r);
+		IO.copy(r.openInputStream(), System.err);
+		XmlTester xt = new XmlTester(r.openInputStream(), "metatype", version.getNamespace());
+		xt.assertNamespace(version.getNamespace());
+		xt.assertExactAttribute("test.metatype.SpecMetatypeTest$SpecReplacementConfig", "metatype:MetaData/OCD/@id");
+
+		xt.assertCount(3, "metatype:MetaData/OCD/@*");
+		xt.assertExactAttribute("replacement name", "metatype:MetaData/OCD/@name");
+		xt.assertExactAttribute("replacement description", "metatype:MetaData/OCD/@description");
+
+		xt.assertCount(5, "metatype:MetaData/OCD/AD[@id='property']/@*");
+		xt.assertExactAttribute("one", "metatype:MetaData/OCD/AD[@id='property']/@name");
+		xt.assertExactAttribute("two", "metatype:MetaData/OCD/AD[@id='property']/@description");
+	}
+
 	@ObjectClassDefinition
 	@interface Escapes {
 		@AttributeDefinition(defaultValue = {

--- a/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
@@ -267,6 +267,9 @@ public class AnnotationReader extends ClassDataCollector {
 	}
 
 	private void doXmlAttribute(Annotation annotation, XMLAttribute xmlAttr) {
+		// make sure doc is namespace aware, since we are adding namespaced
+		// attributes.
+		component.updateVersion(V1_1);
 		if (member == null)
 			component.addExtensionAttribute(xmlAttr, annotation);
 		else {

--- a/biz.aQute.bndlib/src/aQute/bnd/xmlattribute/ExtensionDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/xmlattribute/ExtensionDef.java
@@ -58,6 +58,8 @@ public class ExtensionDef {
 		if (namespaces != null) {
 			for (Map.Entry<XMLAttribute,Annotation> entry : attributes.entrySet()) {
 				String prefix = namespaces.getPrefix(entry.getKey().namespace());
+				if (prefix.length() > 0)
+					prefix = prefix + ":";
 				Annotation a = entry.getValue();
 				Map<String,String> props = finder.getDefaults(a);
 				for (String key : entry.getValue().keySet()) {
@@ -87,7 +89,7 @@ public class ExtensionDef {
 								key = map.substring(match.length());
 						}
 					}
-					tag.addAttribute(prefix + ":" + key, prop.getValue());
+					tag.addAttribute(prefix + key, prop.getValue());
 				}
 			}
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/xmlattribute/Namespaces.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/xmlattribute/Namespaces.java
@@ -1,8 +1,9 @@
 package aQute.bnd.xmlattribute;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-import aQute.lib.tag.*;
+import aQute.lib.tag.Tag;
 
 public class Namespaces {
 
@@ -31,7 +32,8 @@ public class Namespaces {
 
 	public void addNamespaces(Tag tag) {
 		for (Map.Entry<String,String> entry : namespaces.entrySet())
-			tag.addAttribute("xmlns:" + entry.getValue(), entry.getKey());
+			if (entry.getValue().length() > 0)
+				tag.addAttribute("xmlns:" + entry.getValue(), entry.getKey());
 	}
 
 }


### PR DESCRIPTION
For DS, make use of an extension attribute force the 1.1 version to provide a namespace-aware xml document.

Signed-off-by David Jencks <david_jencks@yahoo.com>