### PR TITLE
build: Pass closure instead of fileTree to inputs

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -35,7 +35,7 @@ task('index') {
     exclude '**/*-javadoc.jar'
   }
 
-  inputs.files bundles
+  inputs.files { bundles.files }
 
   /* Index files */
   def index_uncompressed = new File(releaserepo, 'index.xml')


### PR DESCRIPTION
It seems that on windows, passing the fileTree to inputs could keep
some of the files open in the daemon preventing them from being
deleted and replaced in the next build operation.
