### PR TITLE
processor: getUnprocessedProperty must respect the local only filter

### DIFF
--- a/biz.aQute.bndlib.tests/bnd/noactivator.bnd
+++ b/biz.aQute.bndlib.tests/bnd/noactivator.bnd
@@ -1,0 +1,1 @@
+Private-Package: test.api

--- a/biz.aQute.bndlib.tests/src/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/BuilderTest.java
@@ -4,6 +4,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,6 +22,7 @@ import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
@@ -1998,7 +2003,10 @@ public class BuilderTest extends BndTestCase {
 
 			Map<String,Resource> map = jar.getDirectories().get("bnd");
 			assertNotNull(map);
-			assertEquals(2, map.size());
+			try (Stream<Path> paths = Files.find(Paths.get("bnd"), Integer.MAX_VALUE, (t, a) -> a.isRegularFile(),
+				FileVisitOption.FOLLOW_LINKS)) {
+				assertEquals(paths.count(), map.size());
+			}
 		} finally {
 			bmaker.close();
 		}

--- a/biz.aQute.bndlib.tests/src/test/MakeTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MakeTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import java.util.Properties;
+import java.util.jar.Attributes;
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Jar;
@@ -20,19 +21,18 @@ public class MakeTest extends TestCase {
 	 * Test a make plugin
 	 */
 
-	public static void testMakePlugin() throws Exception {
-		Builder b = new Builder();
-		b.setProperty("Export-Package", "*");
-		b.setProperty("Include-Resource", "jar/asm.jar.md5");
-		b.setProperty("-make", "(*).md5;type=md5;file=$1");
-		b.setProperty("-plugin", "test.make.MD5");
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		Jar jar = b.build();
-		System.err.println(b.getErrors());
-		System.err.println(b.getWarnings());
-		assertEquals(0, b.getErrors().size());
-		assertEquals(0, b.getWarnings().size());
-		assertNotNull(jar.getResource("asm.jar.md5"));
+	public void testMakePlugin() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			bmaker.setProperty("Export-Package", "*");
+			bmaker.setProperty("Include-Resource", "jar/asm.jar.md5");
+			bmaker.setProperty("-make", "(*).md5;type=md5;file=$1");
+			bmaker.setProperty("-plugin", "test.make.MD5");
+			bmaker.addClasspath(IO.getFile("jar/osgi.jar"));
+			Jar jar = bmaker.build();
+			report(bmaker);
+
+			assertNotNull(jar.getResource("asm.jar.md5"));
+		}
 	}
 
 	/**
@@ -40,19 +40,19 @@ public class MakeTest extends TestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testCopy() throws Exception {
-		Builder bmaker = new Builder();
-		Properties p = new Properties();
-		p.setProperty("-resourceonly", "true");
-		p.setProperty("-plugin", "aQute.bnd.make.MakeBnd, aQute.bnd.make.MakeCopy");
-		p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd, (*).jar;type=copy;from=jar/$1.jar");
-		p.setProperty("Include-Resource", "asm.jar,xyz=asm.jar");
-		bmaker.setProperties(p);
-		Jar jar = bmaker.build();
-		assertNotNull(jar.getResource("asm.jar"));
-		assertNotNull(jar.getResource("xyz"));
-		report(bmaker);
+	public void testCopy() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.setProperty("-resourceonly", "true");
+			p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd, (*).jar;type=copy;from=jar/$1.jar");
+			p.setProperty("Include-Resource", "asm.jar,xyz=asm.jar");
+			bmaker.setProperties(p);
+			Jar jar = bmaker.build();
+			report(bmaker);
 
+			assertNotNull(jar.getResource("asm.jar"));
+			assertNotNull(jar.getResource("xyz"));
+		}
 	}
 
 	/**
@@ -60,26 +60,60 @@ public class MakeTest extends TestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testJarInJarInJar() throws Exception {
-		Builder bmaker = new Builder();
-		Properties p = new Properties();
-		p.setProperty("-plugin", "aQute.bnd.make.MakeBnd, aQute.bnd.make.MakeCopy");
-		p.setProperty("-resourceonly", "true");
-		p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd");
-		p.setProperty("Include-Resource", "makesondemand.jar");
-		bmaker.setProperties(p);
-		bmaker.setClasspath(new String[] {
+	public void testJarInJarInJar() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.setProperty("-resourceonly", "true");
+			p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd");
+			p.setProperty("Include-Resource", "makesondemand.jar");
+			bmaker.setProperties(p);
+			bmaker.setClasspath(new String[] {
 				"bin"
-		});
-		Jar jar = bmaker.build();
-		JarResource resource = (JarResource) jar.getResource("makesondemand.jar");
-		assertNotNull(resource);
+			});
+			Jar jar = bmaker.build();
+			report(bmaker);
 
-		jar = resource.getJar();
-		resource = (JarResource) jar.getResource("ondemand.jar");
-		assertNotNull(resource);
+			JarResource resource = (JarResource) jar.getResource("makesondemand.jar");
+			assertNotNull(resource);
 
-		report(bmaker);
+			jar = resource.getJar();
+			resource = (JarResource) jar.getResource("ondemand.jar");
+			assertNotNull(resource);
+		}
+	}
+
+	/**
+	 * Check that inner jar does not include filtered headers
+	 * 
+	 * @throws Exception
+	 */
+	public void testFilteredHeader() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.setProperty("Private-Package", "test.activator");
+			p.setProperty("Provide-Capability", "foo");
+			p.setProperty("Bundle-Activator", "test.activator.Activator");
+			p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd");
+			p.setProperty("-includeresource", "noactivator.jar");
+			bmaker.setProperties(p);
+			bmaker.setClasspath(new String[] {
+				"bin"
+			});
+			Jar jar = bmaker.build();
+			report(bmaker);
+
+			Attributes m = jar.getManifest()
+				.getMainAttributes();
+			assertEquals("test.activator.Activator", m.getValue("Bundle-Activator"));
+			assertEquals("foo", m.getValue("Provide-Capability"));
+			JarResource resource = (JarResource) jar.getResource("noactivator.jar");
+			assertNotNull(resource);
+			jar = resource.getJar();
+			m = jar.getManifest()
+				.getMainAttributes();
+			assertNull(m.getValue("Bundle-Activator"));
+			assertNull(m.getValue("Provide-Capability"));
+		}
 	}
 
 	/**
@@ -88,23 +122,23 @@ public class MakeTest extends TestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testComplexOnDemand() throws Exception {
-		Builder bmaker = new Builder();
-		Properties p = new Properties();
-		p.setProperty("-resourceonly", "true");
-		p.setProperty("-plugin", "aQute.bnd.make.MakeBnd, aQute.bnd.make.MakeCopy");
-		p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd");
-		p.setProperty("Include-Resource", "www/xyz.jar=ondemand.jar");
-		bmaker.setProperties(p);
-		bmaker.setClasspath(new String[] {
+	public void testComplexOnDemand() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.setProperty("-resourceonly", "true");
+			p.setProperty("-make", "(*).jar;type=bnd;recipe=bnd/$1.bnd");
+			p.setProperty("Include-Resource", "www/xyz.jar=ondemand.jar");
+			bmaker.setProperties(p);
+			bmaker.setClasspath(new String[] {
 				"bin"
-		});
-		Jar jar = bmaker.build();
-		Resource resource = jar.getResource("www/xyz.jar");
-		assertNotNull(resource);
-		assertTrue(resource instanceof JarResource);
-		report(bmaker);
+			});
+			Jar jar = bmaker.build();
+			report(bmaker);
 
+			Resource resource = jar.getResource("www/xyz.jar");
+			assertNotNull(resource);
+			assertTrue(resource instanceof JarResource);
+		}
 	}
 
 	static void report(Processor processor) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1256,6 +1256,9 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 */
 
 	public String getUnprocessedProperty(String key, String deflt) {
+		if (filter != null && filter.contains(key)) {
+			return (String) getProperties().getOrDefault(key, deflt);
+		}
 		return getProperties().getProperty(key, deflt);
 	}
 


### PR DESCRIPTION
The Verifier was complaining that a bundle did not have a bundle
activator when it was able to see the outer bundle's Bundle-Activator
property.