### PR TITLE
#1291 [build] Default content for bundle

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -66,6 +66,44 @@ public class ProjectBuilder extends Builder {
 		return project.getBuilder(this);
 	}
 
+	/*
+	 * During discussion on bndtools/bndtools#1270, @rotty3000 raised the issue
+	 * that, in a workspace build, bnd will not include anything in a bundle by
+	 * default. One must specify Private-Package, Export-Package,
+	 * Include-Resource, or -includeresource to put any content in a bundle. And
+	 * new users make mistakes and end up with empty bundles which will be
+	 * unexpected. This is different than the non-workspace modes such as the
+	 * bnd gradle plugin or the bnd-maven-plugin which always include default
+	 * content (gradle: normal jar task content, maven: target/classes folder).
+	 * So this bug suggests that we change ProjectBuilder (not Builder which is
+	 * used by non-workspace builds) to use the source output folder (e.g. bin
+	 * folder) as the default contents if the bundle's bnd file does not specify
+	 * any of the following headers: Private-Package, Export-Package,
+	 * Include-Resource, or -includeresource. If the bnd file specifies any of
+	 * those headers, then they will fully control the contents of the bundle.
+	 */
+
+	@Override
+	public void doDefaults(Builder b) throws Exception {
+
+		if (b.getProperty(Constants.RESOURCEONLY) != null)
+			return;
+
+		if (b.getProperty(Constants.PRIVATE_PACKAGE) != null)
+			return;
+
+		if (b.getProperty(Constants.EXPORT_PACKAGE) != null)
+			return;
+
+		if (b.getProperty(Constants.INCLUDE_RESOURCE) != null)
+			return;
+
+		if (b.getProperty(Constants.INCLUDERESOURCE) != null)
+			return;
+
+		b.setIncludeResource("${bin}");
+	}
+
 	public Project getProject() {
 		return project;
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/packageinfo
@@ -1,1 +1,1 @@
-version 2.7.0
+version 2.8.0

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -3,6 +3,7 @@ package aQute.bnd.osgi;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1361,8 +1362,15 @@ public class Builder extends Analyzer {
 		if (builder != null) {
 			builder.setProperties(file);
 			addClose(builder);
+
+			doDefaults(builder);
 		}
+
 		return builder;
+	}
+
+	public void doDefaults(Builder b) throws Exception {
+
 	}
 
 	public Builder getSubBuilder() throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -812,7 +812,9 @@ public class Builder extends Analyzer {
 
 	private void doIncludeResource(Jar jar, Parameters clauses) throws ZipException, IOException, Exception {
 		for (Entry<String,Attrs> entry : clauses.entrySet()) {
-			doIncludeResource(jar, entry.getKey(), entry.getValue());
+
+			String key = removeDuplicateMarker(entry.getKey());
+			doIncludeResource(jar, key, entry.getValue());
 		}
 	}
 


### PR DESCRIPTION
When a bundle has no content headers defined (*_Package, -includeresource, etc) then it will include the contents of the bin directory and not export anything.

(Considered adding a ${packages;VERSIONED} macro but that would make it confusing if they added anything themselves, then they would suddenly loose that feature.)


Fixes #1291.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>