### PR TITLE
Support abbreviated syntax for -runrequires

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
@@ -1,5 +1,11 @@
 package test.resource;
 
+import org.osgi.resource.Requirement;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.osgi.resource.CapabilityBuilder;
 import junit.framework.TestCase;
 
@@ -8,4 +14,50 @@ public class CapReqBuilderTest extends TestCase {
 	public void testSimple() throws Exception {
 		CapabilityBuilder cb = new CapabilityBuilder("test");
 	}
+
+	public void testParseRequirement() throws Exception {
+		Parameters params = OSGiHeader.parseHeader("osgi.identity; filter:='(a=b)'; resolution:=optional");
+		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
+		assertEquals("osgi.identity", req.getNamespace());
+		assertEquals("optional", req.getDirectives().get("resolution"));
+		assertEquals("(a=b)", req.getDirectives().get("filter"));
+	}
+
+	public void testAliasedRequirement() throws Exception {
+		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo");
+		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
+		assertEquals("osgi.identity", req.getNamespace());
+		assertEquals("(osgi.identity=org.example.foo)", req.getDirectives().get("filter"));
+	}
+
+	public void testAliasedRequirementWithVersion() throws Exception {
+		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo; version=1.2");
+		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
+		assertEquals("osgi.identity", req.getNamespace());
+		assertEquals("(&(osgi.identity=org.example.foo)(version>=1.2.0))",
+				req.getDirectives().get("filter"));
+	}
+
+	public void testAliasedRequirementWithVersionRange() throws Exception {
+		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo; version='[1.2,1.3)'");
+		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
+
+		assertEquals("osgi.identity", req.getNamespace());
+		assertEquals("(&(osgi.identity=org.example.foo)(&(version>=1.2.0)(!(version>=1.3.0))))",
+				req.getDirectives().get("filter"));
+	}
+
+	public void testAliasedRequirementCopyAttributesAndDirectives() throws Exception {
+		Attrs attrs = new Attrs();
+		attrs.putTyped("bsn", "org.example.foo");
+		attrs.putTyped("size", 23L);
+		attrs.put("resolution:", "optional");
+		Requirement req = CapReqBuilder.getRequirementFrom("bundle", attrs);
+
+		assertEquals("osgi.identity", req.getNamespace());
+		assertEquals("(osgi.identity=org.example.foo)", req.getDirectives().get("filter"));
+		assertEquals(23L, req.getAttributes().get("size"));
+		assertEquals("optional", req.getDirectives().get("resolution"));
+	}
+
 }

