### PR TITLE
Support DynamicImport-Package expansion (issue #2038)

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/dynamicimport/DynamicImport.java
+++ b/biz.aQute.bndlib.tests/src/test/dynamicimport/DynamicImport.java
@@ -1,0 +1,45 @@
+package test.dynamicimport;
+
+import java.io.IOException;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.EventAdmin;
+
+public class DynamicImport implements ConfigurationAdmin {
+
+	public DynamicImport(BundleContext bc, EventAdmin ea) {}
+
+	@Override
+	public Configuration createFactoryConfiguration(String factoryPid) throws IOException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Configuration createFactoryConfiguration(String factoryPid, String location) throws IOException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Configuration getConfiguration(String pid) throws IOException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Configuration getConfiguration(String pid, String location) throws IOException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Configuration[] listConfigurations(String filter) throws IOException, InvalidSyntaxException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -307,6 +307,7 @@ public interface Constants {
 	String							LINK_ATTRIBUTE								= "link";
 	String							LITERAL_ATTRIBUTE							= "literal";
 	String							NAME_ATTRIBUTE								= "name";
+	String							RESOLUTION_DYNAMIC							= "dynamic";
 	String							DESCRIPTION_ATTRIBUTE						= "description";
 	String							OSNAME_ATTRIBUTE							= "osname";
 	String							OSVERSION_ATTRIBUTE							= "osversion";

--- a/docs/_heads/import_package.md
+++ b/docs/_heads/import_package.md
@@ -18,6 +18,10 @@ If an explicit version is given, then ${@} can be used to substitute the found v
   Import-Package: org.osgi.framework;version=${@}
   Import-Package: org.osgi.framework;version="[${versionmask;==;${@}},${versionmask;=+;${@}})"
 
+Packages with directive resolution:=dynamic will be removed from Import-Package and added to the DynamicImport-Package header after being processed like any other Import-Package entry. For example:
+
+  Import-Package: org.slf4j.*;resolution:=dynamic, *
+
 If an imported package uses mandatory attributes, then bnd will attempt to add those attributes to the import statement. However, in certain (bizarre!) cases this is not wanted. It is therefore possible to remove an attribute from the import clause. This is done with the `-remove-attribute:` directive or by setting the value of an attribute to !. The parameter of the `-remove-attribute` directive is an instruction and can use the standard options with !, *, ?, etc.
 
   Import-Package: org.eclipse.core.runtime;-remove-attribute:common,*


### PR DESCRIPTION
Packages in Import-Package marked with resolution:=dynamic will be moved to the DynamicImport-Package entry after expansion takes place.

The test demonstrates packages get their version attribute added and are properly expanded, and moved to DynamicImport-Package (added after the existing instruction, and removed from Import-Package), and that other imported packages are not affected.

I see no regression risk unless someone used resolution:=dynamic in an existing build... but then again, as far as I know the directive "resolution" is reserved by the OSGi spec.