### PR TITLE
Baseline improvements

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/differ/Baseline.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/Baseline.java
@@ -1,16 +1,28 @@
 package aQute.bnd.differ;
 
-import java.io.*;
-import java.util.*;
-import java.util.jar.*;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.Manifest;
 
-import aQute.bnd.header.*;
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.diff.*;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Descriptors;
+import aQute.bnd.osgi.Instructions;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.diff.Delta;
+import aQute.bnd.service.diff.Diff;
 import aQute.bnd.service.diff.Diff.Ignore;
-import aQute.bnd.version.*;
-import aQute.libg.generics.*;
-import aQute.service.reporter.*;
+import aQute.bnd.service.diff.Differ;
+import aQute.bnd.service.diff.Tree;
+import aQute.bnd.service.diff.Type;
+import aQute.bnd.version.Version;
+import aQute.libg.generics.Create;
+import aQute.service.reporter.Reporter;
 
 /**
  * This class maintains
@@ -193,7 +205,11 @@ public class Baseline {
 				highestDelta = pdiff.getDelta();
 			}
 		}
-		if (firstRelease) {
+		// If this is a first release, or the base has a different symbolic name,
+		// then the newer version must be ok. Otherwise the version bump for
+		// bundles with the same symbolic name should be at least as big as the
+		// biggest semantic change
+		if (firstRelease || !bsn.equals(getBsn(o))) {
 			suggestedVersion = newerVersion;
 		} else {
 			suggestedVersion = bumpBundle(highestDelta, olderVersion, 1, 0);

--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -33,4 +33,34 @@
 			<artifactId>biz.aQute.bndlib</artifactId>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<configuration>
+					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
+					<cloneClean>true</cloneClean>
+					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
+					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
+					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
+					<postBuildHookScript>verify.groovy</postBuildHookScript>
+					<goals>
+						<goal>deploy</goal>
+					</goals>
+					<debug>true</debug>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>install</goal>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	
 </project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/settings.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<localRepository />
+	<interactiveMode>false</interactiveMode>
+	<usePluginRegistry />
+	<offline />
+	<pluginGroups />
+	<servers />
+	<mirrors />
+	<proxies />
+	<profiles/>	
+	<activeProfiles />
+</settings>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/bnd.bnd
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/bnd.bnd
@@ -1,0 +1,1 @@
+-exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>invalid-with-consumer</artifactId>
+	<version>0.0.2</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<configuration>
+					<base>
+						<artifactId>valid-no-previous</artifactId>
+					</base>
+					<includeDistributionManagement>true</includeDistributionManagement>
+					<continueOnError>true</continueOnError>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/TestConsumerIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/TestConsumerIface.java
@@ -1,0 +1,10 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ConsumerType
+public interface TestConsumerIface {
+
+	public String doConsumerStuff();
+
+	public String doMoreConsumerStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/TestProviderIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/TestProviderIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ProviderType
+public interface TestProviderIface {
+
+	public String doProviderStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/package-info.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/src/main/java/bnd/test/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package bnd.test;

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>invalid-with-provider</artifactId>
+	<version>0.0.2</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<configuration>
+					<base>
+						<artifactId>valid-no-previous</artifactId>
+					</base>
+					<includeDistributionManagement>true</includeDistributionManagement>
+					<continueOnError>true</continueOnError>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/TestConsumerIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/TestConsumerIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ConsumerType
+public interface TestConsumerIface {
+
+	public String doConsumerStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/TestProviderIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/TestProviderIface.java
@@ -1,0 +1,10 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ProviderType
+public interface TestProviderIface {
+
+	public String doProviderStuff();
+
+	public String doMoreProviderStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/package-info.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/src/main/java/bnd/test/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package bnd.test;

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -16,6 +16,7 @@
 	<modules>
 		<module>valid-no-previous</module>
 		<module>valid-with-previous-same</module>
+		<module>valid-with-provider</module>
 		<module>invalid-with-provider</module>
 		<module>invalid-with-consumer</module>
 	</modules>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>test</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+
+	<distributionManagement>
+		<repository>
+			<id>Test Repo</id>
+			<url>file:@project.build.directory@/integration-test/test-repo</url>
+		</repository>
+	</distributionManagement>
+
+	<modules>
+		<module>valid-no-previous</module>
+		<module>valid-with-previous-same</module>
+		<module>invalid-with-provider</module>
+		<module>invalid-with-consumer</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.annotation</artifactId>
+				<version>6.0.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-baseline-maven-plugin</artifactId>
+					<version>@project.version@</version>
+					<executions>
+						<execution>
+							<id>baseline</id>
+							<goals>
+								<goal>baseline</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>@project.version@</version>
+					<executions>
+						<execution>
+							<id>default-bnd-process</id>
+							<goals>
+								<goal>bnd-process</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!-- The following configuration is required because bnd-maven-plugin 
+					generates the manifest to target/classes/META-INF/MANIFEST.MF but the normal 
+					maven-jar-plugin does not use it. If the jar-plugin is patched to pick up 
+					the manifest from this location, then the following config is not needed. -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<configuration>
+						<useDefaultManifestFile>
+							true
+						</useDefaultManifestFile>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>valid-no-previous</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<configuration>
+					<failOnMissing>false</failOnMissing>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/TestConsumerIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/TestConsumerIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ConsumerType
+public interface TestConsumerIface {
+
+	public String doConsumerStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/TestProviderIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/TestProviderIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ProviderType
+public interface TestProviderIface {
+
+	public String doProviderStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/package-info.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/src/main/java/bnd/test/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package bnd.test;

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>valid-with-previous-same</artifactId>
+	<version>0.0.2</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<configuration>
+					<base>
+						<artifactId>valid-no-previous</artifactId>
+					</base>
+					<includeDistributionManagement>true</includeDistributionManagement>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/TestConsumerIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/TestConsumerIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ConsumerType
+public interface TestConsumerIface {
+
+	public String doConsumerStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/TestProviderIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/TestProviderIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ProviderType
+public interface TestProviderIface {
+
+	public String doProviderStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/package-info.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/src/main/java/bnd/test/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package bnd.test;

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>valid-with-provider</artifactId>
+	<version>0.0.2</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-baseline-maven-plugin</artifactId>
+				<configuration>
+					<base>
+						<artifactId>valid-no-previous</artifactId>
+					</base>
+					<includeDistributionManagement>true</includeDistributionManagement>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/TestConsumerIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/TestConsumerIface.java
@@ -1,0 +1,8 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ConsumerType
+public interface TestConsumerIface {
+
+	public String doConsumerStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/TestProviderIface.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/TestProviderIface.java
@@ -1,0 +1,10 @@
+package bnd.test;
+
+@org.osgi.annotation.versioning.ProviderType
+public interface TestProviderIface {
+
+	public String doProviderStuff();
+
+	public String doMoreProviderStuff();
+	
+}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/package-info.java
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/src/main/java/bnd/test/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.1.0")
+package bnd.test;

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -1,0 +1,27 @@
+import java.io.*;
+
+println "basedir ${basedir}"
+
+assert new File("${basedir}/build.log").exists();
+
+String fileContents = new File("${basedir}/build.log").getText('UTF-8');
+
+// No previous
+assert fileContents.contains("[WARNING] No previous version of biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 could be found to baseline against");
+
+// With previous-same
+assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1")
+
+// With provider
+assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -\n" +
+"\n" +
+"[ERROR] The bundle version change (0.0.1 to 0.0.2) is too low, the new version must be at least 0.1.0\n" +
+"[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
+
+
+// With consumer
+assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0\n" +
+"\n" +
+"[ERROR] The bundle version change (0.0.1 to 0.0.2) is too low, the new version must be at least 1.0.0\n" +
+"[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
+

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -15,13 +15,11 @@ assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQu
 // With provider
 assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -\n" +
 "\n" +
-"[ERROR] The bundle version change (0.0.1 to 0.0.2) is too low, the new version must be at least 0.1.0\n" +
 "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
 
 
 // With consumer
 assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0\n" +
 "\n" +
-"[ERROR] The bundle version change (0.0.1 to 0.0.2) is too low, the new version must be at least 1.0.0\n" +
 "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
 

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -12,6 +12,10 @@ assert fileContents.contains("[WARNING] No previous version of biz.aQute.bnd-tes
 // With previous-same
 assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1")
 
+// With previous-provider
+assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1")
+
+
 // With provider
 assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -\n" +
 "\n" +

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -4,26 +4,35 @@ println "basedir ${basedir}"
 
 assert new File("${basedir}/build.log").exists();
 
-String fileContents = new File("${basedir}/build.log").getText('UTF-8');
+List<String> fileContents = new ArrayList<String>();
+
+BufferedReader reader = new File("${basedir}/build.log").newReader();
+
+String s = null;
+
+while((s = reader.readLine()) != null) {
+    fileContents.add(s);
+}
 
 // No previous
 assert fileContents.contains("[WARNING] No previous version of biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 could be found to baseline against");
 
 // With previous-same
-assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1")
+assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1");
 
 // With previous-provider
-assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1")
+assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1");
 
 
 // With provider
-assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -\n" +
-"\n" +
-"[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
+int idx = fileContents.indexOf("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -");
+
+assert fileContents.get(idx + 2) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
 
 
 // With consumer
-assert fileContents.contains("[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0\n" +
-"\n" +
-"[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.")
+idx = fileContents.indexOf("[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0");
+
+assert fileContents.get(idx + 2) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
+
 


### PR DESCRIPTION
Tests for the bnd-baseline-maven-plugin, and a fix for the Baseline class when it is used to baseline two bundles with different symbolic names