### PR TITLE
Resolve various locked file issues under Windows

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -816,6 +816,13 @@ public class Workspace extends Processor {
 
 	public void close() {
 		cache.remove(getPropertiesFile().getParentFile().getParentFile());
+
+		try {
+			super.close();
+		}
+		catch (IOException e) {
+			/* For backwards compatibility, we ignore the exception */
+		}
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -1,24 +1,49 @@
 package aQute.lib.deployer;
 
-import java.io.*;
-import java.security.*;
-import java.util.*;
-import java.util.jar.*;
-import java.util.regex.*;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import aQute.bnd.osgi.*;
-import aQute.bnd.service.*;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Instruction;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.Actionable;
+import aQute.bnd.service.Plugin;
+import aQute.bnd.service.Refreshable;
+import aQute.bnd.service.Registry;
+import aQute.bnd.service.RegistryPlugin;
+import aQute.bnd.service.RepositoryListenerPlugin;
+import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
-import aQute.bnd.version.*;
-import aQute.lib.collections.*;
-import aQute.lib.hex.*;
-import aQute.lib.io.*;
-import aQute.lib.json.*;
-import aQute.lib.persistentmap.*;
-import aQute.libg.command.*;
-import aQute.libg.cryptography.*;
-import aQute.libg.reporter.*;
-import aQute.service.reporter.*;
+import aQute.bnd.version.Version;
+import aQute.lib.collections.SortedList;
+import aQute.lib.hex.Hex;
+import aQute.lib.io.IO;
+import aQute.lib.json.JSONCodec;
+import aQute.lib.persistentmap.PersistentMap;
+import aQute.libg.command.Command;
+import aQute.libg.cryptography.SHA1;
+import aQute.libg.cryptography.SHA256;
+import aQute.libg.reporter.ReporterAdapter;
+import aQute.service.reporter.Reporter;
 
 /**
  * A FileRepo is the primary and example implementation of a repository based on
@@ -751,8 +776,11 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 	}
 
 	public void close() throws IOException {
-		if (inited)
+		if (inited) {
 			exec(close, root.getAbsolutePath());
+			if (hasIndex)
+				index.close();
+		}
 	}
 
 	protected void open() {

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/InfoRepositoryWrapper.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/InfoRepositoryWrapper.java
@@ -95,8 +95,9 @@ public class InfoRepositoryWrapper implements Repository {
 
 						@Override
 						public void success(File file) throws Exception {
+							IndexResult index = null;
 							try {
-								IndexResult index = repoIndexer.indexFile(file);
+								index = repoIndexer.indexFile(file);
 
 								ResourceBuilder rb = new ResourceBuilder();
 
@@ -126,6 +127,10 @@ public class InfoRepositoryWrapper implements Repository {
 							}
 							finally {
 								super.success(file);
+
+								if (index != null) {
+									index.resource.close();
+								}
 							}
 						}
 					};

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/Plugin.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/Plugin.java
@@ -1,5 +1,6 @@
 package aQute.bnd.deployer.repository.wrapper;
 
+import java.io.Closeable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,7 +24,7 @@ import aQute.lib.io.IO;
 import aQute.libg.reporter.ReporterAdapter;
 import aQute.service.reporter.Reporter;
 
-public class Plugin implements aQute.bnd.service.Plugin, RegistryPlugin, RegistryDonePlugin, Repository {
+public class Plugin implements aQute.bnd.service.Plugin, RegistryPlugin, RegistryDonePlugin, Repository, Closeable {
 
 	private Registry				registry;
 	private Config					config;
@@ -126,6 +127,13 @@ public class Plugin implements aQute.bnd.service.Plugin, RegistryPlugin, Registr
 			e.printStackTrace();
 			throw e;
 		}
+	}
+
+	public void close() throws java.io.IOException {
+		if (this.wrapper == null) {
+			return;
+		}
+		this.wrapper.close();
 	}
 
 	FilterParser fp = new FilterParser();

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ProjectResolverTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ProjectResolverTest.java
@@ -41,6 +41,7 @@ public class ProjectResolverTest extends TestCase {
 
 	@Override
 	protected void tearDown() throws Exception {
+		fr.close();
 		ws.close();
 		IO.delete(tmp);
 		super.tearDown();

--- a/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
@@ -39,14 +39,13 @@ public class JpmRepoTest extends TestCase {
 
 	public void setUp() throws Exception {
 		tmp.mkdirs();
-		IO.delete(tmp);
-		tmp.mkdirs();
 		IO.copy(IO.getFile("testdata/ws"), tmp);
 		ws = new Workspace(tmp);
 		assertTrue(ws.check());
 	}
 
 	public void tearDown() throws Exception {
+		ws.close();
 		IO.delete(tmp);
 	}
 


### PR DESCRIPTION
There are a couple resolver tests that were leaving behind a 'tmp' directory even though the tests were passing. There were a few issues contributing to this, but mostly we are just not closing things (PersistentMaps and Resources) after we are done using them.

This also changes Workspace.close() to call it's parent's (Processor) close() method as well for additional cleanup.

Signed-off-by: Sean Bright <sean.bright@gmail.com>