### PR TITLE
bnd-maven-plugin: Allow automatic SNAPSHOT replacement override

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -59,7 +59,6 @@ import aQute.lib.strings.Strings;
 public class BndMavenPlugin extends AbstractMojo {
 
 	private static final String	PACKAGING_POM	= "pom";
-	private static final String	SNAPSHOT		= "SNAPSHOT";
 	private static final String	TSTAMP			= "${tstamp}";
 
 	@Parameter(defaultValue = "${project.build.directory}", readonly = true)
@@ -147,8 +146,10 @@ public class BndMavenPlugin extends AbstractMojo {
 
 			// Set Bundle-Version
 			Version version = MavenVersion.parseString(project.getVersion()).getOSGiVersion();
-			version = replaceSNAPSHOT(version);
 			builder.setProperty(Constants.BUNDLE_VERSION, version.toString());
+			if (builder.getProperty(Constants.SNAPSHOT) == null) {
+				builder.setProperty(Constants.SNAPSHOT, TSTAMP);
+			}
 
 			if (log.isDebugEnabled()) {
 				log.debug("builder properties: " + builder.getProperties());
@@ -236,21 +237,6 @@ public class BndMavenPlugin extends AbstractMojo {
 				jar.writeManifest(manifestOut);
 			}
 		}
-	}
-
-	private Version replaceSNAPSHOT(Version version) {
-		String qualifier = version.getQualifier();
-		if (qualifier != null) {
-			int i = qualifier.indexOf(SNAPSHOT);
-			if (i >= 0) {
-				qualifier = new StringBuilder().append(qualifier.substring(0, i))
-						.append(TSTAMP)
-						.append(qualifier.substring(i + SNAPSHOT.length()))
-						.toString();
-				version = new Version(version.getMajor(), version.getMinor(), version.getMicro(), qualifier);
-			}
-		}
-		return version;
 	}
 
 	private class BeanProperties extends Properties {

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/bnd.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/bnd.bnd
@@ -8,3 +8,4 @@ Settings-LocalRepository: ${settings.localRepository}
 SomeVar: ${someVar}
 SomeParentVar: ${someParentVar}
 -include: other.bnd
+-snapshot: SNAPSHOT

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
@@ -7,6 +7,7 @@
 		<version>0.0.1</version>
 	</parent>
 	<artifactId>test-impl-bundle</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
     <properties>
         <someVar>value</someVar>
     </properties>
@@ -25,7 +26,7 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>test-api-bundle</artifactId>
-			<version>${project.version}</version>
+			<version>0.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
@@ -7,12 +7,13 @@
 		<version>0.0.1</version>
 	</parent>
 	<artifactId>test-wrapper-bundle</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>test-api-bundle</artifactId>
-			<version>${project.version}</version>
+			<version>0.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -22,17 +22,17 @@ JarFile wrapper_jar = new JarFile(wrapper_bundle)
 Attributes wrapper_manifest = wrapper_jar.getManifest().getMainAttributes()
 
 // Basic manifest check
-assert 'test-api-bundle' == api_manifest.getValue('Bundle-SymbolicName')
-assert 'test-impl-bundle' == impl_manifest.getValue('Bundle-SymbolicName')
-assert 'test-wrapper-bundle' == wrapper_manifest.getValue('Bundle-SymbolicName')
-assert '0.0.1' == api_manifest.getValue('Bundle-Version')
-assert '0.0.1' == impl_manifest.getValue('Bundle-Version')
-assert '0.0.1' == wrapper_manifest.getValue('Bundle-Version')
+assert api_manifest.getValue('Bundle-SymbolicName') == 'test-api-bundle'
+assert impl_manifest.getValue('Bundle-SymbolicName') == 'test-impl-bundle'
+assert wrapper_manifest.getValue('Bundle-SymbolicName') == 'test-wrapper-bundle'
+assert api_manifest.getValue('Bundle-Version') == '0.0.1'
+assert impl_manifest.getValue('Bundle-Version') == '0.0.1'
+assert wrapper_manifest.getValue('Bundle-Version') == '0.0.1'
 
 // Check inheritance of properties in bnd.bnd from the parent project
-assert 'it worked' == api_manifest.getValue('X-ParentProjectProperty')
-assert 'it worked' == impl_manifest.getValue('X-ParentProjectProperty')
-assert 'overridden' == wrapper_manifest.getValue('X-ParentProjectProperty')
+assert api_manifest.getValue('X-ParentProjectProperty') == 'it worked'
+assert impl_manifest.getValue('X-ParentProjectProperty') == 'it worked'
+assert wrapper_manifest.getValue('X-ParentProjectProperty') == 'overridden'
 
 // Check -include of bnd files
 assert api_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
@@ -41,14 +41,14 @@ assert wrapper_manifest.getValue('X-IncludedParentProjectProperty') == 'Included
 assert impl_manifest.getValue('X-IncludedProjectProperty') == 'Included via -include in project bnd.bnd file'
 
 // Check POM properties
-assert new File(basedir, 'test-impl-bundle/target/classes').absolutePath == impl_manifest.getValue('Project-Build-OutputDirectory')
-assert 'UTF-8' == impl_manifest.getValue('Project-Build-SourceEncoding')
-assert 'biz.aQute.bnd-test:test-impl-bundle' == impl_manifest.getValue('Project-GroupId-ArtifactId')
-assert '${project.nosuchproperty}' == impl_manifest.getValue('Project-NoSuchProperty')
-assert localRepositoryPath.absolutePath == impl_manifest.getValue('Settings-LocalRepository')
-assert 'false' == impl_manifest.getValue('Settings-InteractiveMode')
-assert 'value' == impl_manifest.getValue('SomeVar')
-assert 'parentValue' == impl_manifest.getValue('SomeParentVar')
+assert impl_manifest.getValue('Project-Build-OutputDirectory') == new File(basedir, 'test-impl-bundle/target/classes').absolutePath
+assert impl_manifest.getValue('Project-Build-SourceEncoding') == 'UTF-8'
+assert impl_manifest.getValue('Project-GroupId-ArtifactId') == 'biz.aQute.bnd-test:test-impl-bundle'
+assert impl_manifest.getValue('Project-NoSuchProperty') == '${project.nosuchproperty}'
+assert impl_manifest.getValue('Settings-LocalRepository') == localRepositoryPath.absolutePath
+assert impl_manifest.getValue('Settings-InteractiveMode') == 'false'
+assert impl_manifest.getValue('SomeVar') == 'value'
+assert impl_manifest.getValue('SomeParentVar') == 'parentValue'
 
 // Check bnd properties
 assert api_manifest.getValue('Project-Name') == 'test-api-bundle'
@@ -68,11 +68,11 @@ assert impl_manifest.getValue('Project-Sourcepath')
 assert !wrapper_manifest.getValue('Project-Sourcepath')
 
 // Check contents
-assert null != api_jar.getEntry('org/example/api/')
-assert null != api_jar.getEntry('org/example/types/')
-assert null != api_jar.getEntry('OSGI-OPT/src/')
-assert null != impl_jar.getEntry('org/example/impl/')
-assert null != impl_jar.getEntry('OSGI-INF/org.example.impl.ExampleComponent.xml')
-assert null != impl_jar.getEntry('OSGI-INF/metatype/org.example.impl.Config.xml')
-assert null != wrapper_jar.getEntry('org/example/api/')
-assert null != wrapper_jar.getEntry('org/example/types/')
+assert api_jar.getEntry('org/example/api/') != null
+assert api_jar.getEntry('org/example/types/') != null
+assert api_jar.getEntry('OSGI-OPT/src/') != null
+assert impl_jar.getEntry('org/example/impl/') != null
+assert impl_jar.getEntry('OSGI-INF/org.example.impl.ExampleComponent.xml') != null
+assert impl_jar.getEntry('OSGI-INF/metatype/org.example.impl.Config.xml') != null
+assert wrapper_jar.getEntry('org/example/api/') != null
+assert wrapper_jar.getEntry('org/example/types/') != null

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -8,9 +8,9 @@ println " mavenVersion: ${mavenVersion}"
 // Check the bundles exist!
 File api_bundle = new File(basedir, 'test-api-bundle/target/test-api-bundle-0.0.1.jar')
 assert api_bundle.isFile()
-File impl_bundle = new File(basedir, 'test-impl-bundle/target/test-impl-bundle-0.0.1.jar')
+File impl_bundle = new File(basedir, 'test-impl-bundle/target/test-impl-bundle-0.0.1-SNAPSHOT.jar')
 assert impl_bundle.isFile()
-File wrapper_bundle = new File(basedir, 'test-wrapper-bundle/target/test-wrapper-bundle-0.0.1.jar')
+File wrapper_bundle = new File(basedir, 'test-wrapper-bundle/target/test-wrapper-bundle-0.0.1-SNAPSHOT.jar')
 assert wrapper_bundle.isFile()
 
 // Load manifests
@@ -26,8 +26,9 @@ assert api_manifest.getValue('Bundle-SymbolicName') == 'test-api-bundle'
 assert impl_manifest.getValue('Bundle-SymbolicName') == 'test-impl-bundle'
 assert wrapper_manifest.getValue('Bundle-SymbolicName') == 'test-wrapper-bundle'
 assert api_manifest.getValue('Bundle-Version') == '0.0.1'
-assert impl_manifest.getValue('Bundle-Version') == '0.0.1'
-assert wrapper_manifest.getValue('Bundle-Version') == '0.0.1'
+assert impl_manifest.getValue('Bundle-Version') == '0.0.1.SNAPSHOT'
+assert wrapper_manifest.getValue('Bundle-Version') != '0.0.1.SNAPSHOT'
+assert wrapper_manifest.getValue('Bundle-Version') =~ /^0\.0\.1\./
 
 // Check inheritance of properties in bnd.bnd from the parent project
 assert api_manifest.getValue('X-ParentProjectProperty') == 'it worked'


### PR DESCRIPTION
If a user wants to avoid replacing  `SNAPSHOT` with `${tstamp}` in qualifier in `Bundle-Version`, the `-snapshot: SNAPSHOT` instruction can be used.

For example, to retain SNAPSHOT in the POM version 
```
<version>0.0.1-SNAPSHOT</version>
```

in the `Bundle-Version` header, put the following in the `bnd.bnd` file:

```
-snapshot: SNAPSHOT
```
