### PR TITLE
Don't duplicate properties in standalone Workspace

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/BndEditModelTest.java
+++ b/biz.aQute.bndlib.tests/src/test/BndEditModelTest.java
@@ -1,5 +1,6 @@
 package test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
@@ -8,6 +9,7 @@ import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
 
+import aQute.bnd.build.Run;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.ExportedPackage;
@@ -146,5 +148,25 @@ public class BndEditModelTest extends TestCase {
 		List<String> runrepos = model.getRunRepos();
 		assertEquals(1, runrepos.size());
 		assertEquals("testing", runrepos.get(0));
+	}
+
+	public static void testRemovePropertyFromStandalone() throws Exception {
+		File runFile = new File("testresources/standalone.bndrun");
+		Run run = Run.createRun(null, runFile);
+
+		BndEditModel model = new BndEditModel();
+		model.setWorkspace(run.getWorkspace());
+		model.loadFrom(runFile);
+
+		assertEquals("A", model.getProperties().get("a"));
+		assertEquals("B", model.getProperties().get("b"));
+		assertEquals("C", model.getProperties().get("c"));
+
+		String newContent = "-standalone\n" + "a: A\n" + "c: C"; // remove b
+		model.loadFrom(new ByteArrayInputStream(newContent.getBytes()));
+
+		assertEquals("A", model.getProperties().get("a"));
+		assertNull("removed property should be null", model.getProperties().get("b"));
+		assertEquals("C", model.getProperties().get("c"));
 	}
 }

--- a/biz.aQute.bndlib.tests/testresources/standalone.bndrun
+++ b/biz.aQute.bndlib.tests/testresources/standalone.bndrun
@@ -1,0 +1,4 @@
+-standalone
+a: A
+b: B
+c: C

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -1169,17 +1169,7 @@ public class Workspace extends Processor {
 	public static Workspace createStandaloneWorkspace(Processor run, URI base) throws Exception {
 		Workspace ws = new Workspace(WorkspaceLayout.STANDALONE);
 
-		//
-		// Copy all properties except the type we will add
-		//
-		for (Entry<Object,Object> entry : run.getProperties().entrySet()) {
-			String key = (String) entry.getKey();
-			if (!key.startsWith(PLUGIN_STANDALONE)) {
-				ws.getProperties().put(key, entry.getValue());
-			}
-		}
-
-		Parameters standalone = new Parameters(ws.getProperty(STANDALONE), ws);
+		Parameters standalone = new Parameters(run.getProperty(STANDALONE), ws);
 		StringBuilder sb = new StringBuilder();
 		try (Formatter f = new Formatter(sb, Locale.US)) {
 			int counter = 1;


### PR DESCRIPTION
There does not seem to be a good reason to copy the content of the Run file into
the standalone "Workspace". When we do this, the properties are duplicated at
both levels.

As a result it becomes impossible to remove a key from a BndEditModel... in
`BndEditModel#loadFrom(InputStream)` we do a "clear" which involves repopulating
the map from the content of the workspace, but in the standalone case this just
reloads from whatever the content of the file was when first opened. So you
cannot delete a key from the map.

Signed-off-by: Neil Bartlett <njbartlett@gmail.com>