### PR TITLE
url: fix default return value

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
@@ -55,7 +55,7 @@ public class DefaultURLConnectionHandler implements URLConnectionHandler, Plugin
 			if (g.matcher(string).matches())
 				return true;
 		}
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
small fix of the default return value in DefaultURLConnectionHandler.matches