### PR TITLE
gradle: Move OSGi Test actions from 'check' task to new 'testOSGi' task

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -72,8 +72,8 @@ The `jar` task uses Bnd to build the project's bundles.
 
 The `test` task runs any plain JUnit tests in the project.
 
-The `check` task runs any OSGi JUnit tests in the project by launching a
-framework and running the tests in the launched framework.
+The `check` task runs all verification tasks in the project,
+including `test` and `testOSGi`.
 
 ### Additional Tasks
 
@@ -82,6 +82,9 @@ The `release` task releases the project's bundles to the
 
 The `releaseNeeded` task releases the project and all projects it
 depends on.
+
+The `testOSGi` task runs any OSGi JUnit tests in the project by launching a
+framework and running the tests in the launched framework.
 
 The `checkNeeded` task runs the `check` task on the project and all
 projects it depends on.
@@ -329,7 +332,6 @@ For full details on what the Bnd Gradle Plugins do, check out the
 [11]: https://github.com/bndtools/bndtools/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/filter/root/gradle.properties
 [12]: https://github.com/bndtools/bndtools/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/settings.gradle
 [13]: https://github.com/bndtools/bndtools/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/build.gradle
-[14]: http://gradle.org/docs/current/userguide/plugins.html#sec:plugins_block
 [15]: src/aQute/bnd/gradle/BndPluginConvention.groovy
 [16]: src/aQute/bnd/gradle/BndProperties.groovy
 [18]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -436,7 +436,7 @@ public class BndPlugin implements Plugin<Project> {
         }
       }
 
-      tasks.addRule('Pattern: resolve.<name>: Resolving runbundles required for <name>.bndrun.') { taskName ->
+      tasks.addRule('Pattern: resolve.<name>: Resolve the required runbundles in the <name>.bndrun file.') { taskName ->
         if (taskName.startsWith('resolve.')) {
           def bndrun = taskName - 'resolve.'
           def runFile = file("${bndrun}.bndrun")
@@ -504,7 +504,7 @@ public class BndPlugin implements Plugin<Project> {
         }
       }
 
-      tasks.addRule('Pattern: run.<name>: Run the bndrun file <name>.bndrun.') { taskName ->
+      tasks.addRule('Pattern: run.<name>: Run the runbundles in the <name>.bndrun file.') { taskName ->
         if (taskName.startsWith('run.')) {
           def bndrun = taskName - 'run.'
           def runFile = file("${bndrun}.bndrun")

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -315,8 +315,10 @@ public class BndPlugin implements Plugin<Project> {
         }
       }
 
-      check {
+      task('testOSGi') {
+        description 'Runs the OSGi JUnit tests by launching a framework and running the tests in the launched framework.'
         dependsOn assemble
+        group 'verification'
         enabled !parseBoolean(bnd(Constants.NOJUNITOSGI, 'false')) && !bndUnprocessed(Constants.TESTCASES, '').empty
         ext.ignoreFailures = false
         if (enabled) {
@@ -331,6 +333,10 @@ public class BndPlugin implements Plugin<Project> {
             checkErrors(logger, ignoreFailures)
           }
         }
+      }
+
+      check {
+        dependsOn testOSGi
       }
 
       task('checkNeeded') {

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -29,6 +29,7 @@ class TestBndPlugin extends Specification {
 
         then:
           result.task(":test.simple:test").outcome == SUCCESS
+          result.task(":test.simple:testOSGi").outcome == SUCCESS
           result.task(":test.simple:check").outcome == SUCCESS
           result.task(":test.simple:build").outcome == SUCCESS
           result.task(":test.simple:release").outcome == SUCCESS


### PR DESCRIPTION
The check task is an aggregation/lifecycle task and should not have had
the OSGi test actions on it. So we create a new testosgi task upon which
check depends.