### PR TITLE
exceptions: Add a toString method

### DIFF
--- a/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
+++ b/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
@@ -1,5 +1,8 @@
 package aQute.lib.exceptions;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 public class Exceptions {
 	private Exceptions() {}
 	public static RuntimeException duck(Throwable t) {
@@ -41,4 +44,9 @@ public class Exceptions {
 		};
 	}
 
+	public static String toString(Throwable t) {
+		StringWriter sw = new StringWriter();
+		t.printStackTrace(new PrintWriter(sw));
+		return sw.toString();
+	}
 }

--- a/aQute.libg/src/aQute/lib/exceptions/packageinfo
+++ b/aQute.libg/src/aQute/lib/exceptions/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
This matches the spec for DS failure string output in DS 1.4 spec.