### PR TITLE
gradle: Set jar.archiveName to name of first generated artifact

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -209,6 +209,9 @@ public class BndPlugin implements Plugin<Project> {
         description 'Assemble the project bundles.'
         deleteAllActions() /* Replace the standard task actions */
         enabled !bndProject.isNoBundles()
+        configurations.archives.artifacts.files.find {
+          archiveName = it.name /* use first artifact as archiveName */
+        }
         ext.projectDirInputsExcludes = [] /* Additional excludes for projectDir inputs */
         /* all other files in the project like bnd and resources */
         inputs.files {


### PR DESCRIPTION
If we let the archiveName default, then setting project.version can
cause gradle to add a file, which Bnd will not generate, to the jar task
outputs. This can cause gradle to think outputs have changed when they
have not. So we set jar.archiveName so that it will not default to the
name of an artifact that Bnd may not generate.
