### PR TITLE
maven: Remove readonly=true for better Eclipse pom editing experience

### DIFF
--- a/maven/bnd-baseline-maven-plugin/README.md
+++ b/maven/bnd-baseline-maven-plugin/README.md
@@ -152,6 +152,7 @@ calculation then this can be configured as follows:
 
 |Configuration Property | Description |
 | ---                   | ---         |
+|`base`                 | See [Changing the baseline search parameters](#changing-the-baseline-search-parameters). _Defaults to the highest version of the project's artifact that is less than the version of the project's artifact._|
 |`failOnMissing`        | See [Fail on missing baseline](#fail-on-missing-baseline). _Defaults to `true`._ Override with property `bnd.baseline.fail.on.missing`.|
 |`includeDistributionManagement`| See [Include Distribution Management](#include-distribution-management). _Defaults to `true`._ Override with property `bnd.baseline.include.distribution.management`.|
 |`fullReport`           | See [Full Reporting](#full-reporting). _Defaults to `false`._ Override with property `bnd.baseline.full.report`.|

--- a/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/Base.java
+++ b/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/Base.java
@@ -16,6 +16,12 @@ public class Base {
 		return groupId;
 	}
 
+	/**
+	 * Set the groupId of the baseline artifact.
+	 * 
+	 * @param groupId The groupId of the baseline artifact. This defaults to the
+	 *            groupId of the project.
+	 */
 	public void setGroupId(String groupId) {
 		this.groupId = groupId;
 	}
@@ -24,6 +30,12 @@ public class Base {
 		return artifactId;
 	}
 
+	/**
+	 * Set the artifactId of the baseline artifact.
+	 * 
+	 * @param artifactId The artifactId of the baseline artifact. This defaults
+	 *            to the artifactId of the project.
+	 */
 	public void setArtifactId(String artifactId) {
 		this.artifactId = artifactId;
 	}
@@ -32,6 +44,13 @@ public class Base {
 		return version;
 	}
 
+	/**
+	 * Set the version or version range of the baseline artifact.
+	 * 
+	 * @param version The version or version range of the baseline artifact.
+	 *            This defaults to the highest version less than the version of
+	 *            the project's artifact.
+	 */
 	public void setVersion(String version) {
 		this.version = version;
 	}
@@ -40,6 +59,12 @@ public class Base {
 		return classifier;
 	}
 
+	/**
+	 * Set the classifier of the baseline artifact.
+	 * 
+	 * @param classifier The classifier of the baseline artifact. This defaults
+	 *            to the classifier of the project's artifact.
+	 */
 	public void setClassifier(String classifier) {
 		this.classifier = classifier;
 	}
@@ -48,6 +73,12 @@ public class Base {
 		return extension;
 	}
 
+	/**
+	 * Set the extension of the baseline artifact.
+	 * 
+	 * @param extension The extension of the baseline artifact. This defaults to
+	 *            the extension of the project's artifact.
+	 */
 	public void setExtension(String extension) {
 		this.extension = extension;
 	}

--- a/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -65,7 +65,7 @@ public class BaselineMojo extends AbstractMojo {
 	@Parameter(property = "bnd.baseline.continue.on.error", defaultValue = "false")
 	private boolean					continueOnError;
 
-	@Parameter(readonly = true)
+	@Parameter
 	private Base					base;
 
 	@Parameter(property = "bnd.baseline.skip", defaultValue = "false")

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -50,13 +50,13 @@ public class ExportMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
 	private RepositorySystemSession		repositorySession;
 
-	@Parameter(readonly = true)
+	@Parameter
 	private Bndruns						bndruns	= new Bndruns();
 
 	@Parameter(defaultValue = "${project.build.directory}", readonly = true)
 	private File						targetDir;
 
-	@Parameter(readonly = true, required = false)
+	@Parameter
 	private Bundles						bundles	= new Bundles();
 
 	@Parameter(defaultValue = "true")
@@ -74,7 +74,7 @@ public class ExportMojo extends AbstractMojo {
 	@Parameter(defaultValue = "false")
 	private boolean						bundlesOnly;
 
-	@Parameter(required = false)
+	@Parameter
 	private String						exporter;
 
 	@Parameter(defaultValue = "true")

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -78,7 +78,7 @@ public class IndexerMojo extends AbstractMojo {
 	@Parameter(property = "bnd.indexer.add.mvn.urls", defaultValue = "false")
 	private boolean						addMvnURLs;
 
-	@Parameter(property = "bnd.indexer.scopes", readonly = true)
+	@Parameter(property = "bnd.indexer.scopes")
 	private List<String>				scopes;
 
 	@Parameter(property = "bnd.indexer.include.gzip", defaultValue = "true")

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
@@ -35,7 +35,7 @@ public class LocalIndexerMojo extends AbstractMojo {
 	@Parameter(property = "bnd.indexer.base.file")
 	private File				baseFile;
 
-	@Parameter(readonly = true)
+	@Parameter
 	private FileTree			indexFiles	= new FileTree();
 
 	@Parameter(property = "bnd.indexer.include.gzip", defaultValue = "true")

--- a/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -41,10 +41,10 @@ public class ResolverMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
 	private RepositorySystemSession		repositorySession;
 
-	@Parameter(readonly = true)
+	@Parameter
 	private Bndruns						bndruns	= new Bndruns();
 
-	@Parameter(readonly = true, required = false)
+	@Parameter
 	private List<File>					bundles;
 
 	@Parameter(defaultValue = "true")

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bndruns.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bndruns.java
@@ -5,6 +5,12 @@ import java.io.File;
 public class Bndruns extends FileTree {
 	public Bndruns() {}
 
+	/**
+	 * Add a bndrun file.
+	 * 
+	 * @param bndrun A bndrun file. A relative path is relative to the project
+	 *            base directory.
+	 */
 	public void setBndrun(File bndrun) {
 		addFile(bndrun);
 	}

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bundles.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/Bundles.java
@@ -5,6 +5,12 @@ import java.io.File;
 public class Bundles extends FileTree {
 	public Bundles() {}
 
+	/**
+	 * Add a bundle.
+	 * 
+	 * @param bundle A bundle. A relative path is relative to the project base
+	 *            directory.
+	 */
 	public void setBundle(File bundle) {
 		addFile(bundle);
 	}

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
@@ -31,7 +31,9 @@ public class FileTree {
 	 *            {@link #getFiles(File, String)}.
 	 */
 	protected void addFile(File file) {
-		files.add(file);
+		if (!files.contains(file)) {
+			files.add(file);
+		}
 	}
 
 	/**

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -48,7 +48,7 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(property = "maven.test.skip", defaultValue = "false")
 	private boolean						skip;
 
-	@Parameter(readonly = true)
+	@Parameter
 	private Bndruns						bndruns	= new Bndruns();
 
 	@Parameter(defaultValue = "${project.build.directory}/test", readonly = true)
@@ -66,7 +66,7 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(property = "test")
 	private String						test;
 
-	@Parameter(readonly = true, required = false)
+	@Parameter(required = false)
 	private List<File>					bundles;
 
 	@Parameter(defaultValue = "true")


### PR DESCRIPTION
Also add some javadoc to configuration methods.

Fixes https://github.com/bndtools/bnd/issues/2404