### PR TITLE
mavenrepo: Improve use of Promises in sync

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -461,7 +461,6 @@ public class MavenBndRepository extends BaseRepository
 			File indexFile = IO.getFile(base, configuration.index(name.toLowerCase() + ".mvn"));
 			IndexFile ixf = new IndexFile(reporter, indexFile, storage);
 			ixf.open();
-			ixf.sync();
 			this.index = ixf;
 			startPoll(index);
 


### PR DESCRIPTION
We now avoid waiting for each promise to resolve in some order. The
promises can resolve in any order. The method will return when all
promises have resolved.