### PR TITLE
properties parser: A char is not a number

### DIFF
--- a/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
@@ -97,10 +97,10 @@ final class PropertiesParser {
 
 				default :
 					if (current < ' ') {
-						error("Invalid character in properties: %x at pos %s", current, pos);
+						error("Invalid character in properties: %x at pos %s", Integer.valueOf(current), pos);
 						return current = '?';
-					} else
-						return current;
+					}
+					return current;
 			}
 		}
 		finally {

--- a/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
+++ b/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
@@ -192,6 +192,10 @@ public class UTF8PropertiesTest extends TestCase {
 				+ "a=\\ \n     a;v=4", "a", 1, "Found \\\\<whitespace>", "Invalid property key: `a;v`");
 		assertError("\n\n\n\n\n\n\n" //
 				+ "a", "a", 7, "No value specified for key");
+		assertError("\npropertyName=property\0Value\n", "propertyName", 1,
+				"Invalid character in properties: 0 at pos 21:");
+		assertError("\nproperty\0Name=propertyValue\n", "property?Name", 1,
+				"Invalid character in properties: 0 at pos 8:");
 	}
 
 	private void assertError(String string, String key, int line, String... check) throws IOException {


### PR DESCRIPTION
`%x` supports integral values and char is not one. So we convert to an Integer.