### PR TITLE
bnd-maven-plugin: Add support for alt bnd file path and bnd-in-pom

### DIFF
--- a/maven/bnd-maven-plugin/README.md
+++ b/maven/bnd-maven-plugin/README.md
@@ -1,6 +1,6 @@
 # bnd-maven-plugin
 
-This is a Maven plugin for invoking bnd.
+This is a Maven plugin for invoking Bnd.
 
 The plugin hooks into the process-classes phase and generates artifacts such as:
 
@@ -13,16 +13,48 @@ All of the above artifacts will be generated into the project build output
 directory, i.e. `target/classes`, to be subsequently picked up and included
 in the JAR file by the default `maven-jar-plugin`.
 
-All bnd instructions must be declared in a bnd.bnd file at the root of the
-project. The plugin adds the following implicit instruction, which means that
-the entire content of the project (but no other packages from the build path)
-will be treated as bundle content and analyzed for imported packages:
+All Bnd instructions must be declared in a bnd file. By default, this is `bnd.bnd`
+in the base directory of the project. This can be configured to specify an alternate
+path which can be absolute or relative to the base directory of the project.
+In the following example, the `project.bnd` file in the `bnd` folder of the project
+will be used.
 
-    -includeresource: ${project.build.outputDirectory} # i.e target/classes
+```
+<plugin>
+    <groupId>biz.aQute.bnd</groupId>
+    <artifactId>bnd-maven-plugin</artifactId>
+    <configuration>
+        <bndfile>bnd/project.bnd</bndfile>
+    </configuration>
+</plugin>
+```
 
-NB: If the bnd.bnd file is absent then the bundle will contain only private
-packages, no Bundle-Activator, no Service-Component header, etc.  Therefore
-although it will be valid, the bundle would not be *useful*.
+It is also supported to specify the Bnd instructions embedded in the pom file. This
+is not recommended but can be useful when the parent project is a repository based
+pom. Bnd instructions in the pom are not used if the project has a bnd file.
+
+```
+<plugin>
+    <groupId>biz.aQute.bnd</groupId>
+    <artifactId>bnd-maven-plugin</artifactId>
+    <configuration>
+        <bnd><![CDATA[
+-exportcontents:\
+ org.example.api,\
+ org.example.types
+-sources: true
+]]></bnd>
+    </configuration>
+</plugin>
+```
+
+The plugin adds the entire content of the project from
+`${project.build.outputDirectory}` (but no other packages from 
+the build path) to the bundle content.
+
+NB: If there are no Bnd instructions for the project then the bundle will contain only private
+packages: no Bundle-Activator, no Export-Package header, etc.  Therefore
+although it will be valid, the bundle may not be *useful*.
 
 For further usage information, see the integration test projects under the included
 `src/test/resources/integration-test/test` directory.
@@ -35,12 +67,14 @@ MANIFEST.MF file when using its default configuration. We anticipate a [patch][1
 to the JAR plugin that will do this.
 In the meantime it is necessary to configure the plugin as follows:
 
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-            <useDefaultManifestFile>true</useDefaultManifestFile>
-        </configuration>
-    </plugin>
+```
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <configuration>
+        <useDefaultManifestFile>true</useDefaultManifestFile>
+    </configuration>
+</plugin>
+```
 
 [1]: https://issues.apache.org/jira/browse/MJAR-193

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/bnd.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/bnd.bnd
@@ -1,7 +1,0 @@
-X-ParentProjectProperty: it worked
-Project-Name: ${project.name}
-Project-Dir: ${project.dir}
-Project-Output: ${project.output}
-Project-Sourcepath: ${project.sourcepath}
-Project-Buildpath: ${project.buildpath}
--include: other.bnd

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -32,6 +32,17 @@
 						</goals>
 					</execution>
 				</executions>
+                <configuration>
+                    <bnd><![CDATA[
+X-ParentProjectProperty: it worked
+Project-Name: ${project.name}
+Project-Dir: ${project.dir}
+Project-Output: ${project.output}
+Project-Sourcepath: ${project.sourcepath}
+Project-Buildpath: ${project.buildpath}
+-include: other.bnd
+]]></bnd>
+                </configuration>
 			</plugin>
 
 			<!--

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/bnd.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/bnd.bnd
@@ -1,4 +1,0 @@
--exportcontents: \
-	org.example.api,\
-	org.example.types
--sources: true

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
@@ -37,6 +37,18 @@
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.7</version>
 			</plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                    <bnd><![CDATA[
+-exportcontents: \
+    org.example.api,\
+    org.example.types
+-sources: true
+]]></bnd>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/other.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/other.bnd
@@ -1,0 +1,1 @@
+X-IncludedProperty: Included via -include in project bnd.bnd file

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/wrapper.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/wrapper.bnd
@@ -3,3 +3,4 @@ Export-Package: \
 	org.example.types
 
 X-ParentProjectProperty: overridden
+-include: other.bnd

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
@@ -16,5 +16,16 @@
 			<version>0.0.1</version>
 		</dependency>
 	</dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                    <bndfile>bnd/wrapper.bnd</bndfile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -39,6 +39,7 @@ assert wrapper_manifest.getValue('X-ParentProjectProperty') == 'overridden'
 assert api_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
 assert impl_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
 assert wrapper_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
+assert wrapper_manifest.getValue('X-IncludedProperty') == 'Included via -include in project bnd.bnd file'
 assert impl_manifest.getValue('X-IncludedProjectProperty') == 'Included via -include in project bnd.bnd file'
 
 // Check POM properties


### PR DESCRIPTION
Add `<bndfile>` pom configuration element which specifies an alternate bnd
file path. This will allow the bnd file to be other than 'bnd.bnd' in
project root.

Add `<bnd>` pom configuration element which can hold, via CDATA, a bnd
file. The bnd properties in this element are used if there is no bnd
file found for the project. This will allow the bnd properties to be
carried in the pom.

Fixes https://github.com/bndtools/bnd/issues/1293
Fixes https://github.com/bndtools/bnd/issues/952

Signed-off-by: BJ Hargrave <bj@bjhargrave.com>