### PR TITLE
docs: fix typo runsystempackage -> runsystempackages

### DIFF
--- a/docs/_instructions/runsystempackages.md
+++ b/docs/_instructions/runsystempackages.md
@@ -5,9 +5,9 @@ title: -runsystempackages* PARAMETERS
 summary:  Define extra system packages (packages exported from the remote VM -runpath).
 ---
 
-The resolver will analyses the `-runpath` and `-runfw` JARs for any exported packages and make these available as system packages to the bundles. However, in certain cases this automatic analysis does not suffice. In that case extra packages can be added. These packages must, of course, be available on the class path.
+The resolver will analyse the `-runpath` and `-runfw` JARs for any exported packages and make these available as system packages to the bundles. However, in certain cases this automatic analysis does not suffice. In that case extra packages can be added. These packages must, of course, be available on the class path.
 
 For example:
 
-	-runsystempackage: \
+	-runsystempackages: \
 		com.sun.misc


### PR DESCRIPTION
Typo in runsystempackages' example.