### PR TITLE
docs: fix typo runrequire -> runrequires

### DIFF
--- a/docs/_chapters/300-launching.md
+++ b/docs/_chapters/300-launching.md
@@ -60,7 +60,7 @@ The default launcher in bnd. It creates a new VM with the given options, creates
 	
 	-runproperties:            org.osgi.service.http.port=8080
 	
-	-runrequire:\
+	-runrequires:\
 		bundle:(symbolicname=org.apache.felix.shell),\
 		bundle:(symbolicname=org.apache.felix.shell.tui),\
 		bundle:(symbolicname=org.apache.felix.webconsole),\


### PR DESCRIPTION
This pull-request fixes the first example of http://bnd.bndtools.org/chapters/300-launching.html where runrequires was missing "s".