### PR TITLE
utf8: Avoid sharing CharsetDecoders between threads

### DIFF
--- a/aQute.libg/src/aQute/lib/utf8properties/ThreadLocalCharsetDecoder.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/ThreadLocalCharsetDecoder.java
@@ -1,0 +1,18 @@
+package aQute.lib.utf8properties;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
+class ThreadLocalCharsetDecoder extends ThreadLocal<CharsetDecoder> {
+	private final Charset charset;
+
+	ThreadLocalCharsetDecoder(Charset charset) {
+		super();
+		this.charset = charset;
+	}
+
+	@Override
+	protected CharsetDecoder initialValue() {
+		return charset.newDecoder();
+	}
+}

--- a/aQute.libg/src/aQute/lib/utf8properties/UTF8Properties.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/UTF8Properties.java
@@ -40,8 +40,8 @@ import aQute.service.reporter.Reporter;
  */
 public class UTF8Properties extends Properties {
 	private static final long	serialVersionUID	= 1L;
-	private static final List<CharsetDecoder>	decoders			= Collections
-			.unmodifiableList(Arrays.asList(UTF_8.newDecoder(), ISO_8859_1.newDecoder()));
+	private static final List<ThreadLocalCharsetDecoder>	decoders			= Collections.unmodifiableList(
+			Arrays.asList(new ThreadLocalCharsetDecoder(UTF_8), new ThreadLocalCharsetDecoder(ISO_8859_1)));
 
 	public UTF8Properties(Properties p) {
 		super(p);
@@ -79,7 +79,8 @@ public class UTF8Properties extends Properties {
 	private String decode(byte[] buffer) throws IOException {
 		ByteBuffer bb = ByteBuffer.wrap(buffer);
 		CharBuffer cb = CharBuffer.allocate(buffer.length * 4);
-		for (CharsetDecoder decoder : decoders) {
+		for (ThreadLocalCharsetDecoder tl : decoders) {
+			CharsetDecoder decoder = tl.get();
 			boolean success = !decoder.decode(bb, cb, true).isError();
 			if (success) {
 				decoder.flush(cb);


### PR DESCRIPTION
CharsetDecoders are not thread-safe. We use thread locals to avoid
always having to create new decoders for each invocation.

Reported by @rotty3000.