### PR TITLE
gradle: Add cnf to the project graph so that dependencies are processed

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -42,13 +42,6 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 
   Closure configureSettings() {
     return { Settings settings ->
-      /* Add cnf project to the graph */
-      String cnf = 'cnf'
-      try {
-        cnf = bnd_cnf
-      } catch (MissingPropertyException mpe) {}
-      include cnf
-
       /* Start with the declared build project name */
       String build = ''
       try {
@@ -89,9 +82,16 @@ public class BndWorkspacePlugin implements Plugin<Object> {
         }
       }
 
+      /* Add cnf project to the graph */
+      String cnf = 'cnf'
+      try {
+        cnf = bnd_cnf.trim()
+      } catch (MissingPropertyException mpe) {}
+      projectNames.add(cnf)
+
       /* Add any projects which must always be included */
       try {
-        projectNames.addAll bnd_include.trim().split(/\s*,\s*/)
+        projectNames.addAll(bnd_include.trim().split(/\s*,\s*/))
       } catch (MissingPropertyException mpe) {}
 
       /* Initialize the Bnd workspace */


### PR DESCRIPTION
In the off chance that the cnf project has project dependencies, we need
to make sure they are also included in the project graph.
