### PR TITLE
 analyzer: Don't use provider import range for self implemented interface 

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/util/repository/DownloadListenerPromise.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/util/repository/DownloadListenerPromise.java
@@ -3,9 +3,7 @@ package aQute.bnd.util.repository;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-import org.osgi.util.promise.Failure;
 import org.osgi.util.promise.Promise;
-import org.osgi.util.promise.Success;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,66 +17,56 @@ import aQute.service.reporter.Reporter;
 /**
  * Uses promises to signal the Download Listener from {@link RepositoryPlugin}
  */
-public class DownloadListenerPromise implements Success<File,Void>, Failure {
+public class DownloadListenerPromise {
 	private final static Logger	logger	= LoggerFactory.getLogger(DownloadListenerPromise.class);
 	final DownloadListener		dls[];
 	final Promise<File>			promise;
-	private final Reporter		reporter;
 	private final String		task;
 	private File		linked;
 
 	/**
 	 * Use the promise to signal the Download Listeners
 	 *
-	 * @param reporter a reporter or null (will use a SLF4 in that case)
+	 * @param r a reporter or null (will use a SLF4 in that case)
 	 * @param task
 	 * @param promise
 	 * @param downloadListeners
 	 */
-	public DownloadListenerPromise(Reporter reporter, String task, Promise<File> promise,
+	public DownloadListenerPromise(Reporter r, String task, Promise<File> promise,
 			DownloadListener... downloadListeners) {
-		this.reporter = Slf4jReporter.getAlternative(DownloadListenerPromise.class, reporter);
+		Reporter reporter = Slf4jReporter.getAlternative(DownloadListenerPromise.class, r);
 		this.task = task;
 		this.promise = promise;
 		this.dls = downloadListeners;
 		logger.debug("{}: starting", task);
-		promise.then(this).then(null, this);
-	}
-
-	@Override
-	public Promise<Void> call(Promise<File> resolved) throws Exception {
-		File file = resolved.getValue();
-		if (file == null) {
-			throw new FileNotFoundException("Download failed");
-		}
-		logger.debug("{}: success {}", this, file);
-
-		if (linked != null) {
-			IO.createSymbolicLinkOrCopy(linked, file);
-		}
-
-		for (DownloadListener dl : dls) {
-			try {
-				dl.success(file);
-			} catch (Throwable e) {
-				reporter.warning("%s: Success callback failed to %s: %s", this, dl, e);
+		promise.thenAccept(file -> {
+			if (file == null) {
+				throw new FileNotFoundException("Download failed");
 			}
-		}
-		return null;
-	}
+			logger.debug("{}: success {}", this, file);
 
-	@Override
-	public void fail(Promise< ? > resolved) throws Exception {
-		Throwable failure = resolved.getFailure();
-		logger.debug("{}: failure", this, failure);
-		String reason = Exceptions.toString(failure);
-		for (DownloadListener dl : dls) {
-			try {
-				dl.failure(null, reason);
-			} catch (Throwable e) {
-				reporter.warning("%s: Fail callback failed to %s: %s", this, dl, e);
+			if (linked != null) {
+				IO.createSymbolicLinkOrCopy(linked, file);
 			}
-		}
+
+			for (DownloadListener dl : dls) {
+				try {
+					dl.success(file);
+				} catch (Throwable e) {
+					reporter.warning("%s: Success callback failed to %s: %s", this, dl, e);
+				}
+			}
+		}).onFailure(failure -> {
+			logger.debug("{}: failure", this, failure);
+			String reason = Exceptions.toString(failure);
+			for (DownloadListener dl : dls) {
+				try {
+					dl.failure(null, reason);
+				} catch (Throwable e) {
+					reporter.warning("%s: Fail callback failed to %s: %s", this, dl, e);
+				}
+			}
+		});
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/util/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/util/repository/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("2.0.0")
 package aQute.bnd.util.repository;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
When a class in a package implements a provider type interface in the
same package, exporting that package must not result in a provider import
range for the substitutable import. So we don't consider interfaces when
they are implemented by a class in the same package as triggering
provider range import.