### PR TITLE
libg: Convert some old methods to varargs

### DIFF
--- a/aQute.libg/src/aQute/lib/strings/Strings.java
+++ b/aQute.libg/src/aQute/lib/strings/Strings.java
@@ -48,7 +48,7 @@ public class Strings {
 		}
 	}
 
-	public static String join(String middle, Object[] segments) {
+	public static String join(String middle, Object... segments) {
 		return join(middle, new ExtList<Object>(segments));
 	}
 
@@ -63,11 +63,11 @@ public class Strings {
 		return "";
 	}
 
-	public static String join(String[] strings) {
-		return join(",", strings);
+	public static String join(String... strings) {
+		return join(",", (Object[]) strings);
 	}
 
-	public static String join(Object[] strings) {
+	public static String join(Object... strings) {
 		return join(",", strings);
 	}
 

--- a/aQute.libg/src/aQute/libg/generics/Create.java
+++ b/aQute.libg/src/aQute/libg/generics/Create.java
@@ -37,11 +37,11 @@ public class Create {
 		return Collections.checkedSet(new LinkedHashSet<T>(), c);
 	}
 
-	public static <T> List<T> list(T[] source) {
+	public static <T> List<T> list(T... source) {
 		return new ArrayList<T>(Arrays.asList(source));
 	}
 
-	public static <T> Set<T> set(T[] source) {
+	public static <T> Set<T> set(T... source) {
 		return new HashSet<T>(Arrays.asList(source));
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/RepoResourceUtils.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/RepoResourceUtils.java
@@ -159,9 +159,7 @@ public final class RepoResourceUtils {
 		List<Resource> result;
 		if (aQute.bnd.osgi.Constants.VERSION_ATTR_LATEST.equals(rangeStr)) {
 			Version highest = versionMap.lastKey();
-			result = Create.list(new Resource[] {
-					versionMap.get(highest)
-			});
+			result = Create.list(versionMap.get(highest));
 		} else {
 			VersionRange range = rangeStr != null ? new VersionRange(rangeStr) : null;
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -462,10 +462,8 @@ public class PomRepositoryTest extends TestCase {
 		Map<String,String> config = new HashMap<>();
 		config.put("name", "test-dependencies");
 
-		String pomFiles = Strings.join(new String[] {
-				"testdata/pomrepo/simple.xml",
-				"https://repo1.maven.org/maven2/org/apache/felix/org.apache.felix.gogo.shell/0.12.0/org.apache.felix.gogo.shell-0.12.0.pom"
-		});
+		String pomFiles = Strings.join("testdata/pomrepo/simple.xml",
+				"https://repo1.maven.org/maven2/org/apache/felix/org.apache.felix.gogo.shell/0.12.0/org.apache.felix.gogo.shell-0.12.0.pom");
 
 		config.put("pom", pomFiles);
 		config.put("snapshotUrls", "https://repo1.maven.org/maven2/");


### PR DESCRIPTION
Now that we use newer java versions, we can make some older methods
varargs for easier usage.
