### PR TITLE
maven: Rename option to useMavenDependencies

### DIFF
--- a/maven/bnd-export-maven-plugin/README.md
+++ b/maven/bnd-export-maven-plugin/README.md
@@ -51,4 +51,4 @@ Here's an example setting the `bundles` used for resolution.
 |`failOnChanges`        | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._|
 |`bundlesOnly`          | Instead of creating an executable jar place runbundles into `targetDir`. _Defaults to `false`._|
 |`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
-|`useDefaults`          | If `true` adds `bundles` to the normally calculated defaults rather than replacing them. _Defaults to `true`._|
+|`useMavenDependencies` | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -50,7 +50,7 @@ public class ExportMojo extends AbstractMojo {
 	private List<File>					bundles;
 
 	@Parameter(defaultValue = "true")
-	private boolean						useDefaults;
+	private boolean						useMavenDependencies;
 
 	@Parameter(defaultValue = "false")
 	private boolean				resolve;
@@ -78,7 +78,7 @@ public class ExportMojo extends AbstractMojo {
 					system);
 
 			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles,
-					useDefaults);
+					useMavenDependencies);
 
 			for (File runFile : bndruns) {
 				export(runFile, fileSetRepository);

--- a/maven/bnd-export-maven-plugin/src/test/resources/integration-test/test/export-from-inputbundles/pom.xml
+++ b/maven/bnd-export-maven-plugin/src/test/resources/integration-test/test/export-from-inputbundles/pom.xml
@@ -24,7 +24,7 @@
                         <bundle>${project.basedir}/bundles/org.apache.felix.eventadmin-1.4.8.jar</bundle>
                         <bundle>${project.basedir}/bundles/org.apache.felix.framework-5.4.0.jar</bundle>
                     </bundles>
-                    <useDefaults>false</useDefaults>
+                    <useMavenDependencies>false</useMavenDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven/bnd-resolver-maven-plugin/README.md
+++ b/maven/bnd-resolver-maven-plugin/README.md
@@ -57,4 +57,4 @@ mvn bnd-resolver:resolve
 |`bndruns`              | Contains at least one `bndrun` child element, each element naming a bndrun file defining a runtime and tests to execute against it.|
 |`failOnChanges`        | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._|
 |`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
-|`useDefaults`          | If `true` adds `bundles` to the normally calculated defaults rather than replacing them. _Defaults to `true`._|
+|`useMavenDependencies` | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|

--- a/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -49,7 +49,7 @@ public class ResolverMojo extends AbstractMojo {
 	private List<File>	bundles;
 
 	@Parameter(defaultValue = "true")
-	private boolean						useDefaults;
+	private boolean						useMavenDependencies;
 
 	@Parameter(defaultValue = "true")
 	private boolean				failOnChanges;
@@ -74,7 +74,7 @@ public class ResolverMojo extends AbstractMojo {
 			DependencyResolver dependencyResolver = new DependencyResolver(
 					project, repositorySession, resolver, system);
 
-			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles, useDefaults);
+			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles, useMavenDependencies);
 
 			for (File runFile : bndruns) {
 				resolve(runFile, fileSetRepository);

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-from-inputbundles/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-from-inputbundles/pom.xml
@@ -23,7 +23,7 @@
                         <bundle>${project.basedir}/bundles/org.apache.felix.eventadmin-1.4.8.jar</bundle>
                         <bundle>${project.basedir}/bundles/org.apache.felix.framework-5.4.0.jar</bundle>
                     </bundles>
-                    <useDefaults>false</useDefaults>
+                    <useMavenDependencies>false</useMavenDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -120,11 +120,11 @@ public class DependencyResolver {
 	}
 
 	public FileSetRepository getFileSetRepository(
-			String name, Collection<File> bundlesInputParameter, boolean useDefaults)
+			String name, Collection<File> bundlesInputParameter, boolean useMavenDependencies)
 		throws Exception {
 
 		Collection<File> bundles = new ArrayList<>();
-		if (useDefaults) {
+		if (useMavenDependencies) {
 			Map<File,ArtifactResult> dependencies = resolve();
 			bundles.addAll(dependencies.keySet());
 

--- a/maven/bnd-testing-maven-plugin/README.md
+++ b/maven/bnd-testing-maven-plugin/README.md
@@ -59,4 +59,4 @@ Here's an example setting the `bundles` used for resolution.
 |`testingSelect`                 | A file path to a test file, overrides anything else. _Defaults to `${testing.select}`._ Override with property `testing.select`.|
 |`testing`                       | A glob expression that is matched against the file name of the listed bndrun files. _Defaults to `${testing}`._ Override with property `testing`.|
 |`bundles`                       | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
-|`useDefaults`                   | If `true` adds `bundles` to the normally calculated defaults rather than replacing them. _Defaults to `true`._|
+|`useMavenDependencies`          | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -65,7 +65,7 @@ public class TestingMojo extends AbstractMojo {
 	private List<File>					bundles;
 
 	@Parameter(defaultValue = "true")
-	private boolean						useDefaults;
+	private boolean						useMavenDependencies;
 
 	@Parameter(defaultValue = "false")
 	private boolean				resolve;
@@ -93,7 +93,7 @@ public class TestingMojo extends AbstractMojo {
 					system);
 
 			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles,
-					useDefaults);
+					useMavenDependencies);
 
 			if (testingSelect != null) {
 				logger.info("Using selected testing file {}", testingSelect);


### PR DESCRIPTION
This is to make the option more self-documenting. The old name,
useDefaults, was too vague.