### PR TITLE
prepare: Always make sure primary output folders exist

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -252,6 +252,9 @@ public class Project extends Processor {
 
 		synchronized (preparedPaths) {
 			if (preparedPaths.get()) {
+				// ensure output folders exist
+				getSrcOutput0();
+				getTarget0();
 				return;
 			}
 			if (!workspace.trail.add(this)) {
@@ -315,11 +318,7 @@ public class Project extends Processor {
 				}
 
 				// Set default bin directory
-				output = getSrcOutput().getAbsoluteFile();
-				if (!output.exists()) {
-					IO.mkdirs(output);
-					getWorkspace().changedFile(output);
-				}
+				output = getSrcOutput0();
 				if (!output.isDirectory()) {
 					msgs.NoOutputDirectory_(output);
 				}
@@ -400,6 +399,14 @@ public class Project extends Processor {
 	 *
 	 */
 
+	private File getSrcOutput0() throws IOException {
+		File output = getSrcOutput().getAbsoluteFile();
+		if (!output.exists()) {
+			IO.mkdirs(output);
+			getWorkspace().changedFile(output);
+		}
+		return output;
+	}
 	private File getTarget0() throws IOException {
 		File target = getTargetDir();
 		if (!target.exists()) {


### PR DESCRIPTION
Gradle is aggressive about deleting bin folders when something changes.
Since it does this after the Bnd Projects are first prepared, we need
to ensure the output folders are recreated if necessary on future
calls to prepare.