### PR TITLE
gradle: Ensure only jar type artifacts in builder classpath

### DIFF
--- a/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -63,6 +63,7 @@ class TestBundlePlugin extends Specification {
           jartask_jar.getInputStream(jartask_jar.getEntry('foo.txt')).text =~ /Hi!/
           jartask_jar.getEntry('bar.txt')
           jartask_jar.getInputStream(jartask_jar.getEntry('bar.txt')).text =~ /Some more TEXT/
+          !jartask_jar.getEntry('test.txt')
 
           bundletask_manifest.getValue('Bundle-SymbolicName') == "${testProject}_bundle"
           bundletask_manifest.getValue('Bundle-Version') == '1.1.0'
@@ -72,6 +73,8 @@ class TestBundlePlugin extends Specification {
           !bundletask_jar.getEntry('doubler/impl/DoublerImpl.class')
           bundletask_jar.getEntry('doubler/impl/DoublerImplTest.class')
           bundletask_jar.getEntry('OSGI-OPT/src/')
+          !bundletask_jar.getEntry('foo.txt')
+          !bundletask_jar.getEntry('bar.txt')
           bundletask_jar.getEntry('test.txt')
           bundletask_jar.getInputStream(bundletask_jar.getEntry('test.txt')).text =~ /This is a test resource/
     }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -131,7 +131,7 @@ class BundleTaskConvention {
         def File temporaryFile = new File(temporaryDir, archiveName)
 
         // set builder classpath
-        builder.setClasspath(configuration.resolvedConfiguration.resolvedArtifacts*.file as File[])
+        builder.setClasspath(configuration.resolvedConfiguration.resolvedArtifacts.findAll{it.type == 'jar'}*.file as File[])
         logger.debug 'builder classpath: {}', builder.getClasspath()*.getSource()
 
         // set builder sourcepath if -sources=true

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -132,7 +132,6 @@ class BundleTaskConvention {
 
         // set builder classpath
         def Set<File> artifacts = new LinkedHashSet<File>(configuration.resolvedConfiguration.resolvedArtifacts*.file)
-        artifacts.add(temporaryFile)
         builder.setClasspath(artifacts.toArray(new File[artifacts.size()]))
         logger.debug 'builder classpath: {}', builder.getClasspath()*.getSource()
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -131,14 +131,12 @@ class BundleTaskConvention {
         def File temporaryFile = new File(temporaryDir, archiveName)
 
         // set builder classpath
-        def Set<File> artifacts = new LinkedHashSet<File>(configuration.resolvedConfiguration.resolvedArtifacts*.file)
-        builder.setClasspath(artifacts.toArray(new File[artifacts.size()]))
+        builder.setClasspath(configuration.resolvedConfiguration.resolvedArtifacts*.file as File[])
         logger.debug 'builder classpath: {}', builder.getClasspath()*.getSource()
 
         // set builder sourcepath if -sources=true
         if (builder.hasSources()) {
-          def Set<File> srcDirs = new LinkedHashSet<File>(sourceSet.java.srcDirs)
-          builder.setSourcepath(srcDirs.toArray(new File[srcDirs.size()]))
+          builder.setSourcepath(sourceSet.java.srcDirs as File[])
           logger.debug 'builder sourcepath: {}', builder.getSourcePath()
         }
 


### PR DESCRIPTION
In some circumstances, pom files can appear in the resolved artifacts. We make sure only artifacts of type jar are used for the builder's classpath.

Issue discovered by @rotty3000.