### PR TITLE
launcher: Use java.home to find default java executable

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -265,7 +265,7 @@ public abstract class ProjectLauncher extends Processor {
 			java.var(e.getKey(), e.getValue());
 		}
 
-		java.add(project.getProperty("java", "java"));
+		java.add(project.getProperty("java", getJavaExecutable()));
 		String javaagent = project.getProperty(Constants.JAVAAGENT);
 		if (Processor.isTrue(javaagent)) {
 			for (String agent : agents) {
@@ -309,6 +309,15 @@ public abstract class ProjectLauncher extends Processor {
 			cleanup();
 			listeners.clear();
 		}
+	}
+
+	private String getJavaExecutable() {
+		String javaHome = System.getProperty("java.home");
+		if (javaHome == null) {
+			return "java";
+		}
+		File java = new File(javaHome, "bin/java");
+		return java.getAbsolutePath();
 	}
 
 	/**

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -953,6 +953,7 @@ public class Launcher implements ServiceListener {
 			row(out, "Keep", parms.keep);
 			row(out, "Security", security);
 			list(out, fill("Run bundles", 40), parms.runbundles);
+			row(out, "Java Home", System.getProperty("java.home"));
 			list(out, fill("Classpath", 40), split(System.getProperty("java.class.path"), File.pathSeparator));
 			list(out, fill("System Packages", 40), split(parms.systemPackages, ","));
 			list(out, fill("System Capabilities", 40), split(parms.systemCapabilities, ","));


### PR DESCRIPTION
This means by default, the ProjectLauncher will use the same java to
launch the project as is running Bnd. Otherwise, you use whatever the
default java on the platform which is now Java 9 on my system unless
JAVA_HOME is configured to point to some other Java. And JAVA_HOME
is unset in Eclipse.

This PR allows the test cases which launch a child VM to use the same Java runtime. This allows the tests to pass in Eclipse when you have Java 9 installed since the various frameworks used by test cases do not properly work under Java 9.