### PR TITLE
Improvement to baseline diff formatting

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/differ/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
DiffImpl is made Formattable. Use `%#S` to get the nicely formatted, multil-line output of the changed elements in a Diff including all children. `#` flag triggers this alternate format. `%#S` instead of `%#s` limits the output to just changed elements instead of all elements. Specify a width for the alternate format, e.g. `%#2S`, will indent each line of the output by the specified width.