### PR TITLE
DIAFAMPS-4 allowing to not specify package versions

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1713,7 +1713,9 @@ public class Analyzer extends Processor {
 					exportVersion = cleanupVersion(exportVersion);
 
 					importRange = applyVersionPolicy(exportVersion, importRange, provider);
-					importAttributes.put(VERSION_ATTRIBUTE, importRange);
+					if(!importRange.trim().isEmpty()) {
+						importAttributes.put(VERSION_ATTRIBUTE, importRange);
+					}
 				}
 
 				//


### PR DESCRIPTION
The problem we encountered is - we don't usually specify ranges nor versions in the import-packages block. We didn't find a way of doing it and this change should provide us such functionality. 
What it does: if you provide an empty consumer-policy your versions won't be automatically generated.