### PR TITLE
Allow distro bundles to be augmented

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
@@ -396,10 +396,11 @@ public abstract class AbstractResolveContext extends ResolveContext {
 			log.log(LogService.LOG_ERROR, "Resource is missing an identity capability (osgi.identity).");
 			return false;
 		}
-		if (idCaps.size() > 1) {
-			log.log(LogService.LOG_ERROR, "Resource has more than one identity capability (osgi.identity).");
-			return false;
-		}
+		// if (idCaps.size() > 1) {
+		// log.log(LogService.LOG_ERROR, "Resource has more than one identity
+		// capability (osgi.identity).");
+		// return false;
+		// }
 		String identity = (String) idCaps.get(0).getAttributes().get(IdentityNamespace.IDENTITY_NAMESPACE);
 		if (identity == null) {
 			log.log(LogService.LOG_ERROR, "Resource is missing an identity capability (osgi.identity).");

--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -379,6 +379,19 @@ public class BndrunResolveContext extends AbstractResolveContext {
 		augments.putAll(new Parameters(properties.mergeProperties(Constants.AUGMENT), project));
 
 		if (!augments.isEmpty()) {
+
+			if (project != null) {
+				String distro = properties.mergeProperties(Constants.DISTRO);
+				List<Container> containers = Container
+						.flatten(project.getBundles(Strategy.HIGHEST, distro, Constants.DISTRO));
+				if (!containers.isEmpty()) {
+					File distroFile = containers.get(0).getFile();
+
+					orderedRepositories.add(new DistroRepository(distroFile));
+				}
+			}
+
+
 			AggregateRepository aggregate = new AggregateRepository(orderedRepositories);
 			AugmentRepository augment = new AugmentRepository(augments, aggregate);
 			orderedRepositories = Collections.singleton((Repository) augment);

--- a/biz.aQute.resolve/src/biz/aQute/resolve/DistroRepository.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/DistroRepository.java
@@ -1,0 +1,21 @@
+package biz.aQute.resolve;
+
+import java.io.File;
+
+import org.osgi.resource.Resource;
+
+import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.repository.ResourcesRepository;
+import aQute.bnd.osgi.resource.ResourceBuilder;
+
+public class DistroRepository extends ResourcesRepository {
+
+	public DistroRepository(File distro) throws Exception {
+		Domain manifest = Domain.domain(distro);
+		ResourceBuilder rb = new ResourceBuilder();
+		rb.addManifest(manifest);
+
+		Resource resource = rb.build();
+		add(resource);
+	}
+}


### PR DESCRIPTION
This code is just to get the conversation started.  Here is my original problem.

At Liferay we have a distro that we are building.  We want to be able to use it to resolve services in the distro.  however, some of the Liferay services are legacy and not created with DS, so there is no osgi.service capability in the distro.  One way around this is for us to supply developers with an augments file that augments the distro bundle with extra capabilities.  however, the BndrunResolveContext does not allow for augmenting distro bundles.  

In this PR I've added that ability to augment distro bundles, but I have several questions about this code, so see code for additional comments.  