### PR TITLE
Default Bundle-SymbolicName now comes from the Maven project's artifa…

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -160,6 +160,12 @@ public class BndMavenPlugin extends AbstractMojo {
 				log.debug("builder sourcepath buildContext.hasDelta: " + delta);
 			}
 
+			// Set Bundle-SymbolicName
+			String bundleSymbolicName = builder.getProperty(Constants.BUNDLE_SYMBOLICNAME);
+			if (isEmpty(bundleSymbolicName)) {
+				builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, project.getArtifactId());
+			}
+
 			// Set Bundle-Version
 			Version version = MavenVersion.parseString(project.getVersion()).getOSGiVersion();
 			builder.setProperty(Constants.BUNDLE_VERSION, version.toString());
@@ -342,5 +348,9 @@ public class BndMavenPlugin extends AbstractMojo {
 			}
 			return value;
 		}
+	}
+
+	private boolean isEmpty(String header) {
+		return (header == null) || header.trim().isEmpty() || Constants.EMPTY_HEADER.equals(header);
 	}
 }


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/bndtools-users/u8CBmc_bojY, I have patched and tested (for my simple case) a change making the Bundle-SymbolicName instead default to the artifactId when built using the bad-maven-plugin.
I have not made a pull request before, so I've just accepted GitHub's defaults, which seem to make sense. Apologies if not correct.
Best, Dan.