### PR TITLE
maven dependency resolver: proper scope filtering

### DIFF
--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -66,6 +66,19 @@ public Capability check(Repository repo, String namespace, String filter, String
 	return content;
 }
 
+
+public Capability checkAbsent(Repository repo, String namespace, String filter) {
+	
+	Requirement requirement = new RequirementBuilder(namespace)
+						.addDirective("filter", filter)
+						.buildSyntheticRequirement();
+	
+	Map<Requirement,Collection<Capability>> caps = repo
+						.findProviders(Collections.singleton(requirement));
+	
+	assert caps.get(requirement).isEmpty();
+}
+
 println "TODO: Need to write some test code for the generated index!"
 println "basedir ${basedir}"
 println "localRepositoryPath ${localRepositoryPath}"
@@ -75,7 +88,9 @@ System.setProperty('jsse.enableSNIExtension', 'false')
 
 check("${basedir}/transitive/target/index.xml", "${basedir}/transitive/target/index.xml.gz", 19, false, true);
 check("${basedir}/non-transitive/target/index.xml", "${basedir}/non-transitive/target/index.xml.gz", 3, false, true);
-check("${basedir}/scoped/target/index.xml", "${basedir}/scoped/target/index.xml.gz", 22, false, true);
+repo = check("${basedir}/scoped/target/index.xml", "${basedir}/scoped/target/index.xml.gz", 18, false, true);
+checkAbsent(repo, "osgi.identity", "(osgi.identity=org.apache.felix.log)");
+
 check("${basedir}/require-local/target/index.xml", "${basedir}/require-local/target/index.xml.gz", 19, true, true);
 
 // The in-build needs to check that the snapshot points at the real repo

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -19,7 +19,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -102,16 +101,6 @@ public class DependencyResolver {
 
 		DependencyResolutionRequest request = new DefaultDependencyResolutionRequest(project, session);
 
-		request.setResolutionFilter(new DependencyFilter() {
-			@Override
-			public boolean accept(DependencyNode node, List<DependencyNode> parents) {
-				if (node.getDependency() != null) {
-					return scopes.contains(node.getDependency().getScope());
-				}
-				return false;
-			}
-		});
-
 		DependencyResolutionResult result;
 		try {
 			result = resolver.resolve(request);
@@ -159,6 +148,9 @@ public class DependencyResolver {
 			throws MojoExecutionException {
 
 		for (DependencyNode node : nodes) {
+			if (!scopes.contains(node.getDependency().getScope())) {
+				continue;
+			}
 			// Ensure that the file is downloaded so we can index it
 			try {
 				ArtifactResult resolvedArtifact = postProcessor.postProcessResult(system.resolveArtifact(


### PR DESCRIPTION
Fixes #2198 (scopes not filtering dependencies).

Signed-off-by: Simon Chemouil <simon.chemouil@lambdacube.fr>