--- a/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
@@ -24,14 +24,14 @@ public class CapReqBuilderTest extends TestCase {
 	}
 
 	public void testAliasedRequirement() throws Exception {
-		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo");
+		Parameters params = OSGiHeader.parseHeader("bnd.identity; id=org.example.foo");
 		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
 		assertEquals("osgi.identity", req.getNamespace());
 		assertEquals("(osgi.identity=org.example.foo)", req.getDirectives().get("filter"));
 	}
 
 	public void testAliasedRequirementWithVersion() throws Exception {
-		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo; version=1.2");
+		Parameters params = OSGiHeader.parseHeader("bnd.identity; id=org.example.foo; version=1.2");
 		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
 		assertEquals("osgi.identity", req.getNamespace());
 		assertEquals("(&(osgi.identity=org.example.foo)(version>=1.2.0))",
@@ -39,7 +39,7 @@ public class CapReqBuilderTest extends TestCase {
 	}
 
 	public void testAliasedRequirementWithVersionRange() throws Exception {
-		Parameters params = OSGiHeader.parseHeader("bundle; bsn=org.example.foo; version='[1.2,1.3)'");
+		Parameters params = OSGiHeader.parseHeader("bnd.identity; id=org.example.foo; version='[1.2,1.3)'");
 		Requirement req = CapReqBuilder.getRequirementsFrom(params).get(0);
 
 		assertEquals("osgi.identity", req.getNamespace());
@@ -49,10 +49,10 @@ public class CapReqBuilderTest extends TestCase {
 
 	public void testAliasedRequirementCopyAttributesAndDirectives() throws Exception {
 		Attrs attrs = new Attrs();
-		attrs.putTyped("bsn", "org.example.foo");
+		attrs.putTyped("id", "org.example.foo");
 		attrs.putTyped("size", 23L);
 		attrs.put("resolution:", "optional");
-		Requirement req = CapReqBuilder.getRequirementFrom("bundle", attrs);
+		Requirement req = CapReqBuilder.getRequirementFrom("bnd.identity", attrs);
 
 		assertEquals("osgi.identity", req.getNamespace());
 		assertEquals("(osgi.identity=org.example.foo)", req.getDirectives().get("filter"));

--- a/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/resource/CapReqBuilderTest.java
@@ -60,4 +60,32 @@ public class CapReqBuilderTest extends TestCase {
 		assertEquals("optional", req.getDirectives().get("resolution"));
 	}
 
+	public void testParseLiteralAliasedRequirement() throws Exception {
+		Attrs attrs = new Attrs();
+		attrs.putTyped("bnd.literal", "bnd.identity");
+		attrs.putTyped("size", 23L);
+		attrs.put("resolution:", "optional");
+		attrs.put("filter:", "(bnd.identity=org.example.foo)");
+		Requirement req = CapReqBuilder.getRequirementFrom("bnd.literal", attrs);
+
+		assertEquals("bnd.identity", req.getNamespace());
+		assertEquals("(bnd.identity=org.example.foo)", req.getDirectives().get("filter"));
+		assertEquals(23L, req.getAttributes().get("size"));
+		assertEquals("optional", req.getDirectives().get("resolution"));
+	}
+
+	public void testParseLiteralLiteralRequirement() throws Exception {
+		Attrs attrs = new Attrs();
+		attrs.putTyped("bnd.literal", "bnd.literal");
+		attrs.putTyped("size", 23L);
+		attrs.put("resolution:", "optional");
+		attrs.put("filter:", "(bnd.literal=org.example.foo)");
+		Requirement req = CapReqBuilder.getRequirementFrom("bnd.literal", attrs);
+
+		assertEquals("bnd.literal", req.getNamespace());
+		assertEquals("(bnd.literal=org.example.foo)", req.getDirectives().get("filter"));
+		assertEquals(23L, req.getAttributes().get("size"));
+		assertEquals("optional", req.getDirectives().get("resolution"));
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -41,9 +41,9 @@ import aQute.libg.filters.SimpleFilter;
 
 public class CapReqBuilder {
 
-	private static final String			REQ_ALIAS_BUNDLE				= "bundle";
-	private static final String			REQ_ALIAS_BUNDLE_NAME_ATTRIB	= "bsn";
-	private static final String REQ_ALIAS_BUNDLE_VERSION_ATTRIB = "version";
+	private static final String			REQ_ALIAS_IDENTITY					= "bnd.identity";
+	private static final String			REQ_ALIAS_IDENTITY_NAME_ATTRIB		= "id";
+	private static final String			REQ_ALIAS_IDENTITY_VERSION_ATTRIB	= "version";
 
 	private final String				namespace;
 	private Resource					resource;
@@ -290,10 +290,7 @@ public class CapReqBuilder {
 	public static List<Requirement> getRequirementsFrom(Parameters rr, boolean unalias) throws Exception {
 		List<Requirement> requirements = new ArrayList<Requirement>();
 		for (Entry<String,Attrs> e : rr.entrySet()) {
-			Requirement req = getRequirementFrom(Processor.removeDuplicateMarker(e.getKey()), e.getValue());
-			if (unalias) {
-				req = unalias(req);
-			}
+			Requirement req = getRequirementFrom(Processor.removeDuplicateMarker(e.getKey()), e.getValue(), unalias);
 			requirements.add(req);
 		}
 		return requirements;
@@ -335,17 +332,17 @@ public class CapReqBuilder {
 		final Set<String> consumedAttribs = new HashSet<>();
 		final Set<String> consumedDirectives = new HashSet<>();
 
-		if (REQ_ALIAS_BUNDLE.equals(ns)) {
-			final String bsn = Objects.toString(requirement.getAttributes().get(REQ_ALIAS_BUNDLE_NAME_ATTRIB), null);
-			consumedAttribs.add(REQ_ALIAS_BUNDLE_NAME_ATTRIB);
+		if (REQ_ALIAS_IDENTITY.equals(ns)) {
+			final String bsn = Objects.toString(requirement.getAttributes().get(REQ_ALIAS_IDENTITY_NAME_ATTRIB), null);
+			consumedAttribs.add(REQ_ALIAS_IDENTITY_NAME_ATTRIB);
 			if (bsn == null) {
 				throw new IllegalArgumentException(
 						String.format("Requirement alias '%s' is missing mandatory attribute '%s' of type String",
-								REQ_ALIAS_BUNDLE, REQ_ALIAS_BUNDLE_NAME_ATTRIB));
+								REQ_ALIAS_IDENTITY, REQ_ALIAS_IDENTITY_NAME_ATTRIB));
 			}
 
-			final VersionRange range = toRange(requirement.getAttributes().get(REQ_ALIAS_BUNDLE_VERSION_ATTRIB));
-			consumedAttribs.add(REQ_ALIAS_BUNDLE_VERSION_ATTRIB);
+			final VersionRange range = toRange(requirement.getAttributes().get(REQ_ALIAS_IDENTITY_VERSION_ATTRIB));
+			consumedAttribs.add(REQ_ALIAS_IDENTITY_VERSION_ATTRIB);
 			CapReqBuilder b = CapReqBuilder.createBundleRequirement(bsn, Objects.toString(range, null));
 			copyAttribs(requirement, b, consumedAttribs);
 			copyDirectives(requirement, b, consumedDirectives);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,9 @@ public class CapReqBuilder {
 	private static final String			REQ_ALIAS_IDENTITY					= "bnd.identity";
 	private static final String			REQ_ALIAS_IDENTITY_NAME_ATTRIB		= "id";
 	private static final String			REQ_ALIAS_IDENTITY_VERSION_ATTRIB	= "version";
+
+	private static final String			REQ_ALIAS_LITERAL					= "bnd.literal";
+	private static final String			REQ_ALIAS_LITERAL_ATTRIB			= REQ_ALIAS_LITERAL;
 
 	private final String				namespace;
 	private Resource					resource;
@@ -332,7 +336,20 @@ public class CapReqBuilder {
 		final Set<String> consumedAttribs = new HashSet<>();
 		final Set<String> consumedDirectives = new HashSet<>();
 
-		if (REQ_ALIAS_IDENTITY.equals(ns)) {
+		if (REQ_ALIAS_LITERAL.equals(ns)) {
+			final String literalNs = Objects.toString(requirement.getAttributes().get(REQ_ALIAS_LITERAL_ATTRIB), null);
+			consumedAttribs.add(REQ_ALIAS_LITERAL_ATTRIB);
+			if (literalNs == null) {
+				throw new IllegalArgumentException(
+						String.format("Requirement alias %s is missing mandatory attribute '%s' of type String",
+								REQ_ALIAS_LITERAL, REQ_ALIAS_LITERAL_ATTRIB));
+			}
+
+			CapReqBuilder builder = new CapReqBuilder(literalNs);
+			copyAttribs(requirement, builder, consumedAttribs);
+			copyDirectives(requirement, builder, Collections.<String> emptySet());
+			requirement = builder.buildSyntheticRequirement();
+		} else if (REQ_ALIAS_IDENTITY.equals(ns)) {
 			final String bsn = Objects.toString(requirement.getAttributes().get(REQ_ALIAS_IDENTITY_NAME_ATTRIB), null);
 			consumedAttribs.add(REQ_ALIAS_IDENTITY_NAME_ATTRIB);
 			if (bsn == null) {
@@ -348,6 +365,7 @@ public class CapReqBuilder {
 			copyDirectives(requirement, b, consumedDirectives);
 			requirement = b.buildSyntheticRequirement();
 		}
+
 		return requirement;
 	}
 

--- a/docs/_instructions/runrequires.md
+++ b/docs/_instructions/runrequires.md
@@ -5,22 +5,72 @@ title: -runrequires REQUIREMENT ( ',' REQUIREMENT )*
 summary: The root requirements for a resolve intended to create a constellation for the -runbundles.
 ---
 
-	private void constructInputRequirements() {
-		Parameters inputRequirements = new Parameters(properties.mergeProperties(Constants.RUNREQUIRES));
-		if (inputRequirements == null || inputRequirements.isEmpty()) {
-			inputResource = null;
-		} else {
-			List<Requirement> requires = CapReqBuilder.getRequirementsFrom(inputRequirements);
+The `-runrequires` instruction specifies root requirements for a resolve operation. These requirements are input into the resolver
+which generates a list of bundles (the `-runbundles` list) that can satisfy the requirements.
 
-			ResourceBuilder resBuilder = new ResourceBuilder();
-			CapReqBuilder identity = new CapReqBuilder(IdentityNamespace.IDENTITY_NAMESPACE).addAttribute(
-					IdentityNamespace.IDENTITY_NAMESPACE, IDENTITY_INITIAL_RESOURCE);
-			resBuilder.addCapability(identity);
+Each requirement must be in the format of an entry in the OSGi standard `Require-Capability` header. See Section 3.3.6 ("Bundle Requirements") of OSGi Core Release 6 specification.
 
-			for (Requirement req : requires) {
-				resBuilder.addRequirement(req);
-			}
+A requirement can specify any arbitrary namespace, including but not limited to those listed in Chapter 8 ("Framework Namespaces Specification") of OSGi Core Release 6 specification and Chapter 135 ("Common Namespaces Specification") of OSGi Compendium Release 6.
 
-			inputResource = resBuilder.build();
-		}
-	}
+Bnd also supports *alias* namespaces -- see below. 
+
+## Example
+
+	-runrequires: \
+		osgi.identity; filter:='(osgi.identity=org.example.foo)',\
+		osgi.identity; filter:='(&(osgi.identity=org.example.bar)(version>=1.0)(!(version>=2.0)))'
+
+This specifies a requirement for the resource identified as "org.example.foo" (with any version) AND the resource identified as "org.example.bar" with version in the range 1.0 inclusive to 2.0 exclusive.
+
+## Requirement Aliases
+
+To ease manual entry of requirements bnd supports alias namespaces which translate to standard namespaces and filters.
+
+In all cases, attributes and directives that are not consumed by the alias are passed through to the generated requirement. For example if the `bnd.identity` alias is used with a directive of `resolution:=optional` then the generated `osgi.identity` requirement shall also have the directive `resolution:=optional`.
+
+The following aliases are supported:
+
+### `bnd.identity`
+
+The `bnd.identity` namepace alias takes the following attributes:
+
+* `id`: the identity of the resource
+* `version`: a version range in conventional OSGi form, e.g. `[1.0, 2.0)`.
+
+Example:
+
+	-runrequires:\
+		bnd.identity; id=org.example.foo,\
+		bnd.identity; id=org.example.bar; version=1.0,\
+		bnd.identity; id=org.example.baz; version='[1.0,2.0)'
+
+is translated to:
+
+	-runrequires:\
+		osgi.identity; filter:='(osgi.identity=org.example.foo)',\
+		osgi.identity; filter:='(&(osgi.identity=org.example.bar)(version>=1.0))',\
+		osgi.identity; filter:='(&(osgi.identity=org.example.baz)(version>=1.0)(!(version>=2.0)))'
+
+### `bnd.literal`
+
+The `bnd.literal` alias can be used if you need to create a literal requirement that has a namespace clashing with one of the aliases. For example if you want to have a requirement with the literal namespace `bnd.identity`, i.e. **not** processed as an alias.
+
+Only one attribute is used:
+
+* `bnd.literal`: specifies the literal namespace
+
+Example:
+
+	-runrequires:\
+		bnd.literal; bnd.literal=bnd.identity; filter:='(bnd.identity=foo)',\
+		bnd.literal; bnd.literal=bnd.literal; filter:='(bnd.literal=bar)'
+
+is translated to:
+
+	-runrequires:\
+		bnd.identity; filter:='(bnd.identity=foo)',\
+		bnd.literal; filter:='(bnd.literal=bar)'
+
+## See Also
+
+* [-runbundles](runbundles.html)


### PR DESCRIPTION
Fixes #1996

Example:
  -runrequires: bundle; bsn=org.example.foo; version=1.0

which translates to:

  -runrequires: osgi.identity; filter:=‘(&(osgi.identity=org.example.foo)(version>=1.0.0))’


Signed-off-by: Neil Bartlett <njbartlett@gmail.com>