### PR TITLE
processor: Ignore empty property values when merging properties

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1283,7 +1283,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		for (String k : sortedList) {
 			if (ins.matches(k)) {
 				String v = getLiteralProperty(k, null, this, inherit);
-				if (v != null) {
+				if ((v != null) && !v.isEmpty()) {
 					sb.append(del);
 					del = separator;
 					sb.append(v);


### PR DESCRIPTION
Otherwise, the merged property ends up including ",," which is then
warned about later when parsing as an Empty clause.