### PR TITLE
docs: Fix a small typo in code example for connection-settings.xml file

### DIFF
--- a/docs/_instructions/connection-settings.md
+++ b/docs/_instructions/connection-settings.md
@@ -55,7 +55,7 @@ The settings files have the following structure:
 		  <username>username</username>
 	      <password>password</password>
 		  <verify> true | false </verify>
-		  <trust> comma separated paths to X509 certificates </trus>
+		  <trust> comma separated paths to X509 certificates </trust>
 	    </server>
 	  </servers>
 	</settings> 


### PR DESCRIPTION
Just a small typo I stumbled upon: </trus> should be </trust>