### PR TITLE
antglob: Allow \ as a separator in glob

### DIFF
--- a/aQute.libg/src/aQute/libg/glob/AntGlob.java
+++ b/aQute.libg/src/aQute/libg/glob/AntGlob.java
@@ -27,9 +27,9 @@ public class AntGlob extends Glob {
 			switch (currentChar) {
 				case '*' :
 					int j, k;
-					if ((i == 0 || previousChar == '/') && //
+					if ((i == 0 || isSlashy(previousChar)) && //
 						((j = i + 1) < strLen && line.charAt(j) == '*') && //
-						((k = j + 1) == strLen || line.charAt(k) == '/')) {
+						((k = j + 1) == strLen || isSlashy(line.charAt(k)))) {
 						if (i == 0 && k < strLen) { // line starts with "**/"
 							sb.append("(?:.*" + SLASHY + "|)");
 							i = k;
@@ -49,18 +49,12 @@ public class AntGlob extends Glob {
 					sb.append(NOT_SLASHY);
 					break;
 				case '/' :
+				case '\\' :
 					if (i + 1 == strLen) {
 						// ending with "/" is shorthand for ending with "/**"
 						sb.append("(?:" + SLASHY + ".*|)");
 					} else {
 						sb.append(SLASHY);
-					}
-					break;
-				case '\\' :
-					if (i + 1 < strLen) {
-						sb.append("\\Q")
-							.append(line.charAt(++i))
-							.append("\\E");
 					}
 					break;
 				case '.' :
@@ -83,6 +77,10 @@ public class AntGlob extends Glob {
 			previousChar = currentChar;
 		}
 		return sb.toString();
+	}
+
+	private static boolean isSlashy(char c) {
+		return c == '/' || c == '\\';
 	}
 
 	public static Pattern toPattern(String s) {

--- a/aQute.libg/test/aQute/libg/glob/AntGlobTest.java
+++ b/aQute.libg/test/aQute/libg/glob/AntGlobTest.java
@@ -37,10 +37,6 @@ public class AntGlobTest extends TestCase {
 			.matches());
 		assertFalse(glob.matcher("foo/")
 			.matches());
-	}
-
-	public void testDirs() {
-		Glob glob;
 
 		glob = new AntGlob("/?abc/*/*.java");
 		assertTrue(glob.matcher("/xabc/foobar/test.java")
@@ -49,6 +45,28 @@ public class AntGlobTest extends TestCase {
 			.matches());
 		assertFalse(glob.matcher("/xabc/foobar/test_java")
 			.matches());
+
+		glob = new AntGlob("*");
+		assertTrue(glob.matcher("test")
+			.matches());
+		assertFalse(glob.matcher("org/apache/jakarta/test/ant/CVS/Entries")
+			.matches());
+		assertFalse(glob.matcher("org/apache/test")
+			.matches());
+		assertFalse(glob.matcher("org/apache/test/")
+			.matches());
+		assertFalse(glob.matcher("org\\apache\\test")
+			.matches());
+		assertFalse(glob.matcher("org\\apache\\test\\")
+			.matches());
+		assertFalse(glob.matcher("test/apache/jakarta")
+			.matches());
+		assertFalse(glob.matcher("org/apache/jakarta")
+			.matches());
+	}
+
+	public void testMultiple() {
+		Glob glob;
 
 		glob = new AntGlob("**/CVS/*");
 		assertTrue(glob.matcher("CVS/Repositories")
@@ -134,24 +152,6 @@ public class AntGlobTest extends TestCase {
 		assertTrue(glob.matcher("org/apache/jakarta")
 			.matches());
 
-		glob = new AntGlob("*");
-		assertTrue(glob.matcher("test")
-			.matches());
-		assertFalse(glob.matcher("org/apache/jakarta/test/ant/CVS/Entries")
-			.matches());
-		assertFalse(glob.matcher("org/apache/test")
-			.matches());
-		assertFalse(glob.matcher("org/apache/test/")
-			.matches());
-		assertFalse(glob.matcher("org\\apache\\test")
-			.matches());
-		assertFalse(glob.matcher("org\\apache\\test\\")
-			.matches());
-		assertFalse(glob.matcher("test/apache/jakarta")
-			.matches());
-		assertFalse(glob.matcher("org/apache/jakarta")
-			.matches());
-
 		glob = new AntGlob("**/CVS/");
 		assertTrue(glob.matcher("CVS/Repositories")
 			.matches());
@@ -201,66 +201,49 @@ public class AntGlobTest extends TestCase {
 			.matches());
 		assertTrue(glob.matcher("xyz.xml")
 			.matches());
-	}
 
-	public void testEscape() {
-		Glob glob;
-
-		glob = new AntGlob("\\*/CVS/*");
-		assertTrue(glob.matcher("*/CVS/Repositories")
-			.matches());
-		assertFalse(glob.matcher("x/CVS/Repositories")
-			.matches());
-
-		glob = new AntGlob("\\?/CVS/*");
-		assertTrue(glob.matcher("?/CVS/Repositories")
-			.matches());
-		assertFalse(glob.matcher("x/CVS/Repositories")
-			.matches());
-
-		glob = new AntGlob("\\(CVS\\)/*");
-		assertTrue(glob.matcher("(CVS)/Repositories")
-			.matches());
-		assertFalse(glob.matcher("CVS/Repositories")
-			.matches());
-		glob = new AntGlob("(CVS)/*");
-		assertTrue(glob.matcher("(CVS)/Repositories")
-			.matches());
-		assertFalse(glob.matcher("CVS/Repositories")
-			.matches());
-
-		glob = new AntGlob("**/apache\\/test/**");
+		glob = new AntGlob("**\\apache\\test/**");
 		assertTrue(glob.matcher("org/apache/test/ant/CVS/Entries")
 			.matches());
 		assertTrue(glob.matcher("org/apache/test")
 			.matches());
 		assertTrue(glob.matcher("org/apache/test/")
 			.matches());
-		assertFalse(glob.matcher("org\\apache\\test")
+		assertTrue(glob.matcher("org\\apache\\test")
 			.matches());
-		assertFalse(glob.matcher("org\\apache\\test\\")
+		assertTrue(glob.matcher("org\\apache\\test\\")
 			.matches());
 		assertFalse(glob.matcher("org/apache/jakarta")
 			.matches());
 
-		glob = new AntGlob("\\/**");
-		assertTrue(glob.matcher("/CVS")
-			.matches());
-		assertFalse(glob.matcher("/CVS/Foo")
-			.matches());
-		assertFalse(glob.matcher("\\CVS")
-			.matches());
-		assertFalse(glob.matcher("CVS")
-			.matches());
-
-		glob = new AntGlob("\\/**/");
+		glob = new AntGlob("\\**");
 		assertTrue(glob.matcher("/CVS")
 			.matches());
 		assertTrue(glob.matcher("/CVS/Foo")
 			.matches());
-		assertFalse(glob.matcher("\\CVS")
+		assertTrue(glob.matcher("\\CVS")
 			.matches());
 		assertFalse(glob.matcher("CVS")
+			.matches());
+
+		glob = new AntGlob("\\**\\");
+		assertTrue(glob.matcher("/CVS")
+			.matches());
+		assertTrue(glob.matcher("/CVS/Foo")
+			.matches());
+		assertTrue(glob.matcher("\\CVS")
+			.matches());
+		assertFalse(glob.matcher("CVS")
+			.matches());
+	}
+
+	public void testEscape() {
+		Glob glob;
+
+		glob = new AntGlob("(CVS)/*");
+		assertTrue(glob.matcher("(CVS)/Repositories")
+			.matches());
+		assertFalse(glob.matcher("CVS/Repositories")
 			.matches());
 
 		glob = new AntGlob("[abc]");
@@ -269,19 +252,7 @@ public class AntGlobTest extends TestCase {
 		assertTrue(glob.matcher("[abc]")
 			.matches());
 
-		glob = new AntGlob("\\[abc\\]");
-		assertFalse(glob.matcher("a")
-			.matches());
-		assertTrue(glob.matcher("[abc]")
-			.matches());
-
 		glob = new AntGlob("abc{2}");
-		assertFalse(glob.matcher("abcc")
-			.matches());
-		assertTrue(glob.matcher("abc{2}")
-			.matches());
-
-		glob = new AntGlob("abc\\{2\\}");
 		assertFalse(glob.matcher("abcc")
 			.matches());
 		assertTrue(glob.matcher("abc{2}")
@@ -321,24 +292,6 @@ public class AntGlobTest extends TestCase {
 		assertFalse(glob.matcher("abcc")
 			.matches());
 		assertTrue(glob.matcher("abc+")
-			.matches());
-
-		glob = new AntGlob("abc\\x");
-		assertFalse(glob.matcher("abc\\x")
-			.matches());
-		assertTrue(glob.matcher("abcx")
-			.matches());
-
-		glob = new AntGlob("abc\\x\\\\\\E\\z");
-		assertFalse(glob.matcher("abc\\x\\\\\\E\\z")
-			.matches());
-		assertTrue(glob.matcher("abcx\\Ez")
-			.matches());
-
-		glob = new AntGlob("abc\\");
-		assertFalse(glob.matcher("abc\\")
-			.matches());
-		assertTrue(glob.matcher("abc")
 			.matches());
 	}
 }


### PR DESCRIPTION
Review of ant behavior means this must be supported since users will
expect to use / or \ as separators in the glob expression.