### PR TITLE
Deduplication of plugins

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/PluginTest.java
+++ b/biz.aQute.bndlib.tests/src/test/PluginTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import java.awt.MenuContainer;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +20,27 @@ public class PluginTest extends TestCase {
 	@Override
 	protected void setUp() {
 		main = new Processor();
+	}
+
+	static public class Foo {
+
+	}
+
+	public void testPluginInheritance() throws IOException {
+		Processor top = new Processor();
+		Processor middle = new Processor(top);
+		Processor bottom = new Processor(middle);
+
+		top.setProperty("-plugin.top", Foo.class.getName() + ";l=top");
+		middle.setProperty("-plugin.middle", Foo.class.getName() + ";l=middle");
+
+		assertEquals(1, top.getPlugins(Foo.class).size());
+		assertEquals(2, middle.getPlugins(Foo.class).size());
+		assertEquals(2, bottom.getPlugins(Foo.class).size());
+		assertEquals(top.getPlugin(Foo.class), bottom.getPlugin(Foo.class));
+		assertTrue(top.check());
+		assertTrue(middle.check());
+		assertTrue(bottom.check());
 	}
 
 	public void testMissingPluginNotUsed() throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -305,7 +305,7 @@ public class HttpClient implements Closeable, URLConnector {
 	}
 
 	ProgressPlugin.Task getTask(final HttpRequest< ? > request) {
-		final String name = "Download " + request.url;
+		final String name = (request.upload == null ? "Download " : "Upload ") + request.url;
 		final int size = 100;
 		final ProgressPlugin.Task task;
 		final List<ProgressPlugin> progressPlugins = registry != null ? registry.getPlugins(ProgressPlugin.class)


### PR DESCRIPTION
The plugins were inherited but also recreated. This was inefficient but also could cause duplication of equals was not properly implemented.

No inherit the object references from the parent and only create plugins for the local level.