### PR TITLE
Tweak error message in PropertiesParser

### DIFF
--- a/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
@@ -157,7 +157,7 @@ final class PropertiesParser {
 				properties.put(key, value);
 
 			} else {
-				error("No value specified for key: %s. An empty value should be specified as '<key>:' or '<key>='",
+				error("No value specified for key: %s. An empty value should be specified as '%<s:' or '%<s='",
 						key);
 				properties.put(key, "");
 				continue;


### PR DESCRIPTION
Use actual property key name in the examples in the error message.