### PR TITLE
maven: We need to repeat some URLs to avoid them being “extended”

### DIFF
--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -13,6 +13,12 @@
 	<description>This maven plugin is used to make OSGi indexes from lists of maven dependencies.</description>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
 	<dependencies>
 		<dependency>

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -11,6 +11,12 @@
     <description>Resolve and Export OSGi applications.</description>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
     <dependencies>
         <dependency>

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -13,6 +13,12 @@
 	<description>This maven plugin is used to make OSGi indexes from lists of maven dependencies.</description>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
 	<dependencies>
 		<dependency>

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -13,6 +13,12 @@
 	<description>This maven plugin is used to build OSGi bundles using the bnd tool for generating MANIFEST.MF and other OSGi-specific artifacts.</description>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
 	<dependencies>
 		<dependency>

--- a/maven/bnd-resolver-maven-plugin/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/pom.xml
@@ -11,6 +11,12 @@
     <description>Resolves the -runbundles for an OSGi bndrun file</description>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
     <dependencies>
         <dependency>

--- a/maven/bnd-shared-maven-lib/pom.xml
+++ b/maven/bnd-shared-maven-lib/pom.xml
@@ -10,6 +10,12 @@
 	<artifactId>bnd-shared-maven-lib</artifactId>
 	<description>Shared logic used by bnd maven plugins.</description>
 	<name>${project.groupId}:${project.artifactId}</name>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
 	<dependencies>
 		<dependency>

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -11,6 +11,12 @@
     <description>Run the tests from an OSGi bndrun file</description>
     <name>${project.groupId}:${project.artifactId}</name>
     <packaging>maven-plugin</packaging>
+  <url>http://bnd.bndtools.org/</url>
+  <scm>
+    <url>https://github.com/bndtools/bnd</url>
+    <connection>scm:git:https://github.com/bndtools/bnd.git</connection>
+    <developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+  </scm>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The effective pom takes these URLs from the parent pom and adds the
child pom’s folder name making them invalid URLs. So we have to repeat
in each pom.
