### PR TITLE
strings: Simplify joining Collector

### DIFF
--- a/aQute.libg/src/aQute/lib/strings/Strings.java
+++ b/aQute.libg/src/aQute/lib/strings/Strings.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collector;
@@ -55,13 +54,17 @@ public class Strings {
 
 	public static Collector<CharSequence, ?, String> joining(CharSequence delimiter, CharSequence prefix,
 		CharSequence suffix, CharSequence emptyValue) {
-		CharSequence deflt = (emptyValue != null) ? emptyValue : new String();
-		Function<StringJoiner, String> finisher = (emptyValue != null) ? StringJoiner::toString : j -> {
-			String r = j.toString();
-			return (r != deflt) ? r : null;
-		};
-		return Collector.of(() -> new StringJoiner(delimiter, prefix, suffix).setEmptyValue(deflt),
-			StringJoiner::add, StringJoiner::merge, finisher);
+		return Collector.of(() -> new StringJoiner(delimiter, prefix, suffix), StringJoiner::add, StringJoiner::merge,
+			joiner -> {
+				if (emptyValue != null) {
+					return joiner.setEmptyValue(emptyValue)
+						.toString();
+				}
+				String emptyMarker = new String();
+				String joined = joiner.setEmptyValue(emptyMarker)
+					.toString();
+				return (joined != emptyMarker) ? joined : null;
+			});
 	}
 
 	public static String display(Object o, Object... ifNull) {


### PR DESCRIPTION
We move all the emptyValue handling into the finisher function since
that is really the only place it must be processed.