### PR TITLE
Don't add tmp files to included list

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -2318,16 +2319,11 @@ public class Project extends Processor {
 
 			// Try the included filed in reverse order (last has highest
 			// priority)
-			List<File> included = getIncluded();
-			if (included != null) {
-				List<File> copy = new ArrayList<File>(included);
-				Collections.reverse(copy);
-
-				for (File file : copy) {
-					if (replace(file, pattern, replace)) {
-						logger.debug("replaced version in file {}", file);
-						return;
-					}
+			for (Iterator<File> iter = new ArrayDeque<>(getIncluded()).descendingIterator(); iter.hasNext();) {
+				File file = iter.next();
+				if (replace(file, pattern, replace)) {
+					logger.debug("replaced version in file {}", file);
+					return;
 				}
 			}
 			logger.debug("no version in included files");

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2256,8 +2256,8 @@ public class Project extends Processor {
 	}
 
 	public Jar getValidJar(URL url) throws Exception {
-		try (InputStream in = url.openStream()) {
-			Jar jar = new Jar(url.getFile().replace('/', '.'), in, System.currentTimeMillis());
+		try (Resource resource = Resource.fromURL(url)) {
+			Jar jar = Jar.fromResource(url.getFile().replace('/', '.'), resource);
 			return getValidJar(jar, url.toString());
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -999,6 +999,10 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		return included.addIfAbsent(file);
 	}
 
+	private boolean removeIncluded(File file) {
+		return included.remove(file);
+	}
+
 	/**
 	 * Inspect the properties and if you find -includes parse the line included
 	 * manifest files or properties files. The files are relative from the given
@@ -1050,6 +1054,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 								Files.setLastModifiedTime(tmp, FileTime.fromMillis(resource.lastModified()));
 								doIncludeFile(tmp.toFile(), overwrite, p);
 							} finally {
+								removeIncluded(tmp.toFile());
 								IO.delete(tmp);
 							}
 						} catch (MalformedURLException mue) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1042,10 +1042,13 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 							if (n >= 0)
 								ext = value.substring(n);
 
-							File tmp = File.createTempFile("url", ext);
-							try {
-								IO.copy(url.openStream(), tmp);
-								doIncludeFile(tmp, overwrite, p);
+							Path tmp = Files.createTempFile("url", ext);
+							try (Resource resource = Resource.fromURL(url)) {
+								try (OutputStream out = IO.outputStream(tmp)) {
+									resource.write(out);
+								}
+								Files.setLastModifiedTime(tmp, FileTime.fromMillis(resource.lastModified()));
+								doIncludeFile(tmp.toFile(), overwrite, p);
 							} finally {
 								IO.delete(tmp);
 							}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -17,6 +18,10 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,6 +37,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -62,7 +68,6 @@ import aQute.bnd.service.RegistryPlugin;
 import aQute.bnd.service.url.URLConnectionHandler;
 import aQute.bnd.version.Version;
 import aQute.bnd.version.VersionRange;
-import aQute.lib.collections.ExtList;
 import aQute.lib.collections.SortedList;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.hex.Hex;
@@ -149,7 +154,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	private boolean					fixup			= true;
 	long							modified;
 	Processor						parent;
-	List<File>						included;
+	private final CopyOnWriteArrayList<File>	included		= new CopyOnWriteArrayList<>();
 
 	CL								pluginLoader;
 	Collection<String>				filter;
@@ -986,10 +991,12 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		}
 	}
 
-	public synchronized void addIncluded(File file) {
-		if (included == null)
-			included = new ArrayList<File>();
-		included.add(file);
+	public void addIncluded(File file) {
+		addIncludedIfAbsent(file);
+	}
+
+	private boolean addIncludedIfAbsent(File file) {
+		return included.addIfAbsent(file);
 	}
 
 	/**
@@ -1078,32 +1085,30 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 * @throws IOException
 	 */
 	public void doIncludeFile(File file, boolean overwrite, Properties target, String extensionName) throws Exception {
-		if (included != null && included.contains(file)) {
+		if (!addIncludedIfAbsent(file)) {
 			error("Cyclic or multiple include of %s", file);
-		} else {
-			addIncluded(file);
-			updateModified(file.lastModified(), file.toString());
-			Properties sub;
-			if (file.getName().toLowerCase().endsWith(".mf")) {
-				try (InputStream in = IO.stream(file)) {
-					sub = getManifestAsProperties(in);
-				}
-			} else
-				sub = loadProperties(file);
+		}
+		updateModified(file.lastModified(), file.toString());
+		Properties sub;
+		if (file.getName().toLowerCase().endsWith(".mf")) {
+			try (InputStream in = IO.stream(file)) {
+				sub = getManifestAsProperties(in);
+			}
+		} else
+			sub = loadProperties(file);
 
-			doIncludes(file.getParentFile(), sub);
-			// make sure we do not override properties
-			for (Map.Entry< ? , ? > entry : sub.entrySet()) {
-				String key = (String) entry.getKey();
-				String value = (String) entry.getValue();
+		doIncludes(file.getParentFile(), sub);
+		// make sure we do not override properties
+		for (Map.Entry< ? , ? > entry : sub.entrySet()) {
+			String key = (String) entry.getKey();
+			String value = (String) entry.getValue();
 
-				if (overwrite || !target.containsKey(key)) {
-					target.setProperty(key, value);
-				} else if (extensionName != null) {
-					String extensionKey = extensionName + "." + key;
-					if (!target.containsKey(extensionKey))
-						target.setProperty(extensionKey, value);
-				}
+			if (overwrite || !target.containsKey(key)) {
+				target.setProperty(key, value);
+			} else if (extensionName != null) {
+				String extensionKey = extensionName + "." + key;
+				if (!target.containsKey(extensionKey))
+					target.setProperty(extensionKey, value);
 			}
 		}
 	}
@@ -1122,13 +1127,11 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			return false;
 
 		boolean changed = updateModified(propertiesFile.lastModified(), "properties file");
-		if (included != null) {
-			for (File file : included) {
-				if (changed)
-					break;
+		for (File file : getIncluded()) {
+			if (changed)
+				break;
 
-				changed |= !file.exists() || updateModified(file.lastModified(), "include file: " + file);
-			}
+			changed |= !file.exists() || updateModified(file.lastModified(), "include file: " + file);
 		}
 
 		profile = getProperty(PROFILE); // Used in property access
@@ -1153,7 +1156,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 *
 	 */
 	public void forceRefresh() {
-		included = null;
+		included.clear();
 		Processor p = getParent();
 		properties = (p != null) ? new UTF8Properties(p.getProperties0()) : new UTF8Properties();
 
@@ -1190,7 +1193,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 				} else
 					this.modified = modified;
 
-				included = null;
+				included.clear();
 				Properties p = loadProperties(propertiesFile);
 				setProperties(p);
 			} else {
@@ -2367,16 +2370,11 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			// Get the includes (actually should parse the header
 			// to see if they override or only provide defaults?
 
-			List<File> result = getIncluded();
-			if (result != null) {
-				ExtList<File> reversed = new ExtList<File>(result);
-				Collections.reverse(reversed);
-
-				for (File included : reversed) {
-					fl = findHeader(included, header);
-					if (fl != null)
-
-						return fl;
+			for (Iterator<File> iter = new ArrayDeque<>(getIncluded()).descendingIterator(); iter.hasNext();) {
+				File file = iter.next();
+				fl = findHeader(file, header);
+				if (fl != null) {
+					return fl;
 				}
 			}
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
@@ -1,13 +1,13 @@
 package aQute.bnd.osgi;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import aQute.bnd.osgi.URLResource.JarURLUtil;
 
@@ -28,19 +28,19 @@ public interface Resource extends Closeable {
 
 	static Resource fromURL(URL url) throws IOException {
 		if (url.getProtocol().equalsIgnoreCase("file")) {
-			File file = new File(URI.create(url.toExternalForm()));
-			return new FileResource(file);
+			Path path = Paths.get(Paths.get("").toUri().resolve(url.getPath()));
+			return new FileResource(path);
 		}
 		if (url.getProtocol().equals("jar")) {
 			JarURLUtil util = new JarURLUtil(url);
 			URL jarFileURL = util.getJarFileURL();
 			if (jarFileURL.getProtocol().equalsIgnoreCase("file")) {
-				File file = new File(URI.create(jarFileURL.toExternalForm()));
+				Path path = Paths.get(Paths.get("").toUri().resolve(jarFileURL.getPath()));
 				String entryName = util.getEntryName();
 				if (entryName == null) {
-					return new FileResource(file);
+					return new FileResource(path);
 				}
-				return new ZipResource(file, entryName);
+				return new ZipResource(path, entryName);
 			}
 		}
 		return new URLResource(url);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
@@ -2,12 +2,12 @@ package aQute.bnd.osgi;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -23,8 +23,8 @@ public class ZipResource implements Resource {
 	private long			size;
 	private String			extra;
 
-	ZipResource(File file, String entryName) throws IOException {
-		this(new ZipFile(file), entryName);
+	ZipResource(Path path, String entryName) throws IOException {
+		this(new ZipFile(path.toFile()), entryName);
 	}
 
 	private ZipResource(ZipFile zip, String entryName) throws IOException {


### PR DESCRIPTION
When using `-include: jar:file:/somefile!/someentry`, Bnd will extract the resource to a tmp file and then include the tmp file. The tmp file is then deleted but we left it in the included file list. This PR stops that.

Also the PR avoids opening `jar:file:` URLs directly to avoid Windows file locking issues. It uses `Resource.fromURL` instead to access the resource which avoids the file lock issue on Windows.