### PR TITLE
[launcher] Use reference: urls when an executable JAR is packaged and…

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/pre/EmbeddedLauncher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/pre/EmbeddedLauncher.java
@@ -54,6 +54,17 @@ public class EmbeddedLauncher {
 	}
 
 	private static URL toFileURL(URL resource) throws IOException {
+		//
+		// Don't bother copying file urls
+		//
+		if (resource.getProtocol()
+			.equalsIgnoreCase("file"))
+			return resource;
+
+		//
+		// Need to make a copy to a temp file
+		//
+
 		File f = File.createTempFile("resource", ".jar");
 		Files.createDirectories(f.getParentFile()
 			.toPath());


### PR DESCRIPTION
… expanded. This is much more efficient since it will not copy the JARs.

This code also uses the -runpath JARs directly if they happen to he file: urls.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>