### PR TITLE
Processor: capture error/warning locations as well as the messages.

### DIFF
--- a/biz.aQute.bndlib.tests/bnd.bnd
+++ b/biz.aQute.bndlib.tests/bnd.bnd
@@ -20,7 +20,8 @@
 	osgi.cmpn;version=@6,\
 	slf4j.api;version=latest,\
 	${junit},\
-	${mockito}
+	${mockito},\
+	${assertj}
 
 -testpath: \
     biz.aQute.repository;version=snapshot,\

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -290,7 +290,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (!p.warnings.contains(s))
 			p.warnings.add(s);
 		p.signal();
-		return location(s);
+		return p.location(s);
 	}
 
 	@Override
@@ -303,7 +303,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			String s = formatArrays(string, args);
 			if (!p.errors.contains(s))
 				p.errors.add(s);
-			return location(s);
+			return p.location(s);
 		} finally {
 			p.signal();
 		}

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -48,6 +48,8 @@ org.eclipse.jetty:jetty-util:7.6.3.v20120416
 org.mockito:mockito-core:1.10.19
 org.objenesis:objenesis:2.2
 
+org.assertj:assertj-core:3.9.0
+
 args4j:args4j:2.0.26
 
 org.slf4j:slf4j-api:1.7.13

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -1,4 +1,5 @@
 junit: org.apache.servicemix.bundles.junit;version="[4.11,5)"
 mockito: org.mockito.mockito-core;version="[1.9,2)",\
   org.objenesis;version="[2.1,3)"
+assertj: org.assertj.core;version="[3.9,4)"
 -runsystempackages.objenesis: sun.misc,sun.reflect


### PR DESCRIPTION
Make sure that when error() and warning() call location(), they do so on the current owner process instead of on themselves.

Includes a test case.