### PR TITLE
Bnd gets confused by ill-formed bundle references #1864

### DIFF
--- a/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
+++ b/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
@@ -14,10 +14,20 @@ import junit.framework.TestCase;
 
 /**
  * Test if we properly can read
- * 
+ *
  * @author aqute
  */
 public class UTF8PropertiesTest extends TestCase {
+
+	public void testMissingDelimeterAfterQuotedString() throws IOException {
+		assertError("foo: bar='abc' ' '    ;", "foo", 0,
+				"Found a quote ''' while expecting a delimeter. You should quote the whole values, you can use both single and double quotes:");
+		assertError("foo: bar='abc', baz='def' goo='hji'", "foo", 0,
+				"Expected a delimeter, like comma or semicolon, after a quoted string but found 'g':");
+		assertError("foo: bar='abc'                ,   baz='def'", "foo", 0);
+		assertError("foo: bar='abc'     ;", "foo", 0);
+	}
+
 	String trickypart = "\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF"
 			+ "\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF"
 			+ "\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF"
@@ -220,9 +230,13 @@ public class UTF8PropertiesTest extends TestCase {
 		UTF8Properties up = new UTF8Properties();
 		up.load(string, IO.getFile("foo"), ra);
 		assertNotNull("No '" + key + "' property found", up.getProperty(key));
-		assertTrue(ra.getErrors().size() > 0);
-		Location location = ra.getLocation(ra.getErrors().get(0));
-		assertEquals("Faulty line number", line, location.line);
+		if (check.length == 0)
+			assertEquals(0, ra.getErrors().size());
+		else {
+			assertTrue(ra.getErrors().size() > 0);
+			Location location = ra.getLocation(ra.getErrors().get(0));
+			assertEquals("Faulty line number", line, location.line);
+		}
 		assertTrue(ra.check(check));
 	}
 


### PR DESCRIPTION
The properties parser now detects missing delimiters after 
a quoted string. We could still do checks when we know
what the header means but I think this catches more
of the problems.


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>