### PR TITLE
gradle: Set common bnd properties for non-workspace users

### DIFF
--- a/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle.tests/test/biz/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -21,9 +21,9 @@ class TestBundlePlugin extends Specification {
     def "Simple Bnd Builder Plugin Test"() {
         given:
           def String testProject = 'builderplugin1'
-          def File testProjectDir = new File(testResources, testProject)
+          def File testProjectDir = new File(testResources, testProject).canonicalFile
           assert testProjectDir.isDirectory()
-          def File testProjectBuildDir = new File(testProjectDir, 'build/libs')
+          def File testProjectBuildDir = new File(testProjectDir, 'build').canonicalFile
 
         when:
           def result = GradleRunner.create()
@@ -39,11 +39,11 @@ class TestBundlePlugin extends Specification {
 
           testProjectBuildDir.isDirectory()
 
-          def File jartask_bundle = new File(testProjectBuildDir, "${testProject}-1.0.0.jar")
+          def File jartask_bundle = new File(testProjectBuildDir, "libs/${testProject}-1.0.0.jar")
           jartask_bundle.isFile()
           def JarFile jartask_jar = new JarFile(jartask_bundle)
           def Attributes jartask_manifest = jartask_jar.getManifest().getMainAttributes()
-          def File bundletask_bundle = new File(testProjectBuildDir, "${testProject}_bundle-1.1.0.jar")
+          def File bundletask_bundle = new File(testProjectBuildDir, "libs/${testProject}_bundle-1.1.0.jar")
           bundletask_bundle.isFile()
           def JarFile bundletask_jar = new JarFile(bundletask_bundle)
           def Attributes bundletask_manifest = bundletask_jar.getManifest().getMainAttributes()
@@ -56,6 +56,11 @@ class TestBundlePlugin extends Specification {
           jartask_manifest.getValue('Export-Package') =~ /doubler/
           jartask_manifest.getValue('X-SomeProperty') == 'Included via -include in jar task manifest'
           jartask_manifest.getValue('Override') == 'Override the jar task manifest'
+          jartask_manifest.getValue('Project-Name') == "${testProject}"
+          new File(jartask_manifest.getValue('Project-Dir')).canonicalFile == testProjectDir
+          new File(jartask_manifest.getValue('Project-Output')).canonicalFile == testProjectBuildDir
+          jartask_manifest.getValue('Project-Sourcepath')
+          jartask_manifest.getValue('Project-Buildpath')
           jartask_jar.getEntry('doubler/Doubler.class')
           jartask_jar.getEntry('doubler/packageinfo')
           jartask_jar.getEntry('doubler/impl/DoublerImpl.class')
@@ -80,6 +85,11 @@ class TestBundlePlugin extends Specification {
           bundletask_manifest.getValue('Export-Package') =~ /doubler/
           !bundletask_manifest.getValue('X-SomeProperty')
           bundletask_manifest.getValue('Override') == 'Override the jar task manifest'
+          bundletask_manifest.getValue('Project-Name') == "${testProject}"
+          new File(bundletask_manifest.getValue('Project-Dir')).canonicalFile == testProjectDir
+          new File(bundletask_manifest.getValue('Project-Output')).canonicalFile == testProjectBuildDir
+          bundletask_manifest.getValue('Project-Sourcepath')
+          bundletask_manifest.getValue('Project-Buildpath')
           !bundletask_jar.getEntry('doubler/Doubler.class')
           !bundletask_jar.getEntry('doubler/impl/DoublerImpl.class')
           bundletask_jar.getEntry('doubler/impl/DoublerImplTest.class')

--- a/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/bnd.bnd
+++ b/biz.aQute.bnd.gradle.tests/testresources/builderplugin1/bnd.bnd
@@ -3,3 +3,8 @@ Export-Package: doubler
 My-Header: my-value
 text: TEXT
 Override: Override the jar task manifest
+Project-Name: ${project.name}
+Project-Dir: ${project.dir}
+Project-Output: ${project.output}
+Project-Sourcepath: ${project.sourcepath}
+Project-Buildpath: ${project.buildpath}


### PR DESCRIPTION
project.name, project.output, project.buildpath, project.sourcepath. Then
these can be used in macros in the bnd instructions.

Also removed nonexistent dirs from sourcepath since the Builder would
complain.