### PR TITLE
Add skip option to maven plugins

### DIFF
--- a/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -61,10 +61,17 @@ public class BaselineMojo extends AbstractMojo {
 	@Parameter(readonly = true, required = false)
 	private Base					base;
 
+    @Parameter(defaultValue = "false", readonly = true)
+    private boolean				skip;
+    
 	@Component
 	private RepositorySystem		system;
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
+        if ( skip ) {
+			getLog().debug("skip project as configured");
+			return;
+		}
 
 		Artifact artifact = RepositoryUtils.toArtifact(project.getArtifact());
 

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -92,6 +92,9 @@ public class IndexerMojo extends AbstractMojo {
 	@Parameter(property = "bnd.indexer.scopes", readonly = true, required = false)
 	private List<String>				scopes;
 
+    @Parameter(defaultValue = "false", readonly = true)
+    private boolean				skip;
+    
 	@Component
 	private RepositorySystem			system;
 
@@ -107,6 +110,11 @@ public class IndexerMojo extends AbstractMojo {
 	private boolean						fail;
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
+
+        if ( skip ) {
+			getLog().debug("skip project as configured");
+			return;
+		}
 
 		if (scopes == null || scopes.isEmpty()) {
 			scopes = Arrays.asList("compile", "runtime");

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -85,6 +85,9 @@ public class BndMavenPlugin extends AbstractMojo {
 	@Parameter(defaultValue = "${settings}", readonly = true)
 	private Settings			settings;
 
+    @Parameter(defaultValue = "false", readonly = true)
+    private boolean				skip;
+    
 	@Component
 	private BuildContext		buildContext;
 
@@ -93,6 +96,11 @@ public class BndMavenPlugin extends AbstractMojo {
 	public void execute() throws MojoExecutionException {
 		log = getLog();
 
+        if ( skip ) {
+			log.debug("skip project as configured");
+			return;
+		}
+        
 		// Exit without generating anything if this is a pom-packaging project.
 		// Probably it's just a parent project.
 		if (PACKAGING_POM.equals(project.getPackaging())) {


### PR DESCRIPTION
It's a common practice to enable plugins which are used in most projects in the parent pom. However, sometimes there is a need to not run a specific plugin in one of the projects. Maintaining different parent poms for this is too much work, therefore plugins usually have a skip option which can be enabled in such "special" projects.
This pull request adds the skip option to all three maven plugins