### PR TITLE
resolver: Use Processor's executor for resolving

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndResolver.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndResolver.java
@@ -3,6 +3,7 @@ package biz.aQute.resolve;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.felix.resolver.Logger;
 import org.apache.felix.resolver.ResolverImpl;
 import org.osgi.resource.Resource;
 import org.osgi.resource.Wire;
@@ -10,12 +11,18 @@ import org.osgi.service.resolver.ResolutionException;
 import org.osgi.service.resolver.ResolveContext;
 import org.osgi.service.resolver.Resolver;
 
+import aQute.bnd.osgi.Processor;
+
 public class BndResolver implements Resolver {
 
 	private final Resolver resolver;
 
 	public BndResolver(ResolverLogger logger) {
-		resolver = new ResolverImpl(new InternalResolverLogger(logger));
+		resolver = new ResolverImpl(new InternalResolverLogger(logger), Processor.getExecutor());
+	}
+
+	public BndResolver(Logger logger) {
+		resolver = new ResolverImpl(logger, Processor.getExecutor());
 	}
 
 	public Map<Resource,List<Wire>> resolve(ResolveContext resolveContext) throws ResolutionException {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.felix.resolver.Logger;
-import org.apache.felix.resolver.ResolverImpl;
 import org.osgi.framework.ServiceReference;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -15,6 +14,7 @@ import org.osgi.resource.Resource;
 import org.osgi.resource.Wire;
 import org.osgi.service.log.LogService;
 import org.osgi.service.resolver.ResolutionException;
+import org.osgi.service.resolver.Resolver;
 
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
@@ -78,7 +78,7 @@ public class ProjectResolver extends Processor implements ResolutionCallback {
 	private Project							project;
 	private Map<Resource,List<Wire>>		resolution;
 	private ReporterLogger					log			= new ReporterLogger(0);
-	private ResolverImpl					resolver	= new ResolverImpl(new ReporterLogger(0), null);
+	private Resolver						resolver	= new BndResolver(new ReporterLogger(0));
 	private ResolveProcess					resolve		= new ResolveProcess();
 	private Collection<ResolutionCallback>	cbs			= new ArrayList<ResolutionCallback>();
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolverValidator.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolverValidator.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.felix.resolver.ResolverImpl;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
@@ -38,7 +37,7 @@ import aQute.lib.strings.Strings;
 public class ResolverValidator extends Processor {
 
 	LogReporter	reporter		= new LogReporter(this);
-	Resolver	resolver		= new ResolverImpl(reporter, null);
+	Resolver	resolver		= new BndResolver(reporter);
 	List<URI>	repositories	= new ArrayList<>();
 	Resource	system			= null;
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/packageinfo
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.felix.resolver.ResolverImpl;
 import org.mockito.Mockito;
 import org.osgi.framework.Version;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -151,7 +150,7 @@ public class ResolveTest extends TestCase {
 	 * @throws Exception
 	 */
 
-	public static void testResolveWithAugments() throws Exception {
+	public void testResolveWithAugments() throws Exception {
 		// Add requirement
 		assertAugmentResolve(
 				"org.apache.felix.gogo.shell;capability:='foo;foo=gogo';requirement:='foo;filter:=\"(foo=*)\"'",
@@ -217,7 +216,7 @@ public class ResolveTest extends TestCase {
 	 * @throws URISyntaxException
 	 * @throws MalformedURLException
 	 */
-	public static void testMinimalSetup() throws MalformedURLException, URISyntaxException {
+	public void testMinimalSetup() throws MalformedURLException, URISyntaxException {
 		File index = IO.getFile("testdata/repo3.index.xml");
 		FixedIndexedRepo fir = new FixedIndexedRepo();
 		fir.setLocations(index.toURI().toString());
@@ -249,7 +248,7 @@ public class ResolveTest extends TestCase {
 	 * 
 	 * @throws ResolutionException
 	 */
-	public static void testResolveWithDistro() throws ResolutionException {
+	public void testResolveWithDistro() throws ResolutionException {
 
 		MockRegistry registry = new MockRegistry();
 		registry.addPlugin(createRepo(IO.getFile("testdata/repo3.index.xml")));
@@ -279,7 +278,7 @@ public class ResolveTest extends TestCase {
 	 * this is done in the same way. The {@link #testResolveWithDistro()} has a
 	 * negative check while this one checks positive.
 	 */
-	public static void testSimpleResolve() {
+	public void testSimpleResolve() {
 
 		MockRegistry registry = new MockRegistry();
 		registry.addPlugin(createRepo(IO.getFile("testdata/repo3.index.xml")));
@@ -409,7 +408,7 @@ public class ResolveTest extends TestCase {
 	 * 
 	 * @throws ResolutionException
 	 */
-	public static void testMultipleOptionsNotDuplicated() throws ResolutionException {
+	public void testMultipleOptionsNotDuplicated() throws ResolutionException {
 
 		// Resolve against repo 5
 		MockRegistry registry = new MockRegistry();
@@ -436,7 +435,7 @@ public class ResolveTest extends TestCase {
 
 		// Resolve the bndrun
 		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
-		Resolver resolver = new ResolverImpl(new org.apache.felix.resolver.Logger(4), null);
+		Resolver resolver = new BndResolver(new org.apache.felix.resolver.Logger(4));
 		Collection<Resource> resolvedResources = new ResolveProcess()
 				.resolveRequired(runModel, registry, resolver, Collections.<ResolutionCallback> emptyList(), log)
 				.keySet();

--- a/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
@@ -21,9 +21,11 @@ import org.osgi.service.resolver.Resolver;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.service.repository.InfoRepository;
 import aQute.lib.io.IO;
+import biz.aQute.resolve.BndResolver;
 import biz.aQute.resolve.BndrunResolveContext;
 import biz.aQute.resolve.ResolveProcess;
 import junit.framework.TestCase;
@@ -125,7 +127,7 @@ public class JpmRepoTest extends TestCase {
 		model.setRunRequires(requires);
 		BndrunResolveContext context = new BndrunResolveContext(model, ws, log);
 
-		Resolver resolver = new ResolverImpl(new org.apache.felix.resolver.Logger(4), null);
+		Resolver resolver = new BndResolver(new org.apache.felix.resolver.Logger(4));
 
 		try {
 			Map<Resource,List<Wire>> resolved = resolver.resolve(context);
@@ -154,7 +156,7 @@ public class JpmRepoTest extends TestCase {
 		model.setRunRequires(requires);
 		BndrunResolveContext context = new BndrunResolveContext(model, ws, log);
 
-		Resolver resolver = new ResolverImpl(new org.apache.felix.resolver.Logger(4), null);
+		Resolver resolver = new BndResolver(new org.apache.felix.resolver.Logger(4));
 
 		try {
 			Map<Resource,List<Wire>> resolved = resolver.resolve(context);


### PR DESCRIPTION
Previously many cases were using the caller's thread and some cases were
using a created Executor in the ResolverImpl.