### PR TITLE
Support the remaining features of Bundle annotations

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -301,4 +301,57 @@ public class StdAnnotationHeadersTest extends TestCase {
 		}
 	}
 
+	/**
+	 * Overriding directives and attributes at many levels for the Requirement
+	 * and Capability annotation
+	 * 
+	 * @throws Exception
+	 */
+	public void testStdAnnotationsOverrideAttrsAndDirectives() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders.attrs.std");
+			b.build();
+			assertTrue(b.check());
+			b.getJar()
+				.getManifest()
+				.write(System.out);
+
+			Attributes mainAttributes = b.getJar()
+				.getManifest()
+				.getMainAttributes();
+
+			Header req = Header.parseHeader(mainAttributes.getValue(Constants.REQUIRE_CAPABILITY));
+			Props p = req.get("overriding");
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertEquals("(&(overriding=Chris)(&(version>=1.0.0)(!(version>=2.0.0))))", p.get("filter:"));
+			assertTrue(p.containsKey("foo:List<String>"));
+			assertEquals("foobar", p.get("foo:List<String>"));
+			assertTrue(p.containsKey("x-top-name:"));
+			assertEquals("fizzbuzz", p.get("x-top-name:"));
+			assertTrue(p.containsKey("name"));
+			assertEquals("Steve", p.get("name"));
+			assertTrue(p.containsKey("x-name:"));
+			assertEquals("Dave", p.get("x-name:"));
+
+			Header cap = Header.parseHeader(mainAttributes.getValue(Constants.PROVIDE_CAPABILITY));
+			p = cap.get("overriding");
+			assertNotNull(p);
+			assertTrue(p.containsKey("overriding"));
+			assertEquals("Chris", p.get("overriding"));
+			assertTrue(p.containsKey("version:Version"));
+			assertEquals("1", p.get("version:Version"));
+			assertTrue(p.containsKey("foo:List<String>"));
+			assertEquals("foobar", p.get("foo:List<String>"));
+			assertTrue(p.containsKey("x-top-name:"));
+			assertEquals("fizzbuzz", p.get("x-top-name:"));
+			assertTrue(p.containsKey("name"));
+			assertEquals("Steve", p.get("name"));
+			assertTrue(p.containsKey("x-name:"));
+			assertEquals("Dave", p.get("x-name:"));
+
+		}
+	}
+
 }

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -253,4 +253,52 @@ public class StdAnnotationHeadersTest extends TestCase {
 		}
 	}
 
