### PR TITLE
Allow specification of ClassLoader when calling Annotation.getAnnotat…

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -70,10 +70,14 @@ public class Annotation {
 	}
 
 	public <T extends java.lang.annotation.Annotation> T getAnnotation() throws Exception {
+		return getAnnotation(getClass().getClassLoader());
+	}
+
+	public <T extends java.lang.annotation.Annotation> T getAnnotation(ClassLoader cl) throws Exception {
 		String cname = name.getFQN();
 		try {
 			@SuppressWarnings("unchecked")
-			Class<T> c = (Class<T>) getClass().getClassLoader().loadClass(cname);
+			Class<T> c = (Class<T>) cl.loadClass(cname);
 			return getAnnotation(c);
 		} catch (ClassNotFoundException e) {} catch (NoClassDefFoundError e) {}
 		return null;


### PR DESCRIPTION
…ion()

In order that getAnnotation() can be used for annotations other than ones built in to bndlib, it is necessary to have a mechanism such as the ability to specify the class loader through which the annotation class is loaded.

Signed-off-by: Tom Quarendon <tom@quarendon.net>