### PR TITLE
1504: BndEditModel does not handle -runblacklist

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -104,6 +104,7 @@ public class BndEditModel {
 																										aQute.bnd.osgi.Constants.RUNREPOS,
 																										aQute.bnd.osgi.Constants.RUNREQUIRES,
 																										aQute.bnd.osgi.Constants.RUNEE,
+																										aQute.bnd.osgi.Constants.RUNBLACKLIST,
 																										Constants.BUNDLE_BLUEPRINT,
 																										Constants.INCLUDE_RESOURCE,
 																										"-standalone"


### PR DESCRIPTION
adding runblacklist to the known_properties will fire the corresponding
PropertyChangeEvent which is needed to fix issue 1397 in BndTools.

Signed-off-by: Marc Schlegel <maschlegel@gmail.com>