### PR TITLE
Fix resource leak in XMLResourceParser

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
@@ -1,6 +1,7 @@
 package aQute.bnd.osgi.repository;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
@@ -85,11 +86,24 @@ public class XMLResourceParser extends Processor {
 		this.depth = depth;
 		this.traversed = traversed;
 		this.url = url;
-		reader = inputFactory.createXMLStreamReader(GZipUtils.detectCompression(in));
+		in = GZipUtils.detectCompression(in);
+		addClose(in);
+		this.reader = inputFactory.createXMLStreamReader(in);
 	}
 
 	public XMLResourceParser(File location) throws Exception {
 		this(location.toURI());
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			reader.close();
+		} catch (XMLStreamException e) {
+			throw new IOException(e);
+		} finally {
+			super.close();
+		}
 	}
 
 	List<Resource> getResources() {


### PR DESCRIPTION
XMLResourceParser extends Processor which makes it Closable but it failed
to make sure the input stream is closed.

Fixes https://github.com/bndtools/bndtools/issues/1623