### PR TITLE
maven: Avoid useDefaultManifestFile

### DIFF
--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -70,9 +70,9 @@
 					<artifactId>maven-jar-plugin</artifactId>
                     <version>2.6</version>
 					<configuration>
-						<useDefaultManifestFile>
-							true
-						</useDefaultManifestFile>
+                        <archive>
+                           <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        </archive>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/helloworld-for-indexer-testing/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/helloworld-for-indexer-testing/pom.xml
@@ -38,9 +38,9 @@
 				<artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
 				<configuration>
-					<useDefaultManifestFile>
-						true
-					</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
@@ -15,7 +15,9 @@
 				<artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
 				<configuration>
-					<useDefaultManifestFile>true</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
@@ -15,7 +15,9 @@
 				<artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
 				<configuration>
-					<useDefaultManifestFile>true</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/maven/bnd-maven-plugin/README.md
+++ b/maven/bnd-maven-plugin/README.md
@@ -72,7 +72,9 @@ In the meantime it is necessary to configure the plugin as follows:
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-jar-plugin</artifactId>
     <configuration>
-        <useDefaultManifestFile>true</useDefaultManifestFile>
+        <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+        </archive>
     </configuration>
 </plugin>
 ```

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -55,9 +55,9 @@ Project-Buildpath: ${project.buildpath}
 				<artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
 				<configuration>
-					<useDefaultManifestFile>
-						true
-					</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MJAR-210 has removed
useDefaultManifestFile in maven-jar-plugin 3.0.

Fixes https://github.com/bndtools/bnd/issues/1456