### PR TITLE
gradle: Update Bundle task type to use classpath property

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -206,22 +206,19 @@ bundle. The default value is `project.file('bnd.bnd')`. If the bnd file
 does not exist, this is OK. But without some instructions to Bnd, your
 bundle will not be very interesting.
 
-### configuration
-
-This is the Configuration object to use as the classpath for the Bnd
-builder. The default value is the `project.configurations.compileClasspath`
-Configuration (or the `project.configurations.compile` Configuration in
-Gradle versions prior to 2.12).
-You will only need to specify this property if you want
-to use a different Configuration for the classpath or the default
-Configuration does not exist.
-
 ### sourceSet
 
-This is the SourceSet object to use as the sourcepath for the Bnd
-builder. The default value is the `project.sourceSets.main` SourceSet.
+This is the SourceSet object to use for the Bnd
+builder. The default value is `project.sourceSets.main`.
 You will only need to specify this property if you want to use a different
-SourceSet for the sourcepath or the default SourceSet does not exist.
+SourceSet or the default SourceSet does not exist.
+
+### classpath
+
+This is a FileCollection object to use as the classpath for the Bnd
+builder. The default value is `sourceSet.compileClasspath`.
+You will only need to specify this property if you want
+to use a different classpath or the default SourceSet does not exist.
 
 ### Example
 
@@ -239,7 +236,6 @@ sourceSets {
 task bundle(type: Bundle) {
   from sourceSets.bundle.output
   bndfile = project.file('bundle.bnd')
-  configuration = configurations.bundleCompile
   sourceSet = sourceSets.bundle
 }
 ```

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bundle.groovy
@@ -15,7 +15,6 @@
  *   group 'build'
  *   from sourceSets.bundle.output
  *   bndfile = project.file('bundle.bnd')
- *   configuration = configurations.bundleCompile
  *   sourceSet = sourceSets.bundle
  * }
  * </pre>

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -84,7 +84,7 @@ class TestBundlePlugin extends Specification {
           bundletask_manifest.getValue('Bundle-SymbolicName') == "${testProject}_bundle"
           bundletask_manifest.getValue('Bundle-Version') == '1.1.0'
           bundletask_manifest.getValue('My-Header') == 'my-value'
-          bundletask_manifest.getValue('Export-Package') =~ /doubler/
+          bundletask_manifest.getValue('Export-Package') =~ /doubler\.impl/
           !bundletask_manifest.getValue('X-SomeProperty')
           bundletask_manifest.getValue('Override') == 'Override the jar task manifest'
           bundletask_manifest.getValue('Project-Name') == "${testProject}"
@@ -102,5 +102,17 @@ class TestBundlePlugin extends Specification {
           bundletask_jar.getEntry('test.txt')
           bundletask_jar.getInputStream(bundletask_jar.getEntry('test.txt')).text =~ /This is a test resource/
           bundletask_jar.getEntry('commons-lang-2.6.jar')
+
+        when:
+          result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments('--stacktrace', '--debug', 'build')
+            .withPluginClasspath(pluginClasspath)
+            .forwardOutput()
+            .build()
+
+        then:
+          result.task(":bundle").outcome == UP_TO_DATE
+          result.task(":jar").outcome == UP_TO_DATE
     }
 }

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -36,21 +36,7 @@ task bundle(type: Bundle) {
    group 'build'
    from sourceSets.test.output
    baseName = baseName+'_bundle'
-   bndfile = File.createTempFile(baseName, '.bnd', temporaryDir)
-   bndfile << '''
-Export-Package: doubler
--sources: true
-My-Header: my-value
-text: TEXT
-Override: Override the jar task manifest
-Project-Name: ${project.name}
-Project-Dir: ${project.dir}
-Project-Output: ${project.output}
-Project-Sourcepath: ${project.sourcepath}
-Project-Buildpath: ${project.buildpath}
--includeresource.lib: commons-lang-2.6.jar;lib:=true
-'''
-   configuration = configurations.testCompile
+   bndfile = file('bundle.bnd')
    sourceSet = sourceSets.test
    version = '1.1.0'
 }

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/bundle.bnd
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/bundle.bnd
@@ -1,4 +1,4 @@
--exportcontents: doubler
+-exportcontents: doubler.impl
 -sources: true
 My-Header: my-value
 text: TEXT


### PR DESCRIPTION
This replaces the configuration property and defaults to the
compileClasspath property of the sourceSet property.
