### PR TITLE
Avoid DS annotation scanning when there is no @Component annotation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
@@ -156,6 +156,12 @@ public class AnnotationReader extends ClassDataCollector {
 				return null;
 		}
 
+		if (!clazz.is(ANNOTATED, COMPONENT_INSTR, analyzer)) {
+			// This class is not annotated with @Component and so not suitable
+			// for processing
+			return null;
+		}
+
 		clazz.parseClassFileWithCollector(this);
 		if (component.implementation == null)
 			return null;
@@ -309,8 +315,9 @@ public class AnnotationReader extends ClassDataCollector {
 			Clazz clazz = analyzer.findClass(annotation.getName());
 
 			if (clazz == null) {
-				analyzer.warning("Unable to process the annotation %s as it is not on the project build path",
-						annotation.getName().getFQN()).details(details);
+				analyzer.warning(
+						"Unable to determine whether the annotation %s applied to type %s is a component property type as it is not on the project build path. If this annotation is a component property type then it must be present on the build path in order to be processed",
+						annotation.getName().getFQN(), className.getFQN()).details(details);
 				return;
 			}
 


### PR DESCRIPTION
This change also improves the text of the warning message that occurs when an annotation cannot be loaded to check whether it is a component property annotation.

Signed-off-by: Tim Ward <timothyjward@apache.org>