### PR TITLE
Remove all dependencies on Java 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The git repository contains all code. It contains the following projects:
 * biz.aQute.bndlib - The core library
 * biz.aQute.bndlib.tests - Tests for the core library
 * biz.aQute.jpm - Just another package manager for Java
-* biz.aQute.junit - Junit tester (runs on Java 1.5)
+* biz.aQute.junit - Junit tester (runs on Java 1.6)
 * biz.aQute.launcher - Launcher (runs on Java 1.6)
 * biz.aQute.repository - Different repos with OBR
 * biz.aQute.resolve - OBR Resolver

--- a/biz.aQute.bndlib.tests/src/test/diff/DiffTest.java
+++ b/biz.aQute.bndlib.tests/src/test/diff/DiffTest.java
@@ -198,7 +198,7 @@ public class DiffTest extends TestCase {
 	}
 
 	public void testAwtGeom() throws Exception {
-		Tree newer = differ.tree(IO.getFile("../cnf/repo/ee.j2se/ee.j2se-1.5.0.jar"));
+		Tree newer = differ.tree(IO.getFile("../cnf/repo/ee.j2se/ee.j2se-1.6.0.jar"));
 		Tree gp = newer.get("<api>").get("java.awt.geom").get("java.awt.geom.GeneralPath");
 		assertNotNull(gp);
 		show(gp, 0);

--- a/biz.aQute.junit/.settings/org.eclipse.jdt.launching.prefs
+++ b/biz.aQute.junit/.settings/org.eclipse.jdt.launching.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE=warning


### PR DESCRIPTION
biz.aQute.junit now uses Java 6 as the base Java level.

