### PR TITLE
Support for new DS 1.4/Metatype 1.4 property name mapping rules

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
@@ -2395,7 +2395,11 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	public @interface ConfigNames14 {
+		String PREFIX_ = "test.";
+	
 		String my$_$String7() default "foo";
+	
+		String value() default "foo";
 	}
 
 	@Component()
@@ -2455,10 +2459,13 @@ public class DSAnnotationTest extends BndTestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("1", "count(scr:component/property)");
+		xt.assertAttribute("2", "count(scr:component/property)");
 
-		xt.assertAttribute("foo", "scr:component/property[@name='my-String7']/@value");
-		xt.assertAttribute("String", "scr:component/property[@name='my-String7']/@type");
+		xt.assertAttribute("foo", "scr:component/property[@name='test.my-String7']/@value");
+		xt.assertAttribute("String", "scr:component/property[@name='test.my-String7']/@type");
+
+		xt.assertAttribute("foo", "scr:component/property[@name='test.config.names14']/@value");
+		xt.assertAttribute("String", "scr:component/property[@name='test.config.names14']/@type");
 
 	}
 

--- a/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
@@ -93,7 +93,7 @@ public class DSAnnotationTest extends BndTestCase {
 			fail();
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false);
+		checkRequires(a, null);
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$ValidNSVersion.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -125,7 +125,7 @@ public class DSAnnotationTest extends BndTestCase {
 			fail();
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false);
+		checkRequires(a, null);
 
 		//
 		// Test all the defaults
@@ -759,7 +759,7 @@ public class DSAnnotationTest extends BndTestCase {
 		// n.b. we should merge the 2 logService requires, so when we fix that
 		// we'll need to update this test.
 		// one is plain, other has cardinality multiple.
-		checkRequires(a, true, LogService.class.getName(), LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName(), LogService.class.getName());
 	}
 
 	private void verifyDS11VeryBasic(Jar jar, Class< ? > clazz) throws Exception, XPathExpressionException {
@@ -993,7 +993,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		// Test Felix12 activate gives Felix 1.2 namespace
 		checkDSFelix12(jar, "test.component.DSAnnotationTest$activate_basicFelix12");
@@ -1087,7 +1087,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/enums.xml");
 		assertNotNull(r);
@@ -1167,7 +1167,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/methods.xml");
 		assertNotNull(r);
@@ -1234,18 +1234,18 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	public void testInheritance() throws Exception {
-		testInheritance("-dsannotations-inherit", "true", false);
+		testInheritance("-dsannotations-inherit", "true", null);
 	}
 
 	public void testInheritanceFlag() throws Exception {
-		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit", false);
+		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit", null);
 	}
 
 	public void testInheritanceExtenderFlag() throws Exception {
-		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit,extender", true);
+		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit,extender", "1.3.0");
 	}
 
-	public void testInheritance(String key, String value, boolean extender) throws Exception {
+	public void testInheritance(String key, String value, String extender) throws Exception {
 		Builder b = new Builder();
 		b.setProperty(Constants.DSANNOTATIONS, "test.component.DSAnnotationTest*Bottom");
 		b.setProperty(key, value);
@@ -1336,7 +1336,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/prototypes.xml");
 		assertNotNull(r);
@@ -1388,17 +1388,17 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	public void testBinds() throws Exception {
-		testBinds(false);
+		testBinds(null);
 	}
 
 	public void testBindsExtender() throws Exception {
-		testBinds(true);
+		testBinds("1.3.0");
 	}
 
-	public void testBinds(boolean extender) throws Exception {
+	public void testBinds(String extender) throws Exception {
 		Builder b = new Builder();
 		b.setProperty(Constants.DSANNOTATIONS, "test.component.DSAnnotationTest*CheckBinds");
-		if (extender)
+		if (extender != null)
 			b.setProperty(Constants.DSANNOTATIONS_OPTIONS, "extender");
 		b.setProperty(Constants.DSANNOTATIONS_OPTIONS + ".min", "version;minimum=1.2.0");
 		b.setProperty("Private-Package", "test.component");
@@ -1493,7 +1493,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/" + CheckBinds13.class.getName() + ".xml");
 		assertNotNull(r);
@@ -1537,7 +1537,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, false);
+		checkRequires(a, null);
 
 		Resource r = jar.getResource("OSGI-INF/testConfigPolicy.xml");
 		assertNotNull(r);
@@ -1584,7 +1584,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		{
 			Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$issue347.xml");
@@ -1642,7 +1642,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$ref_on_comp.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -2043,9 +2043,9 @@ public class DSAnnotationTest extends BndTestCase {
 			checkProvides(a, provides);
 		}
 		if (requires == null) {
-			checkRequires(a, true);
+			checkRequires(a, "1.3.0");
 		} else {
-			checkRequires(a, true, requires);
+			checkRequires(a, "1.3.0", requires);
 		}
 		return jar;
 	}
@@ -2102,7 +2102,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 	}
 
 	public enum Foo {
@@ -2220,7 +2220,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true);
+		checkRequires(a, "1.3.0");
 
 		// // Test 1.3 signature methods give 1.3 namespace
 		checkDS13Anno(jar, DS13anno_configTypes_activate.class.getName(), "");
@@ -2314,8 +2314,6 @@ public class DSAnnotationTest extends BndTestCase {
 		String my__String5() default "foo";
 
 		String my$$__String6() default "foo";
-
-		String my$_$String7() default "foo";
 	}
 
 	@Component()
@@ -2346,7 +2344,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true);
+		checkRequires(a, "1.3.0");
 
 		checkDS13AnnoConfigNames(jar, DS13annoNames_config.class.getName());
 	}
@@ -2375,7 +2373,7 @@ public class DSAnnotationTest extends BndTestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("7", "count(scr:component/property)");
+		xt.assertAttribute("6", "count(scr:component/property)");
 
 		xt.assertAttribute("foo", "scr:component/property[@name='myString1']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='myString1']/@type");
@@ -2394,9 +2392,73 @@ public class DSAnnotationTest extends BndTestCase {
 
 		xt.assertAttribute("foo", "scr:component/property[@name='my$_String6']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='my$_String6']/@type");
+	}
 
-		xt.assertAttribute("foo", "scr:component/property[@name='my.String7']/@value");
-		xt.assertAttribute("String", "scr:component/property[@name='my.String7']/@type");
+	public @interface ConfigNames14 {
+		String my$_$String7() default "foo";
+	}
+
+	@Component()
+	public static class DS14annoNames_config implements Serializable, Runnable {
+		private static final long serialVersionUID = 1L;
+	
+		@Activate
+		void activate(@SuppressWarnings("unused") ComponentContext cc,
+				@SuppressWarnings("unused") ConfigNames14 configNames) {}
+	
+		@Deactivate
+		void deactivate(@SuppressWarnings("unused") ComponentContext cc) {}
+	
+		@Modified
+		void modified(@SuppressWarnings("unused") ComponentContext cc) {}
+	
+		@Override
+		public void run() {}
+	}
+
+	public void testAnnoConfigNames14() throws Exception {
+		Builder b = new Builder();
+		b.setProperty(Constants.DSANNOTATIONS, "test.component.DSAnnotationTest$DS14annoNames_config*");
+		b.setProperty("Private-Package", "test.component");
+		b.addClasspath(new File("bin"));
+
+		Jar jar = b.build();
+		assertOk(b);
+		Attributes a = getAttr(jar);
+		checkProvides(a, SERIALIZABLE_RUNNABLE);
+		checkRequires(a, "1.4.0");
+
+		checkDS14AnnoConfigNames(jar, DS14annoNames_config.class.getName());
+	}
+
+	private void checkDS14AnnoConfigNames(Jar jar, String name) throws Exception, XPathExpressionException {
+		Resource r = jar.getResource("OSGI-INF/" + name + ".xml");
+		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
+		assertNotNull(r);
+		r.write(System.err);
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		// Test the defaults
+		xt.assertAttribute(name, "scr:component/implementation/@class");
+
+		// Default must be the implementation class
+		xt.assertAttribute(name, "scr:component/@name");
+
+		xt.assertAttribute("", "scr:component/@configuration-policy");
+		xt.assertAttribute("", "scr:component/@immediate");
+		xt.assertAttribute("", "scr:component/@enabled");
+		xt.assertAttribute("", "scr:component/@factory");
+		xt.assertAttribute("", "scr:component/service/@scope");
+		xt.assertAttribute("", "scr:component/@configuration-pid");
+		xt.assertAttribute("activate", "scr:component/@activate");
+		xt.assertAttribute("deactivate", "scr:component/@deactivate");
+		xt.assertAttribute("modified", "scr:component/@modified");
+		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
+		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
+
+		xt.assertAttribute("1", "count(scr:component/property)");
+
+		xt.assertAttribute("foo", "scr:component/property[@name='my-String7']/@value");
+		xt.assertAttribute("String", "scr:component/property[@name='my-String7']/@type");
 
 	}
 
@@ -2501,7 +2563,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true);
+		checkRequires(a, "1.3.0");
 
 		checkDS13AnnoOverride(jar, DS13annoOverride_a_a.class.getName());
 		checkDS13AnnoOverride(jar, DS13annoOverride_a_d.class.getName());
@@ -2583,7 +2645,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/" + TestFieldInjection.class.getName() + ".xml");
 		assertNotNull(r);
@@ -2656,7 +2718,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/" + TestFieldCollectionType.class.getName() + ".xml");
 		assertNotNull(r);
@@ -2708,7 +2770,7 @@ public class DSAnnotationTest extends BndTestCase {
 		}
 	}
 
-	private void checkRequires(Attributes a, boolean extender, String... objectClass) {
+	private void checkRequires(Attributes a, String extender, String... objectClass) {
 		String p = a.getValue(Constants.REQUIRE_CAPABILITY);
 		System.err.println(Constants.REQUIRE_CAPABILITY + ":" + p);
 		Parameters header = new Parameters(p);
@@ -2725,10 +2787,11 @@ public class DSAnnotationTest extends BndTestCase {
 			assertTrue("objectClass not found: " + o, found);
 		}
 
-		if (extender) {
+		if (extender != null) {
 			Attrs attr = header.get("osgi.extender");
 			assertNotNull(attr);
-			assertEquals("(&(osgi.extender=osgi.component)(version>=1.3.0)(!(version>=2.0.0)))", attr.get("filter:"));
+			assertEquals("(&(osgi.extender=osgi.component)(version>=" + extender + ")(!(version>=2.0.0)))",
+					attr.get("filter:"));
 		}
 	}
 
@@ -3182,7 +3245,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$VolatileField.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -3221,7 +3284,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$FinalDynamicCollectionField.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -3267,7 +3330,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, true, LogService.class.getName());
+		checkRequires(a, "1.3.0", LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$FieldCardinality.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -3338,7 +3401,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b, 0, 8);
 		Attributes a = getAttr(jar);
-		checkRequires(a, false, LogService.class.getName());
+		checkRequires(a, null, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$MismatchedUnbind.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
@@ -3548,7 +3611,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b, 0, 0);
 		Attributes a = getAttr(jar);
-		checkRequires(a, false, Marker.class.getName(), GenericMarker.class.getName(), Object.class.getName());
+		checkRequires(a, null, Marker.class.getName(), GenericMarker.class.getName(), Object.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$RefType.xml");
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));

--- a/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
+++ b/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
@@ -197,6 +197,37 @@ public class SpecMetatypeTest extends TestCase {
 		assertAD(xt, "nullid", "§NULL§");
 	}
 
+	/**
+	 * Test method naming options with '.' and reserved names
+	 */
+	
+	@ObjectClassDefinition
+	public static interface Naming14 {
+		String a$_$b(); // a-b
+	
+		@AttributeDefinition(name = "a-b")
+		String xa$_$b(); // a-b
+	}
+
+	public void testNaming14() throws Exception {
+		Builder b = new Builder();
+		b.addClasspath(new File("bin"));
+		b.setProperty("Export-Package", "test.metatype");
+		b.setProperty(Constants.METATYPE_ANNOTATIONS, Naming14.class.getName());
+		b.build();
+		System.out.println(b.getErrors());
+		assertEquals(0, b.getErrors().size());
+		System.out.println(b.getWarnings());
+		assertEquals(0, b.getWarnings().size());
+
+		Resource r = b.getJar().getResource("OSGI-INF/metatype/test.metatype.SpecMetatypeTest$Naming14.xml");
+		IO.copy(r.openInputStream(), System.err);
+		XmlTester xt = xmlTester14(r);
+
+		assertAD(xt, "a-b", "A b");
+		assertAD(xt, "xa-b", "a-b");
+	}
+
 	@ObjectClassDefinition
 	public static interface ADCollision {
 
@@ -769,6 +800,10 @@ public class SpecMetatypeTest extends TestCase {
 
 	private XmlTester xmlTester13(Resource r) throws Exception {
 		return xmlTester(r, MetatypeVersion.VERSION_1_3);
+	}
+
+	private XmlTester xmlTester14(Resource r) throws Exception {
+		return xmlTester(r, MetatypeVersion.VERSION_1_4);
 	}
 
 	private XmlTester xmlTester(Resource r, MetatypeVersion version) throws Exception {

--- a/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
+++ b/biz.aQute.bndlib.tests/src/test/metatype/SpecMetatypeTest.java
@@ -202,11 +202,19 @@ public class SpecMetatypeTest extends TestCase {
 	 */
 	
 	@ObjectClassDefinition
-	public static interface Naming14 {
-		String a$_$b(); // a-b
+	public static @interface Naming14 {
+		String PREFIX_ = "test.";
+
+		String a$_$b() default "foo"; // test.a-b
 	
 		@AttributeDefinition(name = "a-b")
-		String xa$_$b(); // a-b
+		String xa$_$b() default "foo"; // test.xa-b
+
+		String value() default "foo"; // test.naming14
+	}
+
+	private void assertAD(XmlTester xt, String id, String name, String deflt) throws XPathExpressionException {
+		assertAD(xt, id, name, null, null, deflt, 0, "String", null, null, null);
 	}
 
 	public void testNaming14() throws Exception {
@@ -224,8 +232,9 @@ public class SpecMetatypeTest extends TestCase {
 		IO.copy(r.openInputStream(), System.err);
 		XmlTester xt = xmlTester14(r);
 
-		assertAD(xt, "a-b", "A b");
-		assertAD(xt, "xa-b", "a-b");
+		assertAD(xt, "test.a-b", "A b", "foo");
+		assertAD(xt, "test.xa-b", "a-b", "foo");
+		assertAD(xt, "test.naming14", "Value", "foo");
 	}
 
 	@ObjectClassDefinition

--- a/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
@@ -53,32 +53,34 @@ public class AnnotationReader extends ClassDataCollector {
 	public static final Version			V1_1						= new Version("1.1.0");																											// "1.1.0"
 	public static final Version			V1_2						= new Version("1.2.0");																											// "1.2.0"
 	public static final Version			V1_3						= new Version("1.3.0");																											// "1.3.0"
+	public static final Version			V1_4						= new Version("1.4.0");																											// "1.3.0"
 
-	static Pattern						BINDNAME					= Pattern.compile("(set|add|bind)?(.*)");
+	static final Pattern				BINDNAME					= Pattern.compile("(set|add|bind)?(.*)");
 
-	static Pattern						BINDDESCRIPTORDS10			= Pattern.compile(
+	static final Pattern				BINDDESCRIPTORDS10			= Pattern.compile(
 			"\\(L(((org/osgi/framework/ServiceReference)|(org/osgi/service/component/ComponentServiceObjects)|(java/util/Map\\$Entry)|(java/util/Map))|([^;]+));\\)(V|(Ljava/util/Map;))");
-	static Pattern						BINDDESCRIPTORDS11			= Pattern
+	static final Pattern				BINDDESCRIPTORDS11			= Pattern
 			.compile("\\(L([^;]+);(Ljava/util/Map;)?\\)(V|(Ljava/util/Map;))");
 
 	// includes support for felix extensions
-	static Pattern						BINDDESCRIPTORDS13			= Pattern.compile(
+	static final Pattern				BINDDESCRIPTORDS13			= Pattern.compile(
 			"\\(((Lorg/osgi/framework/ServiceReference;)|(Lorg/osgi/service/component/ComponentServiceObjects;)|(Ljava/util/Map;)|(Ljava/util/Map\\$Entry;)|(L([^;]+);))+\\)(V|(Ljava/util/Map;))");
 
-	static Pattern						LIFECYCLEDESCRIPTORDS10		= Pattern
+	static final Pattern				LIFECYCLEDESCRIPTORDS10		= Pattern
 			.compile("\\((Lorg/osgi/service/component/ComponentContext;)\\)(V|(Ljava/util/Map;))");
-	static Pattern						LIFECYCLEDESCRIPTORDS11		= Pattern.compile(
+	static final Pattern				LIFECYCLEDESCRIPTORDS11		= Pattern.compile(
 			"\\(((Lorg/osgi/service/component/ComponentContext;)|(Lorg/osgi/framework/BundleContext;)|(Ljava/util/Map;))*\\)(V|(Ljava/util/Map;))");
-	static Pattern						LIFECYCLEDESCRIPTORDS13		= Pattern
+	static final Pattern				LIFECYCLEDESCRIPTORDS13		= Pattern
 			.compile("\\((L([^;]+);)*\\)(V|(Ljava/util/Map;))");
-	static Pattern						LIFECYCLEARGUMENT			= Pattern.compile(
+	static final Pattern				LIFECYCLEARGUMENT			= Pattern.compile(
 			"((Lorg/osgi/service/component/ComponentContext;)|(Lorg/osgi/framework/BundleContext;)|(Ljava/util/Map;)|(L([^;]+);))");
 
-	static Pattern						IDENTIFIERTOPROPERTY		= Pattern.compile("(__)|(_)|(\\$\\$)|(\\$)");
+	static final Pattern				IDENTIFIERTOPROPERTY		= Pattern
+			.compile("(__)|(_)|(\\$_\\$)|(\\$\\$)|(\\$)");
 
-	static Pattern						DEACTIVATEDESCRIPTORDS11	= Pattern.compile(
+	static final Pattern				DEACTIVATEDESCRIPTORDS11	= Pattern.compile(
 			"\\(((Lorg/osgi/service/component/ComponentContext;)|(Lorg/osgi/framework/BundleContext;)|(Ljava/util/Map;)|(Ljava/lang/Integer;)|(I))*\\)(V|(Ljava/util/Map;))");
-	static Pattern						DEACTIVATEDESCRIPTORDS13	= Pattern
+	static final Pattern				DEACTIVATEDESCRIPTORDS13	= Pattern
 			.compile("\\(((L([^;]+);)|(I))*\\)(V|(Ljava/util/Map;))");
 
 	final static Map<String,Class< ? >>	wrappers;
@@ -426,83 +428,7 @@ public class AnnotationReader extends ClassDataCollector {
 				try {
 					Clazz clazz = analyzer.findClass(typeRef);
 					if (clazz.isAnnotation()) {
-						final MultiMap<String,String> props = new MultiMap<String,String>();
-						clazz.parseClassFileWithCollector(new ClassDataCollector() {
-
-							@Override
-							public void annotationDefault(Clazz.MethodDef defined) {
-								Object value = defined.getConstant();
-								// check type, exit with warning if annotation
-								// or annotation array
-								boolean isClass = false;
-								Class< ? > typeClass = null;
-								TypeRef type = defined.getType().getClassRef();
-								if (!type.isPrimitive()) {
-									if (Class.class.getName().equals(type.getFQN())) {
-										isClass = true;
-									} else {
-										try {
-											Clazz r = analyzer.findClass(type);
-											if (r.isAnnotation()) {
-												analyzer.warning("Nested annotation type found in field %s, %s",
-														defined.getName(), type.getFQN()).details(details);
-												return;
-											}
-										} catch (Exception e) {
-											analyzer.exception(e,
-													"Exception looking at annotation type to lifecycle method with descriptor %s,  type %s",
-													methodDescriptor, type).details(details);
-										}
-									}
-								} else {
-									typeClass = wrappers.get(type.getFQN());
-								}
-								if (value != null) {
-									String name = identifierToPropertyName(defined.getName());
-									if (value.getClass().isArray()) {
-										// add element individually
-										for (int i = 0; i < Array.getLength(value); i++) {
-											Object element = Array.get(value, i);
-											valueToProperty(name, element, isClass, typeClass);
-										}
-									} else
-										valueToProperty(name, value, isClass, typeClass);
-								}
-							}
-
-							private void valueToProperty(String name, Object value, boolean isClass,
-									Class< ? > typeClass) {
-								if (isClass)
-									value = ((TypeRef) value).getFQN();
-								if (typeClass == null)
-									typeClass = value.getClass();
-								// enums already come out as the enum name, no
-								// processing needed.
-								String type = typeClass.getSimpleName();
-								component.propertyType.put(name, type);
-								props.add(name, value.toString());
-							}
-
-							private String identifierToPropertyName(String name) {
-								Matcher m = IDENTIFIERTOPROPERTY.matcher(name);
-								StringBuffer b = new StringBuffer();
-								while (m.find()) {
-									String replace = "";
-									if (m.group(1) != null) // __ to _
-										replace = "_";
-									else if (m.group(2) != null) // _ to .
-										replace = ".";
-									else if (m.group(3) != null) // $$ to $
-										replace = "\\$";
-									// group 4 $ removed.
-									m.appendReplacement(b, replace);
-								}
-								m.appendTail(b);
-								return b.toString();
-							}
-
-						});
-						component.property.putAll(props);
+						clazz.parseClassFileWithCollector(new ComponentPropertyTypeDataCollector(methodDescriptor, details));
 					} else if (clazz.isInterface() && options.contains(Options.felixExtensions)) {
 						// ok
 					} else {
@@ -515,6 +441,101 @@ public class AnnotationReader extends ClassDataCollector {
 							methodDescriptor, type).details(details);
 				}
 			}
+		}
+	}
+
+	private final class ComponentPropertyTypeDataCollector extends ClassDataCollector {
+		private final String								methodDescriptor;
+		private final DeclarativeServicesAnnotationError	details;
+		private final MultiMap<String,String>				props			= new MultiMap<String,String>();
+		private final Map<String,String>					propertyTypes	= new HashMap<>();
+	
+		private ComponentPropertyTypeDataCollector(String methodDescriptor,
+				DeclarativeServicesAnnotationError details) {
+			this.methodDescriptor = methodDescriptor;
+			this.details = details;
+		}
+	
+		@Override
+		public void annotationDefault(MethodDef defined, Object value) {
+			// check type, exit with warning if annotation
+			// or annotation array
+			boolean isClass = false;
+			Class< ? > typeClass = null;
+			TypeRef type = defined.getType().getClassRef();
+			if (!type.isPrimitive()) {
+				if (Class.class.getName().equals(type.getFQN())) {
+					isClass = true;
+				} else {
+					try {
+						Clazz r = analyzer.findClass(type);
+						if (r.isAnnotation()) {
+							analyzer.warning("Nested annotation type found in field %s, %s",
+									defined.getName(), type.getFQN()).details(details);
+							return;
+						}
+					} catch (Exception e) {
+						analyzer.exception(e,
+								"Exception looking at annotation type to lifecycle method with descriptor %s,  type %s",
+								methodDescriptor, type).details(details);
+					}
+				}
+			} else {
+				typeClass = wrappers.get(type.getFQN());
+			}
+			if (value != null) {
+				String name = identifierToPropertyName(defined.getName());
+				if (value.getClass().isArray()) {
+					// add element individually
+					for (int i = 0; i < Array.getLength(value); i++) {
+						Object element = Array.get(value, i);
+						valueToProperty(name, element, isClass, typeClass);
+					}
+				} else
+					valueToProperty(name, value, isClass, typeClass);
+			}
+		}
+	
+		private void valueToProperty(String name, Object value, boolean isClass,
+				Class< ? > typeClass) {
+			if (isClass)
+				value = ((TypeRef) value).getFQN();
+			if (typeClass == null)
+				typeClass = value.getClass();
+			// enums already come out as the enum name, no
+			// processing needed.
+			String type = typeClass.getSimpleName();
+			propertyTypes.put(name, type);
+			props.add(name, value.toString());
+		}
+	
+		private String identifierToPropertyName(String name) {
+			Matcher m = IDENTIFIERTOPROPERTY.matcher(name);
+			StringBuffer b = new StringBuffer();
+			while (m.find()) {
+				String replace;
+				if (m.group(1) != null) // __ to _
+					replace = "_";
+				else if (m.group(2) != null) // _ to .
+					replace = ".";
+				else if (m.group(3) != null) { // $_$ to -
+					replace = "-";
+					component.updateVersion(V1_4);
+				}
+				else if (m.group(4) != null) // $$ to $
+					replace = "\\$";
+				else // $ removed.
+					replace = "";
+				m.appendReplacement(b, replace);
+			}
+			m.appendTail(b);
+			return b.toString();
+		}
+	
+		@Override
+		public void classEnd() throws Exception {
+			component.property.putAll(props);
+			component.propertyType.putAll(propertyTypes);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/MetatypeVersion.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/MetatypeVersion.java
@@ -4,7 +4,7 @@ import aQute.bnd.version.Version;
 
 public enum MetatypeVersion {
 
-	VERSION_1_2(new Version("1.2.0")), VERSION_1_3(new Version("1.3.0"));
+	VERSION_1_2(new Version("1.2.0")), VERSION_1_3(new Version("1.3.0")), VERSION_1_4(new Version("1.4.0"));
 
 	private final static String	NAMESPACE_STEM	= "http://www.osgi.org/xmlns/metatype/v";
 	private final Version		value;

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
@@ -26,65 +26,52 @@ import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Annotation;
 import aQute.bnd.osgi.ClassDataCollector;
 import aQute.bnd.osgi.Clazz;
+import aQute.bnd.osgi.Clazz.FieldDef;
 import aQute.bnd.osgi.Clazz.MethodDef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
 import aQute.bnd.xmlattribute.XMLAttributeFinder;
 
-public class OCDReader extends ClassDataCollector {
+class OCDReader {
+	final Analyzer				analyzer;
+	private final Clazz			clazz;
+	final EnumSet<Options>		options;
+	private final Set<TypeRef>	analyzed	= new HashSet<TypeRef>();;
+	private final OCDDef		ocd;
+	final XMLAttributeFinder	finder;
 
-	private Analyzer					analyzer;
-	private Clazz						clazz;
-	private EnumSet<Options>			options;
-
-	private TypeRef						name;
-	private boolean						topLevel	= true;
-	private Set<TypeRef>				analyzed;
-
-	private final Map<MethodDef,ADDef>	methods		= new LinkedHashMap<MethodDef,ADDef>();
-	private ADDef						current;
-	private OCDDef						ocd;
-
-	private final XMLAttributeFinder	finder;
-	private final MetatypeVersion		minVersion;
-
-	OCDReader(Analyzer analyzer, Clazz clazz, EnumSet<Options> options, XMLAttributeFinder finder, MetatypeVersion minVersion) {
+	private OCDReader(Analyzer analyzer, Clazz clazz, EnumSet<Options> options, XMLAttributeFinder finder,
+			MetatypeVersion minVersion) {
 		this.analyzer = analyzer;
 		this.clazz = clazz;
 		this.options = options;
 		this.finder = finder;
-		this.minVersion = minVersion;
+		this.ocd = new OCDDef(finder, minVersion);
 	}
 
 	static OCDDef getOCDDef(Clazz c, Analyzer analyzer, EnumSet<Options> options, XMLAttributeFinder finder, MetatypeVersion minVersion)
 			throws Exception {
-
 		OCDReader r = new OCDReader(analyzer, c, options, finder, minVersion);
 		return r.getDef();
 	}
 
 	private OCDDef getDef() throws Exception {
-		clazz.parseClassFileWithCollector(this);
-		if (ocd != null) {
-			topLevel = false;
-			parseExtends(clazz);
-
-			doMethods();
+		clazz.parseClassFileWithCollector(new OCDDataCollector(ocd));
+		if (ocd.id == null) {
+			return null;
 		}
-		return ocd == null || ocd.id == null ? null : ocd;
+		parseExtends(clazz);
+		return ocd;
 	}
 
 	private void parseExtends(Clazz clazz) {
 		TypeRef[] inherits = clazz.getInterfaces();
 		if (inherits != null) {
-			if (analyzed == null) {
-				analyzed = new HashSet<TypeRef>();
-			}
 			for (TypeRef typeRef : inherits) {
 				if (!typeRef.isJava() && analyzed.add(typeRef)) {
 					try {
 						Clazz inherit = analyzer.findClass(typeRef);
 						if (inherit != null) {
-							inherit.parseClassFileWithCollector(this);
+							inherit.parseClassFileWithCollector(new OCDDataCollector(ocd));
 							parseExtends(inherit);
 						} else {
 							analyzer.error("Could not obtain super class %s of class %s", typeRef.getFQN(),
@@ -95,132 +82,13 @@ public class OCDReader extends ClassDataCollector {
 								typeRef.getFQN(), clazz.getClassName().getFQN(), e);
 					}
 				}
-
 			}
 		}
-
-	}
-
-	@Override
-	public void classBegin(int access, TypeRef name) {
-		this.name = name;
-	}
-
-	@Override
-	public void method(MethodDef defined) {
-		current = new ADDef(finder);
-		methods.put(defined, current);
-	}
-
-	@Override
-	public void classEnd() throws Exception {
-		current = null;
-	}
-
-	@Override
-	public void memberEnd() {
-		current = null;
 	}
 
 	// TODO what about Queue|Stack|Deque?
 	static final Pattern GENERIC = Pattern.compile("((" + Collection.class.getName() + "|" + Set.class.getName() + "|"
 			+ List.class.getName() + "|" + Iterable.class.getName() + ")|(.*))<(L.+;)>");
-
-	private void doMethods() throws Exception {
-		for (Map.Entry<MethodDef,ADDef> entry : methods.entrySet()) {
-			MethodDef defined = entry.getKey();
-			if (defined.isConstructor()) {
-				analyzer.error("Constructor %s for %s.%s found; only interfaces and annotations allowed for OCDs",
-						defined.getName(), clazz.getClassName().getFQN(), defined.getName());
-
-			}
-			if (defined.getPrototype().length > 0) {
-				analyzer.error(
-						"Element %s for %s.%s has parameters; only no-parameter elements in an OCD interface allowed",
-						defined.getName(), clazz.getClassName().getFQN(), defined.getName());
-				continue;
-			}
-			ADDef ad = entry.getValue();
-			ocd.attributes.add(ad);
-			ad.id = identifierToPropertyName(defined.getName());
-			ad.name = space(defined.getName());
-			String rtype = defined.getGenericReturnType();
-			if (rtype.endsWith("[]")) {
-				ad.cardinality = Integer.MAX_VALUE;
-				rtype = rtype.substring(0, rtype.length() - 2);
-			}
-			Matcher m = GENERIC.matcher(rtype);
-			if (m.matches()) {
-				boolean knownCollection = m.group(2) != null;
-				boolean collection = knownCollection || identifiableCollection(m.group(3), false, true);
-				if (collection) {
-					if (ad.cardinality != 0)
-						analyzer.error(
-								"AD for %s.%s uses an array of collections in return type (%s), Metatype allows either Vector or array",
-								clazz.getClassName().getFQN(), defined.getName(), defined.getType().getFQN());
-					rtype = Clazz.objectDescriptorToFQN(m.group(4));
-					ad.cardinality = Integer.MIN_VALUE;
-				}
-			}
-			if (rtype.indexOf('<') > 0) {
-				rtype = rtype.substring(0, rtype.indexOf('<'));
-			}
-			ad.type = getType(rtype);
-
-			ad.required = true;
-			TypeRef typeRef = analyzer.getTypeRefFromFQN(rtype);
-			try {
-				Clazz c = analyzer.findClass(typeRef);
-				if (c != null && c.isEnum()) {
-					parseOptionValues(c, ad.options);
-				}
-			} catch (Exception e) {
-				analyzer.exception(e, "AD for %s.%s Can not parse option values from type (%s), %s",
-						clazz.getClassName().getFQN(), defined.getName(), defined.getType().getFQN(), e);
-			}
-			if (ad.ad != null) {
-				doAD(ad);
-			}
-			if (ad.defaults == null && clazz.isAnnotation() && defined.getConstant() != null) {
-				// defaults from annotation default
-				Object value = defined.getConstant();
-				boolean isClass = false;
-				TypeRef type = defined.getType().getClassRef();
-				if (!type.isPrimitive()) {
-					if (Class.class.getName().equals(type.getFQN())) {
-						isClass = true;
-					} else {
-						try {
-							Clazz r = analyzer.findClass(type);
-							if (r.isAnnotation()) {
-								analyzer.warning("Nested annotation type found in field %s, %s", defined.getName(),
-										type.getFQN());
-								return;
-							}
-						} catch (Exception e) {
-							analyzer.exception(e,
-									"Exception looking at annotation type default for element with descriptor %s,  type %s",
-									defined, type);
-						}
-					}
-				}
-				if (value != null) {
-					if (value.getClass().isArray()) {
-						// add element individually
-						ad.defaults = new String[Array.getLength(value)];
-						for (int i = 0; i < Array.getLength(value); i++) {
-							Object element = Array.get(value, i);
-							ad.defaults[i] = valueToProperty(element, isClass);
-						}
-					} else {
-						ad.defaults = new String[] {
-								valueToProperty(value, isClass)
-						};
-					}
-				}
-			}
-		}
-	}
 
 	// Determine if we can identify that this class is a concrete subtype of
 	// collection with a no-arg constructor
@@ -230,229 +98,418 @@ public class OCDReader extends ClassDataCollector {
 			.compile("(" + Collection.class.getName() + "|" + Set.class.getName() + "|" + List.class.getName() + "|"
 					+ Queue.class.getName() + "|" + Stack.class.getName() + "|" + Deque.class.getName() + ")");
 
-	private boolean identifiableCollection(String type, boolean intface, boolean topLevel) {
-		try {
-			Clazz clazz = analyzer.findClass(analyzer.getTypeRefFromFQN(type));
-			if (clazz != null && (!topLevel || !clazz.isAbstract())
-					&& ((intface && clazz.isInterface()) ^ clazz.hasPublicNoArgsConstructor())) {
-				TypeRef[] intfs = clazz.getInterfaces();
-				if (intfs != null) {
-					for (TypeRef intf : intfs) {
-						if (COLLECTION.matcher(intf.getFQN()).matches()
-								|| identifiableCollection(intf.getFQN(), true, false)) {
-							return true;
+	static final Pattern IDENTIFIERTOPROPERTY = Pattern.compile("(__)|(_)|(\\$_\\$)|(\\$\\$)|(\\$)");
+
+	private final class OCDDataCollector extends ClassDataCollector {
+		private final OCDDef				ocd;
+		private final Map<MethodDef,ADDef>	methods			= new LinkedHashMap<MethodDef,ADDef>();
+		private Clazz						clazz;
+		private TypeRef						name;
+		private int							hasNoDefault	= 0;
+		private boolean						hasValue		= false;
+		private FieldDef					prefixField		= null;
+		private ADDef						current;
+
+		OCDDataCollector(OCDDef ocd) {
+			this.ocd = ocd;
+		}
+
+		@Override
+		public boolean classStart(Clazz clazz) {
+			this.clazz = clazz;
+			this.name = clazz.getClassName();
+			return true;
+		}
+
+		@Override
+		public void field(FieldDef defined) {
+			if (defined.getName().equals("PREFIX_") && defined.isPublic() && defined.isStatic() && defined.isFinal()) {
+				prefixField = defined;
+			}
+		}
+
+		@Override
+		public void method(MethodDef defined) {
+			current = new ADDef(finder);
+			methods.put(defined, current);
+			if (clazz.isAnnotation()) {
+				if (defined.getName().equals("value")) {
+					hasValue = true;
+				} else {
+					hasNoDefault++;
+				}
+			}
+		}
+
+		@Override
+		public void annotationDefault(MethodDef defined, Object value) {
+			if (!defined.getName().equals("value")) {
+				hasNoDefault--;
+			}
+		}
+
+		@Override
+		public void annotation(Annotation annotation) throws Exception {
+			try {
+				java.lang.annotation.Annotation a = annotation.getAnnotation();
+				if (a instanceof ObjectClassDefinition)
+					doOCD((ObjectClassDefinition) a, annotation);
+				else if (a instanceof AttributeDefinition) {
+					current.ad = (AttributeDefinition) a;
+					current.a = annotation;
+				} else {
+					XMLAttribute xmlAttr = finder.getXMLAttribute(annotation);
+					if (xmlAttr != null) {
+						doXmlAttribute(annotation, xmlAttr);
+					}
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				analyzer.error("During generation of a component on class %s, exception %s", clazz, e);
+			}
+		}
+
+		@Override
+		public void memberEnd() {
+			current = null;
+		}
+
+		@Override
+		public void classEnd() throws Exception {
+			current = null;
+			if (ocd.id == null) {
+				return; // no ObjectClassDefinition annotation found
+			}
+			String prefix = null;
+			if (prefixField != null) {
+				Object c = prefixField.getConstant();
+				if (c instanceof String) {
+					prefix = (String) c;
+					ocd.updateVersion(MetatypeVersion.VERSION_1_4);
+				} else {
+					analyzer.warning("Field PREFIX_ for %s does not have a String constant value: %s",
+							name.getFQN(), c);
+				}
+			}
+			String singleElementAnnotation = null;
+			if (hasValue && (hasNoDefault == 0)) {
+				StringBuilder sb = new StringBuilder(name.getShorterName());
+				boolean lastLowerCase = false;
+				for (int i = 0; i < sb.length(); i++) {
+					char c = sb.charAt(i);
+					if (Character.isUpperCase(c)) {
+						sb.setCharAt(i, Character.toLowerCase(c));
+						if (lastLowerCase) {
+							sb.insert(i++, '.');
+						}
+						lastLowerCase = false;
+					} else {
+						lastLowerCase = Character.isLowerCase(c);
+					}
+				}
+				singleElementAnnotation = sb.toString();
+				ocd.updateVersion(MetatypeVersion.VERSION_1_4);
+			}
+
+			for (Map.Entry<MethodDef,ADDef> entry : methods.entrySet()) {
+				MethodDef defined = entry.getKey();
+				if (defined.isConstructor()) {
+					analyzer.error("Constructor %s for %s.%s found; only interfaces and annotations allowed for OCDs",
+							defined.getName(), clazz.getClassName().getFQN(), defined.getName());
+		
+				}
+				if (defined.getPrototype().length > 0) {
+					analyzer.error(
+							"Element %s for %s.%s has parameters; only no-parameter elements in an OCD interface allowed",
+							defined.getName(), clazz.getClassName().getFQN(), defined.getName());
+					continue;
+				}
+				ADDef ad = entry.getValue();
+				ocd.attributes.add(ad);
+				String key = defined.getName();
+				if ((singleElementAnnotation != null) && key.equals("value")) {
+					key = singleElementAnnotation;
+				} else {
+					key = identifierToPropertyName(key);
+				}
+				if (prefix != null) {
+					key = prefix + key;
+				}
+				ad.id = key;
+				ad.name = space(defined.getName());
+				String rtype = defined.getGenericReturnType();
+				if (rtype.endsWith("[]")) {
+					ad.cardinality = Integer.MAX_VALUE;
+					rtype = rtype.substring(0, rtype.length() - 2);
+				}
+				Matcher m = GENERIC.matcher(rtype);
+				if (m.matches()) {
+					boolean knownCollection = m.group(2) != null;
+					boolean collection = knownCollection || identifiableCollection(m.group(3), false, true);
+					if (collection) {
+						if (ad.cardinality != 0)
+							analyzer.error(
+									"AD for %s.%s uses an array of collections in return type (%s), Metatype allows either Vector or array",
+									clazz.getClassName().getFQN(), defined.getName(), defined.getType().getFQN());
+						rtype = Clazz.objectDescriptorToFQN(m.group(4));
+						ad.cardinality = Integer.MIN_VALUE;
+					}
+				}
+				if (rtype.indexOf('<') > 0) {
+					rtype = rtype.substring(0, rtype.indexOf('<'));
+				}
+				ad.type = getType(rtype);
+		
+				ad.required = true;
+				TypeRef typeRef = analyzer.getTypeRefFromFQN(rtype);
+				try {
+					Clazz c = analyzer.findClass(typeRef);
+					if (c != null && c.isEnum()) {
+						parseOptionValues(c, ad.options);
+					}
+				} catch (Exception e) {
+					analyzer.exception(e, "AD for %s.%s Can not parse option values from type (%s), %s",
+							clazz.getClassName().getFQN(), defined.getName(), defined.getType().getFQN(), e);
+				}
+				if (ad.ad != null) {
+					doAD(ad);
+				}
+				if (ad.defaults == null && clazz.isAnnotation() && defined.getConstant() != null) {
+					// defaults from annotation default
+					Object value = defined.getConstant();
+					boolean isClass = false;
+					TypeRef type = defined.getType().getClassRef();
+					if (!type.isPrimitive()) {
+						if (Class.class.getName().equals(type.getFQN())) {
+							isClass = true;
+						} else {
+							try {
+								Clazz r = analyzer.findClass(type);
+								if (r.isAnnotation()) {
+									analyzer.warning("Nested annotation type found in field %s, %s", defined.getName(),
+											type.getFQN());
+									return;
+								}
+							} catch (Exception e) {
+								analyzer.exception(e,
+										"Exception looking at annotation type default for element with descriptor %s,  type %s",
+										defined, type);
+							}
+						}
+					}
+					if (value != null) {
+						if (value.getClass().isArray()) {
+							// add element individually
+							ad.defaults = new String[Array.getLength(value)];
+							for (int i = 0; i < Array.getLength(value); i++) {
+								Object element = Array.get(value, i);
+								ad.defaults[i] = valueToProperty(element, isClass);
+							}
+						} else {
+							ad.defaults = new String[] {
+									valueToProperty(value, isClass)
+							};
 						}
 					}
 				}
-				TypeRef ext = clazz.getSuper();
-				return ext != null && identifiableCollection(ext.getFQN(), false, false);
-			}
-		} catch (Exception e) {
-			return false;
-		}
-		return false;
-	}
-
-	private String valueToProperty(Object value, boolean isClass) {
-		if (isClass)
-			return ((TypeRef) value).getFQN();
-		return value.toString();
-	}
-
-	private void doAD(ADDef adDef) throws Exception {
-		AttributeDefinition ad = adDef.ad;
-		Annotation a = adDef.a;
-
-		if (ad.name() != null) {
-			adDef.name = ad.name();
-		}
-		adDef.description = a.get("description");
-		if (a.get("type") != null) {
-			adDef.type = ad.type();
-		}
-		if (a.get("cardinality") != null) {
-			adDef.cardinality = ad.cardinality();
-		}
-		adDef.max = ad.max();
-		adDef.min = ad.min();
-		if (a.get("defaultValue") != null) {
-			adDef.defaults = ad.defaultValue();
-		}
-		if (a.get("required") != null) {
-			adDef.required = ad.required();
-		}
-		if (a.get("options") != null) {
-			adDef.options.clear();
-			for (Object o : (Object[]) a.get("options")) {
-				Option opt = ((Annotation) o).getAnnotation();
-				adDef.options.add(new OptionDef(opt.label(), opt.value()));
 			}
 		}
 
-	}
-
-	static final Pattern IDENTIFIERTOPROPERTY = Pattern.compile("(__)|(_)|(\\$_\\$)|(\\$\\$)|(\\$)");
-
-	private String identifierToPropertyName(String name) {
-		Matcher m = IDENTIFIERTOPROPERTY.matcher(name);
-		StringBuffer b = new StringBuffer();
-		while (m.find()) {
-			String replacement;// null;
-			if (m.group(1) != null) // __ to _
-				replacement = "_";
-			else if (m.group(2) != null) // _ to .
-				replacement = ".";
-			else if (m.group(3) != null) { // $_$ to -
-				replacement = "-";
-				ocd.updateVersion(MetatypeVersion.VERSION_1_4);
+		private void doOCD(ObjectClassDefinition o, Annotation annotation) {
+			if (ocd.id == null) {
+				if (clazz.isInterface()) {
+					ocd.id = o.id() == null ? name.getFQN() : o.id();
+					ocd.name = o.name() == null ? space(ocd.id) : o.name();
+					ocd.description = o.description() == null ? "" : o.description();
+					ocd.localization = o.localization() == null ? "OSGI-INF/l10n/" + name.getFQN() : o.localization();
+					if (annotation.get("pid") != null) {
+						String[] pids = o.pid();
+						designates(pids, false);
+					}
+					if (annotation.get("factoryPid") != null) {
+						String[] pids = o.factoryPid();
+						designates(pids, true);
+					}
+					if (annotation.get("icon") != null) {
+						Icon[] icons = o.icon();
+						for (Icon icon : icons) {
+							ocd.icons.add(new IconDef(icon.resource(), icon.size()));
+						}
+					}
+				} else {
+					analyzer.error("ObjectClassDefinition applied to non-interface, non-annotation class %s", clazz);
+				}
 			}
-			else if (m.group(4) != null) // $$ to $
-				replacement = "\\$";
-			else // $ removed.
-				replacement = "";
-
-			m.appendReplacement(b, replacement);
-		}
-		m.appendTail(b);
-		return b.toString();
-	}
-
-	static String space(String name) {
-		return Clazz.unCamel(name);
-	}
-
-	AttributeType getType(String rtype) {
-		if (rtype.endsWith("[]")) {
-			analyzer.error("Can only handle array of depth one field , nested type %s", rtype);
-			return null;
 		}
 
-		if ("boolean".equals(rtype) || Boolean.class.getName().equals(rtype))
-			return AttributeType.BOOLEAN;
-		else if ("byte".equals(rtype) || Byte.class.getName().equals(rtype))
-			return AttributeType.BYTE;
-		else if ("char".equals(rtype) || Character.class.getName().equals(rtype))
-			return AttributeType.CHARACTER;
-		else if ("short".equals(rtype) || Short.class.getName().equals(rtype))
-			return AttributeType.SHORT;
-		else if ("int".equals(rtype) || Integer.class.getName().equals(rtype))
-			return AttributeType.INTEGER;
-		else if ("long".equals(rtype) || Long.class.getName().equals(rtype))
-			return AttributeType.LONG;
-		else if ("float".equals(rtype) || Float.class.getName().equals(rtype))
-			return AttributeType.FLOAT;
-		else if ("double".equals(rtype) || Double.class.getName().equals(rtype))
-			return AttributeType.DOUBLE;
-		else if (String.class.getName().equals(rtype) || Class.class.getName().equals(rtype) || acceptableType(rtype))
-			return AttributeType.STRING;
-		else {
-			return null;
+		private void doAD(ADDef adDef) throws Exception {
+			AttributeDefinition ad = adDef.ad;
+			Annotation a = adDef.a;
 
+			if (ad.name() != null) {
+				adDef.name = ad.name();
+			}
+			adDef.description = a.get("description");
+			if (a.get("type") != null) {
+				adDef.type = ad.type();
+			}
+			if (a.get("cardinality") != null) {
+				adDef.cardinality = ad.cardinality();
+			}
+			adDef.max = ad.max();
+			adDef.min = ad.min();
+			if (a.get("defaultValue") != null) {
+				adDef.defaults = ad.defaultValue();
+			}
+			if (a.get("required") != null) {
+				adDef.required = ad.required();
+			}
+			if (a.get("options") != null) {
+				adDef.options.clear();
+				for (Object o : (Object[]) a.get("options")) {
+					Option opt = ((Annotation) o).getAnnotation();
+					adDef.options.add(new OptionDef(opt.label(), opt.value()));
+				}
+			}
 		}
-	}
 
-	private boolean acceptableType(String rtype) {
-		TypeRef ref = analyzer.getTypeRefFromFQN(rtype);
-		try {
-			Clazz returnType = analyzer.findClass(ref);
-			if (returnType.isEnum()) {
-				return true;
-			}
-			// TODO check this is true for interfaces and annotations
-			if (!returnType.isAbstract() || (returnType.isInterface() && options.contains(Options.nested))) {
-				return true;
-			}
-			if (!returnType.isInterface()) {
-				analyzer.error("Abstract classes not allowed as interface method return values: %s", rtype);
+		private void doXmlAttribute(Annotation annotation, XMLAttribute xmlAttr) {
+			if (current == null) {
+				if (clazz.isInterface()) {
+					ocd.addExtensionAttribute(xmlAttr, annotation);
+				}
 			} else {
-				analyzer.error("Nested metatype only allowed with option: nested type %s", rtype);
+				current.addExtensionAttribute(xmlAttr, annotation);
+			}
+		}
+
+		private boolean identifiableCollection(String type, boolean intface, boolean topLevel) {
+			try {
+				Clazz clazz = analyzer.findClass(analyzer.getTypeRefFromFQN(type));
+				if (clazz != null && (!topLevel || !clazz.isAbstract())
+						&& ((intface && clazz.isInterface()) ^ clazz.hasPublicNoArgsConstructor())) {
+					TypeRef[] intfs = clazz.getInterfaces();
+					if (intfs != null) {
+						for (TypeRef intf : intfs) {
+							if (COLLECTION.matcher(intf.getFQN()).matches()
+									|| identifiableCollection(intf.getFQN(), true, false)) {
+								return true;
+							}
+						}
+					}
+					TypeRef ext = clazz.getSuper();
+					return ext != null && identifiableCollection(ext.getFQN(), false, false);
+				}
+			} catch (Exception e) {
+				return false;
 			}
 			return false;
-		} catch (Exception e) {
-			analyzer.exception(e, "could not examine class for return type %s, exception message: %s", rtype, e);
-			return false;
 		}
-	}
 
-	private void parseOptionValues(Clazz c, final List<OptionDef> options) throws Exception {
-
-		c.parseClassFileWithCollector(new ClassDataCollector() {
-			@Override
-			public void field(Clazz.FieldDef def) {
-				if (def.isEnum()) {
-					OptionDef o = new OptionDef(def.getName(), def.getName());
-					options.add(o);
-				}
-			}
-		});
-	}
-
-	@Override
-	public void annotation(Annotation annotation) throws Exception {
-		try {
-			java.lang.annotation.Annotation a = annotation.getAnnotation();
-			if (a instanceof ObjectClassDefinition)
-				doOCD((ObjectClassDefinition) a, annotation);
-			else if (a instanceof AttributeDefinition) {
-				current.ad = (AttributeDefinition) a;
-				current.a = annotation;
-			} else {
-				XMLAttribute xmlAttr = finder.getXMLAttribute(annotation);
-				if (xmlAttr != null) {
-					doXmlAttribute(annotation, xmlAttr);
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			analyzer.error("During generation of a component on class %s, exception %s", clazz, e);
+		private String valueToProperty(Object value, boolean isClass) {
+			if (isClass)
+				return ((TypeRef) value).getFQN();
+			return value.toString();
 		}
-	}
 
-	private void doXmlAttribute(Annotation annotation, XMLAttribute xmlAttr) {
-		if (current == null) {
-			if (clazz.isInterface()) {
-				if (ocd == null)
-					ocd = new OCDDef(finder, minVersion);
-				ocd.addExtensionAttribute(xmlAttr, annotation);
-			}
-		} else {
-			current.addExtensionAttribute(xmlAttr, annotation);
-		}
-	}
-
-	private void doOCD(ObjectClassDefinition o, Annotation annotation) {
-		if (topLevel) {
-			if (clazz.isInterface()) {
-				if (ocd == null)
-					ocd = new OCDDef(finder, minVersion);
-				ocd.id = o.id() == null ? name.getFQN() : o.id();
-				ocd.name = o.name() == null ? space(ocd.id) : o.name();
-				ocd.description = o.description() == null ? "" : o.description();
-				ocd.localization = o.localization() == null ? "OSGI-INF/l10n/" + name.getFQN() : o.localization();
-				if (annotation.get("pid") != null) {
-					String[] pids = o.pid();
-					designates(pids, false);
-				}
-				if (annotation.get("factoryPid") != null) {
-					String[] pids = o.factoryPid();
-					designates(pids, true);
-				}
-				if (annotation.get("icon") != null) {
-					Icon[] icons = o.icon();
-					for (Icon icon : icons) {
-						ocd.icons.add(new IconDef(icon.resource(), icon.size()));
+		private void parseOptionValues(Clazz c, final List<OptionDef> options) throws Exception {
+		
+			c.parseClassFileWithCollector(new ClassDataCollector() {
+				@Override
+				public void field(Clazz.FieldDef def) {
+					if (def.isEnum()) {
+						OptionDef o = new OptionDef(def.getName(), def.getName());
+						options.add(o);
 					}
 				}
-			} else {
-				analyzer.error("ObjectClassDefinition applied to non-interface, non-annotation class %s", clazz);
+			});
+		}
+
+		private AttributeType getType(String rtype) {
+			if (rtype.endsWith("[]")) {
+				analyzer.error("Can only handle array of depth one field , nested type %s", rtype);
+				return null;
+			}
+		
+			if ("boolean".equals(rtype) || Boolean.class.getName().equals(rtype))
+				return AttributeType.BOOLEAN;
+			else if ("byte".equals(rtype) || Byte.class.getName().equals(rtype))
+				return AttributeType.BYTE;
+			else if ("char".equals(rtype) || Character.class.getName().equals(rtype))
+				return AttributeType.CHARACTER;
+			else if ("short".equals(rtype) || Short.class.getName().equals(rtype))
+				return AttributeType.SHORT;
+			else if ("int".equals(rtype) || Integer.class.getName().equals(rtype))
+				return AttributeType.INTEGER;
+			else if ("long".equals(rtype) || Long.class.getName().equals(rtype))
+				return AttributeType.LONG;
+			else if ("float".equals(rtype) || Float.class.getName().equals(rtype))
+				return AttributeType.FLOAT;
+			else if ("double".equals(rtype) || Double.class.getName().equals(rtype))
+				return AttributeType.DOUBLE;
+			else if (String.class.getName().equals(rtype) || Class.class.getName().equals(rtype) || acceptableType(rtype))
+				return AttributeType.STRING;
+			else {
+				return null;
+		
+			}
+		}
+
+		private boolean acceptableType(String rtype) {
+			TypeRef ref = analyzer.getTypeRefFromFQN(rtype);
+			try {
+				Clazz returnType = analyzer.findClass(ref);
+				if (returnType.isEnum()) {
+					return true;
+				}
+				// TODO check this is true for interfaces and annotations
+				if (!returnType.isAbstract() || (returnType.isInterface() && options.contains(Options.nested))) {
+					return true;
+				}
+				if (!returnType.isInterface()) {
+					analyzer.error("Abstract classes not allowed as interface method return values: %s", rtype);
+				} else {
+					analyzer.error("Nested metatype only allowed with option: nested type %s", rtype);
+				}
+				return false;
+			} catch (Exception e) {
+				analyzer.exception(e, "could not examine class for return type %s, exception message: %s", rtype, e);
+				return false;
+			}
+		}
+
+		private String identifierToPropertyName(String name) {
+			Matcher m = IDENTIFIERTOPROPERTY.matcher(name);
+			StringBuffer b = new StringBuffer();
+			while (m.find()) {
+				String replacement;// null;
+				if (m.group(1) != null) // __ to _
+					replacement = "_";
+				else if (m.group(2) != null) // _ to .
+					replacement = ".";
+				else if (m.group(3) != null) { // $_$ to -
+					replacement = "-";
+					ocd.updateVersion(MetatypeVersion.VERSION_1_4);
+				}
+				else if (m.group(4) != null) // $$ to $
+					replacement = "\\$";
+				else // $ removed.
+					replacement = "";
+
+				m.appendReplacement(b, replacement);
+			}
+			m.appendTail(b);
+			return b.toString();
+		}
+
+		private String space(String name) {
+			return Clazz.unCamel(name);
+		}
+
+		private void designates(String[] pids, boolean factory) {
+			for (String pid : pids) {
+				ocd.designates.add(new DesignateDef(ocd.id, pid, factory, finder));
 			}
 		}
 	}
-
-	private void designates(String[] pids, boolean factory) {
-		for (String pid : pids) {
-			ocd.designates.add(new DesignateDef(ocd.id, pid, factory, finder));
-		}
-	}
-
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -2053,7 +2053,7 @@ public class Clazz {
 		StringBuilder out = new StringBuilder();
 		for (int i = 0; i < id.length(); i++) {
 			char c = id.charAt(i);
-			if (c == '_' || c == '$' || c == '.') {
+			if (c == '_' || c == '$' || c == '-' || c == '.') {
 				if (out.length() > 0 && !Character.isWhitespace(out.charAt(out.length() - 1)))
 					out.append(' ');
 				continue;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -224,7 +224,7 @@ public class Descriptors {
 		@Override
 		public String getShorterName() {
 			String name = getShortName();
-			int n = name.indexOf('$');
+			int n = name.lastIndexOf('$');
 			if (n <= 0)
 				return name;
 


### PR DESCRIPTION
This adds support for 

- [x] `$_$` to `-` mapping
- [x]  `PREFIX_` name prefixing
- [x] `value` mapping for Single-element annotations
