### PR TITLE
resource: Avoid URI resolve which fails badly with UNC names on Windows

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
@@ -1,13 +1,14 @@
 package aQute.bnd.osgi;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import aQute.bnd.osgi.URLResource.JarURLUtil;
 
@@ -28,14 +29,18 @@ public interface Resource extends Closeable {
 
 	static Resource fromURL(URL url) throws IOException {
 		if (url.getProtocol().equalsIgnoreCase("file")) {
-			Path path = Paths.get(Paths.get("").toUri().resolve(url.getPath()));
+			URI uri = URI.create(url.toExternalForm());
+			Path path = new File(uri.getSchemeSpecificPart()).toPath()
+				.toAbsolutePath();
 			return new FileResource(path);
 		}
 		if (url.getProtocol().equals("jar")) {
 			JarURLUtil util = new JarURLUtil(url);
 			URL jarFileURL = util.getJarFileURL();
 			if (jarFileURL.getProtocol().equalsIgnoreCase("file")) {
-				Path path = Paths.get(Paths.get("").toUri().resolve(jarFileURL.getPath()));
+				URI uri = URI.create(jarFileURL.toExternalForm());
+				Path path = new File(uri.getSchemeSpecificPart()).toPath()
+					.toAbsolutePath();
 				String entryName = util.getEntryName();
 				if (entryName == null) {
 					return new FileResource(path);


### PR DESCRIPTION
We now use a URI object to decode the string and toAbsolutePath to
ensure the path is not relative.

Fixes https://github.com/bndtools/bndtools/issues/1834

This should solve the problem in this bug since the home UNC folder is
no longer referenced since we are not resolving to a URI of that folder.