### PR TITLE
build: Simplify support for relative file urls to the bnd gradle plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,13 +9,9 @@ import aQute.bnd.osgi.Constants
 
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
-  URI repouri = new URI(bnd_repourl)
-  if (!repouri.absolute || repouri.scheme == 'file') {
-    repouri = new File('').toURI().resolve(repouri.schemeSpecificPart)
-  }
   repositories {
     ivy { /* Configure the repository as an "ivy" repository */
-      url repouri
+      url uri(bnd_repourl)
       layout 'pattern', {
             artifact '[module]/[artifact]-[revision].[ext]' /* OSGi repo pattern */
             artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier])(.[ext])' /* maven pattern */


### PR DESCRIPTION
We simplify the support by using the gradle uri method. This is safer
since relative paths are resolved agains the directory of the
settings.gradle script rather than the current working directory.