### PR TITLE
gradle: Baseline task type improvements

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -304,14 +304,13 @@ path relative to the project's [`reporting.baseDir`][19]. The default name is
 
 ### bundle
 
-This is the bundle to be baselined. It can either be a File or a task
-that produces a bundle. This property must be set.
+This is the bundle to be baselined. It can be anything that `Project.files(Object...)`
+can accept to result in a single file. This property must be set.
 
 ### baseline
 
-This is the baseline bundle. It can either be a File or a Configuration.
-If a Configuration is specified, it must contain a single file;
-otherwise an exception will fail the build. This property must be set.
+This is the baseline bundle. It can be anything that `Project.files(Object...)`
+can accept to result in a single file. This property must be set.
 
 ---
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -68,8 +68,10 @@ public class BndBuilderPlugin implements Plugin<Project> {
       }
 
       afterEvaluate {
-        if (baseline.bundleTask && (baseline.baselineConfiguration == configurations.baseline) && configurations.baseline.dependencies.empty) {
-          def baselineDep = dependencies.create('group': group, 'name': baseline.bundleTask.baseName, 'version': "(,${baseline.bundleTask.version})")
+        def bundleTask = baseline.bundleTask
+        def baselineConfiguration = baseline.baselineConfiguration
+        if (bundleTask && (baselineConfiguration == configurations.baseline) && baselineConfiguration.dependencies.empty) {
+          def baselineDep = dependencies.create('group': group, 'name': bundleTask.baseName, 'version': "(,${bundleTask.version})")
           if (configurations.detachedConfiguration(baselineDep).setTransitive(false).resolvedConfiguration.hasError()) {
             dependencies {
               baseline files(baseline.bundle)

--- a/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
@@ -41,8 +41,7 @@ baseline {
 task baselineSelf(type: Baseline) {
    description 'Baseline Self'
    group 'build'
-   dependsOn jar
-   bundle jar.archivePath
+   bundle jar
    baseline jar.archivePath
    ignoreFailures = false
    baselineReportDirName = name

--- a/biz.aQute.bnd.gradle/testresources/baselinetask2/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/baselinetask2/build.gradle
@@ -2,7 +2,6 @@
  *
  */
 
-import aQute.bnd.gradle.Baseline
 import java.util.jar.*
 
 plugins {


### PR DESCRIPTION
Accept more input types for bundle to baseline and baseline. Include
baseline report text in message when a mismatch. Add @OutputFile to
avoid rebaselining unnecessarily.