### PR TITLE
p2repo: Use hash of URI for repository name to detect changes in URI

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0


### PR DESCRIPTION
If the hash of the current URI does not match the repository name in the
index, then the URI was changed since the index was written and the
index is invalid. So we read the repository from the URI.

Replaces https://github.com/bndtools/bnd/pull/2164