### PR TITLE
gradle: Support -include in jar task manifest

### DIFF
--- a/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -53,6 +53,8 @@ class TestBundlePlugin extends Specification {
           jartask_manifest.getValue('Implementation-Version') == '1.0.0'
           jartask_manifest.getValue('My-Header') == 'my-value'
           jartask_manifest.getValue('Export-Package') =~ /doubler/
+          jartask_manifest.getValue('X-SomeProperty') == 'Included via -include in jar task manifest'
+          jartask_manifest.getValue('Override') == 'Override the jar task manifest'
           jartask_jar.getEntry('doubler/Doubler.class')
           jartask_jar.getEntry('doubler/impl/DoublerImpl.class')
           !jartask_jar.getEntry('doubler/impl/DoublerImplTest.class')
@@ -69,6 +71,8 @@ class TestBundlePlugin extends Specification {
           bundletask_manifest.getValue('Bundle-Version') == '1.1.0'
           bundletask_manifest.getValue('My-Header') == 'my-value'
           bundletask_manifest.getValue('Export-Package') =~ /doubler/
+          !bundletask_manifest.getValue('X-SomeProperty')
+          bundletask_manifest.getValue('Override') == 'Override the jar task manifest'
           !bundletask_jar.getEntry('doubler/Doubler.class')
           !bundletask_jar.getEntry('doubler/impl/DoublerImpl.class')
           bundletask_jar.getEntry('doubler/impl/DoublerImplTest.class')

--- a/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/bnd.bnd
+++ b/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/bnd.bnd
@@ -2,3 +2,4 @@ Export-Package: doubler
 -sources: true
 My-Header: my-value
 text: TEXT
+Override: Override the jar task manifest

--- a/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/build.gradle
@@ -24,7 +24,9 @@ jar {
     manifest {
         attributes('Implementation-Title': baseName,
                    'Implementation-Version': version,
-                   '-includeresource': '{bar.txt}', 
+                   '-includeresource': '{bar.txt}',
+                   '-include': 'other.bnd',
+                   'Override': 'This should be overridden by the bnd file'
                    )
     }
 }

--- a/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/other.bnd
+++ b/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/other.bnd
@@ -1,0 +1,1 @@
+X-SomeProperty: Included via -include in jar task manifest


### PR DESCRIPTION
This will allow the user to specify included bnd files from the gradle
DSL.

Fixes https://github.com/bndtools/bnd/issues/1213

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>