### PR TITLE
ds annotations: Ignore bridge methods

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
@@ -1,7 +1,6 @@
 package aQute.bnd.component;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -986,12 +985,10 @@ public class AnnotationReader extends ClassDataCollector {
 
 	@Override
 	public void method(Clazz.MethodDef method) {
-		int access = method.getAccess();
-
-		if (Modifier.isAbstract(access) || Modifier.isStatic(access))
+		if (method.isAbstract() || method.isStatic() || method.isBridge())
 			return;
 
-		if (!baseclass && Modifier.isPrivate(access))
+		if (!baseclass && method.isPrivate())
 			return;
 
 		this.member = method;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -194,6 +194,7 @@ public class Clazz {
 	// Declared a thing not in the source code
 	final static int					ACC_ABSTRACT	= 0x0400;
 	final static int					ACC_SYNTHETIC	= 0x1000;
+	final static int					ACC_BRIDGE		= 0x0040;
 	final static int					ACC_ANNOTATION	= 0x2000;
 	final static int					ACC_ENUM		= 0x4000;
 
@@ -387,6 +388,10 @@ public class Clazz {
 		@Override
 		public TypeRef[] getPrototype() {
 			return descriptor.getPrototype();
+		}
+
+		public boolean isBridge() {
+			return (access & ACC_BRIDGE) != 0;
 		}
 	}
 


### PR DESCRIPTION
If a component class has an annotated method for which the compiler
generates a bridge method, javac will copy the annotations onto the
bridge method. Bnd must ignore bridge methods.

Fixes https://github.com/bndtools/bnd/issues/1546