### PR TITLE
bnd-indexer-maven-plugin misses deployment repo properties

### DIFF
--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -83,6 +83,8 @@
 					<postBuildHookScript>verify.groovy</postBuildHookScript>
                     <properties>
                       <jsse.enableSNIExtension>false</jsse.enableSNIExtension>
+                      <!-- Used in the "no-dist-mgmt" deploy test -->
+                      <altSnapshotDeploymentRepository>LocalSnapshotDeploy::default::file://${project.build.directory}/integration-test/projects/test/localsnapshotdeployrepo</altSnapshotDeploymentRepository>
                     </properties>
 					<goals>
 						<goal>package</goal>

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -266,7 +266,8 @@ public class IndexerMojo extends AbstractMojo {
 								artifact);
 						return file.toURI();
 					}
-					throw new FileNotFoundException("The repository " + artifactResult.getRepository().getId()
+					throw new FileNotFoundException("Unable to index artifact " + artifact + ". The repository "
+							+ artifactResult.getRepository().getId()
 							+ " is not known to this resolver");
 				}
 
@@ -294,7 +295,7 @@ public class IndexerMojo extends AbstractMojo {
 				return URI.create(baseUrl).resolve(artifactPath).normalize();
 			} catch (Exception e) {
 				fail = true;
-				logger.error("Failed to determine the artifact URI", e);
+				logger.error("Failed to determine the artifact URI for artifact {}", artifactResult.getArtifact(), e);
 				throw e;
 			}
 		}

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-deployment-repo-no-dist-mgmt/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-deployment-repo-no-dist-mgmt/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<artifactId>index-deployment-repo-no-dist-mgmt</artifactId>
+	<packaging>pom</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>test-deploy-no-dist-mgmt</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-indexer-maven-plugin</artifactId>
+				<configuration>
+					<includeTransitive>false</includeTransitive>
+					<localURLs>FORBIDDEN</localURLs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -21,6 +21,8 @@
 		<module>include-jar</module>
 		<module>test-deploy</module>
 		<module>index-deployment-repo</module>
+		<module>test-deploy-no-dist-mgmt</module>
+		<module>index-deployment-repo-no-dist-mgmt</module>
 	</modules>
 
 	<dependencyManagement>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>biz.aQute.bnd</groupId>
+	<artifactId>test-deploy-no-dist-mgmt</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+				<configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8</version>
+				<executions>
+					<execution>
+						<id>deploy</id>
+						<phase>package</phase>
+						<goals>
+							<goal>deploy</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/src/main/resources/META-INF/MANIFEST.MF
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: test-deploy-no-dist-mgmt
+Bundle-Version: 1.0.0

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -130,4 +130,11 @@ content = check(repo, "osgi.identity", "(osgi.identity=test-deploy)", "test-depl
 
 assert content.getAttributes().get("url").toString().contains("localdeployrepo");
 
+//Test that we can find things that were deployed into a repository only declared in properties
+
+repo = check("${basedir}/index-deployment-repo-no-dist-mgmt/target/index.xml", "${basedir}/index-deployment-repo-no-dist-mgmt/target/index.xml.gz", 1, true, false);
+content = check(repo, "osgi.identity", "(osgi.identity=test-deploy-no-dist-mgmt)", "test-deploy-no-dist-mgmt", true);
+
+assert content.getAttributes().get("url").toString().contains("localsnapshotdeployrepo");
+
 return;

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -75,7 +75,27 @@ public class DependencyResolver {
 		this.postProcessor = postProcessor;
 	}
 
+	
+	
 	public Map<File, ArtifactResult> resolve() throws MojoExecutionException {
+		List<RemoteRepository> remoteRepositories = new ArrayList<>(project.getRemoteProjectRepositories());
+		ArtifactRepository deployRepo = project.getDistributionManagementArtifactRepository();
+		if (deployRepo != null) {
+			remoteRepositories.add(RepositoryUtils.toRepo(deployRepo));
+		}
+		return resolve(remoteRepositories);
+	}
+
+	public Map<File, ArtifactResult> resolveAgainstRepos(Collection<ArtifactRepository> repositories) throws MojoExecutionException {
+		List<RemoteRepository> remoteRepositories = new ArrayList<>(repositories.size());
+		for(ArtifactRepository ar : repositories) {
+			remoteRepositories.add(RepositoryUtils.toRepo(ar));
+		}
+
+		return resolve(remoteRepositories);
+	}
+		
+	private Map<File, ArtifactResult> resolve(List<RemoteRepository> remoteRepositories) throws MojoExecutionException {
 		if (resolvedDependencies != null) {
 			return resolvedDependencies;
 		}
@@ -104,14 +124,6 @@ public class DependencyResolver {
 		DependencyNode dependencyGraph = result.getDependencyGraph();
 
 		if (dependencyGraph != null && !dependencyGraph.getChildren().isEmpty()) {
-			List<RemoteRepository> remoteRepositories = new ArrayList<>(project.getRemoteProjectRepositories());
-
-			ArtifactRepository deployRepo = project.getDistributionManagementArtifactRepository();
-
-			if (deployRepo != null) {
-				remoteRepositories.add(RepositoryUtils.toRepo(deployRepo));
-			}
-
 			discoverArtifacts(dependencies, dependencyGraph.getChildren(), project.getArtifact().getId(),
 					remoteRepositories);
 		}


### PR DESCRIPTION
It is possible (and often recommended) to configure your deployment repositories using command line properties, as these may vary depending on the user. This is done using one of several properties such as [altReleaseDeploymentRepository](https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#altReleaseDeploymentRepository).

The indexer can't find these repos (as they aren't in the project model) and so blows up. This is less than ideal! We need to pay attention to these properties and to add them to the list of possible indexer locations if they are defined.