### PR TITLE
Drop commas from generated error messages.

### DIFF
--- a/aQute.libg/src/aQute/libg/reporter/ReporterMessages.java
+++ b/aQute.libg/src/aQute/libg/reporter/ReporterMessages.java
@@ -80,11 +80,13 @@ public class ReporterMessages {
 					StringBuilder sb = new StringBuilder();
 					sb.append(name.charAt(0));
 					int n = 0;
+					char c = 0, prev = 0;
 					for (int i = 1; i < name.length(); i++) {
-						char c = name.charAt(i);
+						prev = c;
+						c = name.charAt(i);
 						switch (c) {
 							case '_' :
-								sb.append(" %s, ");
+								sb.append(" %s ");
 								n++;
 								break;
 
@@ -94,7 +96,9 @@ public class ReporterMessages {
 
 							default :
 								if (Character.isUpperCase(c)) {
-									sb.append(" ");
+									if (prev == 0 || prev != ' ') {
+										sb.append(" ");
+									}
 									c = Character.toLowerCase(c);
 								}
 								sb.append(c);

--- a/biz.aQute.bndlib.tests/src/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/BuilderTest.java
@@ -1396,7 +1396,7 @@ public class BuilderTest extends BndTestCase {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
 			b.addClasspath(new File("bin"));
 			Jar jar = b.build();
-			assertTrue(b.check("has 1,  private references"));
+			assertTrue(b.check("has 1 private references"));
 
 			Manifest m = jar.getManifest();
 			String imports = m.getMainAttributes().getValue("Import-Package");

--- a/biz.aQute.bndlib.tests/src/test/NoUsesTest.java
+++ b/biz.aQute.bndlib.tests/src/test/NoUsesTest.java
@@ -23,7 +23,7 @@ public class NoUsesTest extends TestCase {
 		Builder bmaker = new Builder();
 		bmaker.setProperty("Private-Package", "org.osgi.framework");
 		bmaker.setProperty("Export-Package", "org.osgi.util.tracker;uses:=\"<<USES>>,not.used\"");
-		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1,  private");
+		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1 private");
 		assertEquals("not.used", uses);
 	}
 
@@ -47,7 +47,7 @@ public class NoUsesTest extends TestCase {
 		Builder bmaker = new Builder();
 		bmaker.setProperty("Private-Package", "org.osgi.framework");
 		bmaker.setProperty("Export-Package", "org.osgi.util.tracker;uses:=\"not.used,<<USES>>\"");
-		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1,  private");
+		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1 private");
 		assertEquals("not.used", uses);
 	}
 
@@ -84,7 +84,7 @@ public class NoUsesTest extends TestCase {
 		Builder bmaker = new Builder();
 		bmaker.setProperty("Private-Package", "org.osgi.framework");
 		bmaker.setProperty("Export-Package", "org.osgi.util.tracker");
-		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1,  private");
+		String uses = findUses(bmaker, "org.osgi.util.tracker", "has 1 private");
 		assertNull("org.osgi.framework", uses);
 	}
 


### PR DESCRIPTION
Before: Export com.example, has 3, private references [foo.bar, foo.blah, foo.baz]
After: Export com.example has 3 private references [foo.bar, foo.blah, foo.baz]

Signed-off-by: Sean Bright <sean.bright@gmail.com>