### PR TITLE
workspace: Canonicalize file paths to use forward slash

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -378,7 +378,8 @@ public class Workspace extends Processor {
 	}
 
 	public String _workspace(@SuppressWarnings("unused") String args[]) {
-		return getBase().getAbsolutePath();
+		return getBase().getAbsolutePath()
+			.replace('\\', '/');
 	}
 
 	public void addCommand(String menu, Action action) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -719,7 +719,8 @@ public class Macro {
 				.exists()) {
 				sb.append(del);
 				sb.append(f.getParentFile()
-					.getAbsolutePath());
+					.getAbsolutePath()
+					.replace('\\', '/'));
 				del = ",";
 			}
 		}
@@ -1306,7 +1307,8 @@ public class Macro {
 		verifyCommand(args, _fileHelp, null, 3, 3);
 		File base = new File(args[1]);
 		File f = Processor.getFile(base, args[2]);
-		return f.getAbsolutePath();
+		return f.getAbsolutePath()
+			.replace('\\', '/');
 	}
 
 	public String _path(String args[]) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -899,7 +899,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (base == null)
 			throw new IllegalArgumentException("No base dir set");
 
-		return base.getAbsolutePath();
+		return base.getAbsolutePath()
+			.replace('\\', '/');
 	}
 
 	public String _propertiesname(String[] args) {
@@ -925,7 +926,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			return "";
 
 		return pf.getParentFile()
-			.getAbsolutePath();
+			.getAbsolutePath()
+			.replace('\\', '/');
 	}
 
 	static String _uri = "${uri;<uri>[;<baseuri>]}, Resolve the uri against the baseuri. baseuri defaults to the processor base.";
@@ -2683,7 +2685,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		}
 
 		return propertiesFile.getAbsolutePath()
-			.replaceAll("\\\\", "/");
+			.replace('\\', '/');
 	}
 
 	/**


### PR DESCRIPTION
This avoids issues when using paths in replacement strings in ${replace}
macro.
