### PR TITLE
plugins: Use Builder.setJar instead of -includeresource

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -80,7 +80,11 @@ public class Builder extends Analyzer {
 		if (getProperty(CONDUIT) != null)
 			error("Specified " + CONDUIT + " but calls build() instead of builds() (might be a programmer error");
 
-		Jar dot = new Jar("dot");
+		Jar dot = getJar();
+		if (dot == null) {
+			dot = new Jar("dot");
+			setJar(dot);
+		}
 		try {
 			long modified = Long.parseLong(getProperty("base.modified"));
 			dot.updateModified(modified, "Base modified");
@@ -88,7 +92,6 @@ public class Builder extends Analyzer {
 		catch (Exception e) {
 			// Ignore
 		}
-		setJar(dot);
 
 		doExpand(dot);
 		doIncludeResources(dot);

--- a/maven/bnd-baseline-maven-plugin/.gitignore
+++ b/maven/bnd-baseline-maven-plugin/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/bin/
+/.classpath
+/.project
+/.settings

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.jar.Manifest;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -129,13 +130,9 @@ public class BndMavenPlugin extends AbstractMojo {
 
 			// Include local project packages automatically
 			if (classesDir.isDirectory()) {
-				String includes = builder.getProperty(Constants.INCLUDERESOURCE);
-				StringBuilder newIncludes = new StringBuilder().append('"').append(classesDir.getAbsolutePath().replaceAll("\"", "\\\\\"")).append('"');
-				if (includes == null || includes.trim().isEmpty())
-					includes = newIncludes.toString();
-				else
-					includes = newIncludes.append(',').append(includes).toString();
-				builder.setProperty(Constants.INCLUDERESOURCE, includes);
+				Jar classesDirJar = new Jar(project.getName(), classesDir);
+				classesDirJar.setManifest(new Manifest());
+				builder.setJar(classesDirJar);
 			}
 
 			// Set Bundle-Version
@@ -216,8 +213,8 @@ public class BndMavenPlugin extends AbstractMojo {
 				throw new IOException("Could not create directory " + outDir);
 			}
 
-			// Skip the copy if the source and target file are the same
 			Resource resource = entry.getValue();
+			// Skip the copy if the source and target file are the same
 			if (resource instanceof FileResource) {
 				@SuppressWarnings("resource")
 				FileResource fr = (FileResource) resource;
@@ -225,7 +222,7 @@ public class BndMavenPlugin extends AbstractMojo {
 					continue;
 			}
 
-			IO.copy(entry.getValue().openInputStream(), outFile);
+			IO.copy(resource.openInputStream(), outFile);
 		}
 	}
 


### PR DESCRIPTION
We include the jar content already assembled by maven/gradle with `setJar` instead of using `-includeresource` to avoid conflict with any user instructions in the bnd file.