### PR TITLE
[osgirepo] Too many downloads

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -169,7 +169,8 @@ public class HttpClient implements Closeable, URLConnector {
 				// our accepted stale period
 				//
 
-				if (request.maxStale < 0 || info.file.lastModified() + request.maxStale < System.currentTimeMillis()) {
+				if (request.maxStale < 0
+						|| info.jsonFile.lastModified() + request.maxStale < System.currentTimeMillis()) {
 
 					//
 					// Ok, expired. So check if there is a newer one on the

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -111,6 +111,8 @@ public class ResourceUtils {
 																						}
 																					};
 
+	public static final Resource						DUMMY_RESOURCE				= new ResourceBuilder().build();
+
 	static Converter									cnv							= new Converter();
 
 	static {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Formatter;
 import java.util.HashMap;
@@ -30,6 +31,8 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
 import org.osgi.util.promise.Promise;
 
 import aQute.bnd.annotation.plugin.BndPlugin;
@@ -44,6 +47,7 @@ import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
+import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.repository.maven.provider.IndexFile.BundleDescriptor;
 import aQute.bnd.repository.maven.provider.ReleaseDTO.JavadocPackages;
 import aQute.bnd.repository.maven.provider.ReleaseDTO.ReleaseType;
@@ -56,7 +60,6 @@ import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.maven.PomOptions;
 import aQute.bnd.service.maven.ToDependencyPom;
-import aQute.bnd.service.repository.InfoRepository;
 import aQute.bnd.version.Version;
 import aQute.jpm.facade.repo.JpmRepo;
 import aQute.lib.converter.Converter;
@@ -79,8 +82,8 @@ import aQute.service.reporter.Reporter;
  * This is the Bnd repository for Maven.
  */
 @BndPlugin(name = "MavenBndRepository")
-public class MavenBndRepository implements RepositoryPlugin, RegistryPlugin, Plugin, Closeable, Refreshable,
-		InfoRepository, Actionable, ToDependencyPom {
+public class MavenBndRepository extends BaseRepository
+		implements RepositoryPlugin, RegistryPlugin, Plugin, Closeable, Refreshable, Actionable, ToDependencyPom {
 
 	private final Pattern			JPM_REVISION_URL_PATTERN_P	= Pattern
 			.compile("https?://.+#!?/p/sha/(?<sha>([0-9A-F][0-9A-F]){20,20})/.*", Pattern.CASE_INSENSITIVE);
@@ -593,7 +596,6 @@ public class MavenBndRepository implements RepositoryPlugin, RegistryPlugin, Plu
 		return localRepo;
 	}
 
-	@Override
 	public BundleDescriptor getDescriptor(String bsn, Version version) throws Exception {
 		return index.getDescriptor(bsn, version);
 	}
@@ -829,6 +831,12 @@ public class MavenBndRepository implements RepositoryPlugin, RegistryPlugin, Plu
 				.dependencyManagement(options.dependencyManagement)
 				.out(out);
 		
+	}
+
+	@Override
+	public Map<Requirement,Collection<Capability>> findProviders(Collection< ? extends Requirement> requirements) {
+		init();
+		return index.findProviders(requirements);
 	}
 
 }

--- a/biz.aQute.repository/test/aQute/bnd/repository/osgi/OSGiRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/osgi/OSGiRepositoryTest.java
@@ -1,0 +1,94 @@
+package aQute.bnd.repository.osgi;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import aQute.bnd.build.Workspace;
+import aQute.bnd.http.HttpClient;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.progress.ProgressPlugin;
+import aQute.bnd.version.Version;
+import aQute.http.testservers.HttpTestServer.Config;
+import aQute.lib.io.IO;
+import aQute.libg.reporter.slf4j.Slf4jReporter;
+import aQute.maven.provider.FakeNexus;
+import junit.framework.TestCase;
+
+public class OSGiRepositoryTest extends TestCase {
+	File				tmp		= IO.getFile("generated/tmp");
+	File				cache	= IO.getFile(tmp, "cache");
+	File				remote	= IO.getFile("testdata");
+	File				ws		= IO.getFile(tmp, "ws");
+	private FakeNexus	fnx;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		IO.delete(tmp);
+		Config config = new Config();
+		fnx = new FakeNexus(config, remote);
+		fnx.start();
+	}
+
+	public void testSimple() throws Exception {
+		OSGiRepository r = new OSGiRepository();
+		Map<String,String> map = new HashMap<>();
+		map.put("locations", fnx.getBaseURI("/repo/minir5.xml").toString());
+		map.put("cache", "generated/tmp/cache");
+		map.put("max.stale", "10000");
+		r.setProperties(map);
+		Processor p = new Processor();
+		final AtomicInteger tasks = new AtomicInteger();
+
+		p.addBasicPlugin(new ProgressPlugin() {
+
+			@Override
+			public Task startTask(final String name, int size) {
+				System.out.println("Starting " + name);
+				tasks.incrementAndGet();
+				return new Task() {
+
+					@Override
+					public void worked(int units) {
+						System.out.println("Worked " + name + " " + units);
+					}
+
+					@Override
+					public void done(String message, Throwable e) {
+						System.out.println("Done " + name + " " + message);
+					}
+
+					@Override
+					public boolean isCanceled() {
+						return false;
+					}
+				};
+			}
+		});
+		HttpClient httpClient = new HttpClient();
+		httpClient.setRegistry(p);
+		p.addBasicPlugin(httpClient);
+		p.setBase(ws);
+		p.addBasicPlugin(Workspace.createStandaloneWorkspace(p, ws.toURI()));
+		r.setRegistry(p);
+		r.setReporter(new Slf4jReporter());
+
+		assertEquals(0, tasks.get());
+		File file = r.get("dummybundle", new Version("0"), null);
+		assertNotNull(file);
+		assertEquals(2, tasks.get()); // 2 = index + file
+		File file2 = r.get("dummybundle", new Version("0"), null);
+		assertNotNull(file2);
+		// second one should not have downloaded
+		assertEquals(2, tasks.get());
+
+		r.refresh();
+		File file3 = r.get("dummybundle", new Version("0"), null);
+		assertNotNull(file3);
+		// second one should not have downloaded
+		assertEquals(2, tasks.get());
+	}
+
+}


### PR DESCRIPTION
- Fixed the extension in the file name to be jar
- Use the JSON file for timestamping because the real file gets the remote time
- Improved cache location alg.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>