### PR TITLE
Avoid UnsupportedOperationException in resolver

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
@@ -164,8 +164,12 @@ public abstract class AbstractResolveContext extends ResolveContext {
 			}
 		}
 
-		caps.add(hc);
-		return caps.size() - 1;
+		int newIndex = caps.size();
+		// the List passed by Felix does not support the
+		// single-arg version of add()... it throws
+		// UnsupportedOperationException
+		caps.add(newIndex, hc);
+		return newIndex;
 	}
 
 	@Override


### PR DESCRIPTION
Should fix bndtools bug 1289

Signed-off-by: Neil Bartlett <neil.bartlett@paremus.com>