### PR TITLE
Better handle cases where repo provided null file

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
+import aQute.bnd.build.DownloadBlocker.Stage;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Constants;
@@ -79,9 +80,9 @@ public class Container {
 	public File getFile() {
 		DownloadBlocker blocker = db;
 		if (blocker != null) {
-			String r = blocker.getReason();
 			File f = blocker.getFile();
-			if (r != null) {
+			if (blocker.getStage() == Stage.FAILURE) {
+				String r = blocker.getReason();
 				if (error == null) {
 					error = r;
 				}

--- a/biz.aQute.bndlib/src/aQute/bnd/util/repository/DownloadListenerPromise.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/util/repository/DownloadListenerPromise.java
@@ -1,6 +1,7 @@
 package aQute.bnd.util.repository;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 
 import org.osgi.util.promise.Failure;
 import org.osgi.util.promise.Promise;
@@ -41,12 +42,15 @@ public class DownloadListenerPromise implements Success<File,Void>, Failure {
 		this.promise = promise;
 		this.dls = downloadListeners;
 		logger.debug("{}: starting", task);
-		promise.then(this, this);
+		promise.then(this).then(null, this);
 	}
 
 	@Override
 	public Promise<Void> call(Promise<File> resolved) throws Exception {
 		File file = resolved.getValue();
+		if (file == null) {
+			throw new FileNotFoundException("Download failed");
+		}
 		logger.debug("{}: success {}", this, file);
 
 		if (linked != null) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -396,6 +396,9 @@ public class MavenBndRepository extends BaseRepository
 				@Override
 				public Promise<Void> call(Promise<File> resolved) throws Exception {
 					File value = resolved.getValue();
+					if (value == null) {
+						throw new FileNotFoundException("Download failed");
+					}
 					for (DownloadListener dl : listeners) {
 						try {
 							dl.success(value);
@@ -405,7 +408,7 @@ public class MavenBndRepository extends BaseRepository
 					}
 					return null;
 				}
-			}, new Failure() {
+			}).then(null, new Failure() {
 				@Override
 				public void fail(Promise< ? > resolved) throws Exception {
 					String reason = Exceptions.toString(resolved.getFailure());


### PR DESCRIPTION
We convert the promise resolved with null to a DownloadBlocker failure.

So for https://github.com/bndtools/bndtools/issues/1694, the Container will not return a null file.