### PR TITLE
[reporter] Build structure for reporter.

### DIFF
--- a/aQute.libg/src/aQute/lib/tag/Tag.java
+++ b/aQute.libg/src/aQute/lib/tag/Tag.java
@@ -1,7 +1,12 @@
 package aQute.lib.tag;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import aQute.lib.exceptions.Exceptions;
+
 /**
  * The Tag class represents a minimal XML tree. It consist of a named element
  * with a hashtable of named attributes. Methods are provided to walk the tree
@@ -20,16 +27,16 @@ import java.util.regex.Pattern;
  */
 public class Tag {
 
-	final static String			NameStartChar	= ":A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF]\uFDF0-\uFFFD";
-	final static String			NameChar		= "[" + NameStartChar + "0-9.\u00B7\u0300-\u036F\u203F-\u2040\\-]";
-	final static String			Name			= "[" + NameStartChar + "]" + NameChar + "*";
-	final public static Pattern	NAME_P			= Pattern.compile(Name);
+	final static String				NameStartChar	= ":A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF]\uFDF0-\uFFFD";
+	final static String				NameChar		= "[" + NameStartChar + "0-9.\u00B7\u0300-\u036F\u203F-\u2040\\-]";
+	final static String				Name			= "[" + NameStartChar + "]" + NameChar + "*";
+	final public static Pattern		NAME_P			= Pattern.compile(Name);
 
-	Tag								parent;														// Parent
-	String							name;														// Name
-	final Map<String,String>		attributes	= new LinkedHashMap<String,String>();
-	final List<Object>				content		= new ArrayList<Object>();						// Content
-	final static SimpleDateFormat	format		= new SimpleDateFormat("yyyyMMddHHmmss.SSS");
+	Tag								parent;																																											// Parent
+	String							name;																																											// Name
+	final Map<String,String>		attributes		= new LinkedHashMap<String,String>();
+	final List<Object>				content			= new ArrayList<Object>();																																		// Content
+	final static SimpleDateFormat	format			= new SimpleDateFormat("yyyyMMddHHmmss.SSS");
 	boolean							cdata;
 
 	/**
@@ -494,5 +501,18 @@ public class Tag {
 			return name;
 		else
 			return parent.getPath() + "/" + name;
+	}
+
+	public InputStream toInputStream() {
+		try {
+			ByteArrayOutputStream bout = new ByteArrayOutputStream();
+			PrintWriter pw = new PrintWriter(new OutputStreamWriter(bout, "UTF-8"));
+			this.print(2, pw);
+			pw.flush();
+			return new ByteArrayInputStream(bout.toByteArray());
+		} catch (UnsupportedEncodingException e) {
+			// impossible
+			throw Exceptions.duck(e);
+		}
 	}
 }

--- a/aQute.libg/src/aQute/lib/tag/packageinfo
+++ b/aQute.libg/src/aQute/lib/tag/packageinfo
@@ -1,1 +1,1 @@
-version 1.2
+version 1.3

--- a/biz.aQute.bnd.reporter/.classpath
+++ b/biz.aQute.bnd.reporter/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="src" output="bin_test" path="test"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/biz.aQute.bnd.reporter/.gitignore
+++ b/biz.aQute.bnd.reporter/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/bin_test/
+/generated/

--- a/biz.aQute.bnd.reporter/.project
+++ b/biz.aQute.bnd.reporter/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>biz.aQute.bnd.reporter</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/biz.aQute.bnd.reporter/.settings/org.eclipse.core.resources.prefs
+++ b/biz.aQute.bnd.reporter/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/bnd.bnd=UTF-8

--- a/biz.aQute.bnd.reporter/.settings/org.eclipse.jdt.core.prefs
+++ b/biz.aQute.bnd.reporter/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -1,0 +1,12 @@
+Export-Package: \
+	biz.aQute.bnd.reporter.command,\
+	biz.aQute.bnd.reporter.lib
+
+
+-buildpath: \
+	aQute.libg;version=latest,\
+	biz.aQute.bndlib;version=latest
+	
+-testpath: \
+	org.apache.servicemix.bundles.junit
+	

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/command/ReporterCommand.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/command/ReporterCommand.java
@@ -1,0 +1,67 @@
+package biz.aQute.bnd.reporter.command;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.lib.getopt.Description;
+import aQute.lib.getopt.Options;
+import aQute.lib.tag.Tag;
+import aQute.libg.xslt.Transform;
+import biz.aQute.bnd.reporter.lib.ReportGenerator;
+
+public class ReporterCommand extends Processor {
+	
+	private ReporterOptions options;
+
+	public ReporterCommand( Processor p) {
+		super(p);
+	}
+
+	public interface ReporterOptions extends Options {
+		@Description("Output file")
+		String output();
+	}
+
+	public void run(ReporterOptions options) throws Exception {
+		
+		this.options = options;
+		
+		List<String> args = options._arguments();
+		if ( args.isEmpty()) {
+			error("No command");
+			return;
+		}
+			
+		String cmd = args.remove(0);
+		options._command().execute(this, cmd, args);
+	}
+	
+
+	@Description("Generate")
+	interface GenerateOptions extends Options {
+		String template();
+	}
+	
+	public void _generate(GenerateOptions genOptions) throws Exception {
+		System.out.println("Hello Reporter");
+		
+		for ( String arg : genOptions._arguments()) {
+			File f = getFile(arg);
+			ReportGenerator rg  = new ReportGenerator(this);
+
+			Jar jar = new Jar(f);
+			Tag tag = rg.createReport(jar);
+
+			if ( genOptions.template()!=null) {
+				
+				URL xslt = getFile(genOptions.template()).toURI().toURL();
+				Transform.transform(xslt, tag.toInputStream(), System.out);
+			} else
+				System.out.println(tag);
+		}
+	}
+	
+}

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/command/package-info.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/command/package-info.java
@@ -1,0 +1,2 @@
+@aQute.bnd.annotation.Version("1.0.0")
+package biz.aQute.bnd.reporter.command;

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/ReportGenerator.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/ReportGenerator.java
@@ -1,0 +1,29 @@
+package biz.aQute.bnd.reporter.lib;
+
+import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.reporter.ReportGeneratorPlugin;
+import aQute.lib.tag.Tag;
+
+public class ReportGenerator extends Processor {
+
+	public ReportGenerator(Processor processor) {
+		super(processor);
+		use(this);
+	}
+
+	public Tag createReport(Jar jar) throws Exception {
+		Tag top = new Tag("report");
+		
+		Domain d = Domain.domain(jar.getManifest());
+
+		new Tag(top, "bundle-symbolic-name", d.getBundleSymbolicName().getKey());
+		
+		for ( ReportGeneratorPlugin rp : getParent().getPlugins(ReportGeneratorPlugin.class))
+			top.addContent( rp.report(jar));
+		
+		return top;
+	}
+
+}

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/ReportPostBuildPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/ReportPostBuildPlugin.java
@@ -1,0 +1,28 @@
+package biz.aQute.bnd.reporter.lib;
+
+import java.util.Map;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.service.buildevents.PostBuildPlugin;
+import aQute.lib.tag.Tag;
+
+public class ReportPostBuildPlugin implements PostBuildPlugin{
+
+	private static final String REPORT_GENERATE = "-report.generate";
+
+	@Override
+	public void postBuild(Builder builder) throws Exception {
+		Parameters parameters = new Parameters(builder.getProperty(REPORT_GENERATE));
+		
+		for ( Map.Entry<String, Attrs> e : parameters.entrySet()) {
+			String name = e.getKey();
+			
+			ReportGenerator rg = new ReportGenerator(builder);
+			Tag tag = rg.createReport(builder.getJar());
+			builder.getJar().putResource( name, new TagResource(tag));
+		}		
+	}
+
+}

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/TagResource.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/TagResource.java
@@ -1,0 +1,35 @@
+package biz.aQute.bnd.reporter.lib;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+import aQute.bnd.osgi.WriteResource;
+import aQute.lib.io.IO;
+import aQute.lib.tag.Tag;
+public class TagResource extends WriteResource {
+	final Tag tag;
+
+	public TagResource(Tag tag) {
+		this.tag = tag;
+	}
+
+	@Override
+	public void write(OutputStream out) throws IOException {
+		PrintWriter pw = IO.writer(out, UTF_8);
+		pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+		try {
+			tag.print(0, pw);
+		} finally {
+			pw.flush();
+		}
+	}
+
+	@Override
+	public long lastModified() {
+		return 0;
+	}
+
+}

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/package-info.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/lib/package-info.java
@@ -1,0 +1,2 @@
+@aQute.bnd.annotation.Version("1.0.0")
+package biz.aQute.bnd.reporter.lib;

--- a/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/ReporterTest.java
+++ b/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/ReporterTest.java
@@ -1,0 +1,26 @@
+package biz.aQute.bnd.reporter;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Jar;
+import aQute.lib.io.IO;
+import biz.aQute.bnd.reporter.lib.ReportPostBuildPlugin;
+
+public class ReporterTest {
+
+	@Test
+	public void testReporterSimple() throws Exception {
+		Builder b = new Builder();
+		b.addBasicPlugin(new ReportPostBuildPlugin());
+		b.setProperty("-report.generate", "OSGI-INF/report/report.xml");
+		
+		b.addClasspath( IO.getFile("bin_test"));
+		Jar[] jar = b.builds();
+
+		assertNotNull( jar[0].getResource("OSGI-INF/report/report.xml"));
+		
+	}
+}

--- a/biz.aQute.bnd.reporter/xslt/simple.xslt
+++ b/biz.aQute.bnd.reporter/xslt/simple.xslt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format" >
+
+    <xsl:output method="text" omit-xml-declaration="yes" indent="no"/>
+    
+    <xsl:template match="//bundle-symbolic-name">
+    		<xsl:text><xsl:value-of select="text()"/></xsl:text>
+    	</xsl:template>
+    	
+</xsl:stylesheet>

--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -17,6 +17,7 @@ Conditional-Package: 			aQute.libg.*,aQute.lib.*,aQute.configurable, aQute.remot
  @${repo;biz.aQute.bndlib;latest}!/!META-INF/*, \
  @${repo;biz.aQute.repository;latest}!/!META-INF/*, \
  @${repo;biz.aQute.resolve;latest}!/!META-INF/*, \
+ @${repo;biz.aQute.bnd.reporter;latest}!/!META-INF/*, \
  @${repo;slf4j.api;latest}!/!META-INF/*, \
  @${repo;slf4j.simple;latest}!/!META-INF/*
 
@@ -49,6 +50,7 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
 	biz.aQute.resolve;version=latest,\
 	biz.aQute.remote.api;version=latest,\
 	org.yaml.snakeyaml;version=latest,\
+	biz.aQute.bnd.reporter, \
 	slf4j.api;version=latest
 
 

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -141,6 +141,7 @@ import aQute.libg.reporter.ReporterAdapter;
 import aQute.libg.reporter.ReporterMessages;
 import aQute.libg.sed.Sed;
 import aQute.service.reporter.Reporter;
+import biz.aQute.bnd.reporter.command.ReporterCommand;
 
 /**
  * Utility to make bundles. @version $Revision: 1.14 $
@@ -4278,5 +4279,13 @@ public class bnd extends Processor {
 		if (!noExit.get()) {
 			System.exit(code);
 		}
+	}
+
+	@Description("Reporting")
+	public void _report(ReporterCommand.ReporterOptions options) throws Exception {
+		ReporterCommand mc = new ReporterCommand(this);
+		mc.use(this);
+		mc.run(options);
+		getInfo(mc);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -634,6 +634,8 @@ public class ProjectBuilder extends Builder {
 	 */
 	@Override
 	protected void doneBuild(Builder builder) throws Exception {
+		super.doneBuild(builder);
+
 		project.exportedPackages.putAll(builder.getExports());
 		project.importedPackages.putAll(builder.getImports());
 		project.containedPackages.putAll(builder.getContained());

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -42,6 +42,7 @@ import aQute.bnd.metatype.MetatypeAnnotations;
 import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
 import aQute.bnd.service.SignerPlugin;
+import aQute.bnd.service.buildevents.PostBuildPlugin;
 import aQute.bnd.service.diff.Delta;
 import aQute.bnd.service.diff.Diff;
 import aQute.bnd.service.diff.Tree;
@@ -1314,7 +1315,11 @@ public class Builder extends Analyzer {
 	/**
 	 * Called when we're done with a builder
 	 */
-	protected void doneBuild(Builder builder) throws Exception {}
+	protected void doneBuild(Builder builder) throws Exception {
+		for (PostBuildPlugin post : getPlugins(PostBuildPlugin.class)) {
+			post.postBuild(builder);
+		}
+	}
 
 	/**
 	 * Answer a list of builders that represent this file or a list of files

--- a/biz.aQute.bndlib/src/aQute/bnd/service/buildevents/PostBuildPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/buildevents/PostBuildPlugin.java
@@ -1,0 +1,9 @@
+package aQute.bnd.service.buildevents;
+
+import aQute.bnd.osgi.Builder;
+
+public interface PostBuildPlugin {
+
+	void postBuild(Builder builder) throws Exception;
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/reporter/ReportGeneratorPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/reporter/ReportGeneratorPlugin.java
@@ -1,0 +1,8 @@
+package aQute.bnd.service.reporter;
+
+import aQute.bnd.osgi.Jar;
+import aQute.lib.tag.Tag;
+
+public interface ReportGeneratorPlugin {
+	Tag report(Jar jar) throws Exception;
+}


### PR DESCRIPTION
This implements a command. In the bnd root dir
try:

  java -jar biz.aQute.bnd/generated/biz.aQute.bnd.jar report generate -t biz.aQute.bnd.reporter/xslt/simple.xslt biz.aQute.bnd/generated/biz.aQute.bnd.j
ar

It also implements a ReportGenerator skeleton and it 
will participate in a build when the ReportPostBuildPlugin is added to the
set of plugins (this should happen in Gradle later).

There is also a simplistic testcase.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>