### PR TITLE
build: Use maven SNAPSHOT versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
   def bndProject = bndWorkspace.getProject(name)
   if (bndProject != null) {
     plugins.apply 'biz.aQute.bnd'
-    group bnd('groupid')
+    group bnd('-groupid')
     version bnd('base.version')
     /* Turn off javadoc 8 overly pedantic lint checking */
     if (JavaVersion.current().isJava8Compatible()) {

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -65,11 +65,15 @@ copyright.html:         Copyright &copy; aQute SARL (2000, ${tstamp;yyyy}) and o
 baseline.version:       3.1.0
 # biz.aQute.bndlib:aQute.bnd.osgi.About.CURRENT needs to be kept in sync with the base.version.
 base.version:           3.2.0
-build.version:          ${base.version}.${tstamp}
--outputmask:            ${@bsn}-${version;===;${@version}}.jar
-groupid:                biz.aQute.bnd
--groupid:				${groupid}
-Bundle-Version:         ${build.version}
+# Uncomment the following line to build the non-snapshot version.
+#-snapshot:
+Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
+
+# Maven info. The maven artifactId defaults to Bundle-SymbolicName
+-groupid:               biz.aQute.bnd
+-pom:                   version=${versionmask;===s;${@version}}
+
+-outputmask:            ${@bsn}-${versionmask;===;${@version}}.jar
 Bundle-Vendor:          Bndtools http://bndtools.org/
 Bundle-Copyright:       ${copyright}
 Bundle-License:         Apache-2.0; \
@@ -87,9 +91,6 @@ Bundle-Developers: \
         organizationUrl=http://bndtools.org; \
         roles="architect,developer"; \
         timezone=1
--pom = \
- groupid=${groupid}, \
- version=${base.version}
 
 # default version policies
 #   -provider-policy =  ${range;[==,=+)}

--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>biz.aQute.bnd</groupId>
 		<artifactId>bnd-plugin-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
 	</parent>
 

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>biz.aQute.bnd</groupId>
 		<artifactId>bnd-plugin-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>biz.aQute.bnd</groupId>
 		<artifactId>bnd-plugin-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -8,7 +8,7 @@
     <description>Parent POM for the bnd maven plugins.</description>
     <name>${project.groupId}:${project.artifactId}</name>
 	<packaging>pom</packaging>
-	<version>3.2.0</version>
+	<version>3.2.0-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is in preparation to release to a maven repo once the new maven
repo support is integrated.

We also take advantage of recent improvements to the -pom and -snapshot
instructions and the versionmask macro.