### PR TITLE
gradle: Provide access to gradle properties for bnd files

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -29,6 +29,7 @@ import java.util.zip.ZipFile
 import aQute.bnd.osgi.Builder
 import aQute.bnd.osgi.Constants
 import aQute.bnd.osgi.Jar
+import aQute.bnd.osgi.Processor
 import aQute.bnd.version.MavenVersion
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.Configuration
@@ -137,7 +138,10 @@ class BundleTaskConvention {
   void buildBundle() {
     task.configure {
       // create Builder
-      new Builder().withCloseable { builder ->
+      Properties gradleProperties = new PropertiesWrapper()
+      gradleProperties.put('task', task)
+      gradleProperties.put('project', project)
+      new Builder(new Processor(gradleProperties, false)).withCloseable { builder ->
         // load bnd properties
         File temporaryBndFile = File.createTempFile('bnd', '.bnd', temporaryDir)
         temporaryBndFile.withWriter('UTF-8') { writer ->
@@ -155,7 +159,6 @@ class BundleTaskConvention {
           }
         }
         builder.setProperties(temporaryBndFile, project.projectDir) // this will cause project.dir property to be set
-        builder.setProperty('project.name', project.name)
         builder.setProperty('project.output', project.buildDir.canonicalPath)
 
         // If no bundle to be built, we have nothing to do

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
@@ -1,0 +1,30 @@
+/**
+ * PropertiesWrapper for Gradle.
+ *
+ */
+
+package aQute.bnd.gradle
+
+class PropertiesWrapper extends Properties {
+  PropertiesWrapper() {}
+
+  @Override
+  public String getProperty(String key) {
+    final int i = key.indexOf('.')
+    final String name = (i > 0) ? key.substring(0, i) : key
+    Object value = get(name)
+    if ((value != null) && (i > 0)) {
+      try {
+        value = key.substring(i + 1).split(/\./).inject(value) { obj, prop ->
+          obj?."${prop}"
+        }
+      } catch (MissingPropertyException mpe) {
+        value = null
+      }
+    }
+    if (value == null) {
+      return null
+    }
+    return value.toString()
+  }
+}

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -62,6 +62,10 @@ class TestBundlePlugin extends Specification {
           jartask_manifest.getValue('Project-Sourcepath')
           jartask_manifest.getValue('Project-Buildpath')
           jartask_manifest.getValue('Bundle-ClassPath') =~ /commons-lang-2\.6\.jar/
+          jartask_manifest.getValue('Gradle-Project-Prop') == 'prop.project'
+          jartask_manifest.getValue('Gradle-Task-Prop') == 'prop.task'
+          jartask_manifest.getValue('Gradle-Task-Project-Prop') == 'prop.project'
+          jartask_manifest.getValue('Gradle-Missing-Prop') == '${task.projectprop}'
           jartask_jar.getEntry('doubler/Doubler.class')
           jartask_jar.getEntry('doubler/packageinfo')
           jartask_jar.getEntry('doubler/impl/DoublerImpl.class')

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/bnd.bnd
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/bnd.bnd
@@ -9,3 +9,7 @@ Project-Output: ${project.output}
 Project-Sourcepath: ${project.sourcepath}
 Project-Buildpath: ${project.buildpath}
 -includeresource.lib: commons-lang-2.6.jar;lib:=true
+Gradle-Project-Prop: ${project.projectprop}
+Gradle-Task-Prop: ${task.taskprop}
+Gradle-Task-Project-Prop: ${task.project.projectprop}
+Gradle-Missing-Prop: ${task.projectprop}

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'biz.aQute.bnd.builder'
 }
 
+ext.projectprop = 'prop.project'
 version = '1.0.0'
 
 repositories {
@@ -21,6 +22,7 @@ dependencies {
 }
 
 jar {
+  ext.taskprop = 'prop.task'
     manifest {
         attributes('Implementation-Title': baseName,
                    'Implementation-Version': version,


### PR DESCRIPTION
‘task’ stub provides access to the task’s gradle properties. ‘project’
stub provides access to the project’s gradle properties.