### PR TITLE
Support for Bundle annotations

### DIFF
--- a/biz.aQute.bndlib.tests/bnd.bnd
+++ b/biz.aQute.bndlib.tests/bnd.bnd
@@ -12,6 +12,7 @@
 	org.osgi.service.component;version=latest,\
 	org.osgi.service.component.annotations;version=latest,\
 	org.osgi.service.metatype.annotations;version=latest,\
+	org.osgi.annotation.bundle;version=latest,\
     org.osgi.util.function;version=latest,\
     org.osgi.util.promise;version=latest,\
     osgi.annotation;version=6.0.1,\

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -1,0 +1,114 @@
+package test.annotationheaders;
+
+import java.util.jar.Attributes;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.lib.env.Header;
+import aQute.lib.env.Props;
+import aQute.lib.io.IO;
+import junit.framework.TestCase;
+
+/**
+ * This class mirrors the testing from {@link AnnotationHeadersTest} but using
+ * the OSGi R7 standard annotations. Annotations and annotated types are present
+ * in the test.annotationheaders.xxx.std packages
+ */
+public class StdAnnotationHeadersTest extends TestCase {
+
+	/**
+	 * A directly annotated class
+	 */
+
+	public void testStdAnnotations() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders.multiple.std");
+			b.build();
+			assertTrue(b.check());
+			b.getJar().getManifest().write(System.out);
+
+			Attributes mainAttributes = b.getJar().getManifest().getMainAttributes();
+
+			Header req = Header.parseHeader(mainAttributes.getValue(Constants.REQUIRE_CAPABILITY));
+			Props p = req.get("require");
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertTrue(p.get("filter:").contains("(a=b)"));
+			assertTrue(p.get("filter:").contains("(&(version>=1.0.0)(!(version>=2.0.0)))"));
+			assertTrue(p.get("filter:").contains("(require=Required)"));
+
+			p = req.get("require" + Header.DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertTrue(p.get("filter:").contains("(a=b)"));
+			assertTrue(p.get("filter:").contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
+			assertTrue(p.get("filter:").contains("(require=Required2)"));
+
+			Header cap = Header.parseHeader(mainAttributes.getValue(Constants.PROVIDE_CAPABILITY));
+			p = cap.get("provide");
+			assertNotNull(p);
+			assertTrue(p.containsKey("provide"));
+			assertEquals("Provided", p.get("provide"));
+
+			p = cap.get("provide" + Header.DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("provide"));
+			assertEquals("Provided2", p.get("provide"));
+
+			// TODO for some reason these headers aren't included
+			// assertEquals("bar", mainAttributes.getValue("Foo"));
+			// assertEquals("buzz", mainAttributes.getValue("Fizz"));
+
+		}
+	}
+
+	/**
+	 * A Meta annotated class
+	 * 
+	 * @throws Exception
+	 */
+	public void testStdAnnotationsMetaAnnotated() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders.attrs.std");
+			b.build();
+			assertTrue(b.check());
+			b.getJar().getManifest().write(System.out);
+
+			Attributes mainAttributes = b.getJar().getManifest().getMainAttributes();
+
+			Header req = Header.parseHeader(mainAttributes.getValue(Constants.REQUIRE_CAPABILITY));
+			Props p = req.get("require");
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertTrue(p.get("filter:").contains("(a=b)"));
+			assertTrue(p.get("filter:").contains("(&(version>=1.0.0)(!(version>=2.0.0)))"));
+			assertTrue(p.get("filter:").contains("(require=Required)"));
+
+			p = req.get("require" + Header.DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertTrue(p.get("filter:").contains("(a=b)"));
+			assertTrue(p.get("filter:").contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
+			assertTrue(p.get("filter:").contains("(require=Required2)"));
+
+			Header cap = Header.parseHeader(mainAttributes.getValue(Constants.PROVIDE_CAPABILITY));
+			p = cap.get("provide");
+			assertNotNull(p);
+			assertTrue(p.containsKey("provide"));
+			assertEquals("Provided", p.get("provide"));
+
+			p = cap.get("provide" + Header.DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("provide"));
+			assertEquals("Provided2", p.get("provide"));
+
+			// TODO for some reason these headers aren't included
+			// assertEquals("bar", mainAttributes.getValue("Foo"));
+			// assertEquals("buzz", mainAttributes.getValue("Fizz"));
+
+		}
+	}
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AnnotatedAnnotation.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AnnotatedAnnotation.java
@@ -1,0 +1,14 @@
+package test.annotationheaders.attrs.std;
+
+import org.osgi.annotation.bundle.Capability;
+import org.osgi.annotation.bundle.Header;
+import org.osgi.annotation.bundle.Requirement;
+
+@Capability(namespace = "provide", name = "Provided")
+@Capability(namespace = "provide", name = "Provided2")
+@Requirement(namespace = "require", name = "Required", version = "1", filter = "(a=b)")
+@Requirement(namespace = "require", name = "Required2", version = "2", filter = "(a=b)")
+@Header(name = "foo", value = "bar")
+@Header(name = "fizz", value = "buzz")
+public @interface AnnotatedAnnotation {
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/UsingAnnotatedAnnotation.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/UsingAnnotatedAnnotation.java
@@ -1,0 +1,6 @@
+package test.annotationheaders.attrs.std;
+
+@AnnotatedAnnotation
+public class UsingAnnotatedAnnotation {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/multiple/std/PetstoreAppComponent.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/multiple/std/PetstoreAppComponent.java
@@ -1,0 +1,16 @@
+package test.annotationheaders.multiple.std;
+
+import org.osgi.annotation.bundle.Capability;
+import org.osgi.annotation.bundle.Header;
+import org.osgi.annotation.bundle.Requirement;
+
+@Capability(namespace = "provide", name = "Provided")
+@Capability(namespace = "provide", name = "Provided2")
+@Requirement(namespace = "require", name = "Required", version = "1", filter = "(a=b)")
+@Requirement(namespace = "require", name = "Required2", version = "2", filter = "(a=b)")
+@Header(name = "Foo", value = "bar")
+@Header(name = "Fizz", value = "buzz")
+public class PetstoreAppComponent {
+	// ..
+}
+

--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -50,6 +50,7 @@ Conditional-Package:	        aQute.service.*, aQute.configurable
 -buildpath:  \
 	org.osgi.service.component.annotations;version=latest,\
 	org.osgi.service.metatype.annotations;version=latest,\
+	org.osgi.annotation.bundle;version=latest,\
     osgi.annotation;version=6.0.1,\
 	osgi.core;version=@6,\
     org.osgi.util.function;version=latest,\

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/DesignateReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/DesignateReader.java
@@ -76,7 +76,7 @@ public class DesignateReader extends ClassDataCollector {
 			if (a instanceof Designate)
 				designate = annotation;
 			else if (a instanceof Component) {
-				doComponent(a);
+				doComponent(annotation, (Component) a);
 			} else {
 				XMLAttribute xmlAttr = finder.getXMLAttribute(annotation);
 				if (xmlAttr != null) {
@@ -89,16 +89,13 @@ public class DesignateReader extends ClassDataCollector {
 		}
 	}
 
-	void doComponent(java.lang.annotation.Annotation a) {
-		Component component = (Component) a;
-		pids = component.configurationPid();
+	void doComponent(Annotation a, Component c) {
+		pids = a.keySet().contains("configurationPid") ? c.configurationPid() : null;
 		if (pids != null) {
 			pid = pids[0];
 		}
 		if (pids == null || "$".equals(pid)) {
-			pid = component.name();
-			if (pid == null)
-				pid = clazz.getClassName().getFQN();
+			pid = a.keySet().contains("name") ? c.name() : clazz.getClassName().getFQN();
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
@@ -323,10 +323,11 @@ class OCDReader {
 		private void doOCD(ObjectClassDefinition o, Annotation annotation) {
 			if (ocd.id == null) {
 				if (clazz.isInterface()) {
-					ocd.id = o.id() == null ? name.getFQN() : o.id();
-					ocd.name = o.name() == null ? space(ocd.id) : o.name();
-					ocd.description = o.description() == null ? "" : o.description();
-					ocd.localization = o.localization() == null ? "OSGI-INF/l10n/" + name.getFQN() : o.localization();
+					ocd.id = annotation.get("id") == null ? name.getFQN() : o.id();
+					ocd.name = annotation.get("name") == null ? space(ocd.id) : o.name();
+					ocd.description = annotation.get("description") == null ? "" : o.description();
+					ocd.localization = annotation.get("localization") == null ? "OSGI-INF/l10n/" + name.getFQN()
+							: o.localization();
 					if (annotation.get("pid") != null) {
 						String[] pids = o.pid();
 						designates(name.getFQN(), pids, false);
@@ -351,7 +352,7 @@ class OCDReader {
 			AttributeDefinition ad = adDef.ad;
 			Annotation a = adDef.a;
 
-			if (ad.name() != null) {
+			if (a.get("name") != null) {
 				adDef.name = ad.name();
 			}
 			adDef.description = a.get("description");
@@ -361,8 +362,12 @@ class OCDReader {
 			if (a.get("cardinality") != null) {
 				adDef.cardinality = ad.cardinality();
 			}
-			adDef.max = ad.max();
-			adDef.min = ad.min();
+			if (a.get("max") != null) {
+				adDef.max = ad.max();
+			}
+			if (a.get("min") != null) {
+				adDef.min = ad.min();
+			}
 			if (a.get("defaultValue") != null) {
 				adDef.defaults = ad.defaultValue();
 			}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -7,14 +7,32 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import aQute.bnd.annotation.metatype.Configurable;
 import aQute.bnd.osgi.Descriptors.TypeRef;
+import aQute.lib.converter.Converter;
 
 /*
  * This class is referenced in aQute.bnd.annotation.metatype.Configurable in constant
  * BND_ANNOTATION_CLASS_NAME
  */
 public class Annotation {
+
+	private static final Converter CONVERTER;
+
+	static {
+		CONVERTER = new Converter();
+		CONVERTER.hook(null, (t, o) -> {
+			if (t instanceof Class< ? > && ((Class< ? >) t).isAnnotation()) {
+				// Suitable target
+				if (o instanceof Annotation) {
+					Annotation a = (Annotation) o;
+					return a.getName().getFQN().equals(((Class< ? >) t).getName()) ? a.getAnnotation() : null;
+				}
+			}
+
+			return null;
+		});
+	}
+
 	private TypeRef				name;
 	private Map<String,Object>	elements;
 	private ElementType			member;
@@ -87,7 +105,7 @@ public class Annotation {
 		String cname = name.getFQN();
 		if (!c.getName().equals(cname))
 			return null;
-		return Configurable.createConfigurable(c,
+		return CONVERTER.convert(c,
 				elements == null ? elements = new LinkedHashMap<String,Object>() : elements);
 	}
 

--- a/cnf/ext/osgi-snapshots.mvn
+++ b/cnf/ext/osgi-snapshots.mvn
@@ -1,1 +1,2 @@
 org.osgi:org.osgi.service.component.annotations:1.4.0-SNAPSHOT
+org.osgi:org.osgi.annotation.bundle:1.0.0-SNAPSHOT


### PR DESCRIPTION
This is a first attempt at supporting the OSGi R7 bundle annotations, it includes some minor refactoring of the annotation processing logic to make things a little more consistent, as well as support for `@Requirement` and `@Capability`. `@Header` is also processed, but for some reason it never makes it into the output manifest.

This seems worth merging as is, as I know that both @bjhargrave and I will be talking about this support at the OSGi Community Event next week, and if this is integrated we can demonstrate using a Bndtools DEV driver.