### PR TITLE
maven index: Call Promise.getFailure() to wait for promise to resolve

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -80,7 +80,7 @@ class IndexFile {
 			Promise<File> f = i.next();
 			try {
 				if (!f.isDone())
-					f.getValue();
+					f.getFailure();
 			} catch (Exception e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();


### PR DESCRIPTION
This avoids throwing InvocationTargetException if the promise failed.