### PR TITLE
gradle: Test for property on correct object

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -150,7 +150,7 @@ public class BndPlugin implements Plugin<Project> {
           }
           if (!javacBootclasspath.empty) {
             fork = true
-            if (hasProperty('bootstrapClasspath')) { // gradle 4.3
+            if (delegate.hasProperty('bootstrapClasspath')) { // gradle 4.3
               bootstrapClasspath = javacBootclasspath
             } else {
               bootClasspath = javacBootclasspath.asPath


### PR DESCRIPTION
hasProperty was apparently not being called on the options object and
thus never returned true resulting in a warning from gradle.