### PR TITLE
[build] Multiple sub bundles did not show up in Workspace Repository

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1623,6 +1623,8 @@ public class Project extends Processor {
 		if (isNoBundles())
 			return null;
 
+		versionMap.clear();
+
 		//
 		// #761 tstamp can vary between invocations in one build
 		// Macro can handle a @tstamp time so we freeze the time at

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -535,7 +535,7 @@ public class ProjectBuilder extends Builder {
 	 * version.
 	 */
 	protected void startBuild(Builder builder) {
-		project.versionMap.clear();
+		project.versionMap.remove(builder.getBsn());
 	}
 
 	/**


### PR DESCRIPTION
It turned out that each sub bundle build was clearing the map with the other sub bundles. This caused only the last sub bundle to remain in that map. I.e. the workspace repository only showed the last sub bundle.

The project now clears the map before the overall build. Sub bundle builds remove and add their name + version to  this map.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>