### PR TITLE
Revert "project: Use Strategy.LOWEST for -testpath"

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -521,7 +521,7 @@ public class Project extends Processor {
 	}
 
 	private List<Container> parseTestpath() throws Exception {
-		return getBundles(Strategy.LOWEST, mergeProperties(Constants.TESTPATH), Constants.TESTPATH);
+		return getBundles(Strategy.HIGHEST, mergeProperties(Constants.TESTPATH), Constants.TESTPATH);
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit c35b0df1fde84e9352c25a286235f2dc7779fa98.

See https://github.com/bndtools/bndtools/issues/1462

