### PR TITLE
Add support for HTTPS proxies

### DIFF
--- a/biz.aQute.bndlib.comm.tests/bnd.bnd
+++ b/biz.aQute.bndlib.comm.tests/bnd.bnd
@@ -18,5 +18,7 @@
 	org.apache.commons.lang3;version=latest,\
 	org.apache.commons.codec;version=latest,\
 	biz.aQute.repository;version=latest,\
-	com.google.guava;version=latest
+	com.google.guava;version=latest,\
+	bcpkix;version=latest,\
+	bcprov;version=latest
 

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
@@ -51,13 +51,37 @@ public class SettingsParserTest extends TestCase {
 		assertEquals("passwd", p.password);
 	}
 
+	public void testProxies() throws Exception {
+		SettingsDTO settings = getSettings("proxy-types.xml");
+		assertEquals(2, settings.proxies.size());
+		ProxyDTO p = settings.proxies.get(0);
+		assertEquals("http-proxy", p.id);
+		assertEquals(true, p.active);
+		assertEquals(Type.HTTP.name(), p.protocol.toUpperCase());
+		assertEquals("localhost", p.host);
+		assertEquals(80, p.port);
+		assertEquals(null, p.nonProxyHosts);
+		assertEquals(null, p.username);
+		assertEquals(null, p.password);
+
+		p = settings.proxies.get(1);
+		assertEquals("https-proxy", p.id);
+		assertEquals(true, p.active);
+		assertEquals("HTTPS", p.protocol.toUpperCase());
+		assertEquals("localhost", p.host);
+		assertEquals(443, p.port);
+		assertEquals(null, p.nonProxyHosts);
+		assertEquals(null, p.username);
+		assertEquals(null, p.password);
+	}
+
 	public void testSocksAuth() throws Exception {
 		SettingsDTO settings = getSettings("socks-auth.xml");
 		assertEquals(1, settings.proxies.size());
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS, p.protocol);
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
 		assertEquals(1080, p.port);
 		assertEquals(null, p.nonProxyHosts);
 		assertEquals("proxyuser", p.username);
@@ -70,7 +94,7 @@ public class SettingsParserTest extends TestCase {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS, p.protocol);
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
 		assertEquals(1080, p.port);
 		assertEquals(null, p.nonProxyHosts);
 		assertEquals(null, p.username);
@@ -83,7 +107,7 @@ public class SettingsParserTest extends TestCase {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS, p.protocol);
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
 		assertEquals(1080, p.port);
 		assertEquals("*.google.com|ibiblio.org", p.nonProxyHosts);
 		assertEquals(null, p.username);

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/Standalone.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/Standalone.java
@@ -79,6 +79,12 @@ public class Standalone {
 				return "proxyuser".equals(user) && "good".equals(password);
 
 			}
+
+			@Override
+			public String getRealm() {
+				// TODO Auto-generated method stub
+				return null;
+			}
 		});
 		bootstrap.start();
 	}

--- a/biz.aQute.bndlib.comm.tests/testresources/proxy-types.xml
+++ b/biz.aQute.bndlib.comm.tests/testresources/proxy-types.xml
@@ -1,0 +1,31 @@
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<localRepository />
+	<interactiveMode />
+	<usePluginRegistry />
+	<offline />
+	<pluginGroups />
+	<servers />
+	<mirrors />
+	<proxies>
+		<proxy>
+			<id>http-proxy</id>
+			<active>true</active>
+			<protocol>http</protocol>
+			<host>localhost</host>
+			<port>80</port>
+		</proxy>
+		<proxy>
+			<id>https-proxy</id>
+			<active>true</active>
+			<protocol>https</protocol>
+			<host>localhost</host>
+			<port>443</port>
+		</proxy>
+	</proxies>
+	<profiles />
+	<activeProfiles />
+</settings>

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -7,6 +7,7 @@ import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
+import java.net.Proxy.Type;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.URL;
@@ -241,24 +242,37 @@ public class ConnectionSettings extends Processor {
 
 			@Override
 			public ProxySetup forURL(URL url) throws Exception {
-				switch (proxyDTO.protocol) {
 
-					case DIRECT :
+				Proxy.Type type;
+
+				switch (proxyDTO.protocol.toUpperCase()) {
+
+					case "DIRECT" :
+						type = Type.DIRECT;
 						break;
 
-					case HTTP :
-						String scheme = url.getProtocol();
-						if (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")) {
+					case "HTTP" :
+						type = Type.HTTP;
+						if (url.getProtocol().equalsIgnoreCase("http")) {
 							// ok
 						} else
 							return null;
 
 						break;
+					case "HTTPS" :
+						type = Type.HTTP;
+						if (url.getProtocol().equalsIgnoreCase("https")) {
+							// ok
+						} else
+							return null;
+						break;
 
-					case SOCKS :
+					case "SOCKS" :
+						type = Type.SOCKS;
 						break;
 
 					default :
+						type = Type.HTTP;
 						break;
 				}
 
@@ -283,7 +297,7 @@ public class ConnectionSettings extends Processor {
 					else
 						socketAddress = new InetSocketAddress(proxyDTO.port);
 
-					proxySetup.proxy = new Proxy(proxyDTO.protocol, socketAddress);
+					proxySetup.proxy = new Proxy(type, socketAddress);
 				}
 				return proxySetup;
 			}

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ProxyDTO.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ProxyDTO.java
@@ -10,7 +10,7 @@ public class ProxyDTO extends DTO {
 	public String	id			= "default";
 	public boolean	active		= true;
 	public String	mask;
-	public Type		protocol	= Type.HTTP;
+	public String	protocol	= Type.HTTP.name();
 	public String	username;
 	public String	password;
 	public int		port		= 8080;

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -78,7 +78,7 @@ org.slf4j:jcl-over-slf4j:1.7.13
 
 org.yaml:snakeyaml:1.15
 
-org.littleshoot:littleproxy:1.1.0-beta1
+org.littleshoot:littleproxy:1.1.2
 
 io.netty:netty-all:4.1.0.Beta8
 


### PR DESCRIPTION
Fixes #2108 

This PR changes the Proxy DTO to use a String, rather than a type. This, in turn, lets bnd support URL schemes other than HTTP. The rest of the PR fixes up the usage of the DTO, and adds two new tests

* A test to ensure that the parser doesn't blow up when it encounters an https proxy type
* A test to ensure that the HTTPS proxy actually uses HTTPS

The tests are also updated to ensure that the requests actually go through the proxy when they're supposed to.