### PR TITLE
Set up to generate Maven plugin documentation.

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -58,6 +58,25 @@ import aQute.lib.strings.Strings;
 import aQute.lib.utf8properties.UTF8Properties;
 import aQute.service.reporter.Report.Location;
 
+/**
+ * Generate a <pre>MANIFEST.MF</pre> for an OSGi bundle using <strong>bnd</strong>.
+ * This goal runs bnd with the contents of one or more bnd files to generate
+ * <pre>${project.build.outputDirectory}/META-INF/MANIFEST.MF</pre>. The pom must then
+ * configure the maven-jar-plugin to use this generated manifest rather than generate
+ * another:
+ * <pre>{@code
+ *     <plugin>
+ *         <groupId>org.apache.maven.plugins</groupId>
+ *          <artifactId>maven-jar-plugin</artifactId>
+ *            <configuration>
+ *              <archive>
+ *                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+ *              </archive>
+ *            </configuration>
+ *      </plugin>
+ *      }
+ * </pre>
+ */
 @Mojo(name = "bnd-process", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class BndMavenPlugin extends AbstractMojo {
 
@@ -88,6 +107,19 @@ public class BndMavenPlugin extends AbstractMojo {
 
     @Parameter(defaultValue = "false", readonly = true)
     private boolean				skip;
+
+    /* This exists only to allow documentation */
+	/**
+	 * The location of the bnd file that this plugin will supply to <pre>bnd</pre>.
+	 * The plugin combines the contents of bnd files from the project and its parents.
+	 * The plugin walks up the tree of parents. At each level, if the project as a <pre>basedir</pre>,
+	 * the plugin looks for a bnd file. If there is a local configuration of this parameter,
+	 * it determines the file name relative to that project's basedir; otherwise, it looks for the default,
+	 * <pre>${basedir}/bnd.bnd</pre>. For each project's bnd file, <pre>-include</pre> directives are resolved
+	 * relative to that project's basedir.
+	 */
+	@Parameter(defaultValue = "bnd.bnd")
+	String bndfile;
 
 	@Component
 	private BuildContext		buildContext;

--- a/maven/bnd-maven-plugin/src/site/site.xml
+++ b/maven/bnd-maven-plugin/src/site/site.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="BND Maven Plugin">
+    <bannerLeft>
+        <name>BND Maven Plugin</name>
+    </bannerLeft>
+
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>1.3.0</version>
+    </skin>
+
+    <publishDate format="yyyy-MM-dd" position="right" />
+    <version position="right" />
+
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html"/>
+            <item name="Goals" href="plugin-info.html"/>
+        </menu>
+        <menu ref="reports"/>
+    </body>
+</project>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -151,6 +151,12 @@
 								<goal>addPluginArtifactMetadata</goal>
 							</goals>
 						</execution>
+                                                <execution>
+                                                  <id>help-goal</id>
+                                                  <goals>
+                                                    <goal>helpmojo</goal>
+                                                  </goals>
+                                                </execution>
 					</executions>
 				</plugin>
 				<plugin>
@@ -280,4 +286,13 @@
             </plugin>
 		</plugins>
 	</build>
+        <reporting>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-plugin-plugin</artifactId>
+              <version>3.4</version>
+            </plugin>
+          </plugins>
+        </reporting>
 </project>


### PR DESCRIPTION
At least, someone can locally run mvn site and use the results. See #1722.

To see the results of this, run 'mvn site', and the look at target/site/index.html.

