### PR TITLE
httpclient: Don't send exception to task progress

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -516,7 +516,7 @@ public class HttpClient implements Closeable, URLConnector {
 			return new TaggedData(con, in, request.useCacheFile);
 
 		} catch (SocketTimeoutException ste) {
-			task.done("timed out", ste);
+			task.done(ste.toString(), null);
 			return new TaggedData(request.url.toURI(), HttpURLConnection.HTTP_GATEWAY_TIMEOUT, request.useCacheFile);
 		}
 	}


### PR DESCRIPTION
The LoggingProgressPlugin will log the exception as an error and it will
be printed out.
