### PR TITLE
Defend against non-String values

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MacroTest.java
@@ -1149,4 +1149,39 @@ public class MacroTest extends TestCase {
 		assertEquals("F31BAC7F1F70E5D8705B98CC0FBCFF5E", b.getProperty("b"));
 	}
 
+	public void testProcessNullValue() throws Exception {
+		try (Processor b = new Processor()) {
+			Macro m = b.getReplacer();
+			String tst = m.process(null);
+			assertEquals("", tst);
+			assertTrue(b.check());
+		}
+	}
+
+	public void testNonStringValue() throws Exception {
+		try (Processor b = new Processor()) {
+			// getProperty will return null for non-String value
+			b.getProperties().put("tst", new StringBuilder("foo"));
+			b.getProperties().put("num", 2);
+			String tst = b.getProperty("tst");
+			assertNull(tst);
+			String num = b.getProperty("num");
+			assertNull(num);
+			assertTrue(b.check("Key 'tst' has a non-String value", "Key 'num' has a non-String value"));
+		}
+	}
+
+	public void testNonStringFlattenedValue() throws Exception {
+		try (Processor b = new Processor()) {
+			// getProperty will return null for non-String value
+			b.getProperties().put("tst", new StringBuilder("foo"));
+			b.getProperties().put("num", 2);
+			Properties f = b.getFlattenedProperties();
+			String tst = f.getProperty("tst");
+			assertNull(tst);
+			String num = f.getProperty("num");
+			assertNull(num);
+			assertTrue(b.check("Key 'tst' has a non-String value", "Key 'num' has a non-String value"));
+		}
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -93,6 +93,9 @@ public class Macro {
 	}
 
 	int process(CharSequence org, int index, char begin, char end, StringBuilder result, Link link) {
+		if (org == null) { // treat null like empty string
+			return index;
+		}
 		StringBuilder line = new StringBuilder(org);
 		int nesting = 1;
 
@@ -1145,11 +1148,19 @@ public class Macro {
 			Properties source = domain.getProperties();
 			for (Enumeration< ? > e = source.propertyNames(); e.hasMoreElements();) {
 				String key = (String) e.nextElement();
-				if (!key.startsWith("_"))
-					if (ignoreInstructions && key.startsWith("-"))
-						flattened.put(key, source.getProperty(key));
-					else
-						flattened.put(key, process(source.getProperty(key)));
+				if (!key.startsWith("_")) {
+					String value = source.getProperty(key);
+					if (value == null) {
+						Object raw = source.get(key);
+						domain.warning("Key '%s' has a non-String value: %s:%s", key,
+								raw == null ? "" : raw.getClass().getName(), raw);
+					} else {
+						if (ignoreInstructions && key.startsWith("-"))
+							flattened.put(key, value);
+						else
+							flattened.put(key, process(value));
+					}
+				}
 			}
 			return flattened;
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1204,12 +1204,27 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		// Use the key as is first, if found ok
 
 		if (filter != null && filter.contains(key)) {
-			value = (String) getProperties().get(key);
+			Object raw = getProperties().get(key);
+			if (raw != null) {
+				if (raw instanceof String) {
+					value = (String) raw;
+				} else {
+					warning("Key '%s' has a non-String value: %s:%s", key, raw == null ? "" : raw.getClass().getName(),
+							raw);
+				}
+			}
 		} else {
 			while (source != null) {
-				value = (String) source.getProperties().get(key);
-				if (value != null)
+				Object raw = source.getProperties().get(key);
+				if (raw != null) {
+					if (raw instanceof String) {
+						value = (String) raw;
+					} else {
+						warning("Key '%s' has a non-String value: %s:%s", key,
+								raw == null ? "" : raw.getClass().getName(), raw);
+					}
 					break;
+				}
 
 				source = source.getParent();
 			}


### PR DESCRIPTION
Properties.getProperty will return null for non-String values. Groovy
users can think they are putting a String value when it is really a
GString value.

Fixes #1270

Also some other problems I found during this work.