### PR TITLE
[bnd-maven-plugin] Improve compatibility with m2e

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -42,6 +42,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.util.Scanner;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 import aQute.bnd.build.Project;
@@ -106,6 +107,56 @@ public class BndMavenPlugin extends AbstractMojo {
 			builder.setBase(project.getBasedir());
 			loadProjectProperties(builder, project);
 			builder.setProperty("project.output", targetDir.getCanonicalPath());
+
+			// incremental build only if any resource in the project outside of
+			// the targetDir is changed. This implicitly includes POM and bnd files.
+			if (buildContext.isIncremental()) {
+				boolean hasChanges = false;
+
+				// compute relative target path. While changes here should never
+				// be reported, sometimes they are, e.g. due to (temporary)
+				// misconfiguration
+				String basePath = project.getBasedir().getCanonicalPath();
+				String targetPath = targetDir.getCanonicalPath();
+				int i = targetPath.indexOf(basePath);
+				if (i != 0) {
+					// target is not relative to basedir
+					targetPath = null;
+				} else {
+					targetPath = targetPath.substring(basePath.length() + 1);
+					if (!targetPath.endsWith(File.separator)) {
+						targetPath = targetPath + File.separator;
+					}
+				}
+
+				Scanner changeScanner = buildContext.newScanner(project.getBasedir(), true);
+				changeScanner.scan();
+				for (String sourceFile : changeScanner.getIncludedFiles()) {
+					if (targetPath == null || !sourceFile.startsWith(targetPath)) {
+						if (!buildContext.isUptodate(manifestPath, new File(project.getBasedir(), sourceFile))) {
+							hasChanges = true;
+							break;
+						}
+					}
+				}
+				
+				if (!hasChanges) {
+					// check for deleted resources
+					Scanner deleteScanner = buildContext.newDeleteScanner(project.getBasedir());
+					deleteScanner.scan();
+					for (String sourceFile : deleteScanner.getIncludedFiles()) {
+						if (targetPath == null || !sourceFile.startsWith(targetPath)) {
+							hasChanges = true;
+							break;
+						}
+					}
+				}
+
+				if (!hasChanges) {
+					log.info("no incremental changes");
+					return;
+				}
+			}
 
 			// Reject sub-bundle projects
 			List<Builder> subs = builder.getSubBuilders();


### PR DESCRIPTION
According to https://wiki.eclipse.org/M2E_compatible_maven_plugins a m2e
compatible Plugin must use BuildContext to skip execution when there is
no relevant workspace change.

Indeed, without this change we noticed build cycles to occur on very
complex projects.

Signed-off-by: Erwin Tratar <erwin.tratar@gebit.de>