### PR TITLE
maven: Switch to use slf4j for logging in maven plugins

### DIFF
--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -27,6 +27,10 @@
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.eclipse.aether</groupId>
 			<artifactId>aether-api</artifactId>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -27,12 +27,12 @@ assert fileContents.contains("[INFO] Baselining check succeeded checking biz.aQu
 // With provider
 int idx = fileContents.indexOf("[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -");
 
-assert fileContents.get(idx + 2) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
+assert fileContents.get(idx + 1) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
 
 
 // With consumer
 idx = fileContents.indexOf("[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0");
 
-assert fileContents.get(idx + 2) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
+assert fileContents.get(idx + 1) == "[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.";
 
 

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bndlib</artifactId>
         </dependency>

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -16,6 +16,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Run;
@@ -27,6 +29,7 @@ import biz.aQute.resolve.ProjectResolver;
 
 @Mojo(name = "export", defaultPhase = PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class ExportMojo extends AbstractMojo {
+	private static final Logger	logger			= LoggerFactory.getLogger(ExportMojo.class);
 
 	@Parameter(readonly = true, required = true)
 	private List<File>	bndruns;
@@ -95,7 +98,7 @@ public class ExportMojo extends AbstractMojo {
 				if (failOnChanges) {
 					throw new MojoExecutionException("The runbundles have changed. Failing the build");
 				} else {
-					getLog().warn("The runbundles have changed:");
+					logger.warn("The runbundles have changed:");
 					run.setRunBundles(runBundles);
 				}
 			}

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -27,6 +27,10 @@
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.eclipse.aether</groupId>
 			<artifactId>aether-api</artifactId>

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
@@ -31,13 +31,15 @@ import org.osgi.service.indexer.ResourceIndexer;
 import org.osgi.service.indexer.impl.KnownBundleAnalyzer;
 import org.osgi.service.indexer.impl.RepoIndex;
 import org.osgi.service.indexer.impl.URLResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Exports project dependencies to OSGi R5 index format.
  */
 @Mojo(name = "local-index", defaultPhase = PROCESS_RESOURCES)
 public class LocalIndexerMojo extends AbstractMojo {
-
+	private static final Logger	logger	= LoggerFactory.getLogger(LocalIndexerMojo.class);
 
 	@Parameter(property = "bnd.indexer.input.dir", required=true)
 	private File						inputDir;
@@ -59,7 +61,7 @@ public class LocalIndexerMojo extends AbstractMojo {
 	public void execute() throws MojoExecutionException, MojoFailureException {
 
         if ( skip ) {
-			getLog().debug("skip project as configured");
+			logger.debug("skip project as configured");
 			return;
 		}
 
@@ -67,10 +69,10 @@ public class LocalIndexerMojo extends AbstractMojo {
         	baseFile = outputFile.getParentFile();
         }
         
-		getLog().debug("Indexing dependencies in folder: " + inputDir.getAbsolutePath());
-		getLog().debug("Outputting index to: " + outputFile.getAbsolutePath());
-		getLog().debug("Producing additional gzip index: " + includeGzip);
-		getLog().debug("URI paths will be relative to: " + baseFile);
+		logger.debug("Indexing dependencies in folder: {}", inputDir.getAbsolutePath());
+		logger.debug("Outputting index to: {}", outputFile.getAbsolutePath());
+		logger.debug("Producing additional gzip index: {}", includeGzip);
+		logger.debug("URI paths will be relative to: {}", baseFile);
 
 		Set<File> toIndex = new HashSet<>();
 		toIndex.addAll(asList(inputDir.listFiles()));
@@ -126,16 +128,16 @@ public class LocalIndexerMojo extends AbstractMojo {
 	class BaseFileURLResolver implements URLResolver {
 		public URI resolver(File file) throws Exception {
 			try {
-				getLog().debug("Resolving " + file.getAbsolutePath() + " relative to " + baseFile.getAbsolutePath());
+				logger.debug("Resolving {} relative to {}", file.getAbsolutePath(), baseFile.getAbsolutePath());
 				Path relativePath = baseFile.getAbsoluteFile().toPath().relativize(file.getAbsoluteFile().toPath());
-				getLog().debug("Relative Path is: " + relativePath);
+				logger.debug("Relative Path is: {}", relativePath);
 				// Note that relativePath.toURI() gives the wrong answer for us!
 				// We have to do some Windows related mashing here too :(
 				URI relativeURI = URI.create(relativePath.toString().replace(File.separatorChar, '/'));
-				getLog().debug("Relative URI is: " + relativeURI);
+				logger.debug("Relative URI is: {}", relativeURI);
 				return relativeURI;
 			} catch (Exception e) {
-				getLog().error(e);
+				logger.error("Exception resolving URI", e);
 				fail = true;
 				throw e;
 			}

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -332,7 +332,9 @@ public class BndMavenPlugin extends AbstractMojo {
 
 	private void expandJar(Jar jar, File dir) throws Exception {
 		final long lastModified = jar.lastModified();
-		logger.debug(String.format("Bundle lastModified: %tF %<tT.%<tL", lastModified));
+		if (logger.isDebugEnabled()) {
+			logger.debug(String.format("Bundle lastModified: %tF %<tT.%<tL", lastModified));
+		}
 		dir = dir.getAbsoluteFile();
 		Files.createDirectories(dir.toPath());
 

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bndlib</artifactId>
         </dependency>

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -11,11 +11,12 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Container;
 import aQute.bnd.build.ProjectTester;
@@ -30,6 +31,7 @@ import biz.aQute.resolve.ProjectResolver;
 
 @Mojo(name = "testing", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class TestingMojo extends AbstractMojo {
+	private static final Logger	logger			= LoggerFactory.getLogger(TestingMojo.class);
 
 	@Parameter(readonly = true, required = true)
 	private List<File>	bndruns;
@@ -49,25 +51,21 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(readonly = true, required = false)
 	private boolean		failOnChanges	= true;
 
-	private Log			log;
-
 	public void execute() throws MojoExecutionException, MojoFailureException {
-		log = getLog();
-
 		try {
 			if (testingSelect != null) {
-				log.info("Using selected testing file " + testingSelect);
+				logger.info("Using selected testing file {}", testingSelect);
 				testing(testingSelect);
 			} else {
 
 				Glob g = new Glob(testing == null ? "*" : testing);
-				log.info("Matching glob " + g);
+				logger.info("Matching glob {}", g);
 
 				for (File runFile : bndruns) {
 					if (g.matcher(runFile.getName()).matches())
 						testing(runFile);
 					else
-						log.info("Skipping " + g);
+						logger.info("Skipping {}", g);
 				}
 			}
 		} catch (Exception e) {
@@ -149,7 +147,7 @@ public class TestingMojo extends AbstractMojo {
 				if (failOnChanges) {
 					throw new MojoExecutionException("The runbundles have changed. Failing the build");
 				} else {
-					getLog().warn("The runbundles have changed:");
+					logger.warn("The runbundles have changed:");
 					run.setRunBundles(runBundles);
 				}
 			}


### PR DESCRIPTION
Bnd uses slf4j, so this is consistent.
