### PR TITLE
Fix "private reference" warning in biz.aQute.remote

### DIFF
--- a/biz.aQute.remote/api.bnd
+++ b/biz.aQute.remote/api.bnd
@@ -22,4 +22,5 @@ JPM-Command: bndremote;jvmargs="-Xrunjdwp:transport=dt_socket,server=y,suspend=n
 Main-Class: aQute.remote.main.Main
 Export-Package: \
 	aQute.remote.api,\
-	aQute.remote.util
+	aQute.remote.util,\
+	aQute.bnd.util.dto


### PR DESCRIPTION
If biz.aQute.remote.api doesn't export aQute.bnd.util.dto, bnd emits the
warning:

> biz.aQute.remote.api: Export aQute.remote.api,  has 1,  private references [aQute.bnd.util.dto]

Signed-off-by: Sean Bright <sean.bright@gmail.com>