### PR TITLE
[maven] Sources don’t work

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -134,6 +134,7 @@ class RepoActions {
 									bin.putResource("OSGI-OPT/src/" + path, src.getResource(path));
 								bin.write(out);
 							}
+							out.setLastModified(System.currentTimeMillis());
 						}
 					} catch (Exception e) {
 						throw new RuntimeException(e);


### PR DESCRIPTION
I see there is a date/time problem with the file dates. The JAR write sets the file date to bnd highest last modified resource in the manifest and that somehow disagrees with file date of the binary jar. When we build the class path and ask for the binary file we see the sources are older and ignore them. :-(

The file date of the sources file is now > binary JAR.



Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>