### PR TITLE
Fix for #1663

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
@@ -89,11 +89,11 @@ public class ProjectResolver extends Processor implements ResolutionCallback {
 
 		Workspace workspace = project.getWorkspace();
 		if (workspace != null)
-			project.addBasicPlugin(new WorkspaceResourcesRepository(workspace));
+			addBasicPlugin(new WorkspaceResourcesRepository(workspace));
 	}
 
 	public Map<Resource,List<Wire>> resolve() throws ResolutionException {
-		resolution = resolve.resolveRequired(project, project, project, resolver, cbs, log);
+		resolution = resolve.resolveRequired(project, project, this, resolver, cbs, log);
 		return resolution;
 	}
 
@@ -172,7 +172,7 @@ public class ProjectResolver extends Processor implements ResolutionCallback {
 	}
 
 	public BndrunResolveContext getContext() {
-		return new BndrunResolveContext(project, project, project, log);
+		return new BndrunResolveContext(project, project, this, log);
 	}
 
 	public IdentityCapability getResource(String bsn, String version) {


### PR DESCRIPTION
PR #1663 can result in adding multiple workspace resource repositories to a project, especially in a Bndtools use where the Project can live for a long time over multiple resolve operations.

Also, since ProjectResolver now always adds a workspace resource repository, we need to stop the bnd resolve command from also doing it.