### PR TITLE
#1296 Baselining "cross compiler" fails when using switch on an enum

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/differ/JavaElement.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/JavaElement.java
@@ -141,6 +141,10 @@ class JavaElement {
 		packages = new MultiMap<PackageRef,Element>();
 
 		for (Clazz c : analyzer.getClassspace().values()) {
+
+			if (c.isSynthetic())
+				continue;
+
 			if (c.isPublic() || c.isProtected()) {
 				PackageRef packageName = c.getClassName().getPackageRef();
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -1888,6 +1888,10 @@ public class Clazz {
 		return zuper != null && zuper.getBinary().equals("java/lang/Enum");
 	}
 
+	public boolean isSynthetic() {
+		return (0x1000 & accessx) != 0;
+	}
+
 	public JAVA getFormat() {
 		return JAVA.format(major);
 


### PR DESCRIPTION
Skipping synthetic classes in the diff.


Fixes #1296

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>