### PR TITLE
Support OSGi 4.2 runtimes with junit/tester/launcher

### DIFF
--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -1,11 +1,12 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/eclipse/jdt.bnd
 
--buildpath: ${junit},\
-	osgi.cmpn;version=4.3.1,\
+-buildpath: \
+	osgi.core;version=4.2,\
+	osgi.cmpn;version=4.2,\
 	biz.aQute.bndlib;version=project,\
 	aQute.libg;version=project,\
-	osgi.core;version=4.3.1
+    ${junit}
 	
 Tester-Plugin: aQute.junit.plugin.ProjectTesterImpl
 

--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -132,7 +132,7 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 			}
 			if (testBundle != null) {
 				for (Bundle b : context.getBundles()) {
-					String testcasesheader = b.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES);
+					String testcasesheader = (String) b.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES);
 					if (testcasesheader != null) {
 						testBundle = b;
 						break;
@@ -218,7 +218,8 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 				Writer report = getReportWriter(reportDir, bundle);
 				try {
 					trace("test will run");
-					result += test(bundle, bundle.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES), report);
+					result += test(bundle, (String) bundle.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES),
+							report);
 					trace("test ran");
 					if (queue.isEmpty() && !continuous) {
 						trace("queue " + queue);
@@ -237,7 +238,7 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 
 	void checkBundle(List<Bundle> queue, Bundle bundle) {
 		if (bundle.getState() == Bundle.ACTIVE) {
-			String testcases = bundle.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES);
+			String testcases = (String) bundle.getHeaders().get(aQute.bnd.osgi.Constants.TESTCASES);
 			if (testcases != null) {
 				trace("found active bundle with test cases %s : %s", bundle, testcases);
 				synchronized (queue) {

--- a/biz.aQute.junit/src/aQute/junit/JunitXmlReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JunitXmlReport.java
@@ -75,7 +75,7 @@ public class JunitXmlReport implements TestReporter {
 		}
 
 		if (targetBundle != null) {
-			String header = targetBundle.getHeaders().get(aQute.bnd.osgi.Constants.BND_ADDXMLTOTEST);
+			String header = (String) targetBundle.getHeaders().get(aQute.bnd.osgi.Constants.BND_ADDXMLTOTEST);
 			if (header != null) {
 				StringTokenizer st = new StringTokenizer(header, " ,");
 

--- a/biz.aQute.junit/src/aQute/junit/runtime/OSGiTestCase.java
+++ b/biz.aQute.junit/src/aQute/junit/runtime/OSGiTestCase.java
@@ -53,7 +53,7 @@ public abstract class OSGiTestCase extends TestCase {
 	 */
 	protected void assertSvcAvail(String message, Class< ? > service, String filter) {
 		BundleContext context = getBundleContext();
-		ServiceReference< ? >[] refs = null;
+		ServiceReference[] refs = null;
 		try {
 			refs = context.getServiceReferences(service.getName(), filter);
 		} catch (InvalidSyntaxException e) {
@@ -141,18 +141,18 @@ public abstract class OSGiTestCase extends TestCase {
 			throws Exception {
 		BundleContext context = getBundleContext();
 
-		ServiceTracker< ? , ? > tracker = null;
+		ServiceTracker tracker = null;
 		if (filter != null) {
 			try {
 				Filter combined = FrameworkUtil
 						.createFilter("(" + Constants.OBJECTCLASS + "=" + service.getName() + ")");
-				tracker = new ServiceTracker<Object,Object>(context, combined, null);
+				tracker = new ServiceTracker(context, combined, null);
 			} catch (InvalidSyntaxException e) {
 				fail("Invalid filter syntax.");
 				return null;
 			}
 		} else {
-			tracker = new ServiceTracker<Object,Object>(context, service.getName(), null);
+			tracker = new ServiceTracker(context, service.getName(), null);
 		}
 		try {
 			tracker.open();

--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -5,7 +5,7 @@
 
 -buildpath: biz.aQute.bndlib;version=project,\
 	aQute.libg;version=project,\
-	osgi.core;version=4.3.1,\
+	osgi.core;version=4.2,\
 	slf4j.api;version=latest
 
 -testpath: \

--- a/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
+++ b/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
@@ -161,11 +161,11 @@ public class SimplePermissionPolicy implements SynchronousBundleListener {
 	}
 
 	private PermissionAdmin getPermissionAdmin() {
-		ServiceReference<PermissionAdmin> ref = context.getServiceReference(PermissionAdmin.class);
+		ServiceReference ref = context.getServiceReference(PermissionAdmin.class.getName());
 		if (ref == null)
 			return null;
 
-		return context.getService(ref);
+		return (PermissionAdmin) context.getService(ref);
 	}
 
 	/**

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
@@ -110,40 +110,49 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 		jar.close();
 	}
 
+	@Override
 	public BundleContext getBundleContext() {
 		return this;
 	}
 
+	@Override
 	public long getBundleId() {
 		return id;
 	}
 
+	@Override
 	public URL getEntry(String path) {
 		if (path.startsWith("/"))
 			path = path.substring(1);
 		return getResource(path);
 	}
 
+	@Override
 	public Enumeration<String> getEntryPaths(String path) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Dictionary<String,String> getHeaders() {
 		return new Dict();
 	}
 
+	@Override
 	public Dictionary<String,String> getHeaders(String locale) {
 		return new Dict();
 	}
 
+	@Override
 	public long getLastModified() {
 		return jarFile.lastModified();
 	}
 
+	@Override
 	public String getLocation() {
 		return location;
 	}
 
+	@Override
 	public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
 
 		try {
@@ -206,26 +215,32 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 		return paths;
 	}
 
-	public ServiceReference< ? >[] getRegisteredServices() {
+	@Override
+	public ServiceReference[] getRegisteredServices() {
 		return null;
 	}
 
-	public ServiceReference< ? >[] getServicesInUse() {
+	@Override
+	public ServiceReference[] getServicesInUse() {
 		return null;
 	}
 
+	@Override
 	public Map<X509Certificate,List<X509Certificate>> getSignerCertificates(int signersType) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public int getState() {
 		return state;
 	}
 
+	@Override
 	public String getSymbolicName() {
 		return getHeaders().get(aQute.bnd.osgi.Constants.BUNDLE_SYMBOLICNAME).trim();
 	}
 
+	@Override
 	public Version getVersion() {
 		String v = getHeaders().get(aQute.bnd.osgi.Constants.BUNDLE_VERSION).trim();
 		if (v == null)
@@ -233,106 +248,132 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 		return new Version(v);
 	}
 
+	@Override
 	public boolean hasPermission(Object permission) {
 		return true;
 	}
 
+	@Override
 	public void start() throws BundleException {
 		state = Bundle.ACTIVE;
 	}
 
+	@Override
 	public void start(int options) throws BundleException {
 		state = Bundle.ACTIVE;
 	}
 
+	@Override
 	public void stop() throws BundleException {
 		state = Bundle.RESOLVED;
 	}
 
+	@Override
 	public void stop(int options) throws BundleException {
 		state = Bundle.RESOLVED;
 	}
 
+	@Override
 	public void uninstall() throws BundleException {
 		state = Bundle.UNINSTALLED;
 	}
 
+	@Override
 	public void update() throws BundleException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void update(InputStream in) throws BundleException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void addBundleListener(BundleListener listener) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void addFrameworkListener(FrameworkListener listener) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void addServiceListener(ServiceListener listener) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void addServiceListener(ServiceListener listener, String filter) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Filter createFilter(String filter) throws InvalidSyntaxException {
 		throw new UnsupportedOperationException();
 	}
 
-	public ServiceReference< ? >[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	@Override
+	public ServiceReference[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Bundle getBundle() {
 		return this;
 	}
 
+	@Override
 	public Bundle getBundle(long id) {
 		return fw.getBundle(id);
 	}
 
+	@Override
 	public Bundle[] getBundles() {
 		return fw.getBundles();
 	}
 
+	@Override
 	public File getDataFile(String filename) {
 		return null;
 	}
 
+	@Override
 	public String getProperty(String key) {
 		return fw.getProperty(key);
 	}
 
-	public ServiceReference< ? > getServiceReference(String clazz) {
+	@Override
+	public ServiceReference getServiceReference(String clazz) {
 		return null;
 	}
 
-	public ServiceReference< ? >[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	@Override
+	public ServiceReference[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		return null;
 	}
 
+	@Override
 	public Bundle installBundle(String location) throws BundleException {
 		return fw.installBundle(location);
 	}
 
+	@Override
 	public Bundle installBundle(String location, InputStream input) throws BundleException {
 		return fw.installBundle(location, input);
 	}
 
+	@Override
 	public void removeBundleListener(BundleListener listener) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void removeFrameworkListener(FrameworkListener listener) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void removeServiceListener(ServiceListener listener) {
 		throw new UnsupportedOperationException();
 	}
@@ -343,54 +384,47 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	}
 
 	public int compareTo(Bundle var0) {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 
-	public ServiceRegistration< ? > registerService(String[] clazzes, Object service,
-			Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	@Override
+	public ServiceRegistration registerService(String[] clazzes, Object service, Dictionary properties) {
 		return null;
 	}
 
-	public ServiceRegistration< ? > registerService(String clazz, Object service, Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	@Override
+	public ServiceRegistration registerService(String clazz, Object service, Dictionary properties) {
 		return null;
 	}
 
-	public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	public ServiceRegistration registerService(Class< ? > clazz, Object service, Dictionary<String, ? > properties) {
 		return null;
 	}
 
-	public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
-		// TODO Auto-generated method stub
+	public <S> ServiceReference getServiceReference(Class<S> clazz) {
 		return null;
 	}
 
-	public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+	public <S> Collection<ServiceReference> getServiceReferences(Class<S> clazz, String filter)
 			throws InvalidSyntaxException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
-	public <S> S getService(ServiceReference<S> reference) {
-		// TODO Auto-generated method stub
+	@Override
+	public Object getService(ServiceReference reference) {
 		return null;
 	}
 
-	public boolean ungetService(ServiceReference< ? > reference) {
-		// TODO Auto-generated method stub
+	@Override
+	public boolean ungetService(ServiceReference reference) {
 		return false;
 	}
 
 	public Bundle getBundle(String location) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	public <A> A adapt(Class<A> type) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
@@ -46,10 +46,12 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		last = loader = getClass().getClassLoader();
 	}
 
+	@Override
 	public void init() throws BundleException {
 		state = Bundle.ACTIVE;
 	}
 
+	@Override
 	public FrameworkEvent waitForStop(long timeout) throws InterruptedException {
 		long deadline = System.currentTimeMillis() + timeout;
 
@@ -64,101 +66,126 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		return new FrameworkEvent(FrameworkEvent.STOPPED, this, null);
 	}
 
+	@Override
 	public BundleContext getBundleContext() {
 		return this;
 	}
 
+	@Override
 	public long getBundleId() {
 		return 0;
 	}
 
+	@Override
 	public URL getEntry(String path) {
 		if (path.startsWith("/"))
 			path = path.substring(1);
 		return loader.getResource(path);
 	}
 
+	@Override
 	public Enumeration<String> getEntryPaths(String path) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Dictionary<String,String> getHeaders() {
 		return new Hashtable<String,String>();
 	}
 
+	@Override
 	public Dictionary<String,String> getHeaders(String locale) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public long getLastModified() {
 		return 0;
 	}
 
+	@Override
 	public String getLocation() {
 		return "System Bundle";
 	}
 
+	@Override
 	public URL getResource(String name) {
 		return loader.getResource(name);
 	}
 
+	@Override
 	public Enumeration<URL> getResources(String name) throws IOException {
 		return loader.getResources(name);
 	}
 
+	@Override
 	public int getState() {
 		return Bundle.ACTIVE;
 	}
 
+	@Override
 	public String getSymbolicName() {
 		return "system.bundle";
 	}
 
+	@Override
 	public Version getVersion() {
 		return new Version("1.0");
 	}
 
+	@Override
 	public boolean hasPermission(Object permission) {
 		return true;
 	}
 
+	@Override
 	public Class< ? > loadClass(String name) throws ClassNotFoundException {
 		return loader.loadClass(name);
 	}
 
+	@Override
 	public void start() {}
 
+	@Override
 	public void start(int options) {}
 
+	@Override
 	public synchronized void stop() {
 		state = Bundle.UNINSTALLED;
 		notifyAll();
 	}
 
+	@Override
 	public void stop(int options) throws BundleException {}
 
+	@Override
 	public Bundle getBundle() {
 		return this;
 	}
 
+	@Override
 	public Bundle getBundle(long id) {
 		Long l = new Long(id);
 		Bundle b = bundles.get(l);
 		return b;
 	}
 
+	@Override
 	public Bundle[] getBundles() {
 		return bundles.values().toArray(new Bundle[0]);
 	}
 
+	@Override
 	public File getDataFile(String filename) {
 		return null;
 	}
 
+	@Override
 	public String getProperty(String key) {
 		return properties.getProperty(key);
 	}
 
+	@Override
 	public Bundle installBundle(String location) throws BundleException {
 		try {
 			if (location.startsWith("reference:"))
@@ -178,6 +205,7 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		}
 	}
 
+	@Override
 	public Bundle installBundle(String location, InputStream in) throws BundleException {
 		Context c;
 		try {
@@ -200,74 +228,92 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		}
 	}
 
+	@Override
 	public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
 		throw new UnsupportedOperationException();
 	}
 
-	public ServiceReference< ? >[] getRegisteredServices() {
+	@Override
+	public ServiceReference[] getRegisteredServices() {
 		throw new UnsupportedOperationException();
 	}
 
-	public ServiceReference< ? >[] getServicesInUse() {
+	@Override
+	public ServiceReference[] getServicesInUse() {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public Map<X509Certificate,List<X509Certificate>> getSignerCertificates(int signersType) {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void uninstall() throws BundleException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void update() throws BundleException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void update(InputStream in) throws BundleException {
 		throw new UnsupportedOperationException();
 	}
 
+	@Override
 	public void addBundleListener(BundleListener listener) {
 		// no services so cannot do any harm
 	}
 
+	@Override
 	public void addFrameworkListener(FrameworkListener listener) {
 		// no services so cannot do any harm
 	}
 
+	@Override
 	public void addServiceListener(ServiceListener listener) {
 		// no services so cannot do any harm
 	}
 
+	@Override
 	public void addServiceListener(ServiceListener listener, String filter) {
 		// no services so cannot do any harm
 	}
 
+	@Override
 	public Filter createFilter(String filter) throws InvalidSyntaxException {
 		return FrameworkUtil.createFilter(filter);
 	}
 
-	public ServiceReference< ? >[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	@Override
+	public ServiceReference[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		throw new UnsupportedOperationException();
 	}
 
-	public ServiceReference< ? > getServiceReference(String clazz) {
+	@Override
+	public ServiceReference getServiceReference(String clazz) {
 		return null;
 	}
 
-	public ServiceReference< ? >[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	@Override
+	public ServiceReference[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		return null;
 	}
 
+	@Override
 	public void removeBundleListener(BundleListener listener) {
 		// ok
 	}
 
+	@Override
 	public void removeFrameworkListener(FrameworkListener listener) {
 		// ok
 	}
 
+	@Override
 	public void removeServiceListener(ServiceListener listener) {
 		// ok
 	}
@@ -296,50 +342,44 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		return 0;
 	}
 
-	public ServiceRegistration< ? > registerService(String[] clazzes, Object service,
-			Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	@Override
+	public ServiceRegistration registerService(String[] clazzes, Object service, Dictionary properties) {
 		return null;
 	}
 
-	public ServiceRegistration< ? > registerService(String clazz, Object service, Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	@Override
+	public ServiceRegistration registerService(String clazz, Object service, Dictionary properties) {
 		return null;
 	}
 
-	public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ? > properties) {
-		// TODO Auto-generated method stub
+	public <S> ServiceRegistration registerService(Class<S> clazz, S service, Dictionary<String, ? > properties) {
 		return null;
 	}
 
-	public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
-		// TODO Auto-generated method stub
+	public <S> ServiceReference getServiceReference(Class<S> clazz) {
 		return null;
 	}
 
-	public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+	public <S> Collection<ServiceReference> getServiceReferences(Class<S> clazz, String filter)
 			throws InvalidSyntaxException {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
-	public <S> S getService(ServiceReference<S> reference) {
-		// TODO Auto-generated method stub
+	@Override
+	public Object getService(ServiceReference reference) {
 		return null;
 	}
 
-	public boolean ungetService(ServiceReference< ? > reference) {
-		// TODO Auto-generated method stub
+	@Override
+	public boolean ungetService(ServiceReference reference) {
 		return false;
 	}
 
 	public Bundle getBundle(String location) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	public <A> A adapt(Class<A> type) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/biz.aQute.tester/bnd.bnd
+++ b/biz.aQute.tester/bnd.bnd
@@ -34,8 +34,8 @@ Conditional-Package: aQute.lib*
 
 -buildpath: \
 	biz.aQute.junit;version=latest;packages=aQute.junit.*, \
-	${junit},\
-	osgi.core;version=4.3.1,\
-	biz.aQute.bndlib;version=latest
+	osgi.core;version=4.2,\
+	biz.aQute.bndlib;version=latest,\
+	${junit}
 
 -baseline: *

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -1,7 +1,9 @@
 org.osgi:osgi.annotation:6.0.1
+org.osgi:org.osgi.core:4.2.0
 org.osgi:osgi.core:4.3.1
 org.osgi:osgi.core:5.0.0
 org.osgi:osgi.core:6.0.0
+org.osgi:org.osgi.compendium:4.2.0
 org.osgi:osgi.cmpn:4.3.1
 org.osgi:osgi.cmpn:5.0.0
 org.osgi:osgi.cmpn:6.0.0


### PR DESCRIPTION
This PR properly uses OSGi 4.2 companion code jars to target OSGi 4.2 runtimes. The Launcher code had to revert from using the Bundle Wiring API to the older Package Admin api for refreshing bundles.

Fixes https://github.com/bndtools/bnd/issues/1985
Closes https://github.com/bndtools/bnd/pull/1986