### PR TITLE
[build] Revert removal of properties copying

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -1205,8 +1205,23 @@ public class Workspace extends Processor {
 			int counter = 1;
 			for (Map.Entry<String, Attrs> e : standalone.entrySet()) {
 				String locationStr = e.getKey();
-				if ("true".equalsIgnoreCase(locationStr))
+				if ("true".equalsIgnoreCase(locationStr)) {
+
+					//
+					// Copy all properties except the type we will add
+					//
+
+					for (Entry<Object, Object> entry : run.getProperties()
+						.entrySet()) {
+						String key = (String) entry.getKey();
+						if (!key.startsWith(PLUGIN_STANDALONE)) {
+							ws.getProperties()
+								.put(key, entry.getValue());
+						}
+					}
+
 					break;
+				}
 
 				URI resolvedLocation = URIUtil.resolve(base, locationStr);
 


### PR DESCRIPTION
Neil removed the copying of properties from the bndrun file in the standalone workspace. However, this is used by me (and enRoute). Primary use case is defining repositories in a bndrun file. Removing this feature this way was breaking backward compatibility in a rather big way. It basically voids the use of the 'true' option of -standalone. If true is set, not repositories can be defined after this commit ...

However, I guess I can understand the need. Since Neil's model only works when you define the repos in the -standalone instruction and we have a special value 'true' I moved the copying of the properties when 'true' is set. This way Neil can have an empty workspace.

I also do not understand why the overlap in properties is problematic since they are an exact copy. A reason given was that you could not remove properties but I do not see how you can 'do' anything in a bndrun file? Personally I would prefer to not have the properties in the Run file since the bndrun acts more as the workspace in this case.