### PR TITLE
maven: Support include/exclude Ant-style globs in bndruns/bundles config

### DIFF
--- a/maven/bnd-export-maven-plugin/README.md
+++ b/maven/bnd-export-maven-plugin/README.md
@@ -45,12 +45,12 @@ Here's an example setting the `bundles` used for resolution.
 
 |Configuration Property | Description |
 | ---                   | ---         |
-|`bndruns`              | Contains at least one `bndrun` child element, each element naming a bndrun file defining a runtime and tests to execute against it.|
+|`bndruns`              | Can contain `bndrun` child elements naming a bndrun file to export. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bndrun files. These are relative to the `${project.basedir}` directory. _Defaults to `<include>*.bndrun</include>`._|
 |`targetDir`            | The director into which to export the result. _Defaults to `${project.build.directory}`._|
 |`resolve`              | Whether to resolve the `-runbundles` required for a valid runtime. _Defaults to `false`._|
 |`failOnChanges`        | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._|
 |`exporter`          | The name of the exporter plugin to use. Bnd has two built-in exporter plugins. `bnd.executablejar` exports an executable jar and `bnd.runbundles` exports the -runbundles files. _Default to `bnd.executablejar`._|
-|`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
+|`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Can contain `bundle` child elements specifying the path to a bundle. These can be absolute paths. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bundles. These are relative to the `${project.basedir}` directory. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any and `useMavenDependencies` is `true`)._|
 |`useMavenDependencies` | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|
 |`attach` | If `true` then if the exported generates a jar file, the jar file will be attached as an output of the current artifact. _Defaults to `true`._|
 |`reportOptional`       | If `true`, resolution failure reports (see `resolve`) will include optional requirements. _Defaults to `true`._|

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -5,7 +5,6 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.PACKAGE;
 import java.io.File;
 import java.io.OutputStream;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.maven.artifact.DefaultArtifact;
@@ -29,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.exporter.executable.ExecutableJarExporter;
 import aQute.bnd.exporter.runbundles.RunbundlesExporter;
+import aQute.bnd.maven.lib.configuration.Bndruns;
+import aQute.bnd.maven.lib.configuration.Bundles;
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.JarResource;
@@ -49,14 +50,14 @@ public class ExportMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
 	private RepositorySystemSession		repositorySession;
 
-	@Parameter(readonly = true, required = true)
-	private List<File>					bndruns;
+	@Parameter(readonly = true)
+	private Bndruns						bndruns	= new Bndruns();
 
 	@Parameter(defaultValue = "${project.build.directory}", readonly = true)
 	private File						targetDir;
 
 	@Parameter(readonly = true, required = false)
-	private List<File>					bundles;
+	private Bundles						bundles	= new Bundles();
 
 	@Parameter(defaultValue = "true")
 	private boolean						useMavenDependencies;
@@ -96,13 +97,14 @@ public class ExportMojo extends AbstractMojo {
 			DependencyResolver dependencyResolver = new DependencyResolver(project, repositorySession, resolver,
 				system);
 
-			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles,
+			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(),
+				bundles.getFiles(project.getBasedir(), null),
 				useMavenDependencies);
 
 			if (exporter == null) {
 				exporter = bundlesOnly ? RunbundlesExporter.RUNBUNDLES : ExecutableJarExporter.EXECUTABLE_JAR;
 			}
