### PR TITLE
junit: Use getTests().size() for JUnit4TestAdapter

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
@@ -142,7 +142,12 @@ public class JUnitEclipseReport implements TestReporter {
 
 			}
 			sb.append(",");
-			sb.append(test.countTestCases());
+			if (test instanceof JUnit4TestAdapter) {
+				sb.append(((JUnit4TestAdapter) test).getTests()
+					.size());
+			} else {
+				sb.append(test.countTestCases());
+			}
 			message("%TSTTREE", sb.toString());
 		}
 	}


### PR DESCRIPTION
countTestCases() includes ignored tests.

Fixes https://github.com/bndtools/bnd/issues/2377