### PR TITLE
bndrun: Restore resolve method to return a String

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/ResolveCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/ResolveCommand.java
@@ -1,6 +1,7 @@
 package aQute.bnd.main;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -20,7 +21,10 @@ import aQute.bnd.build.Run;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.EE;
 import aQute.bnd.build.model.OSGI_CORE;
-import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.build.model.clauses.HeaderClause;
+import aQute.bnd.build.model.conversions.CollectionFormatter;
+import aQute.bnd.build.model.conversions.Converter;
+import aQute.bnd.build.model.conversions.HeaderClauseFormatter;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.main.bnd.projectOptions;
 import aQute.bnd.osgi.Domain;
@@ -227,6 +231,9 @@ public class ResolveCommand extends Processor {
 
 	}
 
+	private static final Converter<String,Collection< ? extends HeaderClause>> runbundlesFormatter = new CollectionFormatter<>(
+			"\n  ", new HeaderClauseFormatter(), "", "  ", "");
+
 	@Arguments(arg = "<path>...")
 	interface ResolveOptions extends Options {
 		@Description("Use the following workspace")
@@ -273,16 +280,12 @@ public class ResolveCommand extends Processor {
 				Run run = Run.createRun(ws, f);
 				Bndrun bndrun = new Bndrun(run.getWorkspace(), f);
 
-				List<VersionedClause> runbundles = bndrun.resolve(false, options.write());
-				System.out.printf("# %-50s ok%n", f.getName());
-				if (options.bundles()) {
-					StringBuilder buffer = new StringBuilder();
-					for (VersionedClause runbundle : runbundles) {
-						buffer.append("  ");
-						runbundle.formatTo(buffer);
-						buffer.append('\n');
+				String runbundles = bndrun.resolve(false, options.write(), runbundlesFormatter);
+				if (bndrun.isOk()) {
+					System.out.printf("# %-50s ok%n", f.getName());
+					if (options.bundles()) {
+						System.out.println(runbundles);
 					}
-					System.out.println(buffer);
 				}
 				getInfo(bndrun);
 			}

--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -83,12 +83,17 @@ public class Bndrun extends Run {
 	 * @return the calculated <code>-runbundles</code>
 	 * @throws Exception
 	 */
-	public List<VersionedClause> resolve(boolean failOnChanges, boolean writeOnChanges) throws Exception {
+	public String resolve(boolean failOnChanges, boolean writeOnChanges) throws Exception {
+		return resolve(failOnChanges, writeOnChanges, runbundlesListFormatter);
+	}
+
+	public <T> T resolve(boolean failOnChanges, boolean writeOnChanges,
+			Converter<T,Collection< ? extends HeaderClause>> runbundlesFormatter) throws Exception {
 		try (ProjectResolver projectResolver = new ProjectResolver(this)) {
 			try {
 				Map<Resource,List<Wire>> resolution = projectResolver.resolve();
 				if (!projectResolver.isOk()) {
-					return null;
+					return runbundlesFormatter.convert(Collections.<VersionedClause> emptyList());
 				}
 				Set<Resource> resources = resolution.keySet();
 				List<VersionedClause> runBundles = new ArrayList<>();
@@ -130,7 +135,7 @@ public class Bndrun extends Run {
 					if (failOnChanges && !bemRunBundles.isEmpty()) {
 						error("The runbundles have changed. Failing the build!\nWas: %s\nIs: %s",
 								originalRunbundlesString, runbundlesString);
-						return null;
+						return runbundlesFormatter.convert(Collections.<VersionedClause> emptyList());
 					}
 					if (writeOnChanges) {
 						bem.setRunBundles(bemRunBundles);
@@ -141,7 +146,7 @@ public class Bndrun extends Run {
 						IO.store(doc.get(), runFile);
 					}
 				}
-				return bemRunBundles;
+				return runbundlesFormatter.convert(bemRunBundles);
 			} finally {
 				getInfo(projectResolver);
 			}

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -21,9 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Workspace;
-import aQute.bnd.build.model.clauses.VersionedClause;
-import aQute.bnd.build.model.conversions.CollectionFormatter;
-import aQute.bnd.build.model.conversions.HeaderClauseFormatter;
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.repository.fileset.FileSetRepository;
@@ -118,12 +115,10 @@ public class ExportMojo extends AbstractMojo {
 			}
 			if (resolve) {
 				try {
-					List<VersionedClause> resolved = run.resolve(failOnChanges, false);
+					String runBundles = run.resolve(failOnChanges, false);
 					if (!run.isOk()) {
 						return;
 					}
-					String runBundles = new CollectionFormatter<>(",", new HeaderClauseFormatter(), null, "", "")
-							.convert(resolved);
 					run.setProperty(Constants.RUNBUNDLES, runBundles);
 				} finally {
 					report(run);

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -1,7 +1,5 @@
 package aQute.bnd.maven.lib.resolve;
 
-import aQute.bnd.repository.fileset.FileSetRepository;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,13 +28,15 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.repository.fileset.FileSetRepository;
+
 public class DependencyResolver {
 
 	private static final Logger logger = LoggerFactory.getLogger(DependencyResolver.class);
 
 	private final boolean includeTransitive;
 	private final MavenProject project;
-	private final List<String> scopes;
+	final List<String> scopes;
 	private final RepositorySystemSession session;
 	private final RepositorySystem system;
 	private final ProjectDependenciesResolver resolver;

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -20,9 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Workspace;
-import aQute.bnd.build.model.clauses.VersionedClause;
-import aQute.bnd.build.model.conversions.CollectionFormatter;
-import aQute.bnd.build.model.conversions.HeaderClauseFormatter;
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.repository.fileset.FileSetRepository;
@@ -145,12 +142,10 @@ public class TestingMojo extends AbstractMojo {
 			}
 			if (resolve) {
 				try {
-					List<VersionedClause> resolved = run.resolve(failOnChanges, false);
+					String runBundles = run.resolve(failOnChanges, false);
 					if (!run.isOk()) {
 						return;
 					}
-					String runBundles = new CollectionFormatter<>(",", new HeaderClauseFormatter(), null, "", "")
-							.convert(resolved);
 					run.setProperty(Constants.RUNBUNDLES, runBundles);
 				} finally {
 					report(run);


### PR DESCRIPTION
Overload with a method that takes a Converter if custom conversion is
necessary. This avoids most users from being exposed to a list of
VersionedClauses and having to supply a Converter.

Also fixed potential NPE in ResolveCommand where a null List could be
returned. Also restored isOk check before displaying output.