### PR TITLE
native test: Use current OS before changing OS system properties

### DIFF
--- a/aQute.libg/src/aQute/lib/filter/Filter.java
+++ b/aQute.libg/src/aQute/lib/filter/Filter.java
@@ -202,6 +202,8 @@ public class Filter {
 		<T> boolean compare(T obj, int op, String s) {
 			if (obj == null)
 				return false;
+			if ((op == EQ) && (s.length() == 1) && (s.charAt(0) == WILDCARD))
+				return true;
 			try {
 				Class<T> numClass = (Class<T>) obj.getClass();
 				if (numClass == String.class) {

--- a/biz.aQute.bndlib.tests/src/test/ProcessorTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProcessorTest.java
@@ -53,6 +53,12 @@ public class ProcessorTest extends TestCase {
 		try (Processor p = new Processor();) {
 			p.setProperty("a", "${native_capability}");
 
+			// Use the current OS first to enable loading things like default
+			// file system before we change system properties.
+			assertNativeDefault(System.getProperty("os.name"), System.getProperty("os.version"),
+					System.getProperty("os.arch"),
+					"(&(osgi.native.osname=*)(osgi.native.osversion=*)(osgi.native.processor=*)(osgi.native.language=*))");
+
 			//
 			// Mac OS
 			//


### PR DESCRIPTION
This will ensure any things needed by the test are loaded using the
current OS settings before changing the OS system properties.
