### PR TITLE
iterables: Better handle non-String values for Processor

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2233,7 +2233,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			second = parent.iterable(inherit);
 		}
 
-		Iterable<String> iterable = Iterables.intersection(first, second, o -> o.toString());
+		Iterable<String> iterable = Iterables.intersection(first, second,
+			o -> (o instanceof String) ? (String) o : null);
 		return iterable;
 	}
 


### PR DESCRIPTION
Iterables now allows the mapper to return null which means ignore the
value.