### PR TITLE
Export substitution

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -512,9 +512,9 @@ project.allsourcepath:  ${bnd.allSrcDirs.asPath}
 project.testsrc:        ${sourceSets.test.java.sourceDirectories.asPath}
 project.testoutput:     ${compileTestJava.destinationDir}
 project.testpath:       ${compileTestJava.classpath.asPath}
-project.bootclasspath:  ${compileJava.options.bootClasspath}
+project.bootclasspath:  ${compileJava.options.hasProperty('bootstrapClasspath')?compileJava.options.bootstrapClasspath?.asPath?:'':compileJava.options.bootClasspath?:''}
 project.deliverables:   ${configurations.archives.artifacts.files*.path}
-javac:                  ${compileJava.options.forkOptions.executable}
+javac:                  ${compileJava.options.forkOptions.executable?:'javac'}
 javac.source:           ${compileJava.sourceCompatibility}
 javac.target:           ${compileJava.targetCompatibility}
 javac.profile:          ${javacProfile}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -131,6 +131,8 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 
       /* Apply workspace plugin to root project */
       gradle.projectsLoaded { gradle ->
+        gradle.rootProject.ext.bnd_cnf = cnf
+        gradle.rootProject.ext.bndWorkspace = workspace
         gradle.rootProject.apply plugin: BndWorkspacePlugin.class
       }
     }
@@ -143,12 +145,16 @@ public class BndWorkspacePlugin implements Plugin<Object> {
       }
 
       /* Initialize the Bnd workspace */
