### PR TITLE
Move JUnit dependency version back to 4.11

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -33,7 +33,7 @@ org.apache.felix:org.apache.felix.scr:1.8.2
 org.apache.geronimo.specs:geronimo-servlet_2.5_spec:1.2
 org.apache.geronimo.specs:geronimo-servlet_3.0_spec:1.0
 
-org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1
+org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.11_2
 
 org.apache.ant:ant:1.7.1
 


### PR DESCRIPTION
This prevents an unnecessary increase in the dependency version for biz.aQute.tester. Without this change it is possible for bundle integration tests to stop working when moving from 3.3.0.REL to 3.4.0.RC3 (for example if they include JUnit 4.11 in their runbundles).