### PR TITLE
Support the path to local Maven repository to be a symbolic link

### DIFF
--- a/aQute.libg/src/aQute/lib/io/IO.java
+++ b/aQute.libg/src/aQute/lib/io/IO.java
@@ -750,7 +750,11 @@ public class IO {
 	}
 
 	public static void mkdirs(Path dir) throws IOException {
-		Files.createDirectories(dir);
+		if (Files.isSymbolicLink(dir)) {
+			mkdirs(Files.readSymbolicLink(dir));
+		} else {
+			Files.createDirectories(dir);
+		}
 	}
 
 	public static long drain(InputStream in) throws IOException {

--- a/aQute.libg/test/aQute/lib/io/IOTest.java
+++ b/aQute.libg/test/aQute/lib/io/IOTest.java
@@ -1,9 +1,12 @@
 package aQute.lib.io;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import junit.framework.TestCase;
 
@@ -257,6 +260,38 @@ public class IOTest extends TestCase {
 			assertTrue(IO.isSymbolicLink(link));
 			assertTrue(Files.readSymbolicLink(link.toPath()).equals(newSource.toPath()));
 		}
+	}
+
+	public void testCreateDirectory_Symlink() throws Exception {
+		Path rootDirectory = Paths.get("generated/tmp/test/" + getName());
+		IO.delete(rootDirectory);
+		rootDirectory = Files.createDirectories(rootDirectory);
+
+		Path target = Files.createDirectories(rootDirectory.resolve("target").toAbsolutePath());
+		assertTrue(target.toFile().exists());
+
+		Path link = Paths.get(rootDirectory.toAbsolutePath().toString(), "link");
+		Path symbolicLink = Files.createSymbolicLink(link, target);
+		assertTrue(IO.isSymbolicLink(symbolicLink));
+
+		IO.mkdirs(symbolicLink);
+		assertTrue(symbolicLink.toFile().exists());
+	}
+
+	public void testCreateDirectory_SymlinkMissingTarget() throws Exception {
+		Path rootDirectory = Paths.get("generated/tmp/test/" + getName());
+		IO.delete(rootDirectory);
+		rootDirectory = Files.createDirectories(rootDirectory);
+
+		Path target = rootDirectory.resolve("target").toAbsolutePath();
+		assertFalse(target.toFile().exists());
+
+		Path link = Paths.get(rootDirectory.toAbsolutePath().toString(), "link");
+		Path symbolicLink = Files.createSymbolicLink(link, target);
+		assertTrue(IO.isSymbolicLink(symbolicLink));
+
+		IO.mkdirs(symbolicLink);
+		assertTrue(symbolicLink.toFile().exists());
 	}
 
 	public void testCollectEncoded() throws Exception {


### PR DESCRIPTION
When path to the local Maven repository is a symlink:

    file ~/.m2/repository

returns

    /home/user/.m2/repository: symbolic link to /home/user/.cache/m2/repository/

MavenRepository fails with:

    java.nio.file.FileAlreadyExistsException: /home/user/.m2/repository
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:88)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
	at java.nio.file.Files.createDirectory(Files.java:674)
	at java.nio.file.Files.createAndCheckIsDirectory(Files.java:781)
	at java.nio.file.Files.createDirectories(Files.java:727)
	at aQute.lib.io.IO.mkdirs(IO.java:753)
	at aQute.lib.io.IO.mkdirs(IO.java:749)
	at aQute.maven.provider.MavenRepository.<init>(MavenRepository.java:61)
	at aQute.bnd.repository.maven.provider.MavenBndRepository.init(MavenBndRepository.java:494)

This happens because Java NIO Files' createDirectory method explicitly
doesn't allow the directory itself to be a symbolic link:

    try {
	createDirectory(dir, attrs);
    } catch (FileAlreadyExistsException x) {
	if (!isDirectory(dir, LinkOption.NOFOLLOW_LINKS))
	    throw x;
    }

At the same time, it is OK when the path includes symbolic link.

Add tests for cases when a) location is a symbolic link and b) one of
the location's parents is a symbolic link. Having these tests in
MavenBndRepository makes them kind of integration tests but this way
they reproduce the actual problem as close as possible.

Handle this case in MavenRepository instead of IO's mkdirs method
(which is riskier as it has has a lot more usages) by creating the
directory using target directory that link points to and a link
itself.

Signed-off-by: Mykola Nikishov <mn@mn.com.ua>