### PR TITLE
Avoid rebuilding jars on release

### DIFF
--- a/aQute.libg/src/aQute/libg/generics/Create.java
+++ b/aQute.libg/src/aQute/libg/generics/Create.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,7 +43,7 @@ public class Create {
 
 	@SafeVarargs
 	public static <T> Set<T> set(T... source) {
-		return new HashSet<T>(Arrays.asList(source));
+		return new LinkedHashSet<T>(Arrays.asList(source));
 	}
 
 	public static <K, V> Map<K,V> copy(Map<K,V> source) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -543,7 +543,7 @@ Project ${project.name}
           compile handler.project('path': ":${dependency}", 'configuration': 'dependson')
         }
         compileJava.dependsOn(":${dependency}:assemble")
-        jar.dependsOn(":${dependency}:assemble")
+        jar.inputs.files { tasks.getByPath(":${dependency}:jar") }
         checkNeeded.dependsOn(":${dependency}:checkNeeded")
         releaseNeeded.dependsOn(":${dependency}:releaseNeeded")
         cleanNeeded.dependsOn(":${dependency}:cleanNeeded")

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -254,7 +254,7 @@ public class BndPlugin implements Plugin<Project> {
         }
         outputs.file new File(buildDir, Constants.BUILDFILES)
         doLast {
-          def built
+          File[] built
           try {
             built = bndProject.build()
           } catch (Exception e) {
@@ -262,7 +262,7 @@ public class BndPlugin implements Plugin<Project> {
           }
           checkErrors(logger)
           if (built != null) {
-            logger.info 'Generated bundles: {}', built
+            logger.info 'Generated bundles: {}', built as Object
           }
         }
       }

--- a/biz.aQute.bndlib.tests/src/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ProjectTest.java
@@ -18,7 +18,6 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.eclipse.EclipseClasspath;
-import aQute.bnd.service.BndListener;
 import aQute.bnd.service.Strategy;
 import aQute.bnd.version.Version;
 import aQute.lib.deployer.FileRepo;
@@ -334,7 +333,6 @@ public class ProjectTest extends TestCase {
 
 	public void testIsStale() throws Exception {
 		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
-		ws.addBasicPlugin(new BndListener());
 		Project top = ws.getProject("p-stale");
 		assertNotNull(top);
 		top.build();

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -405,7 +405,7 @@ public class Workspace extends Processor {
 			try {
 				l.changed(f);
 			} catch (Exception e) {
-				e.printStackTrace();
+				logger.debug("Exception in a BndListener changedFile method call", e);
 			}
 	}
 
@@ -418,7 +418,10 @@ public class Workspace extends Processor {
 				else
 					l.end();
 			} catch (Exception e) {
-				// who cares?
+				if (begin)
+					logger.debug("Exception in a BndListener begin method call", e);
+				else
+					logger.debug("Exception in a BndListener end method call", e);
 			}
 	}
 
@@ -433,7 +436,7 @@ public class Workspace extends Processor {
 				try {
 					l.signal(this);
 				} catch (Exception e) {
-					// who cares?
+					logger.debug("Exception in a BndListener signal method call", e);
 				}
 		} catch (Exception e) {
 			// Ignore

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -101,7 +101,6 @@ public class Workspace extends Processor {
 	private final Set<String>					modelsUnderConstruction	= newSet();
 	final Map<String,Action>					commands				= newMap();
 	final Maven									maven					= new Maven(Processor.getExecutor());
-	private volatile boolean								hasBndListeners			= false;
 	private final AtomicBoolean								offline					= new AtomicBoolean();
 	Settings									settings				= new Settings();
 	WorkspaceRepository							workspaceRepo			= new WorkspaceRepository(this);
@@ -404,7 +403,6 @@ public class Workspace extends Processor {
 		List<BndListener> listeners = getPlugins(BndListener.class);
 		for (BndListener l : listeners)
 			try {
-				hasBndListeners = true;
 				l.changed(f);
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -712,10 +710,6 @@ public class Workspace extends Processor {
 				error("failed to install extension %s due to %s", blocker, e);
 			}
 		}
-	}
-
-	boolean hasBndListeners() {
-		return hasBndListeners;
 	}
 
 	public boolean isOffline() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -303,18 +303,17 @@ public class Builder extends Analyzer {
 		if (f.isDirectory()) {
 			f = new File(f, "MANIFEST.MF");
 		}
-		f.delete();
-		File fp = f.getParentFile();
-		if (!fp.exists() && !fp.mkdirs()) {
-			throw new IOException("Could not create directory " + fp);
+		if (!f.exists() || f.lastModified() < dot.lastModified()) {
+			f.delete();
+			File fp = f.getParentFile();
+			if (!fp.exists() && !fp.mkdirs()) {
+				throw new IOException("Could not create directory " + fp);
+			}
+			try (OutputStream out = new FileOutputStream(f)) {
+				Jar.writeManifest(dot.getManifest(), out);
+			}
+			changedFile(f);
 		}
-		OutputStream out = new FileOutputStream(f);
-		try {
-			Jar.writeManifest(dot.getManifest(), out);
-		} finally {
-			out.close();
-		}
-		changedFile(f);
 	}
 
 	protected void changedFile(@SuppressWarnings("unused") File f) {}

--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -167,17 +167,9 @@ public class Bndrun extends Run {
 		}
 	}
 
-	@Override
-	public void setBase(File base) {
-		base.mkdirs();
-		super.setBase(base);
-	}
-
 	/**
 	 * Execute the tests defined by the bndrun configuration.
 	 *
-	 * @param cwd the directory used as the current working directory for the
-	 *            test process
 	 * @param reportsDir the directory in which test reports are written
 	 * @throws Exception
 	 */

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -66,6 +66,7 @@ public class ExportMojo extends AbstractMojo {
 		try (Bndrun run = Bndrun.createBndrun(null, runFile)) {
 			String bndrun = getNamePart(runFile);
 			File bndrunBase = new File(targetDir, "export/" + bndrun);
+			bndrunBase.mkdirs();
 			run.setBase(bndrunBase);
 			Workspace workspace = run.getWorkspace();
 			workspace.setOffline(session.getSettings().isOffline());

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -93,6 +93,7 @@ public class TestingMojo extends AbstractMojo {
 		try (Bndrun run = Bndrun.createBndrun(null, runFile)) {
 			String bndrun = getNamePart(runFile);
 			File bndrunBase = new File(cwd, bndrun);
+			bndrunBase.mkdirs();
 			run.setBase(bndrunBase);
 			Workspace workspace = run.getWorkspace();
 			workspace.setOffline(session.getSettings().isOffline());


### PR DESCRIPTION
And a number of other fixes including avoiding rewriting -savemanifest output on release.