### PR TITLE
gradle: bundle task type did not handle plain files in configuration

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
@@ -60,9 +60,11 @@ public class ZipResource implements Resource {
 				}
 			}
 			return zip;
-		} catch (ZipException ze) {
-			throw new ZipException(
-					"The JAR/ZIP file (" + file.getAbsolutePath() + ") seems corrupted, error: " + ze.getMessage());
+		} catch (ZipException e) {
+			ZipException ze = new ZipException(
+					"The JAR/ZIP file (" + file.getAbsolutePath() + ") seems corrupted, error: " + e.getMessage());
+			ze.initCause(e);
+			throw ze;
 		} catch (FileNotFoundException e) {
 			throw new IllegalArgumentException("Problem opening JAR: " + file.getAbsolutePath());
 		}


### PR DESCRIPTION
With a configuration set up using files:

    dependencies {
        compile files('lib/foo.jar')
    }

The jar is not in the resolvedConfiguration. See we now use the getFiles
method on Configuration and then probe each file to make sure it is a
zip file before adding to the builder class path.

Closes #1484