### PR TITLE
maven: Used LinkedHashMap to ensure consistent ordering on traversal

### DIFF
--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -9,7 +9,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -138,7 +138,7 @@ public class IndexerMojo extends AbstractMojo {
 		logger.debug("Local file URLs permitted: {}", localURLs);
 		logger.debug("Adding mvn: URLs as alternative content: {}", addMvnURLs);
 
-		Map<String,ArtifactRepository> repositories = new HashMap<>();
+		Map<String,ArtifactRepository> repositories = new LinkedHashMap<>();
 		for (ArtifactRepository artifactRepository : project.getRemoteArtifactRepositories()) {
 			logger.debug("Located an artifact repository {}", artifactRepository.getId());
 			repositories.put(artifactRepository.getId(), artifactRepository);

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -119,7 +119,7 @@ public class DependencyResolver {
 			throw new MojoExecutionException(e.getMessage(), e);
 		}
 
-		Map<File,ArtifactResult> dependencies = new HashMap<>();
+		Map<File, ArtifactResult> dependencies = new LinkedHashMap<>();
 
 		DependencyNode dependencyGraph = result.getDependencyGraph();
 


### PR DESCRIPTION
Using just HashMap can lead to traversal ordering differences across JVM impls.