### PR TITLE
#1320 -sources: true does not handle split packages properly

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -461,6 +461,9 @@ public class Builder extends Analyzer {
 			String sourcePath = typeRef.getSourcePath();
 			String packagePath = packageRef.getPath();
 
+			if (dot.getDirectories().containsKey("OSGI-OPT/src/" + packageRef.binaryName))
+				continue;
+
 			boolean found = false;
 			String[] fixed = {
 					"packageinfo", "package.html", "module-info.java", "package-info.java"
@@ -487,19 +490,6 @@ public class Builder extends Analyzer {
 					if (packageRef.isDefaultPackage())
 						System.err.println("Duh?");
 					dot.putResource("OSGI-OPT/src/" + sourcePath, new FileResource(f));
-				}
-			}
-			if (!found) {
-				for (Jar jar : getClasspath()) {
-					Resource resource = jar.getResource(sourcePath);
-					if (resource != null) {
-						dot.putResource("OSGI-OPT/src/" + sourcePath, resource);
-					} else {
-						resource = jar.getResource("OSGI-OPT/src/" + sourcePath);
-						if (resource != null) {
-							dot.putResource("OSGI-OPT/src/" + sourcePath, resource);
-						}
-					}
 				}
 			}
 			if (getSourcePath().isEmpty())
@@ -726,6 +716,8 @@ public class Builder extends Analyzer {
 	private void copy(Jar dest, Jar srce, String path, boolean overwrite) {
 		trace("copy d=" + dest + " s=" + srce + " p=" + path);
 		dest.copy(srce, path, overwrite);
+		if (hasSources())
+			dest.copy(srce, "OSGI-OPT/src/" + path, overwrite);
 
 		// bnd.info sources must be preprocessed
 		String bndInfoPath = path + "/bnd.info";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -203,9 +203,15 @@ public class Jar implements Closeable {
 
 		for (Map.Entry<String,Resource> entry : directory.entrySet()) {
 			String key = entry.getKey();
-			if (!key.endsWith(".java")) {
-				duplicates |= putResource(key, entry.getValue(), overwrite);
-			}
+
+			//
+			// Previous version did not copy JAVA files but
+			// I think this is very old (everybody seems to separate the
+			// sources from the binaries nowadays) and it is a fix
+			// on the wrong level. Lets see if someone whines.
+			//
+
+			duplicates |= putResource(key, entry.getValue(), overwrite);
 		}
 		return duplicates;
 	}


### PR DESCRIPTION
I’ve moved the copying of sources from the -buildpath JARs inline with the copying of the binary package, it will therefore follow exactly the same logic.

Fixes #1320

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>