### PR TITLE
gradle: Add outputs for exports.* and runbundles.* tasks

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -342,6 +342,7 @@ public class BndPlugin implements Plugin<Project> {
               dependsOn assemble
               group 'export'
               def executableJar = new File(distsDir, "executable/${bndrun}.jar")
+              outputs.file executableJar
               doFirst {
                 project.mkdir(executableJar.parent)
               }
@@ -379,6 +380,7 @@ public class BndPlugin implements Plugin<Project> {
               dependsOn assemble
               group 'export'
               def runbundlesDir = new File(distsDir, "runbundles/${bndrun}")
+              outputs.dir runbundlesDir
               doFirst {
                 project.delete(runbundlesDir)
                 project.mkdir(runbundlesDir)


### PR DESCRIPTION
Fixes https://github.com/bndtools/bnd/issues/1422