### PR TITLE
resource: avoid buffer creation

### DIFF
--- a/aQute.libg/src/aQute/lib/zip/ZipUtil.java
+++ b/aQute.libg/src/aQute/lib/zip/ZipUtil.java
@@ -1,6 +1,5 @@
 package aQute.lib.zip;
 
-import java.io.IOException;
 import java.util.TimeZone;
 import java.util.zip.ZipEntry;
 
@@ -12,94 +11,13 @@ import java.util.zip.ZipEntry;
 public class ZipUtil {
 	static TimeZone tz = TimeZone.getDefault();
 
-	public static long getModifiedTime(ZipEntry entry) throws IOException {
+	public static long getModifiedTime(ZipEntry entry) {
 		long time = entry.getTime();
 		time += tz.getOffset(time);
 		return Math.min(time, System.currentTimeMillis() - 1);
 	}
-	////
-	//
-	// byte[] extra = entry.getExtra();
-	// if ( extra != null) try {
-	// DataInputStream din = new DataInputStream( new
-	//// ByteArrayInputStream(extra));
-	//
-	// while (din.available() >= 0) {
-	// int type = din.readShort();
-	// int length = din.readShort();
-	//
-	// switch(type) {
-	// case 0x5455: // timestamp
-	// int flags = din.readByte();
-	// long modtime = -1L;
-	// long acctime = -1L;
-	// long crtime = -1L;
-	// if ( (flags & 1) != 0) {
-	// modtime = din.readInt();
-	// modtime *= 1000;
-	// }
-	// if ( (flags & 2) != 0) {
-	// acctime = din.readInt();
-	// acctime *= 1000;
-	// }
-	// if ( (flags & 4) != 0) {
-	// crtime = din.readInt();
-	// crtime *= 1000;
-	// }
-	//
-	// return modtime;
-	//
-	// default:
-	// din.skipBytes(length);
-	// break;
-	// }
-	// }
-	// } catch( Exception e) {
-	// // ignore
-	// }
-	//
-	// return entry.getTime();
-	// }
 
-	public static void setModifiedTime(ZipEntry entry, long utc) throws IOException {
-		// byte[] extra = entry.getExtra();
-		// ByteArrayOutputStream bout = new ByteArrayOutputStream();
-		// DataOutputStream dout = new DataOutputStream(bout);
-		//
-		// dout.writeShort(0x5455);
-		// dout.writeShort(5);
-		// dout.writeByte(1);
-		// dout.writeInt((int) (utc/1000));
-		//
-		// if ( extra != null) try {
-		// DataInputStream din = new DataInputStream( new
-		// ByteArrayInputStream(extra));
-		//
-		// while (din.available() >= 0) {
-		// int type = din.readShort();
-		// int length = din.readShort();
-		//
-		// switch(type) {
-		// case 0x5455: // timestamp
-		// din.skipBytes(length);
-		// break;
-		//
-		// default:
-		// dout.writeShort(type);
-		// dout.writeShort(length);
-		// while(length > 0) {
-		// dout.writeByte( din.readByte());
-		// }
-		// break;
-		// }
-		// }
-		//
-		// } catch( Exception e) {
-		// // ignore
-		// }
-		// dout.flush();
-		// entry.setExtra(bout.toByteArray());
-
+	public static void setModifiedTime(ZipEntry entry, long utc) {
 		utc -= tz.getOffset(utc);
 		entry.setTime(utc);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
@@ -15,9 +15,13 @@ public class FileResource implements Resource {
 	private final File	file;
 	private String		extra;
 	private boolean		deleteOnClose;
+	private final long				lastModified;
+	private final long				size;
 
 	public FileResource(File file) {
 		this.file = file;
+		lastModified = file.lastModified();
+		size = file.length();
 	}
 
 	/**
@@ -28,10 +32,14 @@ public class FileResource implements Resource {
 	 * @throws Exception
 	 */
 	public FileResource(Resource r) throws Exception {
-		this.file = File.createTempFile("fileresource", ".resource");
+		file = File.createTempFile("fileresource", ".resource");
 		deleteOnClose(true);
-		this.file.deleteOnExit();
-		IO.copy(r.openInputStream(), this.file);
+		file.deleteOnExit();
+		try (OutputStream out = IO.outputStream(file)) {
+			r.write(out);
+		}
+		lastModified = r.lastModified();
+		size = file.length();
 	}
 
 	@Override
@@ -82,7 +90,7 @@ public class FileResource implements Resource {
 	}
 
 	public long lastModified() {
-		return file.lastModified();
+		return lastModified;
 	}
 
 	public String getExtra() {
@@ -94,7 +102,7 @@ public class FileResource implements Resource {
 	}
 
 	public long size() {
-		return (int) file.length();
+		return size;
 	}
 
 	public void close() throws IOException {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
@@ -68,7 +68,11 @@ public class FileResource implements Resource {
 	}
 
 	public void write(OutputStream out) throws Exception {
-		IO.copy(buffer(), out);
+		if (buffer != null) {
+			IO.copy(buffer(), out);
+		} else {
+			IO.copy(file, out);
+		}
 	}
 
 	static void traverse(Jar jar, int rootlength, File directory, Pattern doNotCopy) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
@@ -67,7 +67,11 @@ public class URLResource implements Resource {
 	}
 
 	public void write(OutputStream out) throws Exception {
-		IO.copy(buffer(), out);
+		if (buffer != null) {
+			IO.copy(buffer(), out);
+		} else {
+			IO.copy(openConnection().getInputStream(), out);
+		}
 	}
 
 	public long lastModified() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
@@ -94,7 +94,11 @@ public class ZipResource implements Resource {
 	}
 
 	public void write(OutputStream out) throws Exception {
-		IO.copy(buffer(), out);
+		if (buffer != null) {
+			IO.copy(buffer(), out);
+		} else {
+			IO.copy(zip.getInputStream(entry), out);
+		}
 	}
 
 	public long lastModified() {


### PR DESCRIPTION
If a resource is called to write itself out, then use the buffer if it already had been created, otherwise just write out the resource. This can avoid creating the buffer entirely for some resources.