### PR TITLE
Use promise 1.1.1 from OSGi

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -198,7 +198,6 @@ public class ResourceUtils {
 		return capabilityStream(resource, IdentityNamespace.IDENTITY_NAMESPACE, IdentityCapability.class).findFirst()
 			.map(c -> c.getAttributes()
 				.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
-			.filter(Objects::nonNull)
 			.map(Object::toString)
 			.orElse(null);
 	}

--- a/cnf/ext/osgi-snapshots.mvn
+++ b/cnf/ext/osgi-snapshots.mvn
@@ -1,0 +1,1 @@
+org.osgi:org.osgi.util.promise:1.1.1-SNAPSHOT

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -8,6 +8,12 @@ baselinerepo:           https://dl.bintray.com/bnd/dist/${baseline.version}
         name='Maven Central';\
         readOnly=true,\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\
+        releaseUrl="https://oss.sonatype.org/content/groups/osgi/";\
+        snapshotUrl="https://oss.sonatype.org/content/groups/osgi/";\
+        index=${.}/osgi-snapshots.mvn;\
+        name='OSGi Snapshots';\
+        readOnly=true,\
+    aQute.bnd.repository.maven.provider.MavenBndRepository;\
         name='Local';\
         noupdateOnRelease=true,\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\


### PR DESCRIPTION
Promise 1.1.1 runs callbacks on current thread when the promise is
already resolved. This avoids thread context switches.