### PR TITLE
baseline: Only report a bundle/package mismatch for major version != 0

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/baseline/BaselineTest.java
+++ b/biz.aQute.bndlib.tests/src/test/baseline/BaselineTest.java
@@ -115,9 +115,9 @@ public class BaselineTest extends TestCase {
 	public void testJava8DefaultMethods() throws Exception {
 		try (Builder older = new Builder(); Builder newer = new Builder();) {
 			older.addClasspath(IO.getFile("java8/older/bin"));
-			older.setExportPackage("*");
+			older.setExportPackage("*;version=1.0");
 			newer.addClasspath(IO.getFile("java8/newer/bin"));
-			newer.setExportPackage("*");
+			newer.setExportPackage("*;version=1.0");
 			try (Jar o = older.build(); Jar n = newer.build();) {
 				assertTrue(older.check());
 				assertTrue(newer.check());
@@ -129,7 +129,31 @@ public class BaselineTest extends TestCase {
 				assertEquals(1, infoSet.size());
 				for (Info info : infoSet) {
 					assertTrue(info.mismatch);
-					assertEquals(new Version(0, 1, 0), info.suggestedVersion);
+					assertEquals(new Version(1, 1, 0), info.suggestedVersion);
+					assertEquals(info.packageName, "api_default_methods");
+				}
+			}
+		}
+	}
+
+	public void testNoMismatchForZeroMajor() throws Exception {
+		try (Builder older = new Builder(); Builder newer = new Builder();) {
+			older.addClasspath(IO.getFile("java8/older/bin"));
+			older.setExportPackage("*;version=0.1");
+			newer.addClasspath(IO.getFile("java8/newer/bin"));
+			newer.setExportPackage("*;version=0.1");
+			try (Jar o = older.build(); Jar n = newer.build();) {
+				assertTrue(older.check());
+				assertTrue(newer.check());
+
+				DiffPluginImpl differ = new DiffPluginImpl();
+				Baseline baseline = new Baseline(older, differ);
+
+				Set<Info> infoSet = baseline.baseline(n, o, null);
+				assertEquals(1, infoSet.size());
+				for (Info info : infoSet) {
+					assertFalse(info.mismatch);
+					assertEquals(new Version(0, 2, 0), info.suggestedVersion);
 					assertEquals(info.packageName, "api_default_methods");
 				}
 			}

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>biz.aQute.bnd-test</groupId>
 		<artifactId>test</artifactId>
-		<version>0.0.1</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>biz.aQute.bnd-test</groupId>
 	<artifactId>invalid-with-consumer</artifactId>
-	<version>0.0.2</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-provider/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>biz.aQute.bnd-test</groupId>
 		<artifactId>test</artifactId>
-		<version>0.0.1</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>biz.aQute.bnd-test</groupId>
 	<artifactId>invalid-with-provider</artifactId>
-	<version>0.0.2</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>biz.aQute.bnd-test</groupId>
 	<artifactId>test</artifactId>
-	<version>0.0.1</version>
+	<version>1.0.1</version>
 	<packaging>pom</packaging>
 
 	<distributionManagement>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-no-previous/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>biz.aQute.bnd-test</groupId>
 		<artifactId>test</artifactId>
-		<version>0.0.1</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>biz.aQute.bnd-test</groupId>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-previous-same/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>biz.aQute.bnd-test</groupId>
 		<artifactId>test</artifactId>
-		<version>0.0.1</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>biz.aQute.bnd-test</groupId>
 	<artifactId>valid-with-previous-same</artifactId>
-	<version>0.0.2</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<dependencies>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/valid-with-provider/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>biz.aQute.bnd-test</groupId>
 		<artifactId>test</artifactId>
-		<version>0.0.1</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<groupId>biz.aQute.bnd-test</groupId>
 	<artifactId>valid-with-provider</artifactId>
-	<version>0.0.2</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 				<configuration>
 					<base>
 						<artifactId>valid-no-previous</artifactId>
-						<version>0.0.1</version>
+						<version>1.0.1</version>
 					</base>
 					<includeDistributionManagement>true</includeDistributionManagement>
 				</configuration>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -8,24 +8,24 @@ assert build_log_file.exists();
 def build_log = build_log_file.text
 
 // No previous
-assert build_log =~ Pattern.quote('[WARNING] No previous version of biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 could be found to baseline against')
+assert build_log =~ Pattern.quote('[WARNING] No previous version of biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 could be found to baseline against')
 
 // With previous-same
-assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1')
+assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1')
 
 // With previous-provider
-assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1')
+assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1')
 
 
 // With provider
 assert build_log =~ Pattern.quote('[ERROR] Baseline mismatch for package bnd.test, MINOR change. Current is 1.0.0, repo is 1.0.0, suggest 1.1.0 or -')
 
-assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
+assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
 
 
 // With consumer
 assert build_log =~ Pattern.quote('[ERROR] Baseline mismatch for package bnd.test, MAJOR change. Current is 1.0.0, repo is 1.0.0, suggest 2.0.0 or 1.0.0')
 
-assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:0.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:0.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
+assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
 
 


### PR DESCRIPTION
"Major version zero (0.y.z) is for initial development. Anything may
change at any time. The public API should not be considered stable."

See https://semver.org/#spec-item-4

This change still does all the analysis but will only set mismatch to
true if the major version of the older and newer are both non-zero.

Fixes https://github.com/bndtools/bnd/issues/2452