### PR TITLE
[http] PUT users did not close the input stream

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
@@ -1,5 +1,6 @@
 package aQute.bnd.service.url;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +20,7 @@ import aQute.lib.io.IO;
  * 
  * @author Neil Bartlett
  */
-public class TaggedData {
+public class TaggedData implements Closeable {
 
 	private final URLConnection	con;
 	private final int			responseCode;
@@ -237,5 +238,10 @@ public class TaggedData {
 
 	public File getFile() {
 		return file;
+	}
+
+	@Override
+	public void close() throws IOException {
+		IO.close(getInputStream());
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/biz.aQute.repository/src/aQute/maven/nexus/provider/Nexus.java
+++ b/biz.aQute.repository/src/aQute/maven/nexus/provider/Nexus.java
@@ -57,23 +57,23 @@ public class Nexus {
 		return !(uri.getPath().endsWith(".sha1") || uri.getPath().endsWith(".asc") || uri.getPath().endsWith(".md5"));
 	}
 
-
 	public File download(URI uri) throws Exception {
 		return request().useCache().age(30, TimeUnit.SECONDS).go(uri);
 	}
 
 	public void upload(URI uri, byte[] data) throws Exception {
-		TaggedData tag = request().put().upload(data).asTag().go(uri);
-		switch (tag.getState()) {
-			case NOT_FOUND :
-			case OTHER :
-			default :
-				tag.throwIt();
-				break;
+		try (TaggedData tag = request().put().upload(data).asTag().go(uri);) {
+			switch (tag.getState()) {
+				case NOT_FOUND :
+				case OTHER :
+				default :
+					tag.throwIt();
+					break;
 
-			case UNMODIFIED :
-			case UPDATED :
-				break;
+				case UNMODIFIED :
+				case UPDATED :
+					break;
+			}
 		}
 	}
 }

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
@@ -83,20 +83,21 @@ public class MavenRemoteRepository extends MavenBackingRepository {
 		SHA1 sha1 = SHA1.digest(file);
 		MD5 md5 = MD5.digest(file);
 
-		TaggedData go = client.build().put().upload(file).updateTag().asTag().go(url);
+		try (TaggedData go = client.build().put().upload(file).updateTag().asTag().go(url);) {
 
-		switch (go.getState()) {
-			case NOT_FOUND :
-			case OTHER :
-				throw new IOException("Could not store " + path + " from " + file + " with " + go);
+			switch (go.getState()) {
+				case NOT_FOUND :
+				case OTHER :
+					throw new IOException("Could not store " + path + " from " + file + " with " + go);
 
-			case UNMODIFIED :
-			case UPDATED :
-			default :
-				break;
+				case UNMODIFIED :
+				case UPDATED :
+				default :
+					break;
+			}
 		}
-		client.build().put().upload(sha1.asHex()).asTag().go(new URL(base + path + ".sha1"));
-		client.build().put().upload(md5.asHex()).asTag().go(new URL(base + path + ".md5"));
+		try (TaggedData tag = client.build().put().upload(sha1.asHex()).asTag().go(new URL(base + path + ".sha1"));) {}
+		try (TaggedData tag = client.build().put().upload(md5.asHex()).asTag().go(new URL(base + path + ".md5"));) {}
 
 	}
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -27,6 +27,7 @@ import aQute.bnd.osgi.resource.ResourceUtils.IdentityCapability;
 import aQute.bnd.service.RepositoryPlugin.PutOptions;
 import aQute.bnd.service.RepositoryPlugin.PutResult;
 import aQute.bnd.service.maven.PomOptions;
+import aQute.bnd.service.progress.ProgressPlugin;
 import aQute.bnd.version.Version;
 import aQute.http.testservers.HttpTestServer.Config;
 import aQute.lib.io.IO;
@@ -399,7 +400,32 @@ public class MavenBndRepoTest extends TestCase {
 		reporter = new Processor();
 		reporter.setTrace(true);
 		reporter.trace("test");
+		reporter.addBasicPlugin(new ProgressPlugin() {
+
+			@Override
+			public Task startTask(final String name, int size) {
+				System.out.println("Starting " + name);
+				return new Task() {
+
+					@Override
+					public void worked(int units) {
+						System.out.println("Worked " + name + " " + units);
+					}
+
+					@Override
+					public void done(String message, Throwable e) {
+						System.out.println("Done " + name + " " + message + " " + e);
+					}
+
+					@Override
+					public boolean isCanceled() {
+						return false;
+					}
+				};
+			}
+		});
 		HttpClient client = new HttpClient();
+		client.setRegistry(reporter);
 		Executor executor = Executors.newCachedThreadPool();
 		reporter.addBasicPlugin(client);
 		reporter.setTrace(true);


### PR DESCRIPTION
When the input stream was not closed, we never closed the 
progress listener task.

Made TaggedData closable and fixed the code that used the Http Client with a PUT

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>