### PR TITLE
gradle: Work with Bnd plugin loaded in two class loaders

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -4,17 +4,15 @@
 
 package aQute.bnd.gradle
 
-import aQute.service.reporter.Report
-import aQute.service.reporter.Report.Location
 import org.gradle.api.logging.Logger
 
 class BndUtils {
   private BndUtils() { }
 
-  public static void logReport(Report report, Logger logger) {
+  public static void logReport(def report, Logger logger) {
     if (logger.isWarnEnabled()) {
       report.getWarnings().each { String msg ->
-        Location location = report.getLocation(msg)
+        def location = report.getLocation(msg)
         if (location && location.file) {
           logger.warn '{}:{}: warning: {}', location.file, location.line, msg
         } else {
@@ -24,7 +22,7 @@ class BndUtils {
     }
     if (logger.isErrorEnabled()) {
       report.getErrors().each { String msg ->
-        Location location = report.getLocation(msg)
+        def location = report.getLocation(msg)
         if (location && location.file) {
           logger.error '{}:{}: error: {}', location.file, location.line, msg
         } else {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -39,8 +39,6 @@ package aQute.bnd.gradle
 
 import static aQute.bnd.gradle.BndUtils.logReport
 
-import aQute.bnd.build.Project
-
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
@@ -86,7 +84,7 @@ public class TestOSGi extends Bndrun {
   }
 
   @Override
-  protected void worker(Project run) {
+  protected void worker(def run) {
     try {
       logger.info 'Running tests for {} in {}', run.getPropertiesFile(), run.getBase()
       run.test(resultsDir, tests);

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin6/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin6/build.gradle
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        mavenCentral() 
+    }
+    dependencies {
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3'
+    }
+}

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin6/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin6/settings.gradle
@@ -7,6 +7,15 @@ buildscript {
   dependencies {
     classpath files(new File(bnd_plugin).canonicalFile)
   }
+  /* Pass bnd gradle plugin classpath to rootProject once created */
+  def bndPlugin = files(configurations.classpath.files)
+  gradle.rootProject {
+    buildscript {
+      dependencies {
+        classpath bndPlugin
+      }
+    }
+  }
 }
 
 apply plugin: 'biz.aQute.bnd.workspace'

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/build.gradle
@@ -1,6 +1,13 @@
+import aQute.bnd.gradle.Resolve
+
 tasks.getByName('resolve.resolvenochange') {
   failOnChanges = true
 }
 tasks.getByName('resolve.resolvechange') {
   failOnChanges = true
+}
+
+task('resolve2', type: Resolve) {
+  dependsOn assemble
+  bndrun = 'resolve2.bndrun'
 }

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
@@ -1,0 +1,9 @@
+-runfw: org.eclipse.osgi;version='[3.12.50,3.12.51)'
+-runee: JavaSE-1.8
+-runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
+
+-runbundles: osgi.enroute.junit.wrapper
+
+-runproperties: 
+
+-runtrace: true

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin7/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin7/build.gradle
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        mavenCentral() 
+    }
+    dependencies {
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3'
+    }
+}

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin7/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin7/settings.gradle
@@ -7,6 +7,15 @@ buildscript {
   dependencies {
     classpath files(new File(bnd_plugin).canonicalFile)
   }
+  /* Pass bnd gradle plugin classpath to rootProject once created */
+  def bndPlugin = files(configurations.classpath.files)
+  gradle.rootProject {
+    buildscript {
+      dependencies {
+        classpath bndPlugin
+      }
+    }
+  }
 }
 
 apply plugin: 'biz.aQute.bnd.workspace'

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin7/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin7/test.simple/build.gradle
@@ -1,0 +1,8 @@
+import static aQute.bnd.exporter.executable.ExecutableJarExporter.EXECUTABLE_JAR
+import aQute.bnd.gradle.Export
+
+task('export2', type: Export) {
+  dependsOn assemble
+  bndrun = 'export2.bndrun'
+  exporter = EXECUTABLE_JAR
+}

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin7/test.simple/export2.bndrun
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin7/test.simple/export2.bndrun
@@ -1,0 +1,10 @@
+-runfw: org.eclipse.osgi;version='[3.12.50,3.12.51)'
+-runee: JavaSE-1.8
+-runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
+
+-runbundles: osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
+    test.simple;version=snapshot
+
+-runproperties: 
+
+-runtrace: true

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin9/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin9/build.gradle
@@ -1,0 +1,8 @@
+buildscript {
+    repositories {
+        mavenCentral() 
+    }
+    dependencies {
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3'
+    }
+}

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/build.gradle
@@ -6,5 +6,5 @@ testOSGi {
 
 task('testOSGi2', type: TestOSGi) {
   inputs.files jar
-  bndrun = testOSGi.bndrun
+  bndrun = 'testOSGi2.bndrun'
 }

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/testOSGi2.bndrun
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/testOSGi2.bndrun
@@ -1,0 +1,11 @@
+-runfw: org.eclipse.osgi;version='[3.12.0,3.13.0)'
+-runee: JavaSE-1.8
+-runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
+
+-runbundles: \
+    test.simple, \
+	osgi.enroute.junit.wrapper
+	
+-runproperties: 
+
+-runtrace: true


### PR DESCRIPTION
If the build.gradle file declares buildscript, a new class loader will
be used for plugins that is different than the one used for
settings.gradle. This can mean than the Bnd gradle plugin can be loaded
by each class loader and then using task types (like TestOSGi) in build
scripts can result in class cast type issues.

We work around this in the Bndrun, Export, Resolve and TestOSGi task
types by avoiding typed references to Bnd types like Workspace and
Project since the values passed by settings.gradle will use the class
loader for settings.gradle which may be a different class loader than
used by build.gradle.
