### PR TITLE
bnd-testing-maven-plugin ignores maven.test.skip/skipTests props - #1839

### DIFF
--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -35,6 +35,12 @@ import biz.aQute.resolve.ProjectResolver;
 public class TestingMojo extends AbstractMojo {
 	private static final Logger	logger			= LoggerFactory.getLogger(TestingMojo.class);
 
+	@Parameter(property = "skipTests", defaultValue = "false")
+	private boolean				skipTests;
+
+	@Parameter(property = "maven.test.skip", defaultValue = "false")
+	private boolean				skip;
+
 	@Parameter(readonly = true, required = true)
 	private List<File>	bndruns;
 
@@ -57,6 +63,9 @@ public class TestingMojo extends AbstractMojo {
 	private MavenSession session;
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skip || skipTests) {
+			return;
+		}
 		try {
 			if (testingSelect != null) {
 				logger.info("Using selected testing file {}", testingSelect);


### PR DESCRIPTION
I'm not a maven plugin expert, but apparently this solves the referenced issue. Let me know what do you think.

Solve https://github.com/bndtools/bnd/issues/1839
Signed-off-by: Matteo Rulli <matteo.rulli@flairbit.io>