### PR TITLE
Reproducible jars

### DIFF
--- a/.gradle-wrapper/gradle-wrapper.properties
+++ b/.gradle-wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip

--- a/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
+++ b/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
@@ -701,18 +701,24 @@ public class ReplacerAdapter extends ReporterAdapter implements Replacer {
 	}
 
 	public String _tstamp(String args[]) {
-		String format = "yyyyMMddHHmm";
-		long now = System.currentTimeMillis();
-		TimeZone tz = TimeZone.getTimeZone("UTC");
+		String format;
+		long now;
+		TimeZone tz;
 
 		if (args.length > 1) {
 			format = args[1];
+		} else {
+			format = "yyyyMMddHHmm";
 		}
 		if (args.length > 2) {
 			tz = TimeZone.getTimeZone(args[2]);
+		} else {
+			tz = TimeZone.getTimeZone("UTC");
 		}
 		if (args.length > 3) {
 			now = Long.parseLong(args[3]);
+		} else {
+			now = System.currentTimeMillis();
 		}
 		if (args.length > 4) {
 			reporter.warning("Too many arguments for tstamp: %s", Arrays.toString(args));
@@ -720,7 +726,6 @@ public class ReplacerAdapter extends ReporterAdapter implements Replacer {
 
 		SimpleDateFormat sdf = new SimpleDateFormat(format);
 		sdf.setTimeZone(tz);
-
 		return sdf.format(new Date(now));
 	}
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -239,6 +239,7 @@ class BundleTaskConvention {
         }
         File archiveCopyFile = new File(temporaryDir, archiveName)
         Jar bundleJar = new Jar(archiveName, archiveCopyFile)
+        bundleJar.setReproducible(!task.preserveFileTimestamps)
         bundleJar.updateModified(archiveCopyFile.lastModified(), 'time of Jar task generated jar')
         bundleJar.setManifest(new Manifest())
         builder.setJar(bundleJar)

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -628,6 +628,7 @@ public class ProjectBuilder extends Builder {
 				&& (builder.getProperty(Constants.INCLUDE_RESOURCE) == null)
 				&& (builder.getProperty(Constants.INCLUDERESOURCE) == null) && project.getOutput().isDirectory()) {
 			Jar outputDirJar = new Jar(project.getName(), project.getOutput());
+			outputDirJar.setReproducible(is(REPRODUCIBLE));
 			outputDirJar.setManifest(new Manifest());
 			builder.setJar(outputDirJar);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -786,7 +786,9 @@ public class Analyzer extends Processor {
 				main.putValue(CREATED_BY,
 						System.getProperty("java.version") + " (" + System.getProperty("java.vendor") + ")");
 				main.putValue(TOOL, "Bnd-" + getBndVersion());
-				main.putValue(BND_LASTMODIFIED, "" + System.currentTimeMillis());
+				if (!dot.isReproducible()) {
+					main.putValue(BND_LASTMODIFIED, Long.toString(System.currentTimeMillis()));
+				}
 			}
 
 			String exportHeader = printClauses(exports, true);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -87,6 +87,7 @@ public class Builder extends Analyzer {
 		Jar dot = getJar();
 		if (dot == null) {
 			dot = new Jar("dot");
+			dot.setReproducible(is(REPRODUCIBLE));
 			setJar(dot);
 		}
 		try {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -184,6 +184,7 @@ public interface Constants {
 	String							SOURCEPATH									= "-sourcepath";
 	String							STRICT										= "-strict";
 	String							SUB											= "-sub";
+	String								REPRODUCIBLE								= "-reproducible";
 	String							RUNNOREFERENCES								= "-runnoreferences";
 	String							RUNPROPERTIES								= "-runproperties";
 	String							RUNSYSTEMPACKAGES							= "-runsystempackages";
@@ -262,7 +263,7 @@ public interface Constants {
 			CHECK, DISTRO, METATYPE_ANNOTATIONS, METATYPE_ANNOTATIONS_OPTIONS, PACKAGEINFOTYPE, JAVAC_SOURCE,
 			JAVAC_TARGET, JAVAC_PROFILE, JAVAC, JAVA, JAVA_DEBUG, EXPORTTYPE, RUNREMOTE, TESTER, AUGMENT, REQUIRE_BND,
 			GROUPID, STANDALONE, IGNORE_STANDALONE, RUNREPOS, INIT, MAVEN_RELEASE, BUILDREPO, CONNECTION_SETTINGS,
-			RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE
+		RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE, REPRODUCIBLE
 
 	};
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -767,18 +767,34 @@ public class Macro {
 	}
 
 	public String _tstamp(String args[]) {
-		String format = "yyyyMMddHHmm";
-		long now = System.currentTimeMillis();
-		TimeZone tz = TimeZone.getTimeZone("UTC");
+		String format;
+		long now;
+		TimeZone tz;
 
 		if (args.length > 1) {
 			format = args[1];
+		} else {
+			format = "yyyyMMddHHmm";
 		}
 		if (args.length > 2) {
 			tz = TimeZone.getTimeZone(args[2]);
+		} else {
+			tz = TimeZone.getTimeZone("UTC");
 		}
 		if (args.length > 3) {
 			now = Long.parseLong(args[3]);
+		} else {
+			String tstamp = domain.getProperty(Constants.TSTAMP);
+			if (tstamp != null) {
+				try {
+					now = Long.parseLong(tstamp);
+				} catch (NumberFormatException e) {
+					// ignore, just use current time
+					now = System.currentTimeMillis();
+				}
+			} else {
+				now = System.currentTimeMillis();
+			}
 		}
 		if (args.length > 4) {
 			domain.warning("Too many arguments for tstamp: %s", Arrays.toString(args));
@@ -786,13 +802,6 @@ public class Macro {
 
 		SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.US);
 		sdf.setTimeZone(tz);
-		String tstamp = domain.getProperty(Constants.TSTAMP);
-		if (tstamp != null)
-			try {
-				now = Long.parseLong(tstamp);
-			} catch (NumberFormatException e) {
-				// ignore, just use current time
-			}
 		return sdf.format(new Date(now));
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,23 @@
  */
 
 import aQute.lib.io.IO
+import aQute.bnd.osgi.Constants
+
+/*
+ * Compute the build time stamp. 
+ * If the git workspace is clean, the build time is the time of the head commit.
+ * If the git workspace is dirty, the build time is the current time.
+ */
+gradle.projectsEvaluated {
+  if ('git diff --no-ext-diff --quiet'.execute().waitFor() == 0) {
+    bndWorkspace.setProperty(Constants.TSTAMP, 'git show --no-patch --format=%ct000'.execute().text.trim())
+  } else {
+    bndWorkspace.setProperty(Constants.TSTAMP, Long.toString(System.currentTimeMillis()))
+  }
+}
+gradle.buildFinished {
+  bndWorkspace.unsetProperty(Constants.TSTAMP)
+}
 
 /* Configure the subprojects */
 subprojects {

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -51,7 +51,7 @@ Bundle-Developers: \
         timezone=1
 
 -make:                  (*).(jar);type=bnd; recipe="bnd/$1.bnd"
-
+-reproducible: true
 -removeheaders:         Include-Resource
 
 # Used in unit testing


### PR DESCRIPTION
Add support to Bnd to build the identical jar reproducibly. This requires Bnd to not cause variation which is done by `-reproducible: true` which results in jar file entries having a constant time stamp.

Furthmore, the build itself must not add variation to manifest entries like Bundle-Version using a time stamp of the build time. For the Bnd build, the build is changed to use the current time if the git workspace if dirty or the commit time of the tip commit of the git workspace is clean.

The combination of these will allow anyone to checkout a specific commit and build the same jars.