### PR TITLE
[launcher] #1952  Executable JAR working directory

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -129,6 +129,9 @@ public class Launcher implements ServiceListener {
 
 				Properties properties = new Properties();
 				load(in, properties);
+
+				augmentWithSystemProperties(properties);
+
 				Launcher target = new Launcher(properties, propertiesFile);
 				exitcode = target.run(args);
 			} catch (Throwable t) {
@@ -142,6 +145,16 @@ public class Launcher implements ServiceListener {
 			System.exit(exitcode);
 		} finally {
 			System.out.println("gone");
+		}
+	}
+
+	private static void augmentWithSystemProperties(Properties properties) {
+		for (String key : LauncherConstants.LAUNCHER_PROPERTY_KEYS) {
+			String value = System.getProperty(key);
+			if (value == null)
+				continue;
+
+			properties.put(key, value);
 		}
 	}
 
@@ -824,7 +837,10 @@ public class Launcher implements ServiceListener {
 		if (!workingdir.isDirectory())
 			throw new IllegalArgumentException("Cannot create a working dir: " + workingdir);
 
-		p.setProperty(Constants.FRAMEWORK_STORAGE, workingdir.getAbsolutePath());
+		if (System.getProperty(Constants.FRAMEWORK_STORAGE) == null)
+			p.setProperty(Constants.FRAMEWORK_STORAGE, workingdir.getAbsolutePath());
+		else
+			p.setProperty(Constants.FRAMEWORK_STORAGE, System.getProperty(Constants.FRAMEWORK_STORAGE));
 
 		if (parms.systemPackages != null) {
 			p.setProperty(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, parms.systemPackages);

--- a/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
+++ b/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
@@ -46,6 +46,12 @@ public class LauncherConstants {
 	final static String			LAUNCH_NAME					= "launch.name";
 	final static String			LAUNCH_NOREFERENCES			= "launch.noreferences";
 	final static String			LAUNCH_NOTIFICATION_PORT	= "launch.notificationPort";
+
+	public final static String[]	LAUNCHER_PROPERTY_KEYS		= {
+			LAUNCH_SERVICES, LAUNCH_STORAGE_DIR, LAUNCH_KEEP, LAUNCH_NOREFERENCES, LAUNCH_RUNBUNDLES,
+			LAUNCH_SYSTEMPACKAGES, LAUNCH_SYSTEMCAPABILITIES, LAUNCH_SYSTEMPACKAGES, LAUNCH_TRACE, LAUNCH_TIMEOUT,
+			LAUNCH_ACTIVATORS, LAUNCH_EMBEDDED, LAUNCH_NAME, LAUNCH_NOREFERENCES, LAUNCH_NOTIFICATION_PORT
+	};
 	/**
 	 * The command line arguments of the launcher. Launcher are not supposed to
 	 * eat any arguments, they should use -D VM arguments so that applications


### PR DESCRIPTION
Allow override of any of the launcher constants as 
well as allowing to override calculated org.osgi.framework.storage
property when set as system property. That is, the following
forces the framework dir regardless of other settings.

   java -Dorg.osgi.framework.storage=fw -jar foo.jar


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>