-      ext.bnd_cnf = findProperty('bnd_cnf') ?: 'cnf'
-      Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
-      Workspace.addGestalt(Constants.GESTALT_BATCH, null)
-      ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
-      if (gradle.ext.has('bndWorkspaceConfigure')) {
-        gradle.bndWorkspaceConfigure(bndWorkspace)
+      if (!ext.has('bnd_cnf')) { // if not passed from settings
+        ext.bnd_cnf = findProperty('bnd_cnf') ?: 'cnf'
+      }
+      if (!ext.has('bndWorkspace')) { // if not passed from settings
+        Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
+        Workspace.addGestalt(Constants.GESTALT_BATCH, null)
+        ext.bndWorkspace = new Workspace(rootDir, bnd_cnf).setOffline(gradle.startParameter.offline)
+        if (gradle.ext.has('bndWorkspaceConfigure')) {
+          gradle.bndWorkspaceConfigure(bndWorkspace)
+        }
       }
 
       /* Configure cnf project */

--- a/biz.aQute.bndlib.tests/src/test/ExportAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ExportAnnotationTest.java
@@ -4,6 +4,12 @@ import java.io.File;
 import java.util.Properties;
 import java.util.jar.Manifest;
 
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Jar;
 import junit.framework.TestCase;
@@ -11,19 +17,195 @@ import junit.framework.TestCase;
 @SuppressWarnings("resource")
 public class ExportAnnotationTest extends TestCase {
 
-	public static void testStandardAnnotation() throws Exception {
-		Builder builder = new Builder();
-		Jar bin = new Jar(new File("bin"));
-		builder.setClasspath(new Jar[] {
+	public void testCalculated() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
 				bin
-		});
-		Properties p = new Properties();
-		p.setProperty("Private-Package", "test.export.annotation");
-		builder.setProperties(p);
-		Jar jar = builder.build();
-		Manifest manifest = jar.getManifest();
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
 
-		String imph = manifest.getMainAttributes().getValue("Export-Package");
-		assertEquals("test.export.annotation;fizz=buzz;foobar:=fizzbuzz;uses:=\"foo,bar\";version=\"1.0.0\"", imph);
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals("buzz", a.get("fizz"));
+			assertEquals("fizzbuzz", a.get("foobar:"));
+			assertEquals("test.export.annotation." + getName() + ".used", a.get("uses:"));
+			assertEquals(Version.valueOf("1.0.0"), Version.valueOf(a.get("version")));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals(VersionRange.valueOf("[1.0.0,1.1.0)"), VersionRange.valueOf(a.get("version")));
+		}
+	}
+
+	public void testProvider() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
+				bin
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
+
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals("buzz", a.get("fizz"));
+			assertEquals("fizzbuzz", a.get("foobar:"));
+			assertEquals("test.export.annotation." + getName() + ".used", a.get("uses:"));
+			assertEquals(Version.valueOf("1.0.0"), Version.valueOf(a.get("version")));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals(VersionRange.valueOf("[1.0.0,1.1.0)"), VersionRange.valueOf(a.get("version")));
+		}
+	}
+
+	public void testConsumer() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
+				bin
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
+
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals("buzz", a.get("fizz"));
+			assertEquals("fizzbuzz", a.get("foobar:"));
+			assertEquals("test.export.annotation." + getName() + ".used", a.get("uses:"));
+			assertEquals(Version.valueOf("1.0.0"), Version.valueOf(a.get("version")));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals(VersionRange.valueOf("[1.0.0,2.0.0)"), VersionRange.valueOf(a.get("version")));
+		}
+	}
+
+	public void testNoimport() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
+				bin
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
+
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals("buzz", a.get("fizz"));
+			assertEquals("fizzbuzz", a.get("foobar:"));
+			assertEquals("test.export.annotation." + getName() + ".used", a.get("uses:"));
+			assertEquals(Version.valueOf("1.0.0"), Version.valueOf(a.get("version")));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNull(a);
+		}
+	}
+
+	public void testUses() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
+				bin
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
+
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals("foo,bar", a.get("uses:"));
+			assertEquals(Version.valueOf("1.0.0"), Version.valueOf(a.get("version")));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals(VersionRange.valueOf("[1.0.0,1.1.0)"), VersionRange.valueOf(a.get("version")));
+		}
+	}
+
+	public void testNouses() throws Exception {
+		try (Builder builder = new Builder()) {
+			Jar bin = new Jar(new File("bin"));
+			builder.setClasspath(new Jar[] {
+				bin
+			});
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.export.annotation." + getName() + "*");
+			builder.setProperties(p);
+			Jar jar = builder.build();
+			Manifest manifest = jar.getManifest();
+
+			String exported = manifest.getMainAttributes()
+				.getValue("Export-Package");
+			assertNotNull(exported);
+			Parameters e = OSGiHeader.parseHeader(exported);
+			Attrs a = e.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertNull(a.get("uses:"));
+
+			String imported = manifest.getMainAttributes()
+				.getValue("Import-Package");
+			assertNotNull(imported);
+			Parameters i = OSGiHeader.parseHeader(imported);
+			a = i.get("test.export.annotation." + getName());
+			assertNotNull(a);
+			assertEquals(VersionRange.valueOf("[1.0.0,1.1.0)"), VersionRange.valueOf(a.get("version")));
+		}
 	}
 }

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/DummyInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/DummyInterface.java
@@ -1,8 +1,0 @@
-package test.export.annotation;
-
-import org.osgi.annotation.versioning.ProviderType;
-
-@ProviderType
-public interface DummyInterface {
-
-}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/package-info.java
@@ -1,7 +1,0 @@
-@org.osgi.annotation.bundle.Export(uses = {
-		"foo", "bar"
-}, attribute = {
-		"fizz=buzz", "foobar:=fizzbuzz"
-})
-@org.osgi.annotation.versioning.Version("1.0.0")
-package test.export.annotation;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/CalculatedInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/CalculatedInterface.java
@@ -1,0 +1,10 @@
+package test.export.annotation.testCalculated;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import test.export.annotation.testCalculated.used.CalculatedUsed;
+
+@ProviderType
+public interface CalculatedInterface extends CalculatedUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/impl/CalculatedInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/impl/CalculatedInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testCalculated.impl;
+
+import test.export.annotation.testCalculated.CalculatedInterface;
+
+public class CalculatedInterfaceImpl implements CalculatedInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testCalculated.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/package-info.java
@@ -1,0 +1,9 @@
+@Export(attribute = {
+		"fizz=buzz", "foobar:=fizzbuzz"
+}, substitution = Substitution.CALCULATED)
+@Version("1.0.0")
+package test.export.annotation.testCalculated;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.bundle.Export.Substitution;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/used/CalculatedUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/used/CalculatedUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testCalculated.used;
+
+
+public interface CalculatedUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testCalculated/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testCalculated.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/ConsumerInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/ConsumerInterface.java
@@ -1,0 +1,10 @@
+package test.export.annotation.testConsumer;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import test.export.annotation.testConsumer.used.ConsumerUsed;
+
+@ProviderType
+public interface ConsumerInterface extends ConsumerUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/impl/ConsumerInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/impl/ConsumerInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testConsumer.impl;
+
+import test.export.annotation.testConsumer.ConsumerInterface;
+
+public class ConsumerInterfaceImpl implements ConsumerInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testConsumer.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/package-info.java
@@ -1,0 +1,9 @@
+@Export(attribute = {
+		"fizz=buzz", "foobar:=fizzbuzz"
+}, substitution = Substitution.CONSUMER)
+@Version("1.0.0")
+package test.export.annotation.testConsumer;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.bundle.Export.Substitution;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/used/ConsumerUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/used/ConsumerUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testConsumer.used;
+
+
+public interface ConsumerUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testConsumer/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testConsumer.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/NoimportInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/NoimportInterface.java
@@ -1,0 +1,10 @@
+package test.export.annotation.testNoimport;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import test.export.annotation.testNoimport.used.NoimportUsed;
+
+@ProviderType
+public interface NoimportInterface extends NoimportUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/impl/NoimportInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/impl/NoimportInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testNoimport.impl;
+
+import test.export.annotation.testNoimport.NoimportInterface;
+
+public class NoimportInterfaceImpl implements NoimportInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testNoimport.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/package-info.java
@@ -1,0 +1,9 @@
+@Export(attribute = {
+		"fizz=buzz", "foobar:=fizzbuzz"
+}, substitution = Substitution.NOIMPORT)
+@Version("1.0.0")
+package test.export.annotation.testNoimport;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.bundle.Export.Substitution;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/used/NoimportUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/used/NoimportUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testNoimport.used;
+
+
+public interface NoimportUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNoimport/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testNoimport.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/NousesInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/NousesInterface.java
@@ -1,0 +1,10 @@
+package test.export.annotation.testNouses;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import test.export.annotation.testNouses.used.NousesUsed;
+
+@ProviderType
+public interface NousesInterface extends NousesUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/impl/NousesInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/impl/NousesInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testNouses.impl;
+
+import test.export.annotation.testNouses.NousesInterface;
+
+public class NousesInterfaceImpl implements NousesInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testNouses.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/package-info.java
@@ -1,0 +1,6 @@
+@Export(uses = {})
+@Version("1.0.0")
+package test.export.annotation.testNouses;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/used/NousesUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/used/NousesUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testNouses.used;
+
+
+public interface NousesUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testNouses/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testNouses.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/ProviderInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/ProviderInterface.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testProvider;
+
+import test.export.annotation.testProvider.used.ProviderUsed;
+
+public interface ProviderInterface extends ProviderUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/impl/ProviderInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/impl/ProviderInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testProvider.impl;
+
+import test.export.annotation.testProvider.ProviderInterface;
+
+public class ProviderInterfaceImpl implements ProviderInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testProvider.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/package-info.java
@@ -1,0 +1,9 @@
+@Export(attribute = {
+		"fizz=buzz", "foobar:=fizzbuzz"
+}, substitution = Substitution.PROVIDER)
+@Version("1.0.0")
+package test.export.annotation.testProvider;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.bundle.Export.Substitution;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/used/ProviderUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/used/ProviderUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testProvider.used;
+
+
+public interface ProviderUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testProvider/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testProvider.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/UsesInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/UsesInterface.java
@@ -1,0 +1,10 @@
+package test.export.annotation.testUses;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+import test.export.annotation.testUses.used.UsesUsed;
+
+@ProviderType
+public interface UsesInterface extends UsesUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/impl/UsesInterfaceImpl.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/impl/UsesInterfaceImpl.java
@@ -1,0 +1,7 @@
+package test.export.annotation.testUses.impl;
+
+import test.export.annotation.testUses.UsesInterface;
+
+public class UsesInterfaceImpl implements UsesInterface {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/impl/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/impl/package-info.java
@@ -1,0 +1,1 @@
+package test.export.annotation.testUses.impl;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/package-info.java
@@ -1,0 +1,8 @@
+@Export(uses = {
+	"foo", "bar"
+})
+@Version("1.0.0")
+package test.export.annotation.testUses;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/used/UsesUsed.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/used/UsesUsed.java
@@ -1,0 +1,6 @@
+package test.export.annotation.testUses.used;
+
+
+public interface UsesUsed {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/used/package-info.java
+++ b/biz.aQute.bndlib.tests/src/test/export/annotation/testUses/used/package-info.java
@@ -1,0 +1,6 @@
+@Export
+@Version("1.0.0")
+package test.export.annotation.testUses.used;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
@@ -252,9 +252,14 @@ public class Parameters implements Map<String,Attrs> {
 		return allowDuplicateAttributes;
 	}
 
-	public static Collector<String,StringBuilder,Parameters> toParameters() {
-		return Collector.of(StringBuilder::new, (b, s) -> b.append(b.length() == 0 ? "" : ",").append(s),
-				(a, b) -> new StringBuilder(a).append(a.length() == 0 ? "" : ",").append(b),
-				b -> new Parameters(b.toString()));
+	public static Collector<String, Parameters, Parameters> toParameters() {
+		return Collector.of(Parameters::new, Parameters::accumulator, Parameters::combiner);
+	}
+	private static void accumulator(Parameters p, String s) {
+		OSGiHeader.parseHeader(s, null, p);
+	}
+	private static Parameters combiner(Parameters t, Parameters u) {
+		t.mergeWith(u, true);
+		return t;
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -51,6 +51,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.StringJoiner;
 import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.jar.Attributes;
@@ -607,36 +608,46 @@ public class Analyzer extends Processor {
 						}
 						break;
 					case "org.osgi.annotation.bundle.Export" :
-						Object[] attributes = a.get("attribute");
-
-						if (attributes != null) {
-							for (Object s : attributes) {
-								String[] attr = ((String) s).split("=", 2);
-								if (attr.length != 2) {
-									warning("The annotation attribute %s of the exported package %s could not be understood",
-											s, clazz.getClassName().getPackageRef().getFQN());
-									continue;
-								}
-								info.put(attr[0], attr[1]);
-							}
-						}
-
-						Object[] usesClause = a.get("uses");
-						if (usesClause != null) {
+						Object[] usesClauses = a.get("uses");
+						if (usesClauses != null) {
+							StringJoiner sj = new StringJoiner(",");
 							String old = info.get(USES_DIRECTIVE);
-							if (old == null)
-								old = "";
-							StringBuilder sb = new StringBuilder(old);
-							String del = sb.length() == 0 ? "" : ",";
-
-							for (Object use : usesClause) {
-								sb.append(del);
-								sb.append(use);
-								del = ",";
+							if (old != null)
+								sj.add(old);
+							for (Object usesClause : usesClauses) {
+								sj.add(usesClause.toString());
 							}
-							info.put(USES_DIRECTIVE, sb.toString());
+							info.put(USES_DIRECTIVE, sj.toString());
 						}
 
+						Object substitution = a.get("substitution");
+						if (substitution != null) {
+							switch (substitution.toString()) {
+								case "CONSUMER" :
+									info.put(PROVIDE_DIRECTIVE, "false");
+									break;
+								case "PROVIDER" :
+									info.put(PROVIDE_DIRECTIVE, "true");
+									break;
+								case "NOIMPORT" :
+									info.put(NO_IMPORT_DIRECTIVE, "true");
+									break;
+								case "CALCULATED" :
+									// nothing to do; this is the normal case
+									break;
+								default :
+									error("Export annotation in %s has invalid substitution value: %s", clazz,
+										substitution);
+									break;
+							}
+						}
+
+						Object[] attributes = a.get("attribute");
+						if (attributes != null) {
+							for (Object attribute : attributes) {
+								info.mergeWith(OSGiHeader.parseProperties(attribute.toString(), Analyzer.this), false);
+							}
+						}
 						break;
 					case "aQute.bnd.annotation.Export" :
 						// Check mandatory attributes

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1677,7 +1677,6 @@ public class Analyzer extends Processor {
 			// }
 
 			parameters = new Attrs();
-			parameters.remove(VERSION_ATTRIBUTE);
 			result.put(ep, parameters);
 		}
 		return result;
@@ -1801,9 +1800,14 @@ public class Analyzer extends Processor {
 					// be defined externally or locally
 					//
 
-					boolean provider = isTrue(importAttributes.get(PROVIDE_DIRECTIVE))
-							|| isTrue(exportAttributes.get(PROVIDE_DIRECTIVE)) || provided.contains(packageRef);
-
+					boolean provider;
+					if (importAttributes.containsKey(PROVIDE_DIRECTIVE)) {
+						provider = isTrue(importAttributes.get(PROVIDE_DIRECTIVE));
+					} else if (exportAttributes.containsKey(PROVIDE_DIRECTIVE)) {
+						provider = isTrue(exportAttributes.get(PROVIDE_DIRECTIVE));
+					} else {
+						provider = provided.contains(packageRef);
+					}
 					exportVersion = cleanupVersion(exportVersion);
 
 					importRange = applyVersionPolicy(exportVersion, importRange, provider);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2091,9 +2091,7 @@ public class Analyzer extends Processor {
 		Attrs clause = exports.get(packageRef);
 
 		// Check if someone already set the uses: directive
-		String override = clause.get(USES_DIRECTIVE);
-		if (override == null)
-			override = USES_USES;
+		String override = clause.get(USES_DIRECTIVE, USES_USES);
 
 		// Get the used packages
 		Collection<PackageRef> usedPackages = uses.get(packageRef);
@@ -2132,10 +2130,17 @@ public class Analyzer extends Processor {
 				override = override.substring(0, override.length() - 1);
 			if (override.startsWith(","))
 				override = override.substring(1);
-			if (override.length() > 0) {
+			if (override.isEmpty()) {
+				clause.remove(USES_DIRECTIVE);
+			} else {
 				clause.put(USES_DIRECTIVE, override);
 			}
+		} else {
+			if (override.equals(USES_USES)) {
+				clause.remove(USES_DIRECTIVE);
+			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
Complete support for the OSGi Export annotation (see https://github.com/bndtools/bnd/issues/1343).

Also a change to the gradle plugin to improve performance on large workspaces.