### PR TITLE
test: Do not clear test-results folder

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
@@ -78,9 +78,6 @@ public abstract class ProjectTester {
 		if (!reportDir.exists() && !reportDir.mkdirs()) {
 			throw new IOException("Could not create directory " + reportDir);
 		}
-		for (File file : reportDir.listFiles()) {
-			file.delete();
-		}
 		return true;
 	}
 

--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -238,7 +238,9 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 			Version v = bundle.getVersion();
 			File f = new File(reportDir, "TEST-" + bundle.getSymbolicName() + "-" + v.getMajor() + "." + v.getMinor()
 					+ "." + v.getMicro() + ".xml");
-			return new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
+			Writer writer = new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
+			writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+			return writer;
 		}
 		return null;
 	}


### PR DESCRIPTION
ProjectTester does not own the test-results folder and must not clear it out. Plain junit test results may also be in this folder.