### PR TITLE
gradle: Fix bnd extension property lookup for Gradle 2.14

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -61,7 +61,6 @@ public class BndPlugin implements Plugin<Project> {
       }
       this.preCompileRefresh = project.hasProperty('bnd_preCompileRefresh') ? parseBoolean(bnd_preCompileRefresh) : false
       extensions.create('bnd', BndProperties, bndProject)
-      bnd.ext.project = bndProject
       convention.plugins.bnd = new BndPluginConvention(this)
 
       buildDir = relativePath(bndProject.getTargetDir())

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndProperties.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndProperties.groovy
@@ -8,33 +8,47 @@
 
 package aQute.bnd.gradle
 
+import aQute.bnd.build.Project
+import org.gradle.api.plugins.ExtraPropertiesExtension
+
 class BndProperties {
-  private final bndProject
-  BndProperties(bndProject) {
-    this.bndProject = bndProject
+  final Project project
+  BndProperties(Project bndProject) {
+    this.project = bndProject
   }
-  String get(String name) {
-    String value = bndProject.getProperty(name)
-    if (value instanceof String) {
-      value = value.trim()
-    }
-    return value
+
+  def get(String name) {
+    return trimmed(project.getProperty(name))
   }
-  Object get(String name, Object defaultValue) {
+
+  def get(String name, Object defaultValue) {
     def value = get(name)
-    if (value == null) {
-      value = defaultValue
-      if (value instanceof String) {
-        value = value.trim()
-      }
+    if (value != null) {
+      return value
     }
-    return value
+    return trimmed(defaultValue)
   }
-  String propertyMissing(String name) {
-    String value = get(name)
-    if (value == null) {
-      value = get(name.replace('_', '.'))
+
+  def propertyMissing(String name) {
+    if (name == 'ext') {
+      throw new MissingPropertyException(name, String)
     }
-    return value
+    ExtraPropertiesExtension ext = extensions.extraProperties
+    if (ext.has(name)) {
+      return ext.get(name)
+    }
+    def value = extensions.findByName(name)
+    if (value != null) {
+      return value
+    }
+    value = get(name)
+    if (value != null) {
+      return value
+    }
+    return get(name.replace('_', '.'))
+  }
+
+  def trimmed(value) {
+    return (value instanceof String) ? value.trim() : value
   }
 }


### PR DESCRIPTION
Gradle 2.14 has changed the property lookup for ExtensionAware objects
like Project. Instead of consulting the ext properties before asking the
extension object, it now consults the extension object first. This means
that if the extension object implements propertyMissing, it must throw
a MissingPropertyException for 'ext' and also look in the ext properties
before its own properties to preserve the prior behavior.

Fixes https://github.com/bndtools/bnd/issues/1495

See also https://discuss.gradle.org/t/bnd-plugin-broken-in-2-14/17983