### PR TITLE
setExceptions: Use the Processor.use method to inherit settings

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -687,8 +687,7 @@ public class bnd extends Processor {
 				return;
 			}
 
-			b.setTrace(isTrace());
-			b.setPedantic(isPedantic());
+			b.use(this);
 			b.setProperties(f);
 
 			List<Builder> subs = b.getSubBuilders();
@@ -2439,7 +2438,7 @@ public class bnd extends Processor {
 		}
 
 		Project project = new Project(ws, testFile.getAbsoluteFile().getParentFile(), testFile.getAbsoluteFile());
-		project.setTrace(isTrace());
+		project.use(this);
 		project.setProperty(NOBUNDLES, "true");
 
 		ProjectTester tester = project.getProjectTester();
@@ -2705,9 +2704,7 @@ public class bnd extends Processor {
 		if (ws == null)
 			return null;
 
-		ws.setTrace(isTrace());
-		ws.setPedantic(isPedantic());
-		ws.setExceptions(isExceptions());
+		ws.use(this);
 		return ws;
 	}
 
@@ -3393,9 +3390,7 @@ public class bnd extends Processor {
 	@Description("Maven bundle command")
 	public void _maven(Options options) throws Exception {
 		MavenCommand mc = new MavenCommand(this);
-		mc.setTrace(isTrace());
-		mc.setExceptions(isExceptions());
-		mc.setPedantic(isPedantic());
+		mc.use(this);
 		mc.run(options._arguments().toArray(new String[0]), 1);
 		getInfo(mc);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -207,8 +207,7 @@ public class Project extends Processor {
 			builder = new ProjectBuilder(parent);
 
 		builder.setBase(getBase());
-		builder.setPedantic(isPedantic());
-		builder.setTrace(isTrace());
+		builder.use(this);
 		return builder;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -1391,8 +1391,7 @@ public class Builder extends Analyzer {
 	public Builder getSubBuilder() throws Exception {
 		Builder builder = new Builder(this);
 		builder.setBase(getBase());
-		builder.setPedantic(isPedantic());
-		builder.setTrace(isTrace());
+		builder.use(this);
 
 		for (Jar file : getClasspath()) {
 			builder.addClasspath(file);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -401,6 +401,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	public void use(Processor reporter) {
 		setPedantic(reporter.isPedantic());
 		setTrace(reporter.isTrace());
+		setExceptions(reporter.isExceptions());
 		setFailOk(reporter.isFailOk());
 	}
 


### PR DESCRIPTION
This provides for a consistency in inheriting trace/pedantic/exceptions
from "parent" processors. It also allows exceptions to be set in the
gradle script and be inherited by the project builders.
