### PR TITLE
Close jar file streams that were set as classpath when closing

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2139,6 +2139,7 @@ public class Analyzer extends Processor {
 		if (isPedantic() && jar.getResources().isEmpty())
 			warning("There is an empty jar or directory on the classpath: " + jar.getName());
 
+		addClose(jar);
 		classpath.add(jar);
 	}
 


### PR DESCRIPTION
This is primary a problem under windows in combination with the gradle-bundle-plugin and the gradle daemon. I was not able to write some test for verification, but it is obvious, that files which are added by the setClasspath method are not registered for close.