### PR TITLE
mavenversion: Handle strange maven qualifier sorting rules

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/MavenVersionTest.java
+++ b/biz.aQute.bndlib.tests/src/test/MavenVersionTest.java
@@ -1,5 +1,16 @@
 package test;
 
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.MavenVersionRange;
 import aQute.bnd.version.Version;
@@ -232,5 +243,70 @@ public class MavenVersionTest extends TestCase {
 		v = "1.0." + max;
 		c = MavenVersion.cleanupVersion(v);
 		assertEquals(v, c);
+	}
+
+	public void testComparableAliases() throws Exception {
+		MavenVersion mv1 = MavenVersion.parseString("1.2.7");
+		MavenVersion mv2 = MavenVersion.parseString("1.2.7-FINAL");
+		MavenVersion mv3 = MavenVersion.parseString("1.2.7-final");
+		MavenVersion mv4 = MavenVersion.parseString("1.2.7-GA");
+		MavenVersion mv5 = MavenVersion.parseString("1.2.7-ga");
+		assertEquals(0, mv1.compareTo(mv1));
+		assertEquals(0, mv1.compareTo(mv2));
+		assertEquals(0, mv1.compareTo(mv3));
+		assertEquals(0, mv1.compareTo(mv4));
+		assertEquals(0, mv1.compareTo(mv5));
+
+		assertEquals(0, mv2.compareTo(mv1));
+		assertEquals(0, mv2.compareTo(mv2));
+		assertEquals(0, mv2.compareTo(mv3));
+		assertEquals(0, mv2.compareTo(mv4));
+		assertEquals(0, mv2.compareTo(mv5));
+
+		assertEquals(0, mv3.compareTo(mv1));
+		assertEquals(0, mv3.compareTo(mv2));
+		assertEquals(0, mv3.compareTo(mv3));
+		assertEquals(0, mv3.compareTo(mv4));
+		assertEquals(0, mv3.compareTo(mv5));
+
+		assertEquals(0, mv4.compareTo(mv1));
+		assertEquals(0, mv4.compareTo(mv2));
+		assertEquals(0, mv4.compareTo(mv3));
+		assertEquals(0, mv4.compareTo(mv4));
+		assertEquals(0, mv4.compareTo(mv5));
+
+		assertEquals(0, mv5.compareTo(mv1));
+		assertEquals(0, mv5.compareTo(mv2));
+		assertEquals(0, mv5.compareTo(mv3));
+		assertEquals(0, mv5.compareTo(mv4));
+		assertEquals(0, mv5.compareTo(mv5));
+	}
+
+	public void testComparableSorting() throws Exception {
+		List<String> ordered = Arrays.asList("1.2.7-ALPHA", "1.2.7-a2", "1.2.7-beta", "1.2.7-B50", "1.2.7-Milestone",
+			"1.2.7-MILESTONE-2", "1.2.7-RC", "1.2.7-rc5", "1.2.7-SNAPSHOT", "1.2.7", "1.2.7-SP");
+		List<String> shuffled = new ArrayList<>(ordered);
+		Collections.shuffle(shuffled);
+		assertNotEquals(ordered, shuffled);
+		List<MavenVersion> sorted = shuffled.stream()
+			.map(MavenVersion::new)
+			.sorted()
+			.collect(Collectors.toList());
+		assertEquals(ordered.size(), sorted.size());
+		for (int i = 0; i < ordered.size(); i++) {
+			MavenVersion expected = MavenVersion.parseString(ordered.get(i));
+			MavenVersion actual = sorted.get(i);
+			assertEquals(expected, actual);
+			assertEquals(0, expected.compareTo(actual));
+			assertEquals(0, actual.compareTo(expected));
+		}
+	}
+
+	public void testComparableMax() throws Exception {
+		Optional<MavenVersion> m = Stream.of("1.2.7", "1.2.7-SNAPSHOT")
+			.map(MavenVersion::parseString)
+			.max(Comparator.naturalOrder());
+		assertTrue(m.isPresent());
+		assertEquals(new MavenVersion("1.2.7"), m.get());
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/differ/DiffPluginImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/DiffPluginImpl.java
@@ -236,8 +236,8 @@ public class DiffPluginImpl implements Differ {
 
 			if (MAJOR_HEADERS.contains(header)) {
 				if (header.equalsIgnoreCase(Constants.BUNDLE_VERSION)) {
-					Version v = new Version(value).getWithoutQualifier();
-					result.add(new Element(Type.HEADER, header + ":" + v.toString(), null, CHANGED, CHANGED, null));
+					String v = new Version(value).toStringWithoutQualifier();
+					result.add(new Element(Type.HEADER, header + ":" + v, null, CHANGED, CHANGED, null));
 				} else {
 					Parameters clauses = OSGiHeader.parseHeader(value);
 					Collection<Element> clausesDef = new ArrayList<>();

--- a/biz.aQute.bndlib/src/aQute/bnd/differ/JavaElement.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/differ/JavaElement.java
@@ -179,7 +179,7 @@ class JavaElement {
 			String version = exports.get(entry.getKey()).get(Constants.VERSION_ATTRIBUTE);
 			if (version != null) {
 				Version v = new Version(version);
-				set.add(new Element(VERSION, v.getWithoutQualifier().toString(), null, IGNORED, IGNORED, null));
+				set.add(new Element(VERSION, v.toStringWithoutQualifier(), null, IGNORED, IGNORED, null));
 			}
 			Element pd = new Element(PACKAGE, entry.getKey().getFQN(), set, MINOR, MAJOR, null);
 			result.add(pd);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -3116,7 +3116,7 @@ public class Analyzer extends Processor {
 			String bsn = name.getKey();
 			String version = getBundleVersion();
 			Version v = Version.parseVersion(version);
-			String outputName = bsn + "-" + v.getWithoutQualifier() + Constants.DEFAULT_JAR_EXTENSION;
+			String outputName = bsn + "-" + v.toStringWithoutQualifier() + Constants.DEFAULT_JAR_EXTENSION;
 			return new File(outputDir, outputName);
 		}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -427,7 +427,8 @@ public class Builder extends Analyzer {
 			Matcher m = Verifier.VERSION.matcher(defaultVersion);
 			if (m.matches()) {
 				// Strip qualifier from default package version
-				defaultVersion = Version.parseVersion(defaultVersion).getWithoutQualifier().toString();
+				defaultVersion = Version.parseVersion(defaultVersion)
+					.toStringWithoutQualifier();
 			}
 		}
 		for (Map.Entry<PackageRef,Attrs> entry : packages.entrySet()) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -1044,7 +1044,7 @@ public class Jar implements Closeable {
 			String version = main.getValue(new Attributes.Name(Constants.BUNDLE_VERSION));
 			if (version != null && Verifier.isVersion(version)) {
 				Version v = new Version(version);
-				main.putValue(Constants.BUNDLE_VERSION, v.getWithoutQualifier().toString());
+				main.putValue(Constants.BUNDLE_VERSION, v.toStringWithoutQualifier());
 			}
 			writeManifest(m2, dout);
 

--- a/biz.aQute.bndlib/src/aQute/bnd/version/ComparableVersion.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/ComparableVersion.java
@@ -1,0 +1,415 @@
+package aQute.bnd.version;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.math.BigInteger;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
+/**
+ * <p>
+ * Generic implementation of version comparison.
+ * </p>
+ * Features:
+ * <ul>
+ * <li>mixing of '<code>-</code>' (hyphen) and '<code>.</code>' (dot)
+ * separators,</li>
+ * <li>transition between characters and digits also constitutes a separator:
+ * <code>1.0alpha1 =&gt; [1, 0, alpha, 1]</code></li>
+ * <li>unlimited number of version components,</li>
+ * <li>version components in the text can be digits or strings,</li>
+ * <li>strings are checked for well-known qualifiers and the qualifier ordering
+ * is used for version ordering. Well-known qualifiers (case insensitive) are:
+ * <ul>
+ * <li><code>alpha</code> or <code>a</code></li>
+ * <li><code>beta</code> or <code>b</code></li>
+ * <li><code>milestone</code> or <code>m</code></li>
+ * <li><code>rc</code> or <code>cr</code></li>
+ * <li><code>snapshot</code></li>
+ * <li><code>(the empty string)</code> or <code>ga</code> or
+ * <code>final</code></li>
+ * <li><code>sp</code></li>
+ * </ul>
+ * Unknown qualifiers are considered after known qualifiers, with lexical order
+ * (always case insensitive),</li>
+ * <li>a hyphen usually precedes a qualifier, and is always less important than
+ * something preceded with a dot.</li>
+ * </ul>
+ *
+ * @see <a href=
+ *      "https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning">"Versioning"
+ *      on Maven Wiki</a>
+ * @author <a href="mailto:kenney@apache.org">Kenney Westerhof</a>
+ * @author <a href="mailto:hboutemy@apache.org">Hervé Boutemy</a>
+ */
+class ComparableVersion implements Comparable<ComparableVersion> {
+	private static final ComparableVersion	empty	= new ComparableVersion("");
+	private final String	value;
+
+	private final String	canonical;
+
+	private final ListItem	items;
+
+	private interface Item {
+		int	INTEGER_ITEM	= 0;
+		int	STRING_ITEM		= 1;
+		int	LIST_ITEM		= 2;
+
+		int compareTo(Item item);
+
+		int getType();
+
+		boolean isNull();
+	}
+
+	/**
+	 * Represents a numeric item in the version item list.
+	 */
+	private static class IntegerItem implements Item {
+		private static final BigInteger	BIG_INTEGER_ZERO	= new BigInteger("0");
+
+		private final BigInteger		value;
+
+		public static final IntegerItem	ZERO				= new IntegerItem();
+
+		private IntegerItem() {
+			this.value = BIG_INTEGER_ZERO;
+		}
+
+		IntegerItem(String str) {
+			this.value = new BigInteger(str);
+		}
+
+		public int getType() {
+			return INTEGER_ITEM;
+		}
+
+		public boolean isNull() {
+			return BIG_INTEGER_ZERO.equals(value);
+		}
+
+		public int compareTo(Item item) {
+			if (item == null) {
+				return BIG_INTEGER_ZERO.equals(value) ? 0 : 1; // 1.0 == 1, 1.1
+																// > 1
+			}
+
+			switch (item.getType()) {
+				case INTEGER_ITEM :
+					return value.compareTo(((IntegerItem) item).value);
+
+				case STRING_ITEM :
+					return 1; // 1.1 > 1-sp
+
+				case LIST_ITEM :
+					return 1; // 1.1 > 1-1
+
+				default :
+					throw new RuntimeException("invalid item: " + item.getClass());
+			}
+		}
+
+		public String toString() {
+			return value.toString();
+		}
+	}
+
+	/**
+	 * Represents a string in the version item list, usually a qualifier.
+	 */
+	private static class StringItem implements Item {
+		private static final String[]		QUALIFIERS	= {
+			"alpha", "beta", "milestone", "rc", "snapshot", "", "sp"
+		};
+
+		private static final List<String>	_QUALIFIERS	= Arrays.asList(QUALIFIERS);
+
+		private static final Properties		ALIASES		= new Properties();
+		static {
+			ALIASES.put("ga", "");
+			ALIASES.put("final", "");
+			ALIASES.put("cr", "rc");
+		}
+
+		/**
+		 * A comparable value for the empty-string qualifier. This one is used
+		 * to determine if a given qualifier makes the version older than one
+		 * without a qualifier, or more recent.
+		 */
+		private static final String	RELEASE_VERSION_INDEX	= String.valueOf(_QUALIFIERS.indexOf(""));
+
+		private final String		value;
+
+		StringItem(String value, boolean followedByDigit) {
+			if (followedByDigit && value.length() == 1) {
+				// a1 = alpha-1, b1 = beta-1, m1 = milestone-1
+				switch (value.charAt(0)) {
+					case 'a' :
+						value = "alpha";
+						break;
+					case 'b' :
+						value = "beta";
+						break;
+					case 'm' :
+						value = "milestone";
+						break;
+					default :
+				}
+			}
+			this.value = ALIASES.getProperty(value, value);
+		}
+
+		public int getType() {
+			return STRING_ITEM;
+		}
+
+		public boolean isNull() {
+			return (comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX) == 0);
+		}
+
+		/**
+		 * Returns a comparable value for a qualifier. This method takes into
+		 * account the ordering of known qualifiers then unknown qualifiers with
+		 * lexical ordering. just returning an Integer with the index here is
+		 * faster, but requires a lot of if/then/else to check for -1 or
+		 * QUALIFIERS.size and then resort to lexical ordering. Most comparisons
+		 * are decided by the first character, so this is still fast. If more
+		 * characters are needed then it requires a lexical sort anyway.
+		 *
+		 * @param qualifier
+		 * @return an equivalent value that can be used with lexical comparison
+		 */
+		public static String comparableQualifier(String qualifier) {
+			int i = _QUALIFIERS.indexOf(qualifier);
+
+			return i == -1 ? (_QUALIFIERS.size() + "-" + qualifier) : String.valueOf(i);
+		}
+
+		public int compareTo(Item item) {
+			if (item == null) {
+				// 1-rc < 1, 1-ga > 1
+				return comparableQualifier(value).compareTo(RELEASE_VERSION_INDEX);
+			}
+			switch (item.getType()) {
+				case INTEGER_ITEM :
+					return -1; // 1.any < 1.1 ?
+
+				case STRING_ITEM :
+					return comparableQualifier(value).compareTo(comparableQualifier(((StringItem) item).value));
+
+				case LIST_ITEM :
+					return -1; // 1.any < 1-1
+
+				default :
+					throw new RuntimeException("invalid item: " + item.getClass());
+			}
+		}
+
+		public String toString() {
+			return value;
+		}
+	}
+
+	/**
+	 * Represents a version list item. This class is used both for the global
+	 * item list and for sub-lists (which start with '-(number)' in the version
+	 * specification).
+	 */
+	private static class ListItem extends ArrayList<Item> implements Item {
+		private static final long serialVersionUID = 1L;
+
+		ListItem() {}
+
+		public int getType() {
+			return LIST_ITEM;
+		}
+
+		public boolean isNull() {
+			return (size() == 0);
+		}
+
+		void normalize() {
+			for (int i = size() - 1; i >= 0; i--) {
+				Item lastItem = get(i);
+
+				if (lastItem.isNull()) {
+					// remove null trailing items: 0, "", empty list
+					remove(i);
+				} else if (!(lastItem instanceof ListItem)) {
+					break;
+				}
+			}
+		}
+
+		public int compareTo(Item item) {
+			if (item == null) {
+				if (size() == 0) {
+					return 0; // 1-0 = 1- (normalize) = 1
+				}
+				Item first = get(0);
+				return first.compareTo(null);
+			}
+			switch (item.getType()) {
+				case INTEGER_ITEM :
+					return -1; // 1-1 < 1.0.x
+
+				case STRING_ITEM :
+					return 1; // 1-1 > 1-sp
+
+				case LIST_ITEM :
+					Iterator<Item> left = iterator();
+					Iterator<Item> right = ((ListItem) item).iterator();
+
+					while (left.hasNext() || right.hasNext()) {
+						Item l = left.hasNext() ? left.next() : null;
+						Item r = right.hasNext() ? right.next() : null;
+
+						// if this is shorter, then invert the compare and mul
+						// with -1
+						int result = l == null ? (r == null ? 0 : -1 * r.compareTo(l)) : l.compareTo(r);
+
+						if (result != 0) {
+							return result;
+						}
+					}
+
+					return 0;
+
+				default :
+					throw new RuntimeException("invalid item: " + item.getClass());
+			}
+		}
+
+		public String toString() {
+			StringBuilder buffer = new StringBuilder();
+			for (Item item : this) {
+				if (buffer.length() > 0) {
+					buffer.append((item instanceof ListItem) ? '-' : '.');
+				}
+				buffer.append(item);
+			}
+			return buffer.toString();
+		}
+	}
+
+	static ComparableVersion parseVersion(String version) {
+		if (version == null) {
+			return empty;
+		}
+		return new ComparableVersion(version);
+	}
+
+	private ComparableVersion(String version) {
+		this.value = version;
+
+		items = new ListItem();
+
+		version = version.toLowerCase(Locale.ENGLISH);
+
+		ListItem list = items;
+
+		Deque<ListItem> stack = new ArrayDeque<>();
+		stack.push(list);
+
+		boolean isDigit = false;
+
+		int startIndex = 0;
+
+		for (int i = 0; i < version.length(); i++) {
+			char c = version.charAt(i);
+
+			if (c == '.') {
+				if (i == startIndex) {
+					list.add(IntegerItem.ZERO);
+				} else {
+					list.add(parseItem(isDigit, version.substring(startIndex, i)));
+				}
+				startIndex = i + 1;
+			} else if (c == '-') {
+				if (i == startIndex) {
+					list.add(IntegerItem.ZERO);
+				} else {
+					list.add(parseItem(isDigit, version.substring(startIndex, i)));
+				}
+				startIndex = i + 1;
+
+				list.add(list = new ListItem());
+				stack.push(list);
+			} else if (Character.isDigit(c)) {
+				if (!isDigit && i > startIndex) {
+					list.add(new StringItem(version.substring(startIndex, i), true));
+					startIndex = i;
+
+					list.add(list = new ListItem());
+					stack.push(list);
+				}
+
+				isDigit = true;
+			} else {
+				if (isDigit && i > startIndex) {
+					list.add(parseItem(true, version.substring(startIndex, i)));
+					startIndex = i;
+
+					list.add(list = new ListItem());
+					stack.push(list);
+				}
+
+				isDigit = false;
+			}
+		}
+
+		if (version.length() > startIndex) {
+			list.add(parseItem(isDigit, version.substring(startIndex)));
+		}
+
+		while (!stack.isEmpty()) {
+			list = stack.pop();
+			list.normalize();
+		}
+
+		canonical = items.toString();
+	}
+
+	private static Item parseItem(boolean isDigit, String buf) {
+		return isDigit ? new IntegerItem(buf) : new StringItem(buf, false);
+	}
+
+	public int compareTo(ComparableVersion o) {
+		return items.compareTo(o.items);
+	}
+
+	public String toString() {
+		return value;
+	}
+
+	public boolean equals(Object o) {
+		return (o instanceof ComparableVersion) && canonical.equals(((ComparableVersion) o).canonical);
+	}
+
+	public int hashCode() {
+		return canonical.hashCode();
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/MavenVersion.java
@@ -43,8 +43,7 @@ public class MavenVersion implements Comparable<MavenVersion> {
 		String q = osgiVersion.qualifier;
 		this.qualifier = ComparableVersion.parseVersion(q);
 
-		String l = osgiVersion.getWithoutQualifier()
-			.toString();
+		String l = osgiVersion.toStringWithoutQualifier();
 		if (q != null) {
 			l += "-" + q;
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
@@ -91,22 +91,24 @@ public class Version implements Comparable<Version> {
 			return 0;
 
 		Version o = other;
-		if (major != o.major)
-			return major - o.major;
+		int cmp = major - o.major;
+		if (cmp != 0)
+			return cmp;
 
-		if (minor != o.minor)
-			return minor - o.minor;
+		cmp = minor - o.minor;
+		if (cmp != 0)
+			return cmp;
 
-		if (micro != o.micro)
-			return micro - o.micro;
+		cmp = micro - o.micro;
+		if (cmp != 0)
+			return cmp;
 
-		int c = 0;
 		if (qualifier != null)
-			c = 1;
+			cmp = 1;
 		if (o.qualifier != null)
-			c += 2;
+			cmp += 2;
 
-		switch (c) {
+		switch (cmp) {
 			case 0 :
 				return 0;
 			case 1 :

--- a/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
@@ -134,6 +134,16 @@ public class Version implements Comparable<Version> {
 		return sb.toString();
 	}
 
+	public String toStringWithoutQualifier() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(major);
+		sb.append(".");
+		sb.append(minor);
+		sb.append(".");
+		sb.append(micro);
+		return sb.toString();
+	}
+
 	@Override
 	public boolean equals(Object ot) {
 		if (!(ot instanceof Version))

--- a/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
+++ b/biz.aQute.bndlib/src/aQute/lib/deployer/FileRepo.java
@@ -411,13 +411,13 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 			if (!dir.isDirectory())
 				throw new IOException("Could not create directory " + dir);
 
-			String fName = bsn + "-" + version.getWithoutQualifier() + ".jar";
+			String fName = bsn + "-" + version.toStringWithoutQualifier() + ".jar";
 			File file = new File(dir, fName);
 
 			logger.debug("updating {}", file.getAbsolutePath());
 
 			if (hasIndex)
-				index.put(bsn + "-" + version.getWithoutQualifier(),
+				index.put(bsn + "-" + version.toStringWithoutQualifier(),
 						buildDescriptor(tmpFile, tmpJar, digest, bsn, version));
 
 			// An open jar on file will fail rename on windows
@@ -717,19 +717,19 @@ public class FileRepo implements Plugin, RepositoryPlugin, Refreshable, Registry
 				return fjar.getAbsoluteFile();
 		}
 
-		File fjar = new File(dir, bsn + "-" + version.getWithoutQualifier() + ".jar");
+		File fjar = new File(dir, bsn + "-" + version.toStringWithoutQualifier() + ".jar");
 		if (fjar.isFile())
 			return fjar.getAbsoluteFile();
 
-		File sfjar = new File(dir, version.getWithoutQualifier() + ".jar");
+		File sfjar = new File(dir, version.toStringWithoutQualifier() + ".jar");
 		if (sfjar.isFile())
 			return sfjar.getAbsoluteFile();
 
-		File flib = new File(dir, bsn + "-" + version.getWithoutQualifier() + ".lib");
+		File flib = new File(dir, bsn + "-" + version.toStringWithoutQualifier() + ".lib");
 		if (flib.isFile())
 			return flib.getAbsoluteFile();
 
-		File sflib = new File(dir, version.getWithoutQualifier() + ".lib");
+		File sflib = new File(dir, version.toStringWithoutQualifier() + ".lib");
 		if (sflib.isFile())
 			return sflib.getAbsoluteFile();
 


### PR DESCRIPTION
We use the code from maven, with some modifications, to do the sorting:
https://github.com/apache/maven/blob/5988085525a39025a9f3d7cfb0592d42261abaf0/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java

Thanks to @mnlipp for the pointer to the maven-artifact code.

Fixes https://github.com/bndtools/bnd/issues/2287