### PR TITLE
Resolve 'Bundle-ClassPath' header when adding bundles to the bnd build path

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/BundleClasspathCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/BundleClasspathCache.java
@@ -1,0 +1,92 @@
+package aQute.bnd.build;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import aQute.bnd.osgi.Resource;
+import aQute.bnd.service.RepositoryPlugin.PutOptions;
+import aQute.bnd.service.RepositoryPlugin.PutResult;
+import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
+import aQute.bnd.version.Version;
+import aQute.lib.deployer.FileRepo;
+import aQute.libg.cryptography.SHA1;
+
+/**
+ * Caches the entries specified in the Bundle-ClassPath header in a file
+ * repository so that these entries can be added to the build path.
+ */
+public class BundleClasspathCache {
+
+	/** The backing repository for the cached files */
+	private FileRepo repo;
+
+	/**
+	 * Initialise the repository
+	 * 
+	 * @param location
+	 *            where the cached files will be stored
+	 */
+	void init(File location) {
+		FileRepo files = new FileRepo();
+
+		Map<String,String> config = new HashMap<>();
+		config.put(FileRepo.LOCATION, location.getAbsolutePath());
+		config.put(FileRepo.READONLY, "false");
+		config.put(FileRepo.INDEX, "true");
+		files.setProperties(config);
+
+		repo = files;
+	}
+
+	/**
+	 * Looks up the cached file in the file repository. If it doesn't exist it
+	 * is added.
+	 * 
+	 * @param source
+	 *            the container for the bundle using the 'Bundle-ClassPath'
+	 *            header
+	 * @param resource
+	 *            the resource embedded in 'source'
+	 * @param entryName
+	 *            the name of the entry the 'resource' hold the data for
+	 * @return
+	 * @throws Exception
+	 */
+	public File getEntry(Container source, Resource resource, String entryName) throws Exception {
+
+		SHA1 digest = SHA1.digest(resource.openInputStream());
+
+		ResourceDescriptor entry = repo.getResource(digest.toByteArray());
+
+		// we need to put the entry in the cache if the resource was not found
+		if (entry == null) {
+			InputStream stream = resource.openInputStream();
+			PutOptions options = createOptions(source, entryName, digest.hashCode());
+			PutResult result = repo.put(stream, options);
+			return new File(result.artifact);
+		} else {
+			return new File(entry.url);
+		}
+	}
+
+	private PutOptions createOptions(Container source, String entry, int id) {
+		PutOptions options = new PutOptions();
+
+		// use a bsn that encodes the source and the entry within it
+		options.bsn = encodeEntryBsn(source.getBundleSymbolicName(), entry);
+
+		String versionString = source.getVersion();
+		if (Version.isVersion(versionString)) {
+			options.version = Version.parseVersion(versionString);
+		}
+
+		options.type = PutOptions.BUNDLE;
+		return options;
+	}
+
+	private String encodeEntryBsn(String containerBsn, String entryPath) {
+		return containerBsn + "-" + entryPath;
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -397,14 +397,13 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 
 			reporter.trace("updating %s ", file.getAbsolutePath());
 
+			// An open jar on file will fail rename on windows
+			tmpJar.close();
 			IO.rename(tmpFile, file);
 
 			if (hasIndex)
 				index.put(bsn + "-" + version.getWithoutQualifier(),
 						buildDescriptor(file, tmpJar, digest, bsn, version));
-
-			// An open jar on file will fail rename on windows
-			tmpJar.close();
 
 			dirty = true;
 

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -403,7 +403,7 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 
 			if (hasIndex)
 				index.put(bsn + "-" + version.getWithoutQualifier(),
-						buildDescriptor(file, tmpJar, digest, bsn, version));
+						buildDescriptor(file, new Jar(file), digest, bsn, version));
 
 			dirty = true;
 

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -1,24 +1,49 @@
 package aQute.lib.deployer;
 
-import java.io.*;
-import java.security.*;
-import java.util.*;
-import java.util.jar.*;
-import java.util.regex.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.*;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Instruction;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.Actionable;
+import aQute.bnd.service.Plugin;
+import aQute.bnd.service.Refreshable;
+import aQute.bnd.service.Registry;
+import aQute.bnd.service.RegistryPlugin;
+import aQute.bnd.service.RepositoryListenerPlugin;
+import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
-import aQute.bnd.version.*;
-import aQute.lib.collections.*;
-import aQute.lib.hex.*;
-import aQute.lib.io.*;
-import aQute.lib.json.*;
-import aQute.lib.persistentmap.*;
-import aQute.libg.command.*;
-import aQute.libg.cryptography.*;
-import aQute.libg.reporter.*;
-import aQute.service.reporter.*;
+import aQute.bnd.version.Version;
+import aQute.lib.collections.SortedList;
+import aQute.lib.hex.Hex;
+import aQute.lib.io.IO;
+import aQute.lib.json.JSONCodec;
+import aQute.lib.persistentmap.PersistentMap;
+import aQute.libg.command.Command;
+import aQute.libg.cryptography.SHA1;
+import aQute.libg.cryptography.SHA256;
+import aQute.libg.reporter.ReporterAdapter;
+import aQute.service.reporter.Reporter;
 
 /**
  * A FileRepo is the primary and example implementation of a repository based on
@@ -372,15 +397,16 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 
 			reporter.trace("updating %s ", file.getAbsolutePath());
 
+			IO.rename(tmpFile, file);
+
 			if (hasIndex)
 				index.put(bsn + "-" + version.getWithoutQualifier(),
-						buildDescriptor(tmpFile, tmpJar, digest, bsn, version));
+						buildDescriptor(file, tmpJar, digest, bsn, version));
 
 			// An open jar on file will fail rename on windows
 			tmpJar.close();
 
 			dirty = true;
-			IO.rename(tmpFile, file);
 
 			fireBundleAdded(file);
 			afterPut(file, bsn, version, Hex.toHexString(digest));


### PR DESCRIPTION
I noticed that the bnd build path doesn't expand ```Bundle-ClassPath``` entries. I opened this issue https://github.com/bndtools/bndtools/issues/1198 but it was closed as 'won't fix' and suggested that I could put together a pull request.

This pull request is by no means complete, I just figured this is the best way to get some feedback on the approach I am taking, before building upon this core. Please advise if there is a better channel to do such things.

Basically I am extracting the entries, and caching them using an indexed FileRepo, and performing the expansion from a jar to the jar + embedded entries in Container.getMembers()

I look forward to some feedback about whether this a good approach to take.