-			for (File runFile : bndruns) {
+			for (File runFile : bndruns.getFiles(project.getBasedir(), "*.bndrun")) {
 				export(runFile, fileSetRepository);
 			}
 		} catch (Exception e) {

--- a/maven/bnd-indexer-maven-plugin/README.md
+++ b/maven/bnd-indexer-maven-plugin/README.md
@@ -287,13 +287,11 @@ index. The default includes is `**/*.jar`.
 
     <configuration>
         <inputDir>${project.build.directory}/bundles</inputDir>
-        <includes>
+        <indexFiles>
             <include>**/org.osgi.*.jar</include>
-        </includes>
-        <excludes>
-            <exclude>**/*-JAVADOC.jar</exclude>
-            <exclude>**/*-SOURCES.jar</exclude>
-        </excludes>
+            <exclude>**/*-javadoc.jar</exclude>
+            <exclude>**/*-sources.jar</exclude>
+        </indexFiles>
     </configuration>
 
 #### Changing relative directory
@@ -323,8 +321,7 @@ different base directory can be supplied if needed
 |Configuration Properties for `local-index` goal | Description |
 | ---               | ---         |
 |`inputDir`         | A directory contain the bundles to index. Override with property `bnd.indexer.input.dir`.|
-|`includes`         | A set of ant-style globs matching paths within the `inputDir` which should be included in the index. _Defaults to `**/*.jar`.Override with property `bnd.indexer.input.dir.includes`.|
-|`excludes`         | A set of ant-style globs matching paths within the `inputDir` which should be excluded from the index. _Defaults to an empty set.Override with property `bnd.indexer.input.dir.excludes`.|
+|`indexFiles`       | A set of `include` and `exclude` child elements using Ant-style globs matching paths within the `inputDir` which should be included in the index or excluded from the index. _Defaults to `<include>**/*.jar</include>`._|
 |`outputFile`       | The name and location of the resulting index file. _Defaults to `${project.build.directory}/index.xml`._ Override with property `bnd.indexer.output.file`.|
 |`baseFile`         | See [Changing relative directory](#changing-relative-directory). Override with property `bnd.indexer.base.file`.|
 |`includeGzip`      | Include a GZIP'd version of the index file adjacent to the non-GZIP'd one. _Defaults to `true`._ Override with property `bnd.indexer.include.gzip`.|

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder-includes-excludes/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder-includes-excludes/pom.xml
@@ -61,12 +61,10 @@
 						</goals>
 						<configuration>
 							<inputDir>${project.build.directory}/repo</inputDir>
-							<includes>
+							<indexFiles>
 								<include>**/org.apache.felix.*.jar</include>
-							</includes>
-							<excludes>
 								<exclude>**/*e-3.0.0*</exclude>
-							</excludes>
+							</indexFiles>
 							<outputFile>${project.build.directory}/META-INF/index.xml</outputFile>
 						</configuration>
 					</execution>

--- a/maven/bnd-resolver-maven-plugin/README.md
+++ b/maven/bnd-resolver-maven-plugin/README.md
@@ -54,8 +54,8 @@ mvn bnd-resolver:resolve
 
 |Configuration Property | Description |
 | ---                   | ---         |
-|`bndruns`              | Contains at least one `bndrun` child element, each element naming a bndrun file defining a runtime and tests to execute against it.|
+|`bndruns`              | Can contain `bndrun` child elements naming a bndrun file to resolv. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bndrun files. These are relative to the `${project.basedir}` directory. _Defaults to `<include>*.bndrun</include>`._|
 |`failOnChanges`        | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._|
-|`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
+|`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Can contain `bundle` child elements specifying the path to a bundle. These can be absolute paths. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bundles. These are relative to the `${project.basedir}` directory. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any and `useMavenDependencies` is `true`)._|
 |`useMavenDependencies` | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|
 |`reportOptional`       | If `true`, resolution failure reports will include optional requirements. _Defaults to `true`._|

--- a/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.maven.lib.configuration.Bndruns;
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.repository.fileset.FileSetRepository;
 import aQute.bnd.service.RepositoryPlugin;
@@ -40,8 +41,8 @@ public class ResolverMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
 	private RepositorySystemSession		repositorySession;
 
-	@Parameter(readonly = true, required = true)
-	private List<File>					bndruns;
+	@Parameter(readonly = true)
+	private Bndruns						bndruns	= new Bndruns();
 
 	@Parameter(readonly = true, required = false)
 	private List<File>					bundles;
@@ -78,7 +79,7 @@ public class ResolverMojo extends AbstractMojo {
 			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(), bundles,
 				useMavenDependencies);
 
-			for (File runFile : bndruns) {
+			for (File runFile : bndruns.getFiles(project.getBasedir(), "*.bndrun")) {
 				resolve(runFile, fileSetRepository);
 			}
 		} catch (Exception e) {

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -21,9 +21,11 @@
                     <version>@project.version@</version>
                     <configuration>
                         <failOnChanges>false</failOnChanges>
+                        <!-- Default to including *.bndrun
                         <bndruns>
                             <bndrun>test.bndrun</bndrun>
                         </bndruns>
+                        -->
                     </configuration>
                     <executions>
                         <execution>

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bndruns.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bndruns.java
@@ -1,0 +1,11 @@
+package aQute.bnd.maven.lib.configuration;
+
+import java.io.File;
+
+public class Bndruns extends FileTree {
+	public Bndruns() {}
+
+	public void setBndrun(File bndrun) {
+		addFile(bndrun);
+	}
+}

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bundles.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bundles.java
@@ -1,0 +1,11 @@
+package aQute.bnd.maven.lib.configuration;
+
+import java.io.File;
+
+public class Bundles extends FileTree {
+	public Bundles() {}
+
+	public void setBundle(File bundle) {
+		addFile(bundle);
+	}
+}

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
@@ -1,0 +1,99 @@
+package aQute.bnd.maven.lib.configuration;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import aQute.libg.glob.AntGlob;
+
+public class FileTree {
+	private List<File>			files		= new ArrayList<>();
+	private List<Pattern>		includes	= new ArrayList<>();
+	private List<Pattern>		excludes	= new ArrayList<>();
+
+	public FileTree() {}
+
+	/**
+	 * Can be used by subclasses to add specific files to the return value of
+	 * {@link #getFiles(File, String)}.
+	 * 
+	 * @param file A file to include in the return value of
+	 *            {@link #getFiles(File, String)}.
+	 */
+	protected void addFile(File file) {
+		files.add(file);
+	}
+
+	/**
+	 * Add an Ant-style glob to the include patterns.
+	 * 
+	 * @param include Add an Ant-style glob
+	 */
+	public void setInclude(String include) {
+		includes.add(AntGlob.toPattern(include));
+	}
+
+	/**
+	 * Add an Ant-style glob to the exclude patterns.
+	 * 
+	 * @param exclude Add an Ant-style glob
+	 */
+	public void setExclude(String exclude) {
+		excludes.add(AntGlob.toPattern(exclude));
+	}
+
+	/**
+	 * Return a list of files using the specified baseDir and the configured
+	 * include and exclude Ant-style glob expressions.
+	 * 
+	 * @param baseDir The base directory for locating files.
+	 * @param defaultInclude The default include pattern to use of no include
+	 *            patterns were configured.
+	 * @return A list of files.
+	 * @throws MojoExecutionException If an exception occurs.
+	 */
+	public List<File> getFiles(File baseDir, String defaultInclude) throws MojoExecutionException {
+		List<Pattern> includePatterns = includes.isEmpty() && files.isEmpty() && (defaultInclude != null)
+			? singletonList(AntGlob.toPattern(defaultInclude))
+			: includes;
+		if (includePatterns.isEmpty()) {
+			return files;
+		}
+		List<Pattern> excludePatterns = excludes;
+
+		Path basePath = baseDir.toPath();
+		Stream<Path> walker;
+		try {
+			walker = Files.walk(basePath)
+				.skip(1); // skip basePath itself
+		} catch (IOException ioe) {
+			throw new MojoExecutionException(ioe.getMessage(), ioe);
+		}
+		List<File> result = Stream.concat(files.stream(), //
+			walker.filter(p -> {
+				String path = basePath.relativize(p)
+					.toString();
+				return includePatterns.stream()
+					.anyMatch(i -> i.matcher(path)
+						.matches())
+					&& !excludePatterns.stream()
+						.anyMatch(e -> e.matcher(path)
+							.matches());
+			})
+				.sorted()
+				.map(Path::toFile))
+			.distinct()
+			.collect(toList());
+		return result;
+	}
+}

--- a/maven/bnd-testing-maven-plugin/README.md
+++ b/maven/bnd-testing-maven-plugin/README.md
@@ -50,7 +50,7 @@ Here's an example setting the `bundles` used for resolution.
 
 |Configuration Property          | Description |
 | ---                            | ---         |
-|`bndruns`                       | Contains at least one `bndrun` child element, each element naming a bndrun file defining a runtime and tests to execute against it.|
+|`bndruns`              | Can contain `bndrun` child elements naming a bndrun file defining a runtime and tests to execute against it. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bndrun files. These are relative to the `${project.basedir}` directory. _Defaults to `<include>*.bndrun</include>`._|
 |`resolve`                       | Whether to resolve the `-runbundles` required for a valid runtime. _Defaults to `false`._|
 |`failOnChanges`                 | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._|
 |`reportsDir`                    | The output directory for test reports. A subdirectory of `${bndrun}` will be created for each bndrun file supplied. _Defaults to `${project.build.directory}/test-reports`._|
@@ -59,6 +59,6 @@ Here's an example setting the `bundles` used for resolution.
 |`testingSelect`                 | A file path to a test file, overrides anything else. _Defaults to `${testing.select}`._ Override with property `testing.select`.|
 |`testing`                       | A glob expression that is matched against the file name of the listed bndrun files. _Defaults to `${testing}`._ Override with property `testing`.|
 |`test`                          | A comma separated list of the fully qualified names of test classes to run. If not set, or empty, then all the test classes listed in the `Test-Classes` manifest header are run. Override with property `test`.|
-|`bundles`                       | This is the collection of files to use for locating bundles during the bndrun resolution. Paths are relative to `${project.basedir}` by default. Absolute paths are allowed. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any)._|
+|`bundles`              | This is the collection of files to use for locating bundles during the bndrun resolution. Can contain `bundle` child elements specifying the path to a bundle. These can be absolute paths. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bundles. These are relative to the `${project.basedir}` directory. _Defaults to dependencies in the `compile` and `runtime`, plus the current artifact (if any and `useMavenDependencies` is `true`)._|
 |`useMavenDependencies`          | If `true`, adds the project's compile and runtime dependencies to the collection of files to use for locating bundles during the bndrun resolution. _Defaults to `true`._|
 |`reportOptional`                | If `true`, resolution failure reports (see `resolve`) will include optional requirements. _Defaults to `true`._|

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.maven.lib.configuration.Bndruns;
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.repository.fileset.FileSetRepository;
@@ -47,8 +48,8 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(property = "maven.test.skip", defaultValue = "false")
 	private boolean						skip;
 
