### PR TITLE
gradle: Add testrun.* task rule for Bnd Workspace build

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -134,8 +134,11 @@ The `release` task releases the project's bundles to the
 The `releaseNeeded` task releases the project and all projects it
 depends on.
 
-The `testOSGi` task runs any OSGi JUnit tests in the project by launching a
-framework and running the tests in the launched framework.
+The `testOSGi` task runs any OSGi JUnit tests in the project's `bnd.bnd`
+file by launching a framework and running the tests in the launched
+framework. This means the `bnd.bnd` file must have the necessary
+`-runfw` and `-runbundles` to support the test bundles built by
+the project. The `check` task depends on the `testOSGi` task.
 
 The `checkNeeded` task runs the `check` task on the project and all
 projects it depends on.
@@ -164,6 +167,9 @@ instruction in each bndrun file.
 
 The `run.`_name_ tasks, one per bndrun file in the project, runs
 the _name_`.bndrun` file.
+
+The `testrun.`_name_ tasks, one per bndrun file in the project, runs
+the OSGi JUnit tests in the _name_`.bndrun` file.
 
 The `echo` task will display some help information on the dependencies,
 paths and configuration of the project.

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -440,13 +440,28 @@ public class BndPlugin implements Plugin<Project> {
 
       tasks.addRule('Pattern: run.<name>: Run the bndrun file <name>.bndrun.') { taskName ->
         if (taskName.startsWith('run.')) {
-          String bndrun = taskName - 'run.'
-          File runFile = file("${bndrun}.bndrun")
+          String bndrunName = taskName - 'run.'
+          File runFile = file("${bndrunName}.bndrun")
           if (runFile.isFile()) {
             task(taskName, type: Bndrun) {
-              description "Run the bndrun file ${bndrun}.bndrun."
+              description "Run the bndrun file ${bndrunName}.bndrun."
               dependsOn assemble
               group 'export'
+              bndrun = runFile
+            }
+          }
+        }
+      }
+
+      tasks.addRule('Pattern: testrun.<name>: Runs the OSGi JUnit tests in the bndrun file <name>.bndrun.') { taskName ->
+        if (taskName.startsWith('testrun.')) {
+          String bndrunName = taskName - 'testrun.'
+          File runFile = file("${bndrunName}.bndrun")
+          if (runFile.isFile()) {
+            task(taskName, type: TestOSGi) {
+              description "Runs the OSGi JUnit tests in the bndrun file ${bndrunName}.bndrun."
+              dependsOn assemble
+              group 'verification'
               bndrun = runFile
             }
           }

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -370,7 +370,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'check', '--exclude-task', 'testOSGi2')
+            .withArguments('--stacktrace', '--debug', 'check', '--exclude-task', 'testrun.testOSGi2')
             .forwardOutput()
             .build()
 
@@ -409,26 +409,26 @@ class TestBndPlugin extends Specification {
         when:
           result = TestHelper.getGradleRunner('4.6')
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'testOSGi2')
+            .withArguments('--stacktrace', '--debug', 'testrun.testOSGi2')
             .forwardOutput()
             .buildAndFail()
 
         then:
           result.task(':test.simple:jar').outcome == SUCCESS
-          result.task(':test.simple:testOSGi2').outcome == FAILED
+          result.task(':test.simple:testrun.testOSGi2').outcome == FAILED
 
         when:
           result = TestHelper.getGradleRunner('4.6')
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'testOSGi2', '--tests=test.simple.Test')
+            .withArguments('--stacktrace', '--debug', 'testrun.testOSGi2', '--tests=test.simple.Test')
             .forwardOutput()
             .build()
 
         then:
           result.task(':test.simple:jar').outcome == UP_TO_DATE
-          result.task(':test.simple:testOSGi2').outcome == SUCCESS
+          result.task(':test.simple:testrun.testOSGi2').outcome == SUCCESS
 
-          new File(testReports, 'testOSGi2/TEST-testOSGi2.xml').isFile()
+          new File(testReports, 'testrun.testOSGi2/TEST-testrun.testOSGi2.xml').isFile()
     }
 
 }

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/build.gradle
@@ -1,10 +1,3 @@
-import aQute.bnd.gradle.TestOSGi
-
 testOSGi {
   tests = ['test.simple.Test']
-}
-
-task('testOSGi2', type: TestOSGi) {
-  inputs.files jar
-  bndrun = 'testOSGi2.bndrun'
 }


### PR DESCRIPTION
This enables testrun.xxx tasks of type TestOSGi for each xxx.bndrun file
in a project.