### PR TITLE
url: fix default return value

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
@@ -55,7 +55,7 @@ public class DefaultURLConnectionHandler implements URLConnectionHandler, Plugin
 			if (g.matcher(string).matches())
 				return true;
 		}
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
DefaultURLConnectionHandler.matches always returned 'true'. Change return value to 'false' if matchers exists, but none of them matches the url.