### PR TITLE
lib: Handle spaces in reference for URIUtil

### DIFF
--- a/aQute.libg/src/aQute/libg/uri/URIUtil.java
+++ b/aQute.libg/src/aQute/libg/uri/URIUtil.java
@@ -7,7 +7,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class URIUtil {
-
 	private static final Pattern DRIVE_LETTER_PATTERN = Pattern.compile("([a-zA-Z]):\\\\(.*)");
 
 	/**
@@ -24,19 +23,24 @@ public final class URIUtil {
 		URI resolved;
 		boolean emptyRef = reference.isEmpty();
 		if (emptyRef) {
-			resolved = baseURI.resolve(URI.create("#"));
-			String resolvedStr = resolved.toASCIIString();
-			resolved = URI.create(resolvedStr.substring(0, resolvedStr.indexOf('#')));
+			resolved = new URI(baseURI.getScheme(), baseURI.getSchemeSpecificPart(), null);
 		} else {
+			URI refURI;
 			// A Windows path such as "C:\Users" is interpreted as a URI with
 			// a scheme of "C". Use a regex that matches the colon-backslash
 			// combination to handle this specifically as an absolute file URI.
 			Matcher driveLetterMatcher = DRIVE_LETTER_PATTERN.matcher(reference);
 			if (driveLetterMatcher.matches()) {
-				resolved = new File(reference).toURI();
+				refURI = new File(reference).toURI();
 			} else {
-				resolved = baseURI.resolve(reference.replace('\\', '/'));
+				reference = reference.replace('\\', '/');
+				try {
+					refURI = new URI(reference);
+				} catch (URISyntaxException e) {
+					refURI = new URI(null, reference, null);
+				}
 			}
+			resolved = baseURI.resolve(refURI);
 		}
 
 		return resolved;

--- a/aQute.libg/test/aQute/libg/uri/URIUtilsTest.java
+++ b/aQute.libg/test/aQute/libg/uri/URIUtilsTest.java
@@ -18,22 +18,27 @@ public class URIUtilsTest extends TestCase {
 		assertEquals("http://example.com/bar.xml", result.toString());
 	}
 
-	public void testResolveRelativeBlank() throws Exception {
+	public void testResolveBlank() throws Exception {
 		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml"), "");
+		assertEquals("http://example.com/foo.xml", result.toString());
+	}
+
+	public void testResolveFragmentBlank() throws Exception {
+		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml#bar"), "");
 		assertEquals("http://example.com/foo.xml", result.toString());
 	}
 
 	public void testResolveAbsoluteWindowsPath() throws Exception {
 		if (isWindows()) {
-			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:\\Users\\jim\\foo.txt");
-			assertEquals("file:/C:/Users/jim/foo.txt", result.toString());
+			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:\\Users\\sub dir\\foo.txt");
+			assertEquals("file:/C:/Users/sub%20dir/foo.txt", result.toString());
 		}
 	}
 
 	public void testResolveRelativeWindowsPath() throws Exception {
 		if (isWindows()) {
-			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "subdir\\foo.txt");
-			assertEquals("/C:/Users/jim/subdir/foo.txt", result.getPath());
+			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "sub dir\\foo.txt");
+			assertEquals("file:/C:/Users/jim/sub%20dir/foo.txt", result.toString());
 		}
 	}
 


### PR DESCRIPTION
This fixes bugs when the relative URL in the `-standalone` instruction contains spaces or other characters not allowed in URIs.