### PR TITLE
Add support for the standard @Export annotation

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/BuilderTest.java
@@ -2568,6 +2568,11 @@ public class BuilderTest extends BndTestCase {
 			bmaker.setClasspath(new File[] {
 					new File("bin")
 			});
+			bmaker.setProperty("-fixupmessages.export",
+					"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
+			bmaker.setProperty("-fixupmessages.directive",
+					"Unknown directive foobar: in Export-Package, allowed directives are uses:,mandatory:,include:,exclude:,-import:, and 'x-*'");
+
 			Jar jar = bmaker.build();
 			assertTrue(bmaker.check());
 			report("testFindActivator", bmaker, jar);

--- a/biz.aQute.bndlib.tests/src/test/ExportAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ExportAnnotationTest.java
@@ -1,0 +1,29 @@
+package test;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.jar.Manifest;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Jar;
+import junit.framework.TestCase;
+
+@SuppressWarnings("resource")
+public class ExportAnnotationTest extends TestCase {
+
+	public static void testStandardAnnotation() throws Exception {
+		Builder builder = new Builder();
+		Jar bin = new Jar(new File("bin"));
+		builder.setClasspath(new Jar[] {
+				bin
+		});
+		Properties p = new Properties();
+		p.setProperty("Private-Package", "test.export.annotation");
+		builder.setProperties(p);
+		Jar jar = builder.build();
+		Manifest manifest = jar.getManifest();
+
+		String imph = manifest.getMainAttributes().getValue("Export-Package");
+		assertEquals("test.export.annotation;fizz=buzz;foobar:=fizzbuzz;uses:=\"foo,bar\";version=\"1.0.0\"", imph);
+	}
+}

--- a/biz.aQute.bndlib.tests/src/test/VersionPolicyTest.java
+++ b/biz.aQute.bndlib.tests/src/test/VersionPolicyTest.java
@@ -121,6 +121,8 @@ public class VersionPolicyTest extends TestCase {
 														// not automatically
 														// added?
 		a.setProperty("build", "123");
+		a.setProperty("-fixupmessages",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
 		Jar jar = a.build();
 		assertTrue(a.check());
 		Manifest m = jar.getManifest();
@@ -168,6 +170,8 @@ public class VersionPolicyTest extends TestCase {
 		a.setPrivatePackage("test.versionpolicy.uses");
 		a.setExportPackage("test.versionpolicy.api");
 		a.setProperty("build", "123");
+		a.setProperty("-fixupmessages",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
 		Jar jar = a.build();
 		assertTrue(a.check());
 		Manifest m = jar.getManifest();

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/DummyInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/DummyInterface.java
@@ -1,0 +1,8 @@
+package test.export.annotation;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+@ProviderType
+public interface DummyInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/package-info.java
@@ -1,0 +1,7 @@
+@org.osgi.annotation.bundle.Export(uses = {
+		"foo", "bar"
+}, attribute = {
+		"fizz=buzz", "foobar:=fizzbuzz"
+})
+@org.osgi.annotation.versioning.Version("1.0.0")
+package test.export.annotation;

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collector;
 
 import aQute.lib.collections.SortedList;
 import aQute.service.reporter.Reporter;
@@ -249,5 +250,11 @@ public class Parameters implements Map<String,Attrs> {
 
 	public boolean allowDuplicateAttributes() {
 		return allowDuplicateAttributes;
+	}
+
+	public static Collector<String,StringBuilder,Parameters> toParameters() {
+		return Collector.of(StringBuilder::new, (b, s) -> b.append(b.length() == 0 ? "" : ",").append(s),
+				(a, b) -> new StringBuilder(a).append(a.length() == 0 ? "" : ",").append(b),
+				b -> new Parameters(b.toString()));
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/header/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/packageinfo
@@ -1,1 +1,1 @@
-version 1.6
+version 1.7

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -389,9 +389,7 @@ public class Analyzer extends Processor {
 				.map(Clazz::getClassName)
 				.map(TypeRef::getPackageRef)
 				.map(PackageRef::getFQN)
-				.reduce((a, b) -> a + "," + b)
-				.map(Parameters::new)
-				.orElse(new Parameters());
+				.collect(Parameters.toParameters());
 	}
 
 	private Clazz getPackageInfoClazz(PackageRef pr) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -254,12 +254,14 @@ public class Analyzer extends Processor {
 
 				Instructions filter = new Instructions(getExportPackage());
 				filter.append(getExportContents());
+				filter.append(getExportedByAnnotation());
 
 				exports = filter(filter, contained, unused);
 
 				if (!unused.isEmpty()) {
 					warning("Unused " + Constants.EXPORT_PACKAGE + " instructions: %s ", unused)
-							.header(Constants.EXPORT_PACKAGE).context(unused.iterator().next().input);
+							.header(Constants.EXPORT_PACKAGE)
+							.context(unused.iterator().next().input);
 				}
 
 				// See what information we can find to augment the
@@ -300,7 +302,8 @@ public class Analyzer extends Processor {
 					// We ignore the end wildcard catch
 					if (!(unused.size() == 1 && unused.iterator().next().toString().equals("*")))
 						warning("Unused " + Constants.IMPORT_PACKAGE + " instructions: %s ", unused)
-								.header(Constants.IMPORT_PACKAGE).context(unused.iterator().next().input);
+								.header(Constants.IMPORT_PACKAGE)
+								.context(unused.iterator().next().input);
 				}
 
 				// See what information we can find to augment the
@@ -357,6 +360,47 @@ public class Analyzer extends Processor {
 						uses.transpose().get(Descriptors.DEFAULT_PACKAGE));
 			}
 
+			// Check for use of the deprecated bnd @Export annotation
+
+			TypeRef bndAnnotation = descriptors.getTypeRefFromFQN(aQute.bnd.annotation.Export.class.getName());
+			contained.keySet()
+					.stream()
+					.map(this::getPackageInfoClazz)
+					.filter(clz -> clz != null)
+					.filter(clz -> clz.annotations != null)
+					.filter(clz -> clz.annotations.contains(bndAnnotation))
+					.map(Clazz::getClassName)
+					.map(TypeRef::getPackageRef)
+					.map(PackageRef::getFQN)
+					.forEach(fqn -> warning(
+							"The annotation aQute.bnd.annotation.Export applied to package %s is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead",
+							fqn));
+		}
+	}
+
+	private Parameters getExportedByAnnotation() {
+		TypeRef exportAnnotation = descriptors.getTypeRefFromFQN("org.osgi.annotation.bundle.Export");
+		return contained.keySet()
+				.stream()
+				.map(this::getPackageInfoClazz)
+				.filter(clz -> clz != null)
+				.filter(clz -> clz.annotations != null)
+				.filter(clz -> clz.annotations.contains(exportAnnotation))
+				.map(Clazz::getClassName)
+				.map(TypeRef::getPackageRef)
+				.map(PackageRef::getFQN)
+				.reduce((a, b) -> a + "," + b)
+				.map(Parameters::new)
+				.orElse(new Parameters());
+	}
+
+	private Clazz getPackageInfoClazz(PackageRef pr) {
+		String bin = pr.getBinary() + "/package-info";
+		TypeRef tr = descriptors.getTypeRef(bin);
+		try {
+			return findClass(tr);
+		} catch (Exception e) {
+			return null;
 		}
 	}
 
@@ -563,6 +607,38 @@ public class Analyzer extends Processor {
 								// Ignore
 							}
 						}
+						break;
+					case "org.osgi.annotation.bundle.Export" :
+						Object[] attributes = a.get("attribute");
+
+						if (attributes != null) {
+							for (Object s : attributes) {
+								String[] attr = ((String) s).split("=", 2);
+								if (attr.length != 2) {
+									warning("The annotation attribute %s of the exported package %s could not be understood",
+											s, clazz.getClassName().getPackageRef().getFQN());
+									continue;
+								}
+								info.put(attr[0], attr[1]);
+							}
+						}
+
+						Object[] usesClause = a.get("uses");
+						if (usesClause != null) {
+							String old = info.get(USES_DIRECTIVE);
+							if (old == null)
+								old = "";
+							StringBuilder sb = new StringBuilder(old);
+							String del = sb.length() == 0 ? "" : ",";
+
+							for (Object use : usesClause) {
+								sb.append(del);
+								sb.append(use);
+								del = ",";
+							}
+							info.put(USES_DIRECTIVE, sb.toString());
+						}
+
 						break;
 					case "aQute.bnd.annotation.Export" :
 						// Check mandatory attributes


### PR DESCRIPTION
This does not include anything for the substitution attribute of the annotation, as I have no idea how to implement that, but it does cover the attributes and uses behaviour. The commit also deprecates the bnd annotation.

Signed-off-by: Tim Ward <timothyjward@apache.org>