### PR TITLE
executors: Use 2 executors: One normal and one scheduled

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -43,6 +43,8 @@ import aQute.service.reporter.Reporter;
 @BndPlugin(name = "PomRepository")
 public class BndPomRepository extends BaseRepository
 		implements Plugin, RegistryPlugin, RepositoryPlugin, Refreshable, Actionable {
+	static final String			MAVEN_REPO_LOCAL	= System.getProperty("maven.repo.local", "~/.m2/repository");
+
 	boolean						inited;
 	private PomConfiguration	configuration;
 	private Registry			registry;
@@ -62,7 +64,7 @@ public class BndPomRepository extends BaseRepository
 			inited = true;
 			Workspace workspace = registry.getPlugin(Workspace.class);
 			HttpClient client = registry.getPlugin(HttpClient.class);
-			File localRepo = IO.getFile(configuration.local("~/.m2/repository"));
+			File localRepo = IO.getFile(configuration.local(MAVEN_REPO_LOCAL));
 			File location = workspace.getFile(getLocation());
 
 			List<MavenBackingRepository> release = MavenBackingRepository.create(configuration.releaseUrls(), reporter,

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -49,7 +49,7 @@ public class BndPomRepository extends BaseRepository
 	private PomConfiguration	configuration;
 	private Registry			registry;
 	private String				name;
-	private Reporter			reporter	= new Slf4jReporter();
+	private Reporter			reporter			= new Slf4jReporter(BndPomRepository.class);
 	private InnerRepository	repoImpl;
 	private Revision			revision;
 	private BridgeRepository	bridge;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -469,12 +468,11 @@ public class MavenBndRepository extends BaseRepository
 
 			localRepo = IO.getFile(configuration.local(MAVEN_REPO_LOCAL));
 
-			Executor executor = registry.getPlugin(Executor.class);
 			List<MavenBackingRepository> release = MavenBackingRepository.create(configuration.releaseUrl(), reporter,
 					localRepo, client);
 			List<MavenBackingRepository> snapshot = MavenBackingRepository.create(configuration.snapshotUrl(), reporter,
 					localRepo, client);
-			storage = new MavenRepository(localRepo, getName(), release, snapshot, executor, reporter,
+			storage = new MavenRepository(localRepo, getName(), release, snapshot, Processor.getExecutor(), reporter,
 					getRefreshCallback());
 
 			File base = IO.work;

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
@@ -44,7 +44,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 	private final List<MavenBackingRepository>			snapshot	= new ArrayList<>();
 	private final Executor								executor;
 	private final boolean								localOnly;
-	private final Reporter								reporter	= new Slf4jReporter();
+	private final Reporter						reporter	= new Slf4jReporter(MavenRepository.class);
 	private final Map<Revision,Promise<POM>>	poms		= new WeakHashMap<>();
 
 	public MavenRepository(File base, String id, List<MavenBackingRepository> release,

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -26,9 +26,11 @@ import aQute.service.reporter.Reporter;
 import junit.framework.TestCase;
 
 public class PomRepositoryTest extends TestCase {
+	static final String	MAVEN_REPO_LOCAL	= System.getProperty("maven.repo.local", "~/.m2/repository");
+
 	Reporter	reporter	= new Slf4jReporter();
 	File		tmp			= IO.getFile("generated/tmp");
-	File		localRepo	= IO.getFile("~/.m2/repository");
+	File				localRepo			= IO.getFile(MAVEN_REPO_LOCAL);
 	File		location	= IO.getFile(tmp, "index.xml");
 	HttpClient	client;
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 
 import aQute.bnd.build.Workspace
 import aQute.bnd.osgi.Constants
+import aQute.lib.io.IO
 
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
@@ -59,6 +60,9 @@ subprojects {
             return false
           }
         }
+      }
+      if (System.properties['maven.repo.local']) {
+        systemProperty 'maven.repo.local', IO.getFile(rootProject.rootDir, System.properties['maven.repo.local'])
       }
     }
   }


### PR DESCRIPTION
We now use a normal executor with an unbounded queue and thread timeout
for normal Executor needs. A scheduled executor remains available for
tasks needing a schedule.
