### PR TITLE
Repackage the standard Bundle annotations

### DIFF
--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -8,6 +8,7 @@ Private-Package: 				\
 	aQute.bnd.*, \
 	aQute.lib.*;-split-package:=first, \
 	aQute.libg.*;-split-package:=first,\
+    org.osgi.annotation.bundle;-split-package:=first,\
     org.osgi.service.*.annotations.*;-split-package:=first
 
 Export-Package: \


### PR DESCRIPTION
This avoids the need for the standard bundle annotations to be on the build path, and lets us use them at runtime

Signed-off-by: Tim Ward <timothyjward@apache.org>