### PR TITLE
build: Adjust inclusion of org.osgi packages

### DIFF
--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -39,12 +39,21 @@ Export-Package: \
 	aQute.bnd.util.dto;-noimport:=true,\
 	aQute.bnd.util.repository;-noimport:=true,\
 	aQute.bnd.component.error;-noimport:=true,\
-	org.osgi.service.repository,\
-	org.osgi.resource, \
+	org.osgi.service.log;-split-package:=first,\
+	org.osgi.service.repository;-split-package:=first,\
 	org.osgi.util.promise;-split-package:=first, \
 	org.osgi.util.function;-split-package:=first
 
-Conditional-Package:	        aQute.service.*, aQute.configurable
+-conditionalpackage:	 aQute.service.*,\
+ aQute.configurable,\
+ org.osgi.*
+
+Import-Package: junit.framework;resolution:=optional,\
+    org.osgi.service.repository,\
+    org.osgi.service.log,\
+    ${replace;${retainall;${packages;CONDITIONAL};${packages;NAMED;org.osgi.*}};$;\\;provide:=false},\
+	*
+
 -includeresource: 				${workspace}/LICENSE, img/=img/, {readme.md}
 
 -buildpath:  \
@@ -59,15 +68,11 @@ Conditional-Package:	        aQute.service.*, aQute.configurable
 	biz.aQute.bnd.annotation;version=project,\
 	slf4j.api;version=latest
 
-Import-Package: junit.framework;resolution:=optional,\
-	org.osgi.resource;resolution:=optional,\
-	org.osgi.framework;version='[1.5,2)',\
-	*
-
 Bundle-Icon: img/bnd-64.png;size=64
 Bundle-Developers: peter.kriens@aQute.biz, njbartlett@gmail.com
 Bundle-Contributors: per.kristian.soreide@comactivity.net, ferry.huberts@pelagic.nl, bj@bjhargrave.com
 
 -baseline: *
 
--fixupmessages: "Export aQute.bnd.http*aQute.lib.converter"
+-fixupmessages.converter: "Export aQute.bnd.http,* private references \\[aQute.lib.converter\\]"
+-fixupmessages.bundleversion: "The bundle version \\(4.0.0/4.1.0\\) is too low, must be at least 5.0.0"

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -51,7 +51,6 @@ import aQute.bnd.build.model.conversions.SimpleListConverter;
 import aQute.bnd.build.model.conversions.VersionedClauseConverter;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
-import aQute.bnd.properties.Document;
 import aQute.bnd.properties.IDocument;
 import aQute.bnd.properties.IRegion;
 import aQute.bnd.properties.LineType;
@@ -381,7 +380,7 @@ public class BndEditModel {
 		this.workspace = workspace;
 	}
 
-	public BndEditModel(Document document) throws IOException {
+	public BndEditModel(IDocument document) throws IOException {
 		this();
 		loadFrom(document);
 	}
@@ -785,7 +784,7 @@ public class BndEditModel {
 	}
 
 	public void setTestPath(List< ? extends VersionedClause> paths) {
-		List<VersionedClause> oldValue = getBuildPath();
+		List<VersionedClause> oldValue = getTestPath();
 		doSetObject(aQute.bnd.osgi.Constants.TESTPATH, oldValue, paths, headerClauseListFormatter);
 	}
 

--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -3,9 +3,10 @@
 
 -dependson: demo
 
--buildpath: aQute.libg;version=project,\
-    biz.aQute.bndlib;version=latest,\
+-buildpath: \
 	osgi.core;version=4.2,\
+    aQute.libg;version=project,\
+    biz.aQute.bndlib;version=latest,\
 	slf4j.api;version=latest
 
 -testpath: \

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -31,10 +31,6 @@ jetty.libs: org.apache.geronimo.specs.geronimo-servlet_2.5_spec;version=1.2,\
 	biz.aQute.http.testservers;version=latest,\
 	slf4j.simple;version=latest
 
-repoindex-pkgs: \
-	aQute.bnd.osgi.resource,\
-	org.osgi.resource;-split-package:=first
-
 Export-Package: \
 	aQute.bnd.deployer.http;bnd-plugins=true,\
 	aQute.p2.api,\
@@ -52,30 +48,22 @@ Export-Package: \
 	aQute.bnd.repository.fileset;bnd-plugins=true,  \
 	aQute.maven.*, \
 
-
-# NB: `org.osgi.*` API is included in Private-Package for running outside of OSGi.
 Private-Package: \
-	aQute.p2.provider,\
-	${repoindex-pkgs},\
-	org.osgi.service.log;-split-package:=first,\
-	org.osgi.framework;-split-package:=first
+	aQute.p2.provider
 
-Conditional-Package:\
+-conditionalpackage:\
 	aQute.lib.*;-split-package:=first,\
 	aQute.libg.*;-split-package:=first, \
 	org.tukaani.xz.*, \
 	aQute.configurable.*
 
-# We must also explicitly import `org.osgi.framework` etc. for when we *are* running in OSGi.
 Import-Package:\
-	org.osgi.framework;version='[1.5,2)',\
-	org.osgi.service.repository,\
-	org.osgi.resource,\
-	org.osgi.service.log,\
 	aQute.bnd.osgi.resource,\
 	org.osgi.service.coordinator; resolution:=optional,\
 	*
 
--fixupmessages: "private references"
+-fixupmessages.tag: "Export aQute.maven.provider,* private references \\[aQute.lib.tag\\]"
+-fixupmessages.getopts: "Export aQute.bnd.repository.maven.provider,* private references \\[aQute.lib.getopt\\]"
+-fixupmessages.configurable: "Export aQute.bnd.repository.osgi,* private references \\[aQute.configurable\\]"
 
 -baseline: *


### PR DESCRIPTION
When running outside of an OSGi framework, Bnd still needs access to
some org.osgi packages. We adjust how those are included in the bnd jars.

Fixes #2471