### PR TITLE
[manifest annotations] Require/Provide Capabilities did not pick up d…

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/DefaultAttrsAnnotatedType.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/DefaultAttrsAnnotatedType.java
@@ -1,0 +1,7 @@
+package test.annotationheaders.attrs.defaults;
+
+@ProvideDefaultAttrs
+@RequireDefaultAttrs
+public class DefaultAttrsAnnotatedType {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/ProvideDefaultAttrs.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/ProvideDefaultAttrs.java
@@ -1,0 +1,9 @@
+package test.annotationheaders.attrs.defaults;
+
+import aQute.bnd.annotation.headers.ProvideCapability;
+
+@ProvideCapability(ns = "default-attrs")
+public @interface ProvideDefaultAttrs {
+	int foo() default 42;
+}
+

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/RequireDefaultAttrs.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/defaults/RequireDefaultAttrs.java
@@ -1,0 +1,9 @@
+package test.annotationheaders.attrs.defaults;
+
+import aQute.bnd.annotation.headers.RequireCapability;
+
+@RequireCapability(ns = "default-attrs")
+public @interface RequireDefaultAttrs {
+	int foo() default 42;
+}
+

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -98,4 +98,16 @@ public class Annotation {
 				elements.put(e.getKey(), e.getValue());
 		}
 	}
+
+	public void addDefaults(Clazz c) throws Exception {
+		Map<String,Object> defaults = c.getDefaults();
+		if ( defaults == null || defaults.isEmpty())
+			return;
+		
+		for (Map.Entry<String,Object> e : defaults.entrySet()) {
+			if (elements == null || !elements.containsKey(e.getKey())) {
+				put(e.getKey(), e.getValue());
+			}
+		}
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -74,7 +74,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 	// Class we're currently processing
 	Clazz current;
 
-	// we parse the annotations seperately at the ed
+	// we parse the annotations separately at the end
 	boolean finalizing;
 
 	/*
@@ -179,6 +179,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 
 		Annotation root = parent.get(0);
 		root.merge(annotation);
+		root.addDefaults(c);
 		return root;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
@@ -73,4 +73,6 @@ public class ClassDataCollector {
 
 	public void annotationDefault(Clazz.MethodDef last) {}
 
+	public void annotationDefault(Clazz.MethodDef last, Object value) {}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
@@ -73,6 +73,8 @@ public class ClassDataCollector {
 
 	public void annotationDefault(Clazz.MethodDef last) {}
 
-	public void annotationDefault(Clazz.MethodDef last, Object value) {}
+	public void annotationDefault(Clazz.MethodDef last, Object value) {
+		annotationDefault(last);
+	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -467,6 +467,8 @@ public class Clazz {
 
 	private boolean detectLdc;
 
+	private Map<String,Object> defaults;
+
 	public Clazz(Analyzer analyzer, String path, Resource resource) {
 		this.path = path;
 		this.resource = resource;
@@ -940,7 +942,7 @@ public class Clazz {
 			Object value = doElementValue(in, member, RetentionPolicy.RUNTIME, cd != null, access_flags);
 			if (last instanceof MethodDef) {
 				((MethodDef) last).constant = value;
-				cd.annotationDefault((MethodDef) last);
+				cd.annotationDefault((MethodDef) last, value);
 			}
 		} else if ("Exceptions".equals(attributeName))
 			doExceptions(in, access_flags);
@@ -1996,4 +1998,20 @@ public class Clazz {
 	public String getClassSignature() {
 		return classSignature;
 	}
+
+	public Map<String,Object> getDefaults() throws Exception {
+		if (defaults == null) {
+			defaults = new HashMap<String,Object>();
+
+			class DefaultReader extends ClassDataCollector {
+				@Override
+				public void annotationDefault(MethodDef last, Object value) {
+					defaults.put(last.name, value);
+				}
+			}
+			this.parseClassFileWithCollector(new DefaultReader());
+		}
+		return defaults;
+	}
+
 }


### PR DESCRIPTION
…efaults

The annotation processing for the Manifest Annotations did not pickup their defaults since these were of course in a completely different class. This patch merges them with the defaults and tests it.


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>