### PR TITLE
resource: FileResource wraps a file which should not change

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/FileResource.java
@@ -12,6 +12,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 import aQute.lib.io.IO;
 import aQute.lib.io.IOConstants;
 
+/**
+ * Resource for a file. This class implementation assumes the file does not
+ * change underneath this object.
+ */
 public class FileResource implements Resource {
 	private static final int		THRESHOLD	= IOConstants.PAGE_SIZE * 16;
 	private static final ByteBuffer	CLOSED	= ByteBuffer.allocate(0);
@@ -58,8 +62,7 @@ public class FileResource implements Resource {
 	@Override
 	public ByteBuffer buffer() throws Exception {
 		if (buffer != null) {
-			if (buffer.limit() > 0 || file.toFile().length() == 0)
-				return buffer.duplicate();
+			return buffer.duplicate();
 		}
 		if (IO.isWindows() && (size > THRESHOLD)) {
 			return null;


### PR DESCRIPTION
So we remove the change Peter made to handle the file changing (in only
a single place). If, in the future, we want to handle the file changing
underneath a FileResource object, this class will need more extensive
changes.