### PR TITLE
bnd-maven-plugin: Close jar even if we don't build

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -197,13 +197,12 @@ public class BndMavenPlugin extends AbstractMojo {
 
 				// Expand Jar into target/classes
 				expandJar(bndJar, classesDir);
-
-				// Finally, report
-				reportErrorsAndWarnings(builder);
 			} else {
 				log.debug("No build");
 			}
 
+			// Finally, report
+			reportErrorsAndWarnings(builder);
 		} catch (MojoExecutionException e) {
 			throw e;
 		} catch (Exception e) {

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -135,9 +135,10 @@ public class BndMavenPlugin extends AbstractMojo {
 				}
 				File cpe = artifact.getFile().getCanonicalFile();
 				if (cpe.isDirectory()) {
-					Jar cpeDir = new Jar(cpe);
-					builder.updateModified(cpeDir.lastModified(), cpe.getPath());
-					buildpath.add(cpeDir);
+					Jar cpeJar = new Jar(cpe);
+					builder.addClose(cpeJar);
+					builder.updateModified(cpeJar.lastModified(), cpe.getPath());
+					buildpath.add(cpeJar);
 				} else {
 					builder.updateModified(cpe.lastModified(), cpe.getPath());
 					buildpath.add(cpe);
@@ -165,7 +166,6 @@ public class BndMavenPlugin extends AbstractMojo {
 			builder.setProperty("project.sourcepath", Strings.join(File.pathSeparator, sourcepath));
 			if (log.isDebugEnabled()) {
 				log.debug("builder sourcepath: " + builder.getProperty("project.sourcepath"));
-				log.debug("builder sourcepath buildContext.hasDelta: " + delta);
 			}
 
 			// Set Bundle-SymbolicName
@@ -185,6 +185,7 @@ public class BndMavenPlugin extends AbstractMojo {
 
 			if (log.isDebugEnabled()) {
 				log.debug("builder properties: " + builder.getProperties());
+				log.debug("builder delta: " + delta);
 			}
 
 			if (delta || (builder.getJar() == null) || (builder.lastModified() > builder.getJar().lastModified())) {


### PR DESCRIPTION
PR #1347 failed to add Jars to the close list to be closed if we decided not to build the bundle.

We also change to report even if we don't build the jar.