### PR TITLE
Maven repo exists

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1058,7 +1058,7 @@ public class Project extends Processor {
 			return;
 		}
 		Parameters repos = new Parameters(name);
-		trace("build %s - %s", Arrays.toString(jars), repos);
+		trace("releasing %s - %s", Arrays.toString(jars), repos);
 
 		for (Map.Entry<String,Attrs> entry : repos.entrySet()) {
 			for (File jar : jars) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -163,7 +163,7 @@ public class MavenBndRepository extends BaseRepository
 				checkRemotePossible(instructions, binaryArchive.isSnapshot());
 
 				if (!binaryArchive.isSnapshot() && storage.exists(binaryArchive)) {
-					reporter.trace("Alrady released %s", pom.getRevision());
+					reporter.trace("Already released %s to %s", pom.getRevision(), this);
 					result.alreadyReleased = true;
 					return result;
 				}

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
@@ -120,7 +120,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 		return get(archive, true);
 	}
 
-	public Promise<File> get(final Archive archive, final boolean thrw) throws Exception {
+	private Promise<File> get(final Archive archive, final boolean thrw) throws Exception {
 		final File file = toLocalFile(archive);
 
 		if (file.isFile() && !archive.isSnapshot()) {
@@ -135,7 +135,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 			@Override
 			public void run() {
 				try {
-					File f = get0(archive, file);
+					File f = getFile(archive, file);
 					if (thrw && f == null) {
 						deferred.fail(new FileNotFoundException("For Maven artifact " + archive));
 						return;
@@ -158,7 +158,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 		return diff < TimeUnit.DAYS.toMillis(1);
 	}
 
-	private File get0(Archive archive, File file) throws Exception {
+	File getFile(Archive archive, File file) throws Exception {
 		State result = null;
 
 		if (archive.isSnapshot()) {

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
@@ -362,8 +362,13 @@ public class MavenRepository implements IMavenRepo, Closeable {
 
 	@Override
 	public boolean exists(Archive archive) throws Exception {
-		Promise<File> promise = get(archive.getPomArchive());
-		return (promise.getFailure() == null) && (promise.getValue() != null);
+		File file = File.createTempFile("pom", ".xml");
+		try {
+			File result = getFile(archive.getPomArchive(), file);
+			return result != null;
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	public void clear(Revision revision) {


### PR DESCRIPTION
Change exists to check remote repo

It was including the local repo in the exists check, but since we likely
just built the jar and put it in the local repo via the -buildrepo
instruction, including the local repo in the exists check causes release
to do nothing.