### PR TITLE
InfoRepositoryWrapper: Ensure we always return (at least) an empty list

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/InfoRepositoryWrapper.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/wrapper/InfoRepositoryWrapper.java
@@ -168,10 +168,12 @@ public class InfoRepositoryWrapper extends BaseRepository {
 			throws Exception {
 		init();
 
-		nextReq: for (Requirement req : requirements) {
+		for (Requirement req : requirements) {
+			result.putIfAbsent(req, new ArrayList<Capability>(1));
+
 			String f = req.getDirectives().get("filter");
 			if (f == null)
-				continue nextReq;
+				continue;
 
 			Filter filter = new Filter(f);
 
@@ -179,10 +181,8 @@ public class InfoRepositoryWrapper extends BaseRepository {
 				Resource resource = presource.getResource();
 				for (Capability cap : resource.getCapabilities(req.getNamespace())) {
 					if (filter.matchMap(cap.getAttributes())) {
-						List<Capability> l = result.get(req);
-						if (l == null)
-							result.put(req, l = new ArrayList<Capability>());
-						l.add(cap);
+						result.get(req)
+							.add(cap);
 					}
 				}
 			}

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/wrapper/TestWrapper.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/wrapper/TestWrapper.java
@@ -108,7 +108,8 @@ public class TestWrapper extends TestCase {
 
 		Map<Requirement,Collection<Capability>> result = iw.findProviders(Arrays.asList(req));
 		assertNotNull(result);
-		assertEquals(count, result.size());
+		assertEquals(count, result.get(req)
+			.size());
 
 		iw.close();
 
@@ -116,7 +117,8 @@ public class TestWrapper extends TestCase {
 
 		result = iw.findProviders(Arrays.asList(req));
 		assertNotNull(result);
-		assertEquals(count, result.size());
+		assertEquals(count, result.get(req)
+			.size());
 
 		iw.close();
 		for (InfoRepository r : repos) {


### PR DESCRIPTION
Signed-off-by: Sean Bright <sean.bright@gmail.com>