### PR TITLE
gradle: Simplify ignoreFailures by using optional arg to checkErrors

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -279,13 +279,7 @@ public class BndPlugin implements Plugin<Project> {
       test {
         enabled !parseBoolean(bnd(Constants.NOJUNIT, 'false')) && !parseBoolean(bnd('no.junit', 'false'))
         doFirst {
-          try {
-            checkErrors(logger)
-          } catch (Exception e) {
-            if (!ignoreFailures) {
-              throw e
-            }
-          }
+          checkErrors(logger, ignoreFailures)
         }
       }
 
@@ -300,13 +294,7 @@ public class BndPlugin implements Plugin<Project> {
             } catch (Exception e) {
               throw new GradleException("Project ${bndProject.getName()} failed to test", e)
             }
-            try {
-              checkErrors(logger)
-            } catch (Exception e) {
-              if (!ignoreFailures) {
-                throw e
-              }
-            }
+            checkErrors(logger, ignoreFailures)
           }
         }
       }
@@ -486,9 +474,9 @@ public class BndPlugin implements Plugin<Project> {
     return project.files(bndProject.getTestOutput())
   }
 
-  private void checkErrors(Logger logger) {
+  private void checkErrors(Logger logger, boolean ignoreFailures = false) {
     bndProject.getInfo(bndProject.getWorkspace(), "${bndProject.getWorkspace().getBase().name} :")
-    boolean failed = !bndProject.isOk()
+    boolean failed = !ignoreFailures && !bndProject.isOk()
     int errorCount = bndProject.getErrors().size()
     bndProject.getWarnings().each {
       logger.warn 'Warning: {}', it

--- a/rebuild-with-local-plugin
+++ b/rebuild-with-local-plugin
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+## Rebuild using the locally built bnd gradle plugin
+##
+## Since this will use the gradle plugin in dist/bundles, your gradle tasks
+## must not include :biz.aQute.bnd.gradle:release which will attempt to
+## overwrite the plugin being used for the build.
+##
+##############################################################################
+REPO=$(dirname ${BASH_SOURCE[0]})
+ARGS="$@"
+if [ -z "$ARGS" ]; then
+  ARGS="--rerun-tasks :dist:checkNeeded"
+fi
+
+echo $REPO/gradlew --no-daemon -Pbnd_repourl=$REPO/dist/bundles $ARGS
+$REPO/gradlew --no-daemon -Pbnd_repourl=$REPO/dist/bundles $ARGS

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,9 +9,13 @@ import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
+  URI repouri = new URI(bnd_repourl)
+  if (!repouri.absolute || repouri.scheme == 'file') {
+    repouri = new File('').toURI().resolve(repouri.schemeSpecificPart)
+  }
   repositories {
     ivy { /* Configure the repository as an "ivy" repository */
-      url bnd_repourl
+      url repouri
       layout 'pattern', {
             artifact '[module]/[artifact]-[revision].[ext]' /* OSGi repo pattern */
             artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])' /* maven pattern */


### PR DESCRIPTION
We now avoid throwing and discarding an exception when checkErrors should ignore failures.

Also some build improvements to support building with recently built gradle plugin.