### PR TITLE
gradle: No reason to depend on assemble for testOSGi and release tasks

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -242,7 +242,6 @@ public class BndPlugin implements Plugin<Project> {
 
       task('release') {
         description 'Release the project to the release repository.'
-        dependsOn assemble
         group 'release'
         enabled !bndProject.isNoBundles() && !bnd(Constants.RELEASEREPO, 'unset').empty
         inputs.files jar
@@ -273,7 +272,6 @@ public class BndPlugin implements Plugin<Project> {
 
       task('testOSGi') {
         description 'Runs the OSGi JUnit tests by launching a framework and running the tests in the launched framework.'
-        dependsOn assemble
         group 'verification'
         enabled !bndis(Constants.NOJUNITOSGI) && !bndUnprocessed(Constants.TESTCASES, '').empty
         ext.ignoreFailures = false


### PR DESCRIPTION
The inputs.files jar statement means the task will depend on the jar
task.