### PR TITLE
Allow specification of ClassLoader when calling Annotation.getAnnotat…

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -70,10 +70,14 @@ public class Annotation {
 	}
 
 	public <T extends java.lang.annotation.Annotation> T getAnnotation() throws Exception {
+		return getAnnotation(getClass().getClassLoader());
+	}
+
+	public <T extends java.lang.annotation.Annotation> T getAnnotation(ClassLoader cl) throws Exception {
 		String cname = name.getFQN();
 		try {
 			@SuppressWarnings("unchecked")
-			Class<T> c = (Class<T>) getClass().getClassLoader().loadClass(cname);
+			Class<T> c = (Class<T>) cl.loadClass(cname);
 			return getAnnotation(c);
 		} catch (ClassNotFoundException e) {} catch (NoClassDefFoundError e) {}
 		return null;


### PR DESCRIPTION
…ion()

To avoid having to duplicate the implementation of getAnnotation() in my own class and hence get it to use my own class loader and hence see my annotations, provide a version of getAnnotation that allows you to specify the class loader to use. Delegate the original getAnnotation to the new version, passing in getClass().getClassLoader().

See Issue #1547