### PR TITLE
Resolve fixes

### DIFF
--- a/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/repository/JpmRepoTest.java
@@ -160,9 +160,9 @@ public class JpmRepoTest extends TestCase {
 			Map<Resource,List<Wire>> resolved = resolver.resolve(context);
 			fail("Resolve did not fail");
 		} catch (ResolutionException e) {
-			assertTrue(e.getUnresolvedRequirements().size() == 1);
-			ResolutionException augmented = ResolveProcess.augment(new BndrunResolveContext(model, ws, log), e);
-			assertTrue(augmented.getUnresolvedRequirements().size() == 2);
+			assertEquals(1, e.getUnresolvedRequirements().size());
+			ResolutionException augmented = ResolveProcess.augment(context, e);
+			assertEquals(2, augmented.getUnresolvedRequirements().size());
 
 		}
 	}


### PR DESCRIPTION
- Improve exception with collected failed requirements

    When resolving fails, use the failed requirements collected by the
AbstractResolveContext to supplement the unresolved requirements in the
thrown exception.

- Handle inverting a wire to the system resource

    A wire to the system resource could incorrectly result in the inversion
throwing an IllegalStateException.