### PR TITLE
Ensure that commonly used utilities avoid unnecessary internal depend…

### DIFF
--- a/aQute.libg/src/aQute/lib/base64/Base64.java
+++ b/aQute.libg/src/aQute/lib/base64/Base64.java
@@ -2,18 +2,21 @@ package aQute.lib.base64;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.util.regex.Pattern;
 
-import aQute.lib.io.IO;
 /*
  * Base 64 converter.
  * 
@@ -71,14 +74,14 @@ public class Base64 {
 	}
 
 	public static byte[] decodeBase64(InputStream in, int maxLength) throws IOException {
-		return decodeBase64(IO.reader(in, US_ASCII), maxLength);
+		return decodeBase64(new BufferedReader(new InputStreamReader(in, US_ASCII)), maxLength);
 	}
 
 	public final static byte[] decodeBase64(File file) throws IOException {
 		if (file.length() > Integer.MAX_VALUE)
 			throw new IllegalArgumentException("File " + file + " is >4Gb for base 64 decoding");
 		try {
-			return decodeBase64(IO.reader(file, US_ASCII), (int) file.length() * 2 / 3);
+			return decodeBase64(Files.newBufferedReader(file.toPath(), US_ASCII), (int) file.length() * 2 / 3);
 		} catch (IllegalArgumentException iae) {
 			throw new IllegalArgumentException(iae.getMessage() + ": " + file, iae);
 		}
@@ -165,7 +168,7 @@ public class Base64 {
 
 	public static String encodeBase64(File in) throws IOException {
 		StringWriter sw = new StringWriter();
-		encode(IO.stream(in), sw);
+		encode(in, sw);
 		return sw.toString();
 	}
 
@@ -188,7 +191,7 @@ public class Base64 {
 		if (in.length() > Integer.MAX_VALUE)
 			throw new IllegalArgumentException("File > 4Gb " + in);
 
-		encode(IO.stream(in), sb, (int) in.length());
+		encode(new BufferedInputStream(Files.newInputStream(in.toPath())), sb, (int) in.length());
 	}
 
 	public static void encode(InputStream in, Appendable sb) throws IOException {

--- a/aQute.libg/src/aQute/lib/hex/Hex.java
+++ b/aQute.libg/src/aQute/lib/hex/Hex.java
@@ -1,9 +1,8 @@
 package aQute.lib.hex;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.regex.Pattern;
-
-import aQute.lib.strings.Strings;
 
 /*
  * Hex converter.
@@ -18,7 +17,8 @@ public class Hex {
 									};
 
 	public final static byte[] toByteArray(String string) {
-		string = Strings.trim(string);
+		Objects.requireNonNull(string, "The hex string must not be null.");
+		string = string.trim();
 		if ((string.length() & 1) != 0)
 			throw new IllegalArgumentException("a hex string must have an even length");
 

--- a/aQute.libg/src/aQute/lib/strings/Strings.java
+++ b/aQute.libg/src/aQute/lib/strings/Strings.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import aQute.lib.collections.ExtList;
-
 public class Strings {
 
 	public static String join(String middle, Iterable< ? > objects) {
@@ -49,7 +47,7 @@ public class Strings {
 	}
 
 	public static String join(String middle, Object[] segments) {
-		return join(middle, new ExtList<Object>(segments));
+		return join(middle, Arrays.asList(segments));
 	}
 
 	public static String display(Object o, Object... ifNull) {


### PR DESCRIPTION
…encies

* Hex encoding should not require strings to do a single trim
* Strings should not need collections to create an Iterable from an array
* Base64 should not pull in IO for a small number of stream conversions

The result of this change is that the converter and base64 packages no longer need IO or Glob, and the hex and strings packages no longer need collections, IO or Glob

Signed-off-by: Tim Ward <timothyjward@apache.org>

Fixes #2122 