### PR TITLE
Bearer authentication

### DIFF
--- a/aQute.libg/src/aQute/libg/reporter/ReporterAdapter.java
+++ b/aQute.libg/src/aQute/libg/reporter/ReporterAdapter.java
@@ -189,8 +189,10 @@ public class ReporterAdapter implements Reporter, Report, Runnable {
 	public void progress(float progress, String s, Object... args) {
 		if (out != null) {
 			out.format(s, args);
-			if (!s.endsWith(String.format("%n")))
+			if (!s.endsWith(String.format("%n"))) {
 				out.format("%n");
+			}
+			out.flush();
 		}
 	}
 

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
@@ -49,6 +49,10 @@ public class HttpClientServerTest extends TestCase {
 		assertOk("user", "good", true);
 	}
 
+	public void testSimpleSecureVerifyBearer() throws Exception {
+		assertOk(null, "token", true);
+	}
+
 	@SuppressWarnings("resource")
 	private void assertOk(String username, String password, boolean verify) throws Exception {
 		File log = new File(tmp, "log");
@@ -61,9 +65,12 @@ public class HttpClientServerTest extends TestCase {
 			URL url;
 			if (password == null) {
 				url = new URL(httpServer.getBaseURI() + "/get");
-			} else {
+			} else if (username != null) {
 				url = new URL(httpServer.getBaseURI() + "/basic-auth/" + username + "/" + password);
 				settings += ";username=\"" + username + "\";password=\"" + password + "\"";
+			} else {
+				url = new URL(httpServer.getBaseURI() + "/bearer-auth/" + password);
+				settings += ";password=\"" + password + "\"";
 			}
 
 			p.setProperty("-connection-log", log.toURI()

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
@@ -1,10 +1,10 @@
 package aQute.bnd.comm.tests;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 
 import aQute.bnd.connection.settings.ConnectionSettings;
-import aQute.bnd.connection.settings.ServerDTO;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.url.TaggedData;
@@ -17,75 +17,74 @@ import junit.framework.TestCase;
 /**
  */
 public class HttpClientServerTest extends TestCase {
-	File tmp = IO.getFile("generated/tmp");
-
-	{
-		IO.delete(tmp);
-		tmp.mkdirs();
-
-	}
-
-	public void testSimpleSecureNoVerify() throws Exception {
-		createSecureServer();
-		assertOk(null, false);
-	}
-
-	public void testSimpleSecureVerify() throws Exception {
-		createSecureServer();
-		assertOk(null, true);
-	}
-
-	@SuppressWarnings("resource")
-	private void assertOk(String password, boolean verify) throws Exception {
-		File log = new File(tmp, "log");
-		Processor p = new Processor();
-		p.setProperty("-connection-log", log.toURI()
-			.getPath());
-
-		HttpClient hc = new HttpClient();
-		hc.setLog(log);
-		ConnectionSettings cs = new ConnectionSettings(p, hc);
-
-		ServerDTO server = new ServerDTO();
-		server.id = httpServer.getBaseURI()
-			.toString();
-		server.verify = verify;
-		if (password != null) {
-			server.username = "user";
-			server.password = password;
-		}
-
-		server.trust = Strings.join(httpServer.getTrustedCertificateFiles(IO.getFile("generated")));
-
-		cs.add(server);
-
-		System.out.println(httpServer.getBaseURI());
-
-		URL url = password == null ? new URL(httpServer.getBaseURI() + "/get")
-			: new URL(httpServer.getBaseURI() + "/basic-auth/user/good");
-		TaggedData tag = hc.connectTagged(url);
-		assertNotNull(tag);
-		String s = IO.collect(tag.getInputStream());
-		assertNotNull(s);
-		assertTrue(s.trim()
-			.startsWith("{"));
-		IO.copy(log, System.out);
-	}
-
+	private File	tmp;
 	private Httpbin httpServer;
 
 	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		if (httpServer != null)
-			httpServer.close();
-	}
-
-	public void createSecureServer() throws Exception {
+	protected void setUp() throws Exception {
+		tmp = IO.getFile("generated/tmp/test/" + getName());
+		IO.delete(tmp);
+		IO.mkdirs(tmp);
 		Config config = new Config();
 		config.https = true;
 		httpServer = new Httpbin(config);
 		httpServer.start();
 	}
 
+	@Override
+	protected void tearDown() throws Exception {
+		IO.close(httpServer);
+		super.tearDown();
+	}
+
+	public void testSimpleSecureNoVerify() throws Exception {
+		assertOk(null, null, false);
+	}
+
+	public void testSimpleSecureVerify() throws Exception {
+		assertOk(null, null, true);
+	}
+
+	public void testSimpleSecureVerifyBasic() throws Exception {
+		assertOk("user", "good", true);
+	}
+
+	@SuppressWarnings("resource")
+	private void assertOk(String username, String password, boolean verify) throws Exception {
+		File log = new File(tmp, "log");
+		try (Processor p = new Processor(); HttpClient hc = new HttpClient()) {
+			System.out.println(httpServer.getBaseURI());
+
+			String settings = "server;id=\"" + httpServer.getBaseURI() + "\";verify=" + verify + ";trust=\""
+				+ Strings.join(httpServer.getTrustedCertificateFiles(tmp)) + "\"";
+
+			URL url;
+			if (password == null) {
+				url = new URL(httpServer.getBaseURI() + "/get");
+			} else {
+				url = new URL(httpServer.getBaseURI() + "/basic-auth/" + username + "/" + password);
+				settings += ";username=\"" + username + "\";password=\"" + password + "\"";
+			}
+
+			p.setProperty("-connection-log", log.toURI()
+				.getPath());
+			p.setProperty("-connection-settings", settings);
+			hc.setLog(log);
+
+			ConnectionSettings cs = new ConnectionSettings(p, hc);
+			cs.readSettings();
+
+			TaggedData tag = hc.connectTagged(url);
+			assertNotNull(tag);
+			assertEquals(200, tag.getResponseCode());
+			InputStream in = tag.getInputStream();
+			assertNotNull(in);
+			String s = IO.collect(in);
+			assertNotNull(s);
+			System.out.println(s);
+			assertTrue(s.trim()
+				.startsWith("{"));
+		}
+		IO.copy(log, System.out);
+	}
 }

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
@@ -18,9 +18,10 @@ public class SettingsParserTest extends TestCase {
 	public void testMavenEncryptedPassword() throws Exception {
 
 		System.setProperty(ConnectionSettings.M2_SETTINGS_SECURITY_PROPERTY, "testresources/settings-security.xml");
-		Processor proc = new Processor();
-		proc.setProperty("-connection-settings", "testresources/server-maven-encrypted-selection.xml");
-		try (ConnectionSettings cs = new ConnectionSettings(proc, new HttpClient());) {
+
+		try (Processor proc = new Processor(); HttpClient hc = new HttpClient()) {
+			proc.setProperty("-connection-settings", "testresources/server-maven-encrypted-selection.xml");
+			ConnectionSettings cs = new ConnectionSettings(proc, hc);
 			cs.readSettings();
 			List<ServerDTO> serverDTOs = cs.getServerDTOs();
 			assertEquals(1, serverDTOs.size());
@@ -49,6 +50,17 @@ public class SettingsParserTest extends TestCase {
 		assertEquals(null, p.privateKey);
 		assertEquals("user", p.username);
 		assertEquals("passwd", p.password);
+	}
+
+	public void testServerSelectionOAuth2() throws Exception {
+		SettingsDTO settings = getSettings("server-selection-oauth2.xml");
+		assertEquals(1, settings.servers.size());
+		ServerDTO p = settings.servers.get(0);
+		assertEquals("httpbin.org", p.id);
+		assertEquals(null, p.passphrase);
+		assertEquals(null, p.privateKey);
+		assertEquals(null, p.username);
+		assertEquals("token", p.password);
 	}
 
 	public void testProxies() throws Exception {

--- a/biz.aQute.bndlib.comm.tests/testresources/server-selection-oauth2.xml
+++ b/biz.aQute.bndlib.comm.tests/testresources/server-selection-oauth2.xml
@@ -1,0 +1,20 @@
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<localRepository />
+	<interactiveMode />
+	<usePluginRegistry />
+	<offline />
+	<pluginGroups />
+	<servers>
+		<server>
+			<id>httpbin.org</id>
+			<password>token</password>
+		</server>
+	</servers>
+	<mirrors />
+	<profiles />
+	<activeProfiles />
+</settings>

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -48,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.annotation.plugin.BndPlugin;
-import aQute.bnd.connection.settings.ConnectionSettings;
 import aQute.bnd.exporter.executable.ExecutableJarExporter;
 import aQute.bnd.exporter.runbundles.RunbundlesExporter;
 import aQute.bnd.header.Attrs;
@@ -624,9 +623,7 @@ public class Workspace extends Processor {
 				HttpClient client = new HttpClient();
 				client.setOffline(getOffline());
 				client.setRegistry(this);
-				try (ConnectionSettings cs = new ConnectionSettings(this, client)) {
-					cs.readSettings();
-				}
+				client.readSettings(this);
 
 				list.add(client);
 			} catch (Exception e) {

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -35,6 +35,7 @@ import aQute.bnd.osgi.Processor.FileLine;
 import aQute.bnd.service.url.ProxyHandler;
 import aQute.bnd.service.url.URLConnectionHandler;
 import aQute.bnd.url.BasicAuthentication;
+import aQute.bnd.url.BearerAuthentication;
 import aQute.bnd.url.HttpsVerification;
 import aQute.lib.concurrentinit.ConcurrentInitialize;
 import aQute.lib.converter.Converter;
@@ -193,7 +194,7 @@ public class ConnectionSettings {
 	 */
 	private void parseServer(Attrs value) throws Exception {
 		ServerDTO server = Converter.cnv(ServerDTO.class, value);
-		if (isBasicAuth(server) || isPrivateKey(server) || isHttpsVerification(server)) {
+		if (isBasicAuth(server) || isBearerAuth(server) || isPrivateKey(server) || isHttpsVerification(server)) {
 
 			if (server.id == null)
 				server.id = "*";
@@ -214,6 +215,13 @@ public class ConnectionSettings {
 			return false;
 		else
 			return true;
+	}
+
+	private boolean isBearerAuth(ServerDTO server) {
+		if (isEmpty(server.username) && !isEmpty(server.password))
+			return true;
+		else
+			return false;
 	}
 
 	private boolean isHttpsVerification(ServerDTO server) {
@@ -244,7 +252,7 @@ public class ConnectionSettings {
 			} else if (serverDTO.username != null) {
 				handler = new BasicAuthentication(serverDTO.username, serverDTO.password, processor);
 			} else {
-				handler = null;
+				handler = new BearerAuthentication(serverDTO.password, processor);
 			}
 			https = new HttpsVerification(serverDTO.trust, serverDTO.verify, processor);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -1,6 +1,8 @@
 package aQute.bnd.connection.settings;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -19,6 +21,7 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -28,6 +31,7 @@ import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Processor.FileLine;
 import aQute.bnd.service.url.ProxyHandler;
 import aQute.bnd.service.url.URLConnectionHandler;
 import aQute.bnd.url.BasicAuthentication;
@@ -38,8 +42,9 @@ import aQute.lib.io.IO;
 import aQute.lib.mavenpasswordobfuscator.MavenPasswordObfuscator;
 import aQute.lib.xpath.XPathParser;
 import aQute.libg.glob.Glob;
+import aQute.service.reporter.Reporter.SetLocation;
 
-public class ConnectionSettings extends Processor {
+public class ConnectionSettings {
 	final static Logger						logger							= LoggerFactory
 		.getLogger(ConnectionSettings.class);
 	public static final String				M2_SETTINGS_SECURITY_XML		= "~/.m2/settings-security.xml";
@@ -47,45 +52,75 @@ public class ConnectionSettings extends Processor {
 	private static final String				M2_SETTINGS_XML					= "~/.m2/settings.xml";
 	private static final String				BND_CONNECTION_SETTINGS_XML		= "~/.bnd/connection-settings.xml";
 	private static final String				CONNECTION_SETTINGS				= "-connection-settings";
-	private HttpClient						client;
-	private List<ServerDTO>					servers							= new ArrayList<>();
-	private ConcurrentInitialize<String>	mavenMasterPassphrase			= new ConcurrentInitialize<String>() {
-
-																				@Override
-																				public String create()
-																					throws Exception {
-																					return readMavenMasterPassphrase();
-																				}
-
-																			};
+	private final Processor					processor;
+	private final HttpClient					client;
+	private final List<ServerDTO>				servers							= new ArrayList<>();
+	private final ConcurrentInitialize<String>	mavenMasterPassphrase;
 
 	public ConnectionSettings(Processor processor, HttpClient client) throws Exception {
-		super(processor);
+		this.processor = Objects.requireNonNull(processor);
 		this.client = client;
+		mavenMasterPassphrase = new MasterPassphrase(processor);
+	}
+
+	private static final class MasterPassphrase extends ConcurrentInitialize<String> {
+		private final Processor processor;
+
+		MasterPassphrase(Processor processor) {
+			this.processor = processor;
+		}
+
+		@Override
+		public String create() throws Exception {
+			String path = System.getProperty(M2_SETTINGS_SECURITY_PROPERTY, M2_SETTINGS_SECURITY_XML);
+			File file = IO.getFile(path);
+			if (!file.isFile()) {
+				logger.info("No Maven security settings file {}", path);
+				return null;
+			}
+
+			XPathParser sp = new XPathParser(file);
+			String master = sp.parse("/settingsSecurity/master");
+			if (master == null || master.isEmpty()) {
+				processor.warning("Found Maven security settings file %s but not master password in it", path);
+				return null;
+			} else {
+				if (!MavenPasswordObfuscator.isObfuscatedPassword(master)) {
+					processor.warning("Master password in %s was not obfuscated, using actual value", path);
+					return master;
+				}
+				try {
+					return MavenPasswordObfuscator.decrypt(master, M2_SETTINGS_SECURITY_PROPERTY);
+				} catch (Exception e) {
+					processor.exception(e, "Could not decrypt the master password from %s with key %s", path,
+						M2_SETTINGS_SECURITY_PROPERTY);
+					return null;
+				}
+			}
+		}
 	}
 
 	public void readSettings() throws Exception {
-		File tmp = null;
-		try {
-			Parameters connectionSettings = new Parameters(mergeProperties(CONNECTION_SETTINGS), getParent());
-			if (connectionSettings.isEmpty()) {
-
-				File file = IO.getFile(BND_CONNECTION_SETTINGS_XML);
+		Parameters connectionSettings = new Parameters(processor.mergeProperties(CONNECTION_SETTINGS), processor);
+		if (connectionSettings.isEmpty()) {
+			File file = IO.getFile(BND_CONNECTION_SETTINGS_XML);
+			if (!file.isFile()) {
+				file = IO.getFile(M2_SETTINGS_XML);
 				if (!file.isFile()) {
-					file = IO.getFile(M2_SETTINGS_XML);
-					if (!file.isFile()) {
-						return;
-					}
+					return;
 				}
-				parse(file);
-				return;
 			}
+			parse(file);
+			return;
+		}
 
+		List<File> tmps = new ArrayList<>();
+		try {
 			for (Map.Entry<String, Attrs> entry : connectionSettings.entrySet()) {
-
 				String key = entry.getKey();
-				if ("false".equalsIgnoreCase(key))
+				if ("false".equalsIgnoreCase(key)) {
 					continue;
+				}
 
 				switch (key) {
 					case "maven" :
@@ -100,19 +135,21 @@ public class ConnectionSettings extends Processor {
 						Attrs attrs = entry.getValue();
 						String variable = attrs.get("var");
 						if (variable == null) {
-							getParent().error(
-								"Specified -connection-settings: %s, with 'env' but the 'var' parameter is no found",
+							processor.error(
+								"Specified -connection-settings: %s, with 'env' but the 'var' parameter was not found",
 								connectionSettings);
 						} else {
-							String value = System.getenv(key);
+							String value = System.getenv(variable);
 							if (value != null) {
-								tmp = File.createTempFile("tmp", ".bnd");
+								File tmp = File.createTempFile(variable, ".xml");
 								IO.store(value, tmp);
 								key = IO.absolutePath(tmp);
-							} else
-								getParent().error(
+								tmps.add(tmp);
+							} else {
+								processor.error(
 									"Specified -connection-settings: %s, but no such environment variable %s is found",
-									connectionSettings, key);
+									connectionSettings, variable);
+							}
 						}
 						break;
 				}
@@ -127,24 +164,22 @@ public class ConnectionSettings extends Processor {
 				if ("server".equals(key)) {
 					parseServer(entry.getValue());
 				} else {
-
-					File file = getParent() != null ? IO.getFile(key) : getParent().getFile(key);
+					File file = processor.getFile(key);
 					if (!file.isFile()) {
-
 						if (!ignoreError) {
-							SetLocation error = getParent()
+							SetLocation error = processor
 								.error("Specified -connection-settings: %s, but no such file or is directory", file);
-							FileLine header = getParent().getHeader(CONNECTION_SETTINGS, key);
+							FileLine header = processor.getHeader(CONNECTION_SETTINGS, key);
 							if (header != null)
 								header.set(error);
 						}
-					} else
+					} else {
 						parse(file);
+					}
 				}
 			}
 		} finally {
-			if (tmp != null)
-				IO.delete(tmp);
+			tmps.forEach(IO::delete);
 		}
 
 	}
@@ -158,7 +193,7 @@ public class ConnectionSettings extends Processor {
 	 */
 	private void parseServer(Attrs value) throws Exception {
 		ServerDTO server = Converter.cnv(ServerDTO.class, value);
-		if (isPassword(server) || isPrivateKey(server)) {
+		if (isBasicAuth(server) || isPrivateKey(server) || isHttpsVerification(server)) {
 
 			if (server.id == null)
 				server.id = "*";
@@ -174,173 +209,183 @@ public class ConnectionSettings extends Processor {
 			return true;
 	}
 
-	private boolean isPassword(ServerDTO server) {
+	private boolean isBasicAuth(ServerDTO server) {
 		if (isEmpty(server.username) || isEmpty(server.password))
 			return false;
 		else
 			return true;
 	}
 
+	private boolean isHttpsVerification(ServerDTO server) {
+		if (isEmpty(server.trust))
+			return false;
+		else
+			return true;
+	}
+	
 	private boolean isEmpty(String s) {
 		return s == null || s.trim()
 			.isEmpty();
 	}
 
-	public URLConnectionHandler createUrlConnectionHandler(ServerDTO serverDTO) {
-
-		final Glob match = new Glob(serverDTO.match == null ? serverDTO.id : serverDTO.match);
-		final BasicAuthentication basic = getBasicAuthentication(serverDTO.username, serverDTO.password);
-		final HttpsVerification https = new HttpsVerification(serverDTO.trust, serverDTO.verify, getParent());
-
-		return new URLConnectionHandler() {
-
-			@Override
-			public boolean matches(URL url) {
-				String scheme = url.getProtocol()
-					.toLowerCase();
-
-				StringBuilder address = new StringBuilder();
-				address.append(scheme)
-					.append("://")
-					.append(url.getHost());
-
-				if (url.getPort() > 0 && url.getPort() != url.getDefaultPort())
-					address.append(":")
-						.append(url.getPort());
-
-				return match.matcher(address)
-					.matches();
-			}
-
-			@Override
-			public void handle(URLConnection connection) throws Exception {
-				if (basic != null)
-					basic.handle(connection);
-
-				if (isHttps(connection) && https != null) {
-					https.handle(connection);
-				}
-
-			}
-
-			boolean isHttps(URLConnection connection) {
-				return "https".equalsIgnoreCase(connection.getURL()
-					.getProtocol());
-			}
-
-			@Override
-			public String toString() {
-				return "Server [ match=" + match + ", basic=" + basic + ", https=" + https + "]";
-			}
-		};
+	public URLConnectionHandler createURLConnectionHandler(ServerDTO serverDTO) {
+		return new SettingsURLConnectionHandler(serverDTO, processor);
 	}
 
-	public BasicAuthentication getBasicAuthentication(String username, String password) {
-		if (username != null && password != null) {
-			return new BasicAuthentication(username, password, getParent());
+	private static final class SettingsURLConnectionHandler implements URLConnectionHandler {
+		private final Glob					match;
+		private final URLConnectionHandler	handler;
+		private final URLConnectionHandler	https;
+
+		SettingsURLConnectionHandler(ServerDTO serverDTO, Processor processor) {
+			match = new Glob(serverDTO.match != null ? serverDTO.match : serverDTO.id);
+			if (serverDTO.password == null) {
+				handler = null;
+			} else if (serverDTO.username != null) {
+				handler = new BasicAuthentication(serverDTO.username, serverDTO.password, processor);
+			} else {
+				handler = null;
+			}
+			https = new HttpsVerification(serverDTO.trust, serverDTO.verify, processor);
 		}
-		return null;
+
+		@Override
+		public boolean matches(URL url) {
+			String scheme = url.getProtocol()
+				.toLowerCase();
+
+			StringBuilder address = new StringBuilder();
+			address.append(scheme)
+				.append("://")
+				.append(url.getHost());
+
+			if (url.getPort() > 0 && url.getPort() != url.getDefaultPort())
+				address.append(":")
+					.append(url.getPort());
+
+			return match.matcher(address)
+				.matches();
+		}
+
+		@Override
+		public void handle(URLConnection connection) throws Exception {
+			if (handler != null) {
+				handler.handle(connection);
+			}
+
+			if ((https != null) && isHttps(connection)) {
+				https.handle(connection);
+			}
+		}
+
+		private boolean isHttps(URLConnection connection) {
+			return "https".equalsIgnoreCase(connection.getURL()
+				.getProtocol());
+		}
+
+		@Override
+		public String toString() {
+			return "Server [ match=" + match + ", handler=" + handler + ", https=" + https + "]";
+		}
 	}
 
 	/**
 	 * Create Proxy Handler from ProxyDTO
 	 */
-	public static ProxyHandler createProxyHandler(final ProxyDTO proxyDTO) {
-		return new ProxyHandler() {
-			Glob				globs[];
-			private ProxySetup	proxySetup;
+	public ProxyHandler createProxyHandler(ProxyDTO proxyDTO) {
+		return new SettingsProxyHandler(proxyDTO);
+	}
 
-			@Override
-			public ProxySetup forURL(URL url) throws Exception {
+	private static final class SettingsProxyHandler implements ProxyHandler {
+		private final ProxyDTO	proxyDTO;
+		private List<Glob>	globs;
+		private ProxySetup	proxySetup;
 
-				Proxy.Type type;
+		SettingsProxyHandler(ProxyDTO proxyDTO) {
+			this.proxyDTO = proxyDTO;
+		}
 
-				switch (proxyDTO.protocol.toUpperCase()) {
+		@Override
+		public ProxySetup forURL(URL url) throws Exception {
+			Proxy.Type type;
 
-					case "DIRECT" :
-						type = Type.DIRECT;
-						break;
+			switch (proxyDTO.protocol.toUpperCase()) {
 
-					case "HTTP" :
-						type = Type.HTTP;
-						if (url.getProtocol()
-							.equalsIgnoreCase("http")) {
-							// ok
-						} else
-							return null;
+				case "DIRECT" :
+					type = Type.DIRECT;
+					break;
 
-						break;
-					case "HTTPS" :
-						type = Type.HTTP;
-						if (url.getProtocol()
-							.equalsIgnoreCase("https")) {
-							// ok
-						} else
-							return null;
-						break;
-
-					case "SOCKS" :
-						type = Type.SOCKS;
-						break;
-
-					default :
-						type = Type.HTTP;
-						break;
-				}
-
-				String host = url.getHost();
-				if (host != null) {
-
-					if (isNonProxyHost(host))
+				case "HTTP" :
+					type = Type.HTTP;
+					if (url.getProtocol()
+						.equalsIgnoreCase("http")) {
+						// ok
+					} else
 						return null;
 
-				}
-				// not synchronized because conflicts only do some double work
+					break;
+				case "HTTPS" :
+					type = Type.HTTP;
+					if (url.getProtocol()
+						.equalsIgnoreCase("https")) {
+						// ok
+					} else
+						return null;
+					break;
 
-				if (proxySetup == null) {
-					proxySetup = new ProxySetup();
-					if (proxyDTO.username != null && proxyDTO.password != null)
-						proxySetup.authentication = new PasswordAuthentication(proxyDTO.username,
-							proxyDTO.password.toCharArray());
+				case "SOCKS" :
+					type = Type.SOCKS;
+					break;
 
-					SocketAddress socketAddress;
-					if (proxyDTO.host != null)
-						socketAddress = new InetSocketAddress(proxyDTO.host, proxyDTO.port);
-					else
-						socketAddress = new InetSocketAddress(proxyDTO.port);
-
-					proxySetup.proxy = new Proxy(type, socketAddress);
-				}
-				return proxySetup;
+				default :
+					type = Type.HTTP;
+					break;
 			}
 
-			public boolean isNonProxyHost(String host) {
+			if (isNonProxyHost(url.getHost())) {
+				return null;
+			}
 
-				Glob[] globs = getNonProxyHosts(proxyDTO);
+			// not synchronized because conflicts only do some double work
+			if (proxySetup == null) {
+				proxySetup = new ProxySetup();
+				if (proxyDTO.username != null && proxyDTO.password != null)
+					proxySetup.authentication = new PasswordAuthentication(proxyDTO.username,
+						proxyDTO.password.toCharArray());
 
-				for (Glob glob : globs) {
-					if (glob.matcher(host)
-						.matches())
-						return true;
-				}
+				SocketAddress socketAddress;
+				if (proxyDTO.host != null)
+					socketAddress = new InetSocketAddress(proxyDTO.host, proxyDTO.port);
+				else
+					socketAddress = new InetSocketAddress(proxyDTO.port);
+
+				proxySetup.proxy = new Proxy(type, socketAddress);
+			}
+			return proxySetup;
+		}
+
+		private boolean isNonProxyHost(String host) {
+			if (host == null) {
 				return false;
 			}
+			return getNonProxyHosts().stream()
+				.anyMatch(g -> g.matcher(host)
+					.matches());
+		}
 
-			public Glob[] getNonProxyHosts(final ProxyDTO proxyDTO) {
-				// not synchronized because conflicts only do some double work
-				if (globs == null) {
-					if (proxyDTO.nonProxyHosts == null)
-						globs = new Glob[0];
-					else {
-						String parts[] = proxyDTO.nonProxyHosts.split("\\s*\\|\\s*");
-						globs = new Glob[parts.length];
-						for (int i = 0; i < parts.length; i++)
-							globs[i] = new Glob(parts[i]);
-					}
-				}
+		private List<Glob> getNonProxyHosts() {
+			// not synchronized because conflicts only do some double work
+			if (globs != null) {
 				return globs;
 			}
-		};
+			if (proxyDTO.nonProxyHosts == null) {
+				return globs = emptyList();
+			}
+			return globs = Processor.split(proxyDTO.nonProxyHosts, "\\s*\\|\\s*")
+				.stream()
+				.map(Glob::new)
+				.collect(toList());
+		}
 	}
 
 	private void parse(File file) throws Exception {
@@ -376,35 +421,6 @@ public class ConnectionSettings extends Processor {
 		if (deflt != null)
 			add(deflt);
 
-	}
-
-	private String readMavenMasterPassphrase() throws Exception {
-		String path = System.getProperty(M2_SETTINGS_SECURITY_PROPERTY, M2_SETTINGS_SECURITY_XML);
-		File file = IO.getFile(path);
-		if (!file.isFile()) {
-			logger.info("No Maven security settings file {}", path);
-			return null;
-		}
-
-		XPathParser sp = new XPathParser(file);
-		String master = sp.parse("/settingsSecurity/master");
-		if (master == null || master.isEmpty()) {
-			warning("Found Maven security settings file %s but not master password in it", path);
-			return null;
-		} else {
-
-			if (!MavenPasswordObfuscator.isObfuscatedPassword(master)) {
-				warning("Master password in %s was not obfuscated, using actual value", path);
-				return master;
-			}
-			try {
-				return MavenPasswordObfuscator.decrypt(master, M2_SETTINGS_SECURITY_PROPERTY);
-			} catch (Exception e) {
-				exception(e, "Could not decrypt the master password from %s with key %s", path,
-					M2_SETTINGS_SECURITY_PROPERTY);
-				return null;
-			}
-		}
 	}
 
 	final static String	IPNR_PART_S	= "([01]\\d\\d)|(2[0-4]\\d)|(25[0-5])";
@@ -474,7 +490,7 @@ public class ConnectionSettings extends Processor {
 				}
 
 			} catch (Exception e) {
-				exception(e, "Failed to parse proxy 'mask' clause in settings: %s", clause);
+				processor.exception(e, "Failed to parse proxy 'mask' clause in settings: %s", clause);
 			}
 
 		return false;
@@ -483,7 +499,8 @@ public class ConnectionSettings extends Processor {
 	public static String makeAbsolute(File cwd, String trust) {
 		if (trust == null)
 			return null;
-		return split(trust).stream()
+		return Processor.split(trust)
+			.stream()
 			.map(part -> new File(cwd, part))
 			.map(IO::absolutePath)
 			.collect(joining(","));
@@ -492,7 +509,7 @@ public class ConnectionSettings extends Processor {
 	public void add(ServerDTO server) {
 		servers.add(server);
 		if (client != null)
-			client.addURLConnectionHandler(createUrlConnectionHandler(server));
+			client.addURLConnectionHandler(createURLConnectionHandler(server));
 	}
 
 	public void add(ProxyDTO proxy) {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -688,9 +688,8 @@ public class HttpClient implements Closeable, URLConnector {
 	}
 
 	public void readSettings(Processor processor) throws IOException, Exception {
-		try (ConnectionSettings cs = new ConnectionSettings(processor, this)) {
-			cs.readSettings();
-		}
+		ConnectionSettings cs = new ConnectionSettings(processor, this);
+		cs.readSettings();
 	}
 
 	public URI makeDir(URI uri) throws URISyntaxException {

--- a/biz.aQute.bndlib/src/aQute/bnd/url/BasicAuthentication.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/BasicAuthentication.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.lib.base64.Base64;
+import aQute.lib.converter.Converter;
 import aQute.libg.cryptography.SHA1;
 import aQute.service.reporter.Reporter;
 
@@ -32,12 +33,9 @@ public class BasicAuthentication extends DefaultURLConnectionHandler {
 
 	interface Config extends DefaultURLConnectionHandler.Config {
 		String user();
-
 		String _password();
 	}
 
-	private static final String	USER					= "user";
-	private static final String	PASSWORD				= ".password";
 	private static final String	HEADER_AUTHORIZATION	= "Authorization";
 	private static final String	PREFIX_BASIC_AUTH		= "Basic ";
 	private String				password;
@@ -59,17 +57,18 @@ public class BasicAuthentication extends DefaultURLConnectionHandler {
 	@Override
 	public void setProperties(Map<String, String> map) throws Exception {
 		super.setProperties(map);
-		this.password = map.get(PASSWORD);
-		this.user = map.get(USER);
+		Config config = Converter.cnv(Config.class, map);
+		this.password = config._password();
+		this.user = config.user();
 
 		init(map);
 	}
 
-	void init(Map<String, String> map) {
+	private void init(Map<String, String> map) {
 		if (this.password == null) {
 			error("No .password property set on this plugin %s", map);
 		}
-		if (this.password == null) {
+		if (this.user == null) {
 			error("No user property set on this plugin %s", map);
 		}
 		String authString = user + ":" + password;

--- a/biz.aQute.bndlib/src/aQute/bnd/url/BearerAuthentication.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/BearerAuthentication.java
@@ -1,0 +1,69 @@
+package aQute.bnd.url;
+
+import java.net.HttpURLConnection;
+import java.net.URLConnection;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import aQute.lib.converter.Converter;
+import aQute.service.reporter.Reporter;
+
+/**
+ * Provide Http Bearer Authentication. This URL Connection Handler plugin will
+ * add bearer authentication to the matching URL Connections. The following
+ * properties must be specified.
+ * <ul>
+ * <li>{@link aQute.bnd.service.url.URLConnectionHandler#MATCH MATCH} — The URL
+ * {@link aQute.libg.glob.Glob Glob} expressions
+ * <li>{@code .oauth2Token} — The password for basic authentication
+ * </ul>
+ */
+@aQute.bnd.annotation.plugin.BndPlugin(name = "url.bearer.authentication", parameters = BearerAuthentication.Config.class)
+public class BearerAuthentication extends DefaultURLConnectionHandler {
+	private final static Logger logger = LoggerFactory.getLogger(BearerAuthentication.class);
+
+	interface Config extends DefaultURLConnectionHandler.Config {
+		String _oauth2Token();
+	}
+
+	private static final String	HEADER_AUTHORIZATION	= "Authorization";
+	private static final String	PREFIX_BEARER_AUTH		= "Bearer ";
+	private String				oauth2Token;
+	private String				authentication;
+
+	public BearerAuthentication() {}
+
+	public BearerAuthentication(String oauth2Token, Reporter reporter) {
+		setReporter(reporter);
+		this.oauth2Token = oauth2Token;
+		this.authentication = PREFIX_BEARER_AUTH + oauth2Token;
+	}
+
+	@Override
+	public void setProperties(Map<String, String> map) throws Exception {
+		super.setProperties(map);
+		Config config = Converter.cnv(Config.class, map);
+		this.oauth2Token = config._oauth2Token();
+		this.authentication = PREFIX_BEARER_AUTH + oauth2Token;
+	}
+
+	@Override
+	public void handle(URLConnection connection) {
+		if (connection instanceof HttpURLConnection && matches(connection) && oauth2Token != null) {
+			if (!(connection instanceof HttpsURLConnection))
+				logger.debug("using bearer authentication with http instead of https, this is very insecure: {}",
+					connection.getURL());
+
+			connection.setRequestProperty(HEADER_AUTHORIZATION, authentication);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "BearerAuthentication [oauth2Token=" + oauth2Token + "]";
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/url/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/ConnectionSettings.java
@@ -46,9 +46,7 @@ public class ConnectionSettings extends DefaultURLConnectionHandler {
 				connection.setConnectTimeout(config.readTimeout());
 
 			for (Entry<String, String> entry : headers.entrySet()) {
-				if (Character.isUpperCase(entry.getKey()
-					.charAt(0)))
-					connection.setRequestProperty(entry.getKey(), entry.getValue());
+				connection.setRequestProperty(entry.getKey(), entry.getValue());
 			}
 
 			if (connection instanceof HttpURLConnection) {
@@ -68,10 +66,11 @@ public class ConnectionSettings extends DefaultURLConnectionHandler {
 	@Override
 	public void setProperties(Map<String, String> map) throws Exception {
 		super.setProperties(map);
-		for (Entry<String, String> entry : headers.entrySet()) {
+		for (Entry<String, String> entry : map.entrySet()) {
 			if (Character.isUpperCase(entry.getKey()
-				.charAt(0)))
+				.charAt(0))) {
 				headers.put(entry.getKey(), entry.getValue());
+			}
 		}
 		config = Converter.cnv(Config.class, map);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
@@ -12,10 +12,12 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.Registry;
 import aQute.bnd.service.RegistryPlugin;
 import aQute.bnd.service.url.URLConnectionHandler;
+import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
 import aQute.libg.glob.Glob;
 import aQute.service.reporter.Reporter;
@@ -86,11 +88,9 @@ public class DefaultURLConnectionHandler implements URLConnectionHandler, Plugin
 
 	@Override
 	public void setProperties(Map<String, String> map) throws Exception {
-		String matches = map.get(MATCH);
-		if (matches != null) {
-			for (String p : matches.split("\\s*,\\s*")) {
-				matchers.add(new Glob(p));
-			}
+		Config config = Converter.cnv(Config.class, map);
+		for (String p : Processor.split(config.match())) {
+			matchers.add(new Glob(p));
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/url/HttpsVerification.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/HttpsVerification.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import aQute.lib.converter.Converter;
 import aQute.lib.io.IO;
 import aQute.service.reporter.Reporter;
 
@@ -132,8 +133,8 @@ public class HttpsVerification extends DefaultURLConnectionHandler {
 	@Override
 	public void setProperties(Map<String, String> map) throws Exception {
 		super.setProperties(map);
-
-		certificatesPath = map.get("trusted");
+		Config config = Converter.cnv(Config.class, map);
+		certificatesPath = config.trusted();
 	}
 
 	List<X509Certificate> createCertificates(String paths)

--- a/biz.aQute.bndlib/src/aQute/bnd/url/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/packageinfo
@@ -1,1 +1,1 @@
-version 1.2
+version 1.3

--- a/biz.aQute.http.testservers/src/aQute/http/testservers/Httpbin.java
+++ b/biz.aQute.http.testservers/src/aQute/http/testservers/Httpbin.java
@@ -129,6 +129,7 @@ public class Httpbin extends HttpTestServer {
 	}
 
 	static Pattern BASIC_AUTH_P = Pattern.compile("Basic\\s+(?<auth>[^\\s]+)\\s*", Pattern.CASE_INSENSITIVE);
+	static Pattern	BEARER_AUTH_P	= Pattern.compile("Bearer\\s+(?<auth>[^\\s]+)\\s*", Pattern.CASE_INSENSITIVE);
 
 	public Request _basic$2dauth(Request req, Response response, String user, String passwrd)
 		throws UnsupportedEncodingException {
@@ -145,6 +146,22 @@ public class Httpbin extends HttpTestServer {
 		}
 		response.code = 401;
 		response.headers.put("WWW-Authenticate", "Basic realm=\"Test\"");
+		return null;
+	}
+
+	public Request _bearer$2dauth(Request req, Response response, String token) throws UnsupportedEncodingException {
+
+		String authorization = req.headers.get("Authorization");
+		if (authorization != null) {
+			Matcher m = BEARER_AUTH_P.matcher(authorization);
+			if (m.matches()) {
+				if (token.equals(m.group("auth"))) {
+					return req;
+				}
+			}
+		}
+		response.code = 401;
+		response.headers.put("WWW-Authenticate", "Bearer realm=\"Test\"");
 		return null;
 	}
 


### PR DESCRIPTION
Add support for Bearer (OAuth2) authentication.

If the `<server>` configuration has only a password and no username, then Bearer authentication is in effect with the password used as the token.

`-connection-settings: server;id="http://*.com";password="oauth2token"`

will cause 

`Authorization: Bearer oauth2token`

request header to be sent to servers matching the glob `http://*.com`.

See https://github.github.com/maven-plugins/site-plugin/authentication.html for an example of a `<server>` configuration for OAuth2.