### PR TITLE
gradle: Support configuring Workspace after construction

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -93,6 +93,9 @@ public class BndWorkspacePlugin implements Plugin<Object> {
       Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
       Workspace.addGestalt(Constants.GESTALT_BATCH, null)
       Workspace workspace = new Workspace(rootDir, cnf).setOffline(startParameter.offline)
+      if (gradle.ext.has('bndWorkspaceConfigure')) {
+        gradle.bndWorkspaceConfigure(workspace)
+      }
 
       /* Add each project and its dependencies to the graph */
       projectNames.each { String projectName ->
@@ -120,6 +123,9 @@ public class BndWorkspacePlugin implements Plugin<Object> {
       Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
       Workspace.addGestalt(Constants.GESTALT_BATCH, null)
       ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
+      if (gradle.ext.has('bndWorkspaceConfigure')) {
+        gradle.bndWorkspaceConfigure(bndWorkspace)
+      }
 
       /* Configure cnf project */
       Project cnfProject = findProject(bnd_cnf)


### PR DESCRIPTION
The gradle.ext.bndWorkspaceConfigure property can be set to a closure
that is passed the Workspace object after construction. The closure can
then further configure the Workspace object.