### PR TITLE
bnd-maven-plugin: Avoid building jar in memory if possible

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2131,6 +2131,7 @@ public class Analyzer extends Processor {
 
 		addClose(jar);
 		classpath.add(jar);
+		updateModified(jar.lastModified(), jar.toString());
 	}
 
 	public void addClasspath(Collection< ? > jars) throws IOException {

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/src/main/resources/org/example/api/aresource.txt
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/src/main/resources/org/example/api/aresource.txt
@@ -1,0 +1,1 @@
+This is a resource

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -70,6 +70,8 @@ assert !wrapper_manifest.getValue('Project-Sourcepath')
 
 // Check contents
 assert api_jar.getEntry('org/example/api/') != null
+assert api_jar.getEntry('org/example/api/aresource.txt') != null
+assert api_jar.getInputStream(api_jar.getEntry('org/example/api/aresource.txt')).text =~ /This is a resource/
 assert api_jar.getEntry('org/example/types/') != null
 assert api_jar.getEntry('OSGI-OPT/src/') != null
 assert impl_jar.getEntry('org/example/impl/') != null


### PR DESCRIPTION
The BuildContext.hasDelta method is used to find if any project source
has changed since the last build. The jar is built only if there is a
delta or the builder inputs are newer than the target/classes dir.