### PR TITLE
snapshot: Clean up code to be more precise about SNAPSHOT replacement

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -380,11 +380,37 @@ public class Builder extends Analyzer {
 		String version = getProperty(BUNDLE_VERSION);
 		if (version != null) {
 			version = cleanupVersion(version);
-			if (version.endsWith(".SNAPSHOT") || version.endsWith("-SNAPSHOT")) {
-				version = version.replaceAll("SNAPSHOT$", getProperty(SNAPSHOT, "SNAPSHOT"));
-			}
+			version = doSnapshot(version);
 			setProperty(BUNDLE_VERSION, version);
 		}
+	}
+
+	private String doSnapshot(String version) {
+		String snapshot = getProperty(SNAPSHOT);
+		if (snapshot == null) {
+			return version;
+		}
+		if (snapshot.isEmpty()) {
+			snapshot = null;
+		}
+		Version v = Version.parseVersion(version);
+		String q = v.getQualifier();
+		if (q == null) {
+			return version;
+		}
+		if (q.equals("SNAPSHOT")) {
+			q = snapshot;
+		} else if (q.endsWith("-SNAPSHOT")) {
+			int end = q.length() - "SNAPSHOT".length();
+			if (snapshot == null) {
+				q = q.substring(0, end - 1);
+			} else {
+				q = q.substring(0, end) + snapshot;
+			}
+		} else {
+			return version;
+		}
+		return new Version(v.getMajor(), v.getMinor(), v.getMicro(), q).toString();
 	}
 
 	public void cleanupVersion(Packages packages, String defaultVersion) {


### PR DESCRIPTION
SNAPSHOT is only replaced if the qualifier equals SNAPSHOT or ends with
-SNAPSHOT.