### PR TITLE
index: parse referrals correctly

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
@@ -210,6 +210,7 @@ public class XMLResourceParser extends Processor {
 
 			}
 		}
+		next();
 		tagEnd(TAG_REFERRAL);
 	}
 


### PR DESCRIPTION
The referral element is read but the XML parser was not moved
to the end tag, causing the whole parsing to fail. This patch
simply makes sure the parser is moved ahead the same way it is
done for other XML elements such as resources. Fixes #2210.

Please note that there is currently no unit test for referrals, or the
bug would have been caught. This patch merely fixes the bug 
but I have no time to add a test case.