### PR TITLE
promise: Concurrency fixes in MavenRepository

### DIFF
--- a/biz.aQute.repository/src/aQute/maven/provider/POM.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/POM.java
@@ -352,6 +352,9 @@ public class POM implements IPom {
 		for (Dependency d : breadthFirst)
 			try {
 				POM pom = repo.getPom(d.getRevision());
+				if (pom == null) {
+					continue;
+				}
 				pom.getDependencies(deps, scope, transitive, visited);
 			} catch (Exception ee) {
 				ee.printStackTrace();

--- a/biz.aQute.repository/test/aQute/maven/provider/CentralTest.java
+++ b/biz.aQute.repository/test/aQute/maven/provider/CentralTest.java
@@ -7,7 +7,6 @@ import aQute.bnd.http.HttpClient;
 import aQute.http.testservers.HttpTestServer.Config;
 import aQute.lib.io.IO;
 import aQute.libg.reporter.ReporterAdapter;
-import aQute.maven.api.IPom;
 import aQute.maven.api.MavenScope;
 import aQute.maven.api.Program;
 import aQute.maven.api.Revision;
@@ -44,7 +43,7 @@ public class CentralTest extends TestCase {
 
 	public void testBasic() throws Exception {
 		Revision r = Program.valueOf("org.lunarray.model.extensions.descriptor", "spring").version("1.0");
-		IPom pom = storage.getPom(r);
+		POM pom = storage.getPom(r);
 		assertNotNull(pom);
 		System.out.println(pom.getDependencies(MavenScope.compile, true));
 	}


### PR DESCRIPTION
Cleaned up usage of promise and fixed a deadlock problem with calling
Promise.getValue in a synchronized block. Also fixed some NPEs.
