### PR TITLE
Baselining fixes

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Classpath.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Classpath.java
@@ -1,44 +1,41 @@
-package aQute.bnd.osgi;
+package aQute.bnd.build;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.osgi.annotation.versioning.ProviderType;
-
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Clazz;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
 import aQute.lib.strings.Strings;
 import aQute.service.reporter.Reporter;
 
-/**
- * Type caused coupling to build package and was never locally used. This class
- * was moved to the aQute.bnd.build package
- */
-@Deprecated()
-@ProviderType
 public class Classpath {
 
 	public interface ClassVisitor {
 		boolean visit(Clazz clazz) throws Exception;
 	}
 
-	List<File>	entries	= new ArrayList<File>();
+	List<File>			entries	= new ArrayList<File>();
+	private Reporter	project;
+	private String		name;
 
-	public Classpath(Reporter project, String name) {}
-
-	public void add(Collection<Object> testpath) throws Exception {
-		throw new UnsupportedOperationException();
+	public Classpath(Reporter project, String name) {
+		this.project = project;
+		this.name = name;
 	}
 
-	// public void add(Collection<Container> testpath) throws Exception {
-	// for (Container c : Container.flatten(testpath)) {
-	// if (c.getError() != null) {
-	// project.error("Adding %s to %s, got error: %s", c, name, c.getError());
-	// } else {
-	// entries.add(c.getFile().getAbsoluteFile());
-	// }
-	// }
-	// }
+	public void add(Collection<Container> testpath) throws Exception {
+		for (Container c : Container.flatten(testpath)) {
+			if (c.getError() != null) {
+				project.error("Adding %s to %s, got error: %s", c, name, c.getError());
+			} else {
+				entries.add(c.getFile().getAbsoluteFile());
+			}
+		}
+	}
 
 	public List<File> getEntries() {
 		return entries;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import aQute.bnd.osgi.Classpath;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
 import aQute.libg.command.Command;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/packageinfo
@@ -1,1 +1,1 @@
-version 2.9.0
+version 2.10.0

--- a/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
@@ -7,7 +7,6 @@ import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import aQute.bnd.osgi.Verifier;
 
 public class MavenVersion implements Comparable<MavenVersion> {
 
@@ -18,6 +17,9 @@ public class MavenVersion implements Comparable<MavenVersion> {
 	static Pattern					fuzzyModifier		= Pattern.compile("(\\d+[.-])*(.*)", Pattern.DOTALL);
 	public static final String		VERSION_STRING		= "(\\d{1,15})(\\.(\\d{1,9})(\\.(\\d{1,9}))?)?([-\\.]?([-_\\.\\da-zA-Z]+))?";
 	final static SimpleDateFormat	snapshotTimestamp	= new SimpleDateFormat("yyyyMMdd.HHmmss", Locale.ROOT);
+	public final static Pattern		VERSIONRANGE		= Pattern.compile("((\\(|\\[)"
+
+			+ VERSION_STRING + "," + VERSION_STRING + "(\\]|\\)))|" + VERSION_STRING);
 
 	static {
 		snapshotTimestamp.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -175,7 +177,7 @@ public class MavenVersion implements Comparable<MavenVersion> {
 		if (version == null || version.trim().isEmpty())
 			return "0";
 
-		Matcher m = Verifier.VERSIONRANGE.matcher(version);
+		Matcher m = VERSIONRANGE.matcher(version);
 
 		if (m.matches()) {
 			try {

--- a/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.osgi.framework.namespace.PackageNamespace;
 
 public class VersionRange {
 	final Version	high;
@@ -158,7 +157,7 @@ public class VersionRange {
 	 * Convert to an OSGi filter expression
 	 */
 	public String toFilter() {
-		return toFilter(PackageNamespace.CAPABILITY_VERSION_ATTRIBUTE);
+		return toFilter("version");
 	}
 
 	/**


### PR DESCRIPTION
- Removed some unnecessary couplings between packages that made the reuse of the version package and aQute.bnd.osgi cumbersome. This includes moving Classpath to the build package and moving constants into the version package.
- Added a reason field to the Baseline package info (info) structure and the bundle info (binfo) structure that specifies the root reason.
