### PR TITLE
gradle: Handle null return for BndEditModel.getRunBundles()

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -487,7 +487,7 @@ public class BndPlugin implements Plugin<Project> {
                     Document doc = new Document(IO.collect(runFile))
                     bem.loadFrom(doc)
 
-                    List<VersionedClause> bemRunBundles = bem.getRunBundles()
+                    List<VersionedClause> bemRunBundles = bem.getRunBundles() ?: []
                     List<VersionedClause> deltaAdd = runBundles.collect()
                     deltaAdd.removeAll(bemRunBundles)
                     List<VersionedClause> deltaRemove = bemRunBundles.collect()


### PR DESCRIPTION
This can happen when there is no -runbundles instruction in the bndrun
file.

Fixes https://github.com/bndtools/bnd/issues/1770