### PR TITLE
buildpath: Remove output folder from buildpath

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -256,9 +256,6 @@ public class BndPlugin implements Plugin<Project> {
           configurations.archives.artifacts.files
         }
         outputs.file new File(buildDir, Constants.BUILDFILES)
-        doFirst {
-          project.mkdir(compileJava.destinationDir)
-        }
         doLast {
           def built
           try {
@@ -557,11 +554,11 @@ Project ${project.name}
   }
 
   private FileCollection compilePath() {
-    return project.files(bndProject.getBuildpath()*.getFile() - bndProject.getSrcOutput())
+    return project.files(bndProject.getBuildpath()*.getFile())
   }
 
   private FileCollection testCompilePath() {
-    return project.files(bndProject.getTestpath()*.getFile() - bndProject.getTestOutput())
+    return project.files(bndProject.getTestpath()*.getFile())
   }
 
   private FileCollection runtimePath() {

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -3550,6 +3550,10 @@ public class bnd extends Processor {
 				error("This is not a project directory and you have specified no jar files ...");
 				return;
 			}
+			File output = p.getOutput();
+			if (output.exists()) {
+				files.add(output);
+			}
 			for (Container c : p.getBuildpath()) {
 				files.add(c.getFile());
 			}

--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -112,7 +112,7 @@ public class ProjectTest extends TestCase {
 		assertEquals(3, runpath.size());
 
 		List<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(4, buildpath.size()); // adds output ...
+		assertEquals(3, buildpath.size());
 
 		List<Container> testpath = new ArrayList<Container>(project.getTestpath());
 		assertEquals(3, testpath.size());
@@ -125,10 +125,10 @@ public class ProjectTest extends TestCase {
 		project.setProperty("-buildpath", "p3; version='[1,2)'; repo=Relea*");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(2, buildpath.size());
+		assertEquals(1, buildpath.size());
 		// Without repos filter we would get lowest version, i.e. 1.0.0 from the
 		// repo named "Repo".
-		assertEquals("1.1.0", buildpath.get(1).getVersion());
+		assertEquals("1.1.0", buildpath.get(0).getVersion());
 	}
 
 	public void testRepoFilterBuildPathMultiple() throws Exception {
@@ -137,9 +137,9 @@ public class ProjectTest extends TestCase {
 
 		project.setProperty("-buildpath", "org.apache.felix.configadmin; version=latest; repo=\"Rel*,Repo\"");
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(2, buildpath.size());
+		assertEquals(1, buildpath.size());
 		// Expect 1.2.0 from Release repo; not 1.8.8 from Repo2
-		assertEquals("1.2.0", buildpath.get(1).getVersion());
+		assertEquals("1.2.0", buildpath.get(0).getVersion());
 	}
 
 	public void testWildcardBuildPath() throws Exception {
@@ -164,13 +164,13 @@ public class ProjectTest extends TestCase {
 		project.setProperty("-buildpath", "*; repo=Relea*");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(3, buildpath.size());
+		assertEquals(2, buildpath.size());
+
+		assertEquals(Container.TYPE.REPO, buildpath.get(0).getType());
+		assertEquals("org.apache.felix.configadmin", buildpath.get(0).getBundleSymbolicName());
 
 		assertEquals(Container.TYPE.REPO, buildpath.get(1).getType());
-		assertEquals("org.apache.felix.configadmin", buildpath.get(1).getBundleSymbolicName());
-
-		assertEquals(Container.TYPE.REPO, buildpath.get(2).getType());
-		assertEquals("p3", buildpath.get(2).getBundleSymbolicName());
+		assertEquals("p3", buildpath.get(1).getBundleSymbolicName());
 	}
 
 	/**
@@ -873,8 +873,8 @@ public class ProjectTest extends TestCase {
 				"tmp; version=hash; hash=7fe83bfd5999fa4ef9cec40282d5d67dd0ff3303bac6b8c7b0e8be80a821441c");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(2, buildpath.size());
-		assertEquals("bar", buildpath.get(1).getManifest().getMainAttributes().getValue("Prints"));
+		assertEquals(1, buildpath.size());
+		assertEquals("bar", buildpath.get(0).getManifest().getMainAttributes().getValue("Prints"));
 	}
 
 	public void testHashVersionWithAlgorithm() throws Exception {
@@ -885,8 +885,8 @@ public class ProjectTest extends TestCase {
 				"tmp; version=hash; hash=SHA-256:7fe83bfd5999fa4ef9cec40282d5d67dd0ff3303bac6b8c7b0e8be80a821441c");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(2, buildpath.size());
-		assertEquals("bar", buildpath.get(1).getManifest().getMainAttributes().getValue("Prints"));
+		assertEquals(1, buildpath.size());
+		assertEquals("bar", buildpath.get(0).getManifest().getMainAttributes().getValue("Prints"));
 	}
 
 	public void testHashVersionWithAlgorithmNotFound() throws Exception {
@@ -897,7 +897,7 @@ public class ProjectTest extends TestCase {
 				"tmp; version=hash; hash=SHA-1:7fe83bfd5999fa4ef9cec40282d5d67dd0ff3303bac6b8c7b0e8be80a821441c");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(1, buildpath.size());
+		assertEquals(0, buildpath.size());
 	}
 
 	public void testHashVersionNonMatchingBsn() throws Exception {
@@ -908,6 +908,6 @@ public class ProjectTest extends TestCase {
 				"WRONG; version=hash; hash=SHA-256:7fe83bfd5999fa4ef9cec40282d5d67dd0ff3303bac6b8c7b0e8be80a821441c");
 
 		ArrayList<Container> buildpath = new ArrayList<Container>(project.getBuildpath());
-		assertEquals(1, buildpath.size());
+		assertEquals(0, buildpath.size());
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
@@ -49,6 +49,10 @@ public class JUnitLauncher extends ProjectLauncher {
 		// trace = Processor.isTrue(project.getProperty(Constants.RUNTRACE));
 		cp = new Classpath(project, "junit");
 		addClasspath(project.getTestpath());
+		File output = project.getOutput();
+		if (output.exists()) {
+			addClasspath(new Container(project, output));
+		}
 		addClasspath(project.getBuildpath());
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -320,12 +320,8 @@ public class Project extends Processor {
 					}
 					getWorkspace().changedFile(output);
 				}
-				if (!output.isDirectory())
+				if (!output.isDirectory()) {
 					msgs.NoOutputDirectory_(output);
-				else {
-					Container c = new Container(this, output);
-					if (!buildpath.contains(c))
-						buildpath.add(c);
 				}
 
 				// Where we store all our generated stuff.

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -92,6 +92,11 @@ public class ProjectBuilder extends Builder {
 					addClasspath(file);
 				}
 
+				File output = project.getOutput();
+				if (output.exists()) {
+					addClasspath(output);
+				}
+
 				for (Container file : project.getBuildpath()) {
 					addClasspath(file);
 				}
@@ -103,7 +108,6 @@ public class ProjectBuilder extends Builder {
 				for (File file : project.getAllsourcepath()) {
 					addSourcepath(file);
 				}
-
 			}
 		} catch (Exception e) {
 			msgs.Unexpected_Error_("ProjectBuilder init", e);


### PR DESCRIPTION
The output folder had to be removed from the buildpath for bndtools and
the gradle plugin since it is not part of the compile path.
Project builder must add the output folder to the builder classpath.