### PR TITLE
Issue #2040: Fix NPE when a project has no distributionManagement

### DIFF
--- a/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -143,7 +143,11 @@ public class BaselineMojo extends AbstractMojo {
 				releaseDistroRepo = RepositoryUtils.toRepo(project.getDistributionManagementArtifactRepository());
 			}
 
-			aetherRepos.add(0, releaseDistroRepo);
+			// Issue #2040:
+			// Don't fail on projects without distributionManagement
+			if (releaseDistroRepo != null) {
+				aetherRepos.add(0, releaseDistroRepo);
+			}
 		}
 
 		return aetherRepos;


### PR DESCRIPTION
On projects without distributionManagement, releaseDistroRepo is null, inserted at the head of the list and it causes Aether to throw a NPE.

It is difficult to test because the current maven baseline tests rely on distributionManagement with a local repo to find a baseline, and this happens only after a baseline has been found. It might be possible by setting settings to offline, and provisioning a test m2 local repository, but I hope a NPE fix does not warrant so much maven pain. :grin: 

There is a workaround with:
```xml
<properties>		
   <bnd.baseline.include.distribution.management>false</bnd.baseline.include.distribution.management>
</properties>
```
