### PR TITLE
Better error handling for -include of URL resources.

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1020,12 +1020,14 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 							} finally {
 								tmp.delete();
 							}
-						} catch (Exception mue) {
-							// ignore
+						} catch (MalformedURLException mue) {
+							if (fileMustExist)
+								error("Included file %s %s", file,
+										(file.isDirectory() ? "is directory" : "does not exist"));
+						} catch (Exception e) {
+							if (fileMustExist)
+								error("Error in processing included URL: %s", e, value);
 						}
-						if (fileMustExist)
-							error("Included file %s %s", file,
-									(file.isDirectory() ? "is directory" : "does not exist"));
 					} else
 						doIncludeFile(file, overwrite, p);
 				} catch (Exception e) {


### PR DESCRIPTION
- When user supplies a valid URL, now reports specific errors relating
to failures in including the named resource.
- No longer gives spurious errors after valid URL includes.

Fixes #1534

Signed-off-by: Elias N Vasylenko <eliasvasylenko@gmail.com>