### PR TITLE
Added support for ${packages;versioned}

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MacroTest.java
@@ -1121,21 +1121,23 @@ public class MacroTest extends TestCase {
 				new Jar(IO.getFile("bin"))
 		});
 		b.setProperty("Private-Package",
-				"test.packageinfo.annotated,test.packageinfo.notannotated,test.packageinfo.nopackageinfo");
-
+				"test.packageinfo.annotated,test.packageinfo.notannotated,test.packageinfo.nopackageinfo,test.activator");
 		b.setProperty("All-Packages", "${packages}");
 		b.setProperty("Annotated", "${packages;annotated;test.packageinfo.annotated.BlahAnnotation}");
 		b.setProperty("Named", "${packages;named;*.notannotated}");
 		b.setProperty("Negated", "${packages;named;!*.no*}");
+		b.setProperty("Versioned", "${packages;versioned}");
 		b.build();
 
 		assertEquals(0, b.getErrors().size());
 
-		assertEquals("test.packageinfo.annotated,test.packageinfo.notannotated,test.packageinfo.nopackageinfo",
+		assertEquals(
+				"test.packageinfo.annotated,test.packageinfo.notannotated,test.packageinfo.nopackageinfo,test.activator",
 				b.getProperty("All-Packages"));
 		assertEquals("test.packageinfo.annotated", b.getProperty("Annotated"));
 		assertEquals("test.packageinfo.notannotated", b.getProperty("Named"));
-		assertEquals("test.packageinfo.annotated", b.getProperty("Negated"));
+		assertEquals("test.packageinfo.annotated,test.activator", b.getProperty("Negated"));
+		assertEquals("test.packageinfo.annotated,test.packageinfo.notannotated", b.getProperty("Versioned"));
 	}
 
 	public void testBase64() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2562,6 +2562,9 @@ public class Analyzer extends Processor {
 							throw new IllegalArgumentException("Not enough arguments in ${packages} macro");
 						accept = pkgInfo != null && pkgInfo.is(Clazz.QUERY.ANNOTATED, instr, this);
 						break;
+					case VERSIONED :
+						accept = entry.getValue().getVersion() != null;
+						break;
 				}
 			} else {
 				accept = true;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Packages.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Packages.java
@@ -14,7 +14,7 @@ public class Packages implements Map<PackageRef,Attrs> {
 	static Map<PackageRef,Attrs>			EMPTY	= Collections.emptyMap();
 
 	public static enum QUERY {
-		ANY, ANNOTATED, NAMED
+		ANY, ANNOTATED, NAMED, VERSIONED
 	}
 
 	public Packages(Packages other) {


### PR DESCRIPTION
As discussed with @pkriens, this adds support for `${packages;exported}`. Useful when wrapping other bundles, and the exported packages of that bundle should be exported by the wrapper as well.

Signed-off-by: Paul Bakker <paul.bakker@luminis.eu>