### PR TITLE
jar: Make sure there is always a blank line after manifest main attrs

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -561,6 +561,7 @@ public class Jar implements Closeable {
 	public static void outputManifest(Manifest manifest, OutputStream out) throws IOException {
 		writeEntry(out, "Manifest-Version", "1.0");
 		attributes(manifest.getMainAttributes(), out);
+		out.write(EOL);
 
 		TreeSet<String> keys = new TreeSet<>();
 		for (Object o : manifest.getEntries()
@@ -568,9 +569,9 @@ public class Jar implements Closeable {
 			keys.add(o.toString());
 
 		for (String key : keys) {
-			out.write(EOL);
 			writeEntry(out, "Name", key);
 			attributes(manifest.getAttributes(key), out);
+			out.write(EOL);
 		}
 		out.flush();
 	}


### PR DESCRIPTION
Per the Jar Manifest spec, there must always be a blank line after the
main attributes even if there are no individual sections.

This change also emits a blank line after each individual section. The
Jar Manifest spec does not require this but the java.util.jar package
does this when writing a manifest.
