### PR TITLE
Avoid using upper case for generated requirement directives

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -132,6 +132,13 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(filter, filter.contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
 			assertTrue(filter, filter.contains("(require=Required2)"));
 
+			p = req.get("maybe");
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertEquals("(maybe=test)", p.get("filter:"));
+			assertEquals("optional", p.get("resolution:"));
+			assertEquals("multiple", p.get("cardinality:"));
+
 			p = cap.get("provide" + DUPLICATE_MARKER + DUPLICATE_MARKER);
 			assertNotNull(p);
 			assertTrue(p.containsKey("provide"));

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AnnotatedAnnotation.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AnnotatedAnnotation.java
@@ -1,5 +1,8 @@
 package test.annotationheaders.attrs.std;
 
+import static org.osgi.annotation.bundle.Requirement.Cardinality.MULTIPLE;
+import static org.osgi.annotation.bundle.Requirement.Resolution.OPTIONAL;
+
 import org.osgi.annotation.bundle.Capability;
 import org.osgi.annotation.bundle.Header;
 import org.osgi.annotation.bundle.Requirement;
@@ -8,6 +11,7 @@ import org.osgi.annotation.bundle.Requirement;
 @Capability(namespace = "provide", name = "Provided2", version = "2")
 @Requirement(namespace = "require", name = "Required", version = "1", filter = "(a=b)")
 @Requirement(namespace = "require", name = "Required2", version = "2", filter = "(a=b)")
+@Requirement(namespace = "maybe", name = "test", resolution = OPTIONAL, cardinality = MULTIPLE)
 @Header(name = "foo", value = "bar")
 @Header(name = "fizz", value = "buzz")
 public @interface AnnotatedAnnotation {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -518,11 +518,11 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 		}
 
 		if (a.keySet().contains("resolution")) {
-			req.append(";resolution:=").append(annotation.resolution());
+			req.append(";resolution:=").append(annotation.resolution().name().toLowerCase());
 		}
 
 		if (a.keySet().contains("cardinality")) {
-			req.append(";cardinality:=").append(annotation.cardinality());
+			req.append(";cardinality:=").append(annotation.cardinality().name().toLowerCase());
 		}
 
 		if (a.keySet().contains("effective")) {


### PR DESCRIPTION
Using the cardinality or resolution attributes of the Requirement annotation resulted in an upper cased value in the manifest which caused bnd to complain.