### PR TITLE
build: .gitignore maven repo .mvn files when building non-SNAPSHOT

### DIFF
--- a/cnf/.gitignore
+++ b/cnf/.gitignore
@@ -1,3 +1,5 @@
 /bin/
 /generated/
 /cache/
+/local.mvn
+/release.mvn


### PR DESCRIPTION
[ci skip]