### PR TITLE
Be more lenient with required DS version

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/component_extra/DSPropertyAnnotationsTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component_extra/DSPropertyAnnotationsTest.java
@@ -29,7 +29,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		super.setUp();
 
 		Builder b = new Builder();
-		b.setProperty("Private-Package", SimpleDSPropertyAnnotated.class.getPackage().getName());
+		b.setProperty("Private-Package", DSPropertyAnnotationsTest.class.getPackage().getName());
 		b.addClasspath(new File("bin"));
 
 		jar = b.build();
@@ -54,7 +54,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(SimpleDSPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(1, "scr:component/property");
@@ -80,7 +80,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(DefaultDSPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(1, "scr:component/property");
@@ -106,7 +106,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(IntDSPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(1, "scr:component/property");
@@ -134,7 +134,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(MultiDSPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(2, "scr:component/property");
@@ -164,7 +164,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(PrefixPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(1, "scr:component/property");
@@ -192,7 +192,7 @@ public class DSPropertyAnnotationsTest extends BndTestCase {
 		System.err.println(Processor.join(jar.getResources().keySet(), "\n"));
 		assertNotNull(r);
 		r.write(System.err);
-		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
+		XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
 		// Test the defaults
 		xt.assertAttribute(ArrayPropertyAnnotated.class.getName(), "scr:component/implementation/@class");
 		xt.assertCount(1, "scr:component/property");

--- a/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/AnnotationReader.java
@@ -521,8 +521,9 @@ public class AnnotationReader extends ClassDataCollector {
 
 		private ComponentPropertyTypeDataCollector(Annotation componentPropertyAnnotation,
 				DeclarativeServicesAnnotationError details) {
-			// Component Property annotations added in 1.4
-			component.updateVersion(V1_4);
+			// Component Property annotations added in 1.4, but they just map to
+			// normal DS properties, so there's not really a need to require DS
+			// 1.4. Therefore we just leave the required version as is
 
 			this.methodDescriptor = null;
 			this.details = details;
@@ -625,7 +626,15 @@ public class AnnotationReader extends ClassDataCollector {
 				if (prefixField.isFinal() && (prefixField.getType() == analyzer.getTypeRef("java/lang/String"))
 						&& (c instanceof String)) {
 					prefix = (String) c;
-					component.updateVersion(V1_4);
+
+					// If we have a method descriptor then this is an injected
+					// component property type and the prefix must be processed
+					// and understood by DS 1.4. Otherwise bnd handles the
+					// property prefix mapping transparently here and DS doesn't
+					// need to care
+					if (methodDescriptor != null) {
+						component.updateVersion(V1_4);
+					}
 				} else {
 					analyzer.warning(
 							"Field PREFIX_ in %s is not a static final String field with a compile-time constant value: %s",
@@ -650,7 +659,14 @@ public class AnnotationReader extends ClassDataCollector {
 					}
 				}
 				singleElementAnnotation = sb.toString();
-				component.updateVersion(V1_4);
+				// If we have a method descriptor then this is an injected
+				// component property type and the single elementness must
+				// be processed and understood by DS 1.4. Otherwise bnd handles
+				// the property mapping transparently here and DS doesn't
+				// need to care
+				if (methodDescriptor != null) {
+					component.updateVersion(V1_4);
+				}
 			}
 			for (Entry<String,List<String>> entry : props.entrySet()) {
 				String key = entry.getKey();


### PR DESCRIPTION
When using a ComponentPropertyType annotation on a DS component the properties are merged into standard XML and no special runtime knowledge is needed. We should therefore avoid bumping the required version needlessly

Signed-off-by: Tim Ward <timothyjward@apache.org>