-	@Parameter(readonly = true, required = true)
-	private List<File>					bndruns;
+	@Parameter(readonly = true)
+	private Bndruns						bndruns	= new Bndruns();
 
 	@Parameter(defaultValue = "${project.build.directory}/test", readonly = true)
 	private File						cwd;
@@ -111,7 +112,7 @@ public class TestingMojo extends AbstractMojo {
 				Glob g = new Glob(testing == null ? "*" : testing);
 				logger.info("Matching glob {}", g);
 
-				for (File runFile : bndruns) {
+				for (File runFile : bndruns.getFiles(project.getBasedir(), "*.bndrun")) {
 					if (g.matcher(runFile.getName())
 						.matches())
 						testing(runFile, fileSetRepository);

--- a/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -61,7 +61,7 @@
 					<version>@project.version@</version>
 					<configuration>
 						<bndruns>
-							<bndrun>test.bndrun</bndrun>
+							<include>*.bndrun</include>
 						</bndruns>
 						<failOnChanges>false</failOnChanges>
 					</configuration>


### PR DESCRIPTION
The Ant-style glob support was refactored into a FileTree class which
is used in several places for plugin configuration as a complex config
type.

`<bndruns>` configuration can now take:
- `<bndrun>` elements naming a specific file
- `<include>` elements specifying an Ant-style glob to include from the
project basedir
- `<exclude>` elements specifying an Ant-style glob to exclude from the
project basedir

`<bundles>` configuration can now take:
- `<bundle>` elements naming a specific file
- `<include>` elements specifying an Ant-style glob to include from the
project basedir
- `<exclude>` elements specifying an Ant-style glob to exclude from the
project basedir

The recent support for Ant-style globbing in the indexer plugin was
also modified to use this common function and the configuration element
was changed to `<indexFiles>`.

`<indexFiles>` configuration can now take:
- `<include>` elements specifying an Ant-style glob to include from the
inputDir
- `<exclude>` elements specifying an Ant-style glob to exclude from the
inputDir

Fixes https://github.com/bndtools/bnd/issues/1995
