### PR TITLE
Enable Baselining in most projects

### DIFF
--- a/aQute.libg/bnd.bnd
+++ b/aQute.libg/bnd.bnd
@@ -15,4 +15,4 @@ Bundle-Description: A library to be statically linked. Contains many small utili
 -baseline: *
 -sources= true
 
--fixupmessages: The bundle version (3.2.0/3.3.0) is too low, must be at least 4.0.0
+-fixupmessages: The bundle version * is too low

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -29,4 +29,5 @@ Bundle-Activator: aQute.junit.Activator
 Embedded-Activator: aQute.junit.Activator
 Bundle-Release: Use main thread for testing, optionally allowing old separate thread model
 
-
+-baseline: *
+-diffpackages: !org.junit.*, *

--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -19,3 +19,5 @@ Private-Package: aQute.launcher.*
 Conditional-Package: aQute.lib*
 	
 Premain-Class: aQute.launcher.agent.LauncherAgent
+
+-baseline: *

--- a/biz.aQute.remote/bnd.bnd
+++ b/biz.aQute.remote/bnd.bnd
@@ -26,5 +26,6 @@ Conditional-Package: aQute.lib*, aQute.configurable.*,aQute.service.reporter, aQ
 # TODO Some tests were hanging on Travis. They ran fine on the mac
 # likely network issues.
 #
+-nojunit: true
 
-no.junit=true
+-baseline: *

--- a/biz.aQute.repository.aether/bnd.bnd
+++ b/biz.aQute.repository.aether/bnd.bnd
@@ -65,3 +65,5 @@ Import-Package: \
 	!com.google.inject.*,\
 	!org.codehaus.plexus.*,\
 	*
+
+-baseline: *

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -97,3 +97,5 @@ Import-Package:\
 	*
 	
 -fixupmessages: "private references"
+
+-baseline: *

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package aQute.bnd.repository.p2.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.resolve/bnd.bnd
+++ b/biz.aQute.resolve/bnd.bnd
@@ -26,3 +26,5 @@ Private-Package: \
 Conditional-Package: aQute.lib*
 
 -fixupmessages: private references
+
+-baseline: *

--- a/biz.aQute.tester/bnd.bnd
+++ b/biz.aQute.tester/bnd.bnd
@@ -37,3 +37,5 @@ Conditional-Package: aQute.lib*
 	${junit},\
 	osgi.core;version=4.3.1,\
 	biz.aQute.bndlib;version=latest
+
+-baseline: *

--- a/org.osgi.impl.bundle.repoindex.ant/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.ant/bnd.bnd
@@ -37,3 +37,5 @@ Private-Package: \
 	${osgi-pkgs}
 Include-Resource: taskdef.properties
 Bundle-Activator: org.osgi.service.indexer.osgi.Activator
+
+-baseline: *

--- a/org.osgi.impl.bundle.repoindex.api/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.api/bnd.bnd
@@ -4,3 +4,5 @@
 Export-Package: org.osgi.service.indexer
 -buildpath: \
 	osgi.annotation;version=6.0.1
+
+-baseline: *

--- a/org.osgi.impl.bundle.repoindex.api/src/org/osgi/service/indexer/packageinfo
+++ b/org.osgi.impl.bundle.repoindex.api/src/org/osgi/service/indexer/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.1.1

--- a/org.osgi.impl.bundle.repoindex.cli/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.cli/bnd.bnd
@@ -50,3 +50,5 @@ Bundle-Description: RepoIndex: Repository Index Generator (Standalone)
 Main-Class: org.osgi.impl.bundle.bindex.cli.Index
 Bundle-Activator: org.osgi.service.indexer.osgi.Activator
 JPM-Command: repoindex
+
+-baseline: *

--- a/org.osgi.impl.bundle.repoindex.lib/bnd.bnd
+++ b/org.osgi.impl.bundle.repoindex.lib/bnd.bnd
@@ -32,3 +32,5 @@ Export-Package: \
 	org.osgi.service.indexer.impl,\
 	org.osgi.service.indexer.impl.types,\
 	org.osgi.service.indexer.impl.util
+
+-baseline: *


### PR DESCRIPTION
New `-diffpackages` features is used for `biz.aQute.junit`.