### PR TITLE
plugins: Discard the plugin class loader on refresh

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -884,8 +884,13 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		for (Closeable c : toBeClosed) {
 			IO.close(c);
 		}
-		if (pluginLoader != null)
-			pluginLoader.close();
+		synchronized (this) {
+			plugins = null;
+		}
+		if (pluginLoader != null) {
+			IO.close(pluginLoader);
+			pluginLoader = null;
+		}
 
 		toBeClosed.clear();
 	}
@@ -1169,6 +1174,10 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	public boolean refresh() {
 		synchronized (this) {
 			plugins = null; // We always refresh our plugins
+		}
+		if (pluginLoader != null) {
+			IO.close(pluginLoader);
+			pluginLoader = null;
 		}
 
 		if (propertiesFile == null)


### PR DESCRIPTION
If the build makes a jar which is used to load a plugin, we need to get
a new class loader when the project is refreshed to access the updated
plugin class.