+	/**
+	 * Overriding members of the Requirement and Capability annotation
+	 * 
+	 * @throws Exception
+	 */
+	public void testStdAnnotationsOverrideMembers() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders.attrs.std");
+			b.build();
+			assertTrue(b.check());
+			b.getJar()
+				.getManifest()
+				.write(System.out);
+
+			Attributes mainAttributes = b.getJar()
+				.getManifest()
+				.getMainAttributes();
+
+			Header req = Header.parseHeader(mainAttributes.getValue(Constants.REQUIRE_CAPABILITY));
+			Props p = req.get("osgi.extender");
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertEquals("(&(osgi.extender=test1)(&(version>=1.0.0)(!(version>=2.0.0))))", p.get("filter:"));
+
+			p = req.get("osgi.extender" + DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("filter:"));
+			assertEquals("(&(osgi.extender=test2)(&(version>=2.0.0)(!(version>=3.0.0))))", p.get("filter:"));
+
+			Header cap = Header.parseHeader(mainAttributes.getValue(Constants.PROVIDE_CAPABILITY));
+			p = cap.get("osgi.extender");
+			assertNotNull(p);
+			assertTrue(p.containsKey("osgi.extender"));
+			assertEquals("test1", p.get("osgi.extender"));
+			assertTrue(p.containsKey("version:Version"));
+			assertEquals("1.0.0", p.get("version:Version"));
+
+			p = cap.get("osgi.extender" + DUPLICATE_MARKER);
+			assertNotNull(p);
+			assertTrue(p.containsKey("osgi.extender"));
+			assertEquals("test2", p.get("osgi.extender"));
+			assertTrue(p.containsKey("version:Version"));
+			assertEquals("2", p.get("version:Version"));
+
+		}
+	}
+
 }

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AttributeDirectiveOverriding.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/AttributeDirectiveOverriding.java
@@ -1,0 +1,61 @@
+package test.annotationheaders.attrs.std;
+
+import org.osgi.annotation.bundle.Attribute;
+import org.osgi.annotation.bundle.Capability;
+import org.osgi.annotation.bundle.Directive;
+import org.osgi.annotation.bundle.Requirement;
+
+/**
+ * Should have
+ * <ul>
+ * <li>foo:List<String>=foobar</li>
+ * <li>x-top-name:=fizzbuzz</li>
+ * <li>name=Steve</li>
+ * <li>x-name:=Dave</li>
+ * <li>overriding=Chris</li>
+ * </ul>
+ */
+@FinalAnnotation(name = "Chris")
+public class AttributeDirectiveOverriding {}
+
+@BottomAnnotation(foo = "foobar")
+@interface FinalAnnotation {
+
+	// This overrides the name from the req/cap of Top
+	String name();
+
+}
+
+@Capability(namespace = "overriding", name = "foo", version = "1")
+@Requirement(namespace = "overriding", name = "foo", version = "1")
+@interface TopAnnotation {
+
+	// Not an override as this is an attribute
+	@Attribute
+	String name();
+
+	@Attribute
+	String foo();
+
+	@Directive("x-top-name")
+	String fizz();
+}
+
+@TopAnnotation(name = "Steve", foo = "bar", fizz = "buzz")
+@interface MiddleAnnotation {
+	// Not an override as this is a directive
+	@Directive("x-name")
+	String name();
+
+	// Override, even though the member name is different
+	@Directive("x-top-name")
+	String middle();
+}
+
+@MiddleAnnotation(name = "Dave", middle = "fizzbuzz")
+@interface BottomAnnotation {
+	// Overrides and changes type
+	@Attribute
+	String[] foo();
+}
+

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapReq1.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapReq1.java
@@ -1,0 +1,7 @@
+package test.annotationheaders.attrs.std;
+
+@ExtenderRequirement(name="test1")
+@ExtenderCapability(name="test1")
+public class ExtenderCapReq1 {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapReq2.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapReq2.java
@@ -1,0 +1,7 @@
+package test.annotationheaders.attrs.std;
+
+@ExtenderRequirement(name = "test2", version = "2")
+@ExtenderCapability(name = "test2", version = "2")
+public class ExtenderCapReq2 {
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapability.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderCapability.java
@@ -1,0 +1,14 @@
+package test.annotationheaders.attrs.std;
+
+import static org.osgi.namespace.extender.ExtenderNamespace.EXTENDER_NAMESPACE;
+
+import org.osgi.annotation.bundle.Capability;
+
+@Capability(namespace = EXTENDER_NAMESPACE, version = "1.0.0")
+public @interface ExtenderCapability {
+	// Adds a name that gets into the generated filter
+	String name();
+
+	// overrides the version if set (and affects the generated filter)
+	String version() default "0";
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderRequirement.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/attrs/std/ExtenderRequirement.java
@@ -1,0 +1,14 @@
+package test.annotationheaders.attrs.std;
+
+import static org.osgi.namespace.extender.ExtenderNamespace.EXTENDER_NAMESPACE;
+
+import org.osgi.annotation.bundle.Requirement;
+
+@Requirement(namespace = EXTENDER_NAMESPACE, version = "1.0.0")
+public @interface ExtenderRequirement {
+	// Adds a name that gets into the generated filter
+	String name();
+
+	// overrides the version if set (and affects the generated filter)
+	String version() default "0";
+}


### PR DESCRIPTION
* members of `@Requirement` and `@Capability` can be overridden by using the same member name with no `@Attribute` or `@Directive`. 

* `@Attribute` and `@Directive` can override annotation members from higher up the chain.