### PR TITLE
maven: Fix Traverser to remove timing issue

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
@@ -105,16 +105,15 @@ class Traverser {
 	}
 
 	private void parse(final Archive archive, final String parent) {
-		//
-		// Prune duplicates by adding the archive to a set. We
-		// use a dummy for the resource, the resource is set later
-		//
-
-		Resource prev = resources.putIfAbsent(archive, DUMMY);
-		if (prev != null)
-			return;
-
 		if (transitive || parent == ROOT) {
+			//
+			// Prune duplicates by adding the archive to a set. We
+			// use a dummy for the resource, the resource is set later
+			//
+
+			Resource prev = resources.putIfAbsent(archive, DUMMY);
+			if (prev != null)
+				return;
 
 			//
 			// Every parse must be matched by a background


### PR DESCRIPTION
If a pom is encountered with transitive false before the pom is
encountered as a root pom, then it will fail to be parsed.

See https://groups.google.com/d/msg/bndtools-users/_AbaKPmhkKg/JjPJHe-8BgAJ

