### PR TITLE
Fixed #1772 (optional imports)

### DIFF
--- a/docs/_chapters/920-faq.md
+++ b/docs/_chapters/920-faq.md
@@ -45,7 +45,7 @@ If you have an unwanted import than you can remove it from the Import-Package ma
 
 A usually better way is to make the imports optional:
 
-    Import-Package: com.unwanted.reference.*;optional:=true, *
+    Import-Package: com.unwanted.reference.*;resolution:=optional, *
 
 Note the end at the Import-Package statement, that wildcard '*' is crucial for remaining imports, see [No Imports Show Up](?#noImports).
 


### PR DESCRIPTION
Updated `optional:=true` to `resolution:=optional` in order to make optional imports 1) not display a warning from bnd and 2) actually be optional in OSGi.

Fixes #1772

Signed-off-by: Gary Sheppard <gsheppard@esri.com>