### PR TITLE
bnd-maven-plugin: Force build if the manifest is not present in target

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -156,7 +156,7 @@ public class BndMavenPlugin extends AbstractMojo {
 			}
 
 			// Compute bnd sourcepath
-			boolean delta = !buildContext.isIncremental();
+			boolean delta = !buildContext.isIncremental() || !manifestPath.exists();
 			List<File> sourcepath = new ArrayList<File>();
 			if (sourceDir.exists()) {
 				sourcepath.add(sourceDir.getCanonicalFile());


### PR DESCRIPTION
Fixes https://github.com/bndtools/bnd/issues/1405