### PR TITLE
resource: Avoid using mapped ByteBuffers on Windows

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -516,8 +516,9 @@ public class bnd extends Processor {
 	 * @param base
 	 * @param path
 	 * @param report
+	 * @throws IOException
 	 */
-	private void add(Jar jar, File base, String path, boolean report) {
+	private void add(Jar jar, File base, String path, boolean report) throws IOException {
 		if (path.endsWith("/"))
 			path = path.substring(0, path.length() - 1);
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2263,9 +2263,8 @@ public class Analyzer extends Processor {
 				Resource resource = dot.getResource(path);
 				if (resource != null) {
 					try {
-						Jar jar = new Jar(path);
+						Jar jar = Jar.fromResource(path, resource);
 						addClose(jar);
-						EmbeddedResource.build(jar, resource);
 						analyzeJar(jar, "", true);
 					} catch (Exception e) {
 						warning("Invalid bundle classpath entry: %s: %s", path, e);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -450,9 +450,9 @@ public class Builder extends Analyzer {
 	}
 
 	/**
-	 *
+	 * @throws IOException
 	 */
-	private void addSources(Jar dot) {
+	private void addSources(Jar dot) throws Exception {
 		if (!hasSources())
 			return;
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/EmbeddedResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/EmbeddedResource.java
@@ -6,11 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import aQute.lib.io.IO;
-import aQute.lib.io.NonClosingInputStream;
 public class EmbeddedResource implements Resource {
 	private final ByteBuffer	buffer;
 	private final long			lastModified;
@@ -43,31 +40,8 @@ public class EmbeddedResource implements Resource {
 		return ":" + size() + ":";
 	}
 
-	public static void build(Jar jar, InputStream in, long lastModified) throws IOException {
-		try (ZipInputStream jin = new ZipInputStream(in)) {
-			InputStream read = new NonClosingInputStream(jin);
-			ZipEntry entry = jin.getNextEntry();
-			while (entry != null) {
-				if (!entry.isDirectory()) {
-					byte data[] = IO.read(read);
-					jar.putResource(entry.getName(), new EmbeddedResource(data, lastModified), true);
-				}
-				entry = jin.getNextEntry();
-			}
-			IO.drain(in);
-		}
-	}
-
 	public long lastModified() {
 		return lastModified;
-	}
-
-	public static void build(Jar sub, Resource resource) throws Exception {
-		try (InputStream in = resource.openInputStream()) {
-			build(sub, in, resource.lastModified());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
 	}
 
 	public String getExtra() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2622,17 +2622,16 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		try {
 			// Lets try a URL
 			URL url = new URL(name);
-			Jar jar = new Jar(fileName(url.getPath()));
-			addClose(jar);
 			URLConnection connection = url.openConnection();
 			try (InputStream in = connection.getInputStream()) {
 				long lastModified = connection.getLastModified();
-				if (lastModified == 0)
+				if (lastModified == 0L)
 					// We assume the worst :-(
 					lastModified = System.currentTimeMillis();
-				EmbeddedResource.build(jar, in, lastModified);
+				Jar jar = new Jar(fileName(url.getPath()), in, lastModified);
+				addClose(jar);
+				return jar;
 			}
-			return jar;
 		} catch (IOException ee) {
 			// ignore
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
@@ -2,17 +2,11 @@ package aQute.bnd.osgi;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.Enumeration;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import aQute.lib.io.IO;
@@ -62,35 +56,6 @@ public class ZipResource implements Resource {
 	@Override
 	public String toString() {
 		return ":" + zip.getName() + "(" + entry.getName() + "):";
-	}
-
-	public static ZipFile build(Jar jar, File file) throws ZipException, IOException {
-		return build(jar, file, null);
-	}
-
-	public static ZipFile build(Jar jar, File file, Pattern pattern) throws ZipException, IOException {
-		try {
-			ZipFile zip = new ZipFile(file);
-			nextEntry: for (Enumeration< ? extends ZipEntry> e = zip.entries(); e.hasMoreElements();) {
-				ZipEntry entry = e.nextElement();
-				if (pattern != null) {
-					Matcher m = pattern.matcher(entry.getName());
-					if (!m.matches())
-						continue nextEntry;
-				}
-				if (!entry.isDirectory()) {
-					jar.putResource(entry.getName(), new ZipResource(zip, entry), true);
-				}
-			}
-			return zip;
-		} catch (ZipException e) {
-			ZipException ze = new ZipException(
-					"The JAR/ZIP file (" + file.getAbsolutePath() + ") seems corrupted, error: " + e.getMessage());
-			ze.initCause(e);
-			throw ze;
-		} catch (FileNotFoundException e) {
-			throw new IllegalArgumentException("Problem opening JAR: " + file.getAbsolutePath());
-		}
 	}
 
 	public void write(OutputStream out) throws Exception {


### PR DESCRIPTION
Their use can pin files. So for Windows, we just use the input stream for large files rather than a mapped byte buffer.

Also, the Jar building logic is concentrated in a single class now.