### PR TITLE
bnd-maven-plugin: Avoid writing output if not out-of-date

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1332,13 +1332,12 @@ public class Analyzer extends Processor {
 	 * Set the JAR file we are going to work in. This will read the JAR in
 	 * memory.
 	 * 
-	 * @param jar
+	 * @param file
 	 * @throws IOException
 	 */
-	public Jar setJar(File jar) throws IOException {
-		Jar jarx = new Jar(jar);
-		addClose(jarx);
-		return setJar(jarx);
+	public Jar setJar(File file) throws IOException {
+		Jar jar = new Jar(file);
+		return setJar(jar);
 	}
 
 	/**
@@ -2151,8 +2150,7 @@ public class Analyzer extends Processor {
 		if (!cp.exists())
 			warning("File on classpath that does not exist: " + cp);
 		Jar jar = new Jar(cp);
-		addClose(jar);
-		classpath.add(jar);
+		addClasspath(jar);
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -108,6 +108,7 @@ public class Builder extends Analyzer {
 		if (mf != null) {
 			File mff = getFile(mf);
 			if (mff.isFile()) {
+				updateModified(mff.lastModified(), "Manifest " + mff);
 				try {
 					InputStream in = new FileInputStream(mff);
 					manifest = new Manifest(in);


### PR DESCRIPTION
The Builder collects that latest modified time of it source material
such as bnd files and included files. The Jar collects the latest
modified time of all its contents including the Builder which built it.

So we modify the expandJar method to only write files out when either the
file does not exist or the file is older than the Jar last modified time.
For incremental builds, this should avoid writing any output files if
none of the input material to the built Jar has changed. Thus we avoid
downstream dependencies from rebuilding because unchanged files were
rewritten.

Alternative to bndtools#1316