### PR TITLE
Handle duplicate values allowed in some instructions such as -runvm

### DIFF
--- a/aQute.libg/src/aQute/lib/collections/SortedList.java
+++ b/aQute.libg/src/aQute/lib/collections/SortedList.java
@@ -97,10 +97,11 @@ public class SortedList<T> implements SortedSet<T>, List<T> {
 	}
 
 	@SafeVarargs
-	public SortedList(Comparable< ? super T>... x) {
+	public <C extends Comparable<? super T>> SortedList(C... x) {
 		this((T[]) x, 0, x.length, null);
 	}
 
+	@SafeVarargs
 	public SortedList(Comparator<? super T> cmp, T... x) {
 		this(x, 0, x.length, cmp);
 	}

--- a/aQute.libg/src/aQute/libg/command/Command.java
+++ b/aQute.libg/src/aQute/libg/command/Command.java
@@ -209,6 +209,10 @@ public class Command {
 		return exitValue;
 	}
 
+	public void add(String arg) {
+		arguments.add(arg);
+	}
+
 	public void add(String... args) {
 		Collections.addAll(arguments, args);
 	}
@@ -273,6 +277,11 @@ public class Command {
 
 	public Command var(String name, String value) {
 		variables.put(name, value);
+		return this;
+	}
+
+	public Command arg(String arg) {
+		add(arg);
 		return this;
 	}
 

--- a/aQute.libg/src/aQute/libg/command/packageinfo
+++ b/aQute.libg/src/aQute/libg/command/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/biz.aQute.bndlib.tests/src/test/ParseHeaderTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ParseHeaderTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -11,6 +12,7 @@ import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.version.Version;
+import aQute.lib.strings.Strings;
 import junit.framework.TestCase;
 
 public class ParseHeaderTest extends TestCase {
@@ -243,5 +245,12 @@ public class ParseHeaderTest extends TestCase {
 		assertNotNull(a);
 		assertEquals(Attrs.Type.VERSION, a.getType("viking"));
 		assertEquals(Version.parseVersion("2.0.0"), Version.parseVersion(a.get("viking")));
+	}
+
+	public void testParametersKeyList() throws Exception {
+		String s = "--add-opens, mod1, --add-opens, mod2";
+		Parameters map = Processor.parseHeader(s, null);
+		Collection<String> keyList = map.keyList();
+		assertEquals("--add-opens mod1 --add-opens mod2", Strings.join(" ", keyList));
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -3066,7 +3066,7 @@ public class Project extends Processor {
 			javac.add("-deprecation");
 
 		if (test || debug == null) {
-			javac.add("-g:source,lines,vars" + debug);
+			javac.add("-g:source,lines,vars");
 		} else {
 			javac.add("-g:" + debug);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2693,12 +2693,12 @@ public class Project extends Processor {
 
 	public Collection<String> getRunVM() {
 		Parameters hdr = getMergedParameters(RUNVM);
-		return hdr.keySet();
+		return hdr.keyList();
 	}
 
 	public Collection<String> getRunProgramArgs() {
 		Parameters hdr = getMergedParameters(RUNPROGRAMARGS);
-		return hdr.keySet();
+		return hdr.keyList();
 	}
 
 	public Map<String,String> getRunProperties() {
@@ -3071,8 +3071,7 @@ public class Project extends Processor {
 			javac.add("-g:" + debug);
 		}
 
-		for (String option : options.keySet())
-			javac.add(option);
+		javac.addAll(options.keyList());
 
 		StringBuilder bootclasspath = new StringBuilder();
 		String bootclasspathDel = "-Xbootclasspath/p:";

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
@@ -1,7 +1,10 @@
 package aQute.bnd.header;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collector;
@@ -86,6 +89,12 @@ public class Parameters implements Map<String,Attrs> {
 		return map.keySet();
 	}
 
+	public List<String> keyList() {
+		return keySet().stream()
+			.map(this::removeDuplicateMarker)
+			.collect(toList());
+	}
+
 	public Attrs put(String key, Attrs value) {
 		assert key != null;
 		assert value != null;
@@ -143,10 +152,12 @@ public class Parameters implements Map<String,Attrs> {
 		}
 	}
 
-	private Object removeDuplicateMarker(String key) {
-		while (key.endsWith("~"))
-			key = key.substring(0, key.length() - 1);
-		return key;
+	private String removeDuplicateMarker(String key) {
+		int i = key.length() - 1;
+		while (i >= 0 && key.charAt(i) == '~')
+			--i;
+
+		return key.substring(0, i + 1);
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -3372,22 +3372,22 @@ public class Analyzer extends Processor {
 	public boolean check(Check key) {
 		if (checks == null) {
 			Parameters p = new Parameters(getProperty("-check"), this);
-			checks = new HashSet<>();
-			for (String k : p.keySet())
+			checks = EnumSet.noneOf(Check.class);
+			for (String k : p.keyList()) {
 				try {
 					if (k.equalsIgnoreCase("all")) {
 						checks = EnumSet.allOf(Check.class);
 						break;
 					}
 
-					Check c = Enum.valueOf(Check.class, k.toUpperCase().replace('-', '_'));
+					Check c = Check.valueOf(k.toUpperCase()
+						.replace('-', '_'));
 					checks.add(c);
 
 				} catch (Exception e) {
 					error("Invalid -check constant, allowed values are %s", Arrays.toString(Check.values()));
 				}
-			if (!checks.isEmpty())
-				checks = EnumSet.copyOf(checks);
+			}
 		}
 		return checks.contains(key) || checks.contains(Check.ALL);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -800,10 +800,10 @@ public class Verifier extends Processor {
 	private void verifyRequirements() throws IllegalArgumentException, Exception {
 		Parameters map = parseHeader(manifest.getMainAttributes().getValue(Constants.REQUIRE_CAPABILITY));
 		for (String key : map.keySet()) {
-
+			Attrs attrs = map.get(key);
+			key = Processor.removeDuplicateMarker(key);
 			verifyNamespace(key, "Require");
 
-			Attrs attrs = map.get(key);
 			verify(attrs, "filter:", FILTERPATTERN, false, "Requirement %s filter not correct", key);
 
 			String filter = attrs.get("filter:");
@@ -864,8 +864,9 @@ public class Verifier extends Processor {
 	private void verifyCapabilities() {
 		Parameters map = parseHeader(manifest.getMainAttributes().getValue(Constants.PROVIDE_CAPABILITY));
 		for (String key : map.keySet()) {
-			verifyNamespace(key, "Provide");
 			Attrs attrs = map.get(key);
+			key = Processor.removeDuplicateMarker(key);
+			verifyNamespace(key, "Provide");
 			verify(attrs, "cardinality:", CARDINALITY_PATTERN, false, "Capability %s cardinality not correct", key);
 			verify(attrs, "resolution:", RESOLUTION_PATTERN, false, "Capability %s resolution not correct", key);
 
@@ -899,7 +900,7 @@ public class Verifier extends Processor {
 	}
 
 	private void verifyNamespace(String ns, String type) {
-		if (!isBsn(Processor.removeDuplicateMarker(ns))) {
+		if (!isBsn(ns)) {
 			error("The %s-Capability with namespace %s is not a symbolic name", type, ns);
 		}
 	}


### PR DESCRIPTION
A new method is added to Parameter to return a list of the keys with duplicate markers removed.

Some other fixes are also in this PR.