### PR TITLE
gradle: Change Bundle class to avoid Groovy 2.4 error

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -22,7 +22,8 @@ public class BndBuilderPlugin implements Plugin<Project> {
   /**
    * Apply the {@code biz.aQute.bnd.builder} plugin to the specified project.
    */
-  void apply(Project p) {
+  @Override
+  public void apply(Project p) {
     p.configure(p) { project ->
       if (plugins.hasPlugin(BndPlugin.PLUGINID)) {
           throw new GradleException("Project already has '${BndPlugin.PLUGINID}' plugin applied.")

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -36,7 +36,8 @@ public class BndPlugin implements Plugin<Project> {
   /**
    * Apply the {@code biz.aQute.bnd} plugin to the specified project.
    */
-  void apply(Project p) {
+  @Override
+  public void apply(Project p) {
     p.configure(p) { project ->
       this.project = project
       if (plugins.hasPlugin(BndBuilderPlugin.PLUGINID)) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
@@ -23,6 +23,7 @@
 
 package aQute.bnd.gradle
 
+import groovy.transform.CompileStatic
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.bundling.Jar
 
@@ -48,7 +49,20 @@ public class Bundle extends Jar {
   @TaskAction
   @Override
   protected void copy() {
-    super.copy()
+    supercopy()
     buildBundle()
+  }
+
+  /**
+   * Private method to call super.copy().
+   *
+   * <p>
+   * We need to compile the call to super.copy() with @CompileStatic to
+   * avoid a Groovy 2.4 error where the super.copy() call instead results in
+   * calling this.copy() causing a StackOverflowError.
+   */
+  @CompileStatic
+  private void supercopy() {
+    super.copy()
   }
 }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
@@ -46,6 +46,7 @@ public class Bundle extends Jar {
    * to transform the Jar task built jar into a bundle.
    */
   @TaskAction
+  @Override
   protected void copy() {
     super.copy()
     buildBundle()

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -97,7 +97,7 @@ class BundleTaskConvention {
     this.sourceSet = sourceSet
   }
 
-  private void buildBundle() {
+  void buildBundle() {
     task.configure {
       // create Builder and set trace level from gradle
       def Builder builder = new Builder()


### PR DESCRIPTION
We need to compile the call to `super.copy()` with `@CompileStatic` to
avoid a Groovy 2.4 error where the `super.copy()` call instead results in
calling `this.copy()` causing a StackOverflowError.

See <https://discuss.gradle.org/t/gradle-2-8-causes-stackoverflowerror-on-super-call/12348>
for a discussion.