### PR TITLE
resource: Fix file locking when using jar:file: URL

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/ResourcesTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ResourcesTest.java
@@ -1,8 +1,12 @@
 package test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.net.URL;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -478,6 +482,25 @@ public class ResourcesTest extends TestCase {
 		assertTrue(hasDir);
 		assertFalse(hasContent);
 		IO.delete(tstDir);
+	}
+
+	public void testURLResourceJarLocking() throws Exception {
+		File f = new File("generated/tmp/test/" + getName() + "/locking.jar");
+		try (Builder b = new Builder()) {
+			b.setProperty("-includeresource", "TargetFolder=testresources/ws/p2/Resources");
+			b.setProperty("-resourceonly", "true");
+			Jar jar = b.build();
+
+			f.getParentFile().mkdirs();
+			jar.write(f);
+		}
+		URL url = new URL("jar:" + f.toURI() + "!/TargetFolder/resource3.txt");
+
+		try (Resource resource = Resource.fromURL(url)) {
+			assertEquals("Resource3", IO.collect(resource.buffer(), UTF_8));
+		}
+
+		Files.delete(f.toPath());
 	}
 
 	static void report(Processor processor) {

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/JUnitFramework.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/JUnitFramework.java
@@ -39,7 +39,6 @@ import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.JarResource;
 import aQute.bnd.osgi.Resource;
-import aQute.bnd.osgi.URLResource;
 import aQute.bnd.service.Strategy;
 import aQute.bnd.version.VersionRange;
 import aQute.lib.exceptions.Exceptions;
@@ -232,8 +231,8 @@ public class JUnitFramework implements AutoCloseable {
 			setBundleSymbolicName("test-" + n.incrementAndGet());
 		}
 
-		public BundleBuilder addResource(String path, URL url) {
-			return addResource(path, new URLResource(url));
+		public BundleBuilder addResource(String path, URL url) throws IOException {
+			return addResource(path, Resource.fromURL(url));
 		}
 
 		public BundleBuilder addResource(String path, Resource resource) {
@@ -264,7 +263,7 @@ public class JUnitFramework implements AutoCloseable {
 			super.close();
 		}
 
-		public BundleBuilder addResource(Class< ? > class1) {
+		public BundleBuilder addResource(Class< ? > class1) throws IOException {
 			String name = class1.getName();
 			name = name.replace('.', '/') + ".class";
 			addResource(name, class1.getResource("/" + name));

--- a/biz.aQute.bndlib/src/aQute/bnd/make/MakeCopy.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/MakeCopy.java
@@ -11,7 +11,6 @@ import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.EmbeddedResource;
 import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Resource;
-import aQute.bnd.osgi.URLResource;
 import aQute.bnd.service.MakePlugin;
 public class MakeCopy implements MakePlugin {
 
@@ -32,7 +31,7 @@ public class MakeCopy implements MakePlugin {
 			return new FileResource(f);
 		try {
 			URL url = new URL(from);
-			return new URLResource(url);
+			return Resource.fromURL(url);
 		} catch (MalformedURLException mfue) {
 			// We ignore this
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2739,7 +2739,7 @@ public class Analyzer extends Processor {
 			getClass().getClassLoader();
 			URL url = ClassLoader.getSystemResource(typeRef.getPath());
 			if (url != null)
-				r = new URLResource(url);
+				r = Resource.fromURL(url);
 		}
 		if (r != null) {
 			c = new Clazz(this, typeRef.getPath(), r);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
@@ -1,8 +1,10 @@
 package aQute.bnd.osgi;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URL;
 import java.nio.ByteBuffer;
 
 public interface Resource extends Closeable {
@@ -19,4 +21,8 @@ public interface Resource extends Closeable {
 	long size() throws Exception;
 
 	ByteBuffer buffer() throws Exception;
+
+	static Resource fromURL(URL url) throws IOException {
+		return new URLResource(url);
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 
 import aQute.lib.io.IO;
 
-public class URLResource implements Resource {
+class URLResource implements Resource {
 	private static final ByteBuffer	CLOSED			= ByteBuffer.allocate(0);
 	private ByteBuffer		buffer;
 	private final URL		url;
@@ -18,7 +18,12 @@ public class URLResource implements Resource {
 	private long			lastModified	= -1L;
 	private int						size			= -1;
 
-	public URLResource(URL url) {
+	/**
+	 * This constructor is not for use other than by {@link Resource#fromURL(URL)}.
+	 * 
+	 * @see Resource#fromURL(URL)
+	 */
+	URLResource(URL url) {
 		this.url = url;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
@@ -1,12 +1,14 @@
 package aQute.bnd.osgi;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
+import java.util.jar.JarFile;
 
 import aQute.lib.io.IO;
 
@@ -35,11 +37,6 @@ class URLResource implements Resource {
 	private ByteBuffer getBuffer() throws Exception {
 		if (buffer != null) {
 			return buffer;
-		}
-		if (url.getProtocol().equals("file")) {
-			File file = new File(url.getPath());
-			lastModified = file.lastModified();
-			return buffer = IO.read(file.toPath());
 		}
 		URLConnection conn = openConnection();
 		if (size == -1) {
@@ -112,5 +109,22 @@ class URLResource implements Resource {
 		 * remapped for this URLResouce.
 		 */
 		buffer = CLOSED;
+	}
+
+	/**
+	 * Use JarURLConnection to parse jar: URL into URL to jar URL and entry.
+	 */
+	static class JarURLUtil extends JarURLConnection {
+		JarURLUtil(URL url) throws MalformedURLException {
+			super(url);
+		}
+
+		@Override
+		public JarFile getJarFile() throws IOException {
+			return null;
+		}
+
+		@Override
+		public void connect() throws IOException {}
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/testing/DSTestWiring.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/testing/DSTestWiring.java
@@ -20,7 +20,6 @@ import aQute.bnd.make.component.ComponentAnnotationReader;
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Clazz;
 import aQute.bnd.osgi.Resource;
-import aQute.bnd.osgi.URLResource;
 import aQute.lib.collections.MultiMap;
 
 /**
@@ -174,7 +173,7 @@ public class DSTestWiring {
 			// Get the component definition
 			//
 
-			try (Analyzer a = new Analyzer(); Resource resource = new URLResource(url)) {
+			try (Analyzer a = new Analyzer(); Resource resource = Resource.fromURL(url)) {
 				Clazz clazz = new Clazz(a, "", resource);
 				Map<String,String> d = ComponentAnnotationReader.getDefinition(clazz);
 

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -39,7 +39,7 @@ import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
-import aQute.bnd.osgi.URLResource;
+import aQute.bnd.osgi.Resource;
 import aQute.launcher.constants.LauncherConstants;
 import aQute.launcher.pre.EmbeddedLauncher;
 import aQute.lib.strings.Strings;
@@ -313,14 +313,14 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 			m.getMainAttributes().putValue("Main-Class", JPM_LAUNCHER_FQN);
 			m.getMainAttributes().putValue("JPM-Classpath", Processor.join(runpathShas));
 			m.getMainAttributes().putValue("JPM-Runbundles", Processor.join(runbundleShas));
-			URLResource jpmLauncher = new URLResource(this.getClass().getResource("/" + JPM_LAUNCHER));
+			Resource jpmLauncher = Resource.fromURL(this.getClass().getResource("/" + JPM_LAUNCHER));
 			jar.putResource(JPM_LAUNCHER, jpmLauncher);
 			doStart(jar, JPM_LAUNCHER_FQN);
 		} else {
 			logger.debug("Use Embedded launcher");
 			m.getMainAttributes().putValue("Main-Class", EMBEDDED_LAUNCHER_FQN);
 			m.getMainAttributes().putValue(EmbeddedLauncher.EMBEDDED_RUNPATH, Processor.join(classpath));
-			URLResource embeddedLauncher = new URLResource(this.getClass().getResource("/" + EMBEDDED_LAUNCHER));
+			Resource embeddedLauncher = Resource.fromURL(this.getClass().getResource("/" + EMBEDDED_LAUNCHER));
 			jar.putResource(EMBEDDED_LAUNCHER, embeddedLauncher);
 			doStart(jar, EMBEDDED_LAUNCHER_FQN);
 		}

--- a/biz.aQute.remote/src/aQute/remote/plugin/RemoteProjectLauncherPlugin.java
+++ b/biz.aQute.remote/src/aQute/remote/plugin/RemoteProjectLauncherPlugin.java
@@ -19,7 +19,7 @@ import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Jar;
-import aQute.bnd.osgi.URLResource;
+import aQute.bnd.osgi.Resource;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
@@ -257,7 +257,7 @@ public class RemoteProjectLauncherPlugin extends ProjectLauncher {
 
 		Jar jar = new Jar(bsn);
 		String path = "aQute/remote/embedded/activator/EmbeddedActivator.class";
-		URLResource resource = new URLResource(getClass().getClassLoader().getResource(path));
+		Resource resource = Resource.fromURL(getClass().getClassLoader().getResource(path));
 		jar.putResource("aQute/remote/embedded/activator/EmbeddedActivator.class", resource);
 
 		Collection<Container> rb = getProject().getRunbundles();


### PR DESCRIPTION
On Windows, using a jar:file: URL locks the file. This is for 2 reasons.
One, unless setUseCaches(false) is set, the JarURLConnection will hold
the created JarFile open in a cache. Two, even then, the JarURLConnection
holds a FileURLConnection keeps an open input stream on the file and
there is no way to close this inputstream.

So we completely avoid using jar:file: URLs by inspecting the URL and
using either a FileResource or a ZipResource to read the item described
by the URL.

Closes #2184 