### PR TITLE
bnd-maven-plugin: Set Bundle-SymbolicName and Bundle-Name from project

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -162,6 +162,14 @@ public class BndMavenPlugin extends AbstractMojo {
 				log.debug("builder sourcepath buildContext.hasDelta: " + delta);
 			}
 
+			// Set Bundle-SymbolicName
+			if (builder.getProperty(Constants.BUNDLE_SYMBOLICNAME) == null) {
+				builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, project.getArtifactId());
+			}
+			// Set Bundle-Name
+			if (builder.getProperty(Constants.BUNDLE_NAME) == null) {
+				builder.setProperty(Constants.BUNDLE_NAME, project.getName());
+			}
 			// Set Bundle-Version
 			Version version = MavenVersion.parseString(project.getVersion()).getOSGiVersion();
 			builder.setProperty(Constants.BUNDLE_VERSION, version.toString());

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
@@ -6,7 +6,8 @@
 		<artifactId>test</artifactId>
 		<version>0.0.1</version>
 	</parent>
-	<artifactId>test-api-bundle</artifactId>
+	<artifactId>test.api.bundle</artifactId>
+    <name>Test API Bundle</name>
 
 	<dependencies>
 		<dependency>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/bnd.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/bnd.bnd
@@ -7,5 +7,6 @@ Settings-InteractiveMode: ${settings.interactiveMode}
 Settings-LocalRepository: ${settings.localRepository}
 SomeVar: ${someVar}
 SomeParentVar: ${someParentVar}
+Bundle-Name: Test Impl Bundle
 -include: other.bnd
 -snapshot: SNAPSHOT

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
@@ -25,7 +25,7 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>test-api-bundle</artifactId>
+			<artifactId>test.api.bundle</artifactId>
 			<version>0.0.1</version>
 		</dependency>
 	</dependencies>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/wrapper.bnd
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/bnd/wrapper.bnd
@@ -1,6 +1,6 @@
 Export-Package: \
 	org.example.api,\
 	org.example.types
-
+Bundle-SymbolicName: test.wrapper.bundle
 X-ParentProjectProperty: overridden
 -include: other.bnd

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-wrapper-bundle/pom.xml
@@ -12,7 +12,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>test-api-bundle</artifactId>
+			<artifactId>test.api.bundle</artifactId>
 			<version>0.0.1</version>
 		</dependency>
 	</dependencies>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -6,7 +6,7 @@ println " localRepositoryPath: ${localRepositoryPath}"
 println " mavenVersion: ${mavenVersion}"
 
 // Check the bundles exist!
-File api_bundle = new File(basedir, 'test-api-bundle/target/test-api-bundle-0.0.1.jar')
+File api_bundle = new File(basedir, 'test-api-bundle/target/test.api.bundle-0.0.1.jar')
 assert api_bundle.isFile()
 File impl_bundle = new File(basedir, 'test-impl-bundle/target/test-impl-bundle-0.0.1-SNAPSHOT.jar')
 assert impl_bundle.isFile()
@@ -22,9 +22,12 @@ JarFile wrapper_jar = new JarFile(wrapper_bundle)
 Attributes wrapper_manifest = wrapper_jar.getManifest().getMainAttributes()
 
 // Basic manifest check
-assert api_manifest.getValue('Bundle-SymbolicName') == 'test-api-bundle'
+assert api_manifest.getValue('Bundle-SymbolicName') == 'test.api.bundle'
 assert impl_manifest.getValue('Bundle-SymbolicName') == 'test-impl-bundle'
-assert wrapper_manifest.getValue('Bundle-SymbolicName') == 'test-wrapper-bundle'
+assert wrapper_manifest.getValue('Bundle-SymbolicName') == 'test.wrapper.bundle'
+assert api_manifest.getValue('Bundle-Name') == 'Test API Bundle'
+assert impl_manifest.getValue('Bundle-Name') == 'Test Impl Bundle'
+assert wrapper_manifest.getValue('Bundle-Name') == 'test-wrapper-bundle'
 assert api_manifest.getValue('Bundle-Version') == '0.0.1'
 assert impl_manifest.getValue('Bundle-Version') == '0.0.1.SNAPSHOT'
 assert wrapper_manifest.getValue('Bundle-Version') != '0.0.1.BUILD-SNAPSHOT'
@@ -53,7 +56,7 @@ assert impl_manifest.getValue('SomeVar') == 'value'
 assert impl_manifest.getValue('SomeParentVar') == 'parentValue'
 
 // Check bnd properties
-assert api_manifest.getValue('Project-Name') == 'test-api-bundle'
+assert api_manifest.getValue('Project-Name') == 'Test API Bundle'
 assert impl_manifest.getValue('Project-Name') == 'test-impl-bundle'
 assert wrapper_manifest.getValue('Project-Name') == 'test-wrapper-bundle'
 assert api_manifest.getValue('Project-Dir') == new File(basedir, 'test-api-bundle').absolutePath


### PR DESCRIPTION
If unset, Bundle-SymbolicName is set to the project artifactId. If
unset, Bundle-Name is set to the project name.

Closes https://github.com/bndtools/bnd/pull/1336
