### PR TITLE
Fix Launcher isFragment check to work without PackageAdmin

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -855,7 +855,10 @@ public class Launcher implements ServiceListener {
 	}
 
 	private boolean isFragment(Bundle b) {
-		return padmin != null && padmin.getBundleType(b) == PackageAdmin.BUNDLE_TYPE_FRAGMENT;
+		if (padmin != null)
+			return padmin.getBundleType(b) == PackageAdmin.BUNDLE_TYPE_FRAGMENT;
+
+		return b.getHeaders().get(Constants.FRAGMENT_HOST) != null;
 	}
 
 	public void deactivate() throws Exception {


### PR DESCRIPTION
This was already fixed by BJ in https://github.com/bndtools/bnd/commit/1ad80861fd0c20eca994e34d5198be8a3efd21d7

But it reappeared as part of https://github.com/bndtools/bnd/commit/deaa9651d5f7dab1368eeabbe58076e98df95490

However, I think the implementation of https://github.com/bndtools/bnd/commit/1ad80861fd0c20eca994e34d5198be8a3efd21d7 is the correct one