### PR TITLE
workspace offline: Repurpose meaning of offline for no network access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
-sudo: required
+sudo: false
 
 language: java
-
-# required for oraclejdk9
-dist: trusty
-group: edge
 
 jdk:
   - oraclejdk7
   - oraclejdk8
 
-matrix:
-  fast_finish: true
-  include:
-    - jdk: oraclejdk9
-      env: MAVEN_SKIP_RC=true
-  allow_failures:
-    - jdk: oraclejdk9
+# required for oraclejdk9
+#sudo: required
+#dist: trusty
+#group: edge
+#
+#matrix:
+#  fast_finish: true
+#  include:
+#    - jdk: oraclejdk9
+#      env: MAVEN_SKIP_RC=true
+#  allow_failures:
+#    - jdk: oraclejdk9
 
 before_install:
   - rvm --version

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -44,7 +44,7 @@ public class BndPlugin implements Plugin<Project> {
           throw new GradleException("Project already has '${BndBuilderPlugin.PLUGINID}' plugin applied.")
       }
       if (!rootProject.hasProperty('bndWorkspace')) {
-        rootProject.ext.bndWorkspace = new Workspace(rootDir)
+        rootProject.ext.bndWorkspace = new Workspace(rootDir).setOffline(rootProject.gradle.startParameter.offline)
       }
       this.bndProject = bndWorkspace.getProject(name)
       if (bndProject == null) {

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin1/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
+ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
 
 ext.cnf = rootProject.project(bnd_cnf)
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin1/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin1/settings.gradle
@@ -22,7 +22,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-def workspace = new Workspace(rootDir, bnd_cnf)
+def workspace = new Workspace(rootDir, bnd_cnf).setOffline(startParameter.offline)
 
 /* Add cnf project to the graph */
 include bnd_cnf

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin2/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin2/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
+ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
 
 ext.cnf = rootProject.project(bnd_cnf)
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin2/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin2/settings.gradle
@@ -22,7 +22,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-def workspace = new Workspace(rootDir, bnd_cnf)
+def workspace = new Workspace(rootDir, bnd_cnf).setOffline(startParameter.offline)
 
 /* Add cnf project to the graph */
 include bnd_cnf

--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -18,6 +18,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.eclipse.EclipseClasspath;
+import aQute.bnd.service.BndListener;
 import aQute.bnd.service.Strategy;
 import aQute.bnd.version.Version;
 import aQute.lib.deployer.FileRepo;
@@ -333,7 +334,7 @@ public class ProjectTest extends TestCase {
 
 	public void testIsStale() throws Exception {
 		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
-		ws.setOffline(false);
+		ws.addBasicPlugin(new BndListener());
 		Project top = ws.getProject("p-stale");
 		assertNotNull(top);
 		top.build();

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1596,7 +1596,7 @@ public class Project extends Processor {
 	 * Check if this project needs building. This is defined as:
 	 */
 	public boolean isStale() throws Exception {
-		if (workspace == null || workspace.isOffline()) {
+		if (workspace == null || !workspace.hasBndListeners()) {
 			trace("working %s offline, so always stale", this);
 			return true;
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-ext.bndWorkspace = new Workspace(rootDir, bnd_cnf)
+ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
 
 ext.cnf = rootProject.project(bnd_cnf)
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,7 +41,7 @@ buildscript {
 /* Initialize the bnd workspace */
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-def workspace = new Workspace(rootDir, bnd_cnf)
+def workspace = new Workspace(rootDir, bnd_cnf).setOffline(startParameter.offline)
 
 /* Add cnf project to the graph */
 include bnd_cnf


### PR DESCRIPTION
The original meaning of offline was whether the workspace had any
BndListeners. This is moved to another field/method and offline can now
be used to record whether the workspace is in offline mode and should
avoid network access.
