### PR TITLE
Implement meta-annotation for arbitrary manifest header generation

### DIFF
--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/headers/BundleHeader.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/headers/BundleHeader.java
@@ -1,0 +1,68 @@
+package aQute.bnd.annotation.headers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This meta-annotation allows the developer to define an annotation that
+ * generates an arbitrary manifest header in the output bundle
+ * <p>
+ * For example given the following annotation and its usage:
+ * 
+ * <pre>
+ * &#64;BundleHeader(name = "My-Bundle-Header")
+ * public @interface MyBundleHeader {}
+ * 
+ * package org.example;
+ * &#64;MyBundleHeader
+ * public class Example {}
+ * </pre>
+ * 
+ * the following bundle header is generated:
+ * 
+ * <pre>
+ * My-Bundle-Header: org.example.Example
+ * </pre>
+ * <p>
+ * Where an annotation is used on multiple classes within the bundle, the value
+ * of each shall be appended as a list into a single manifest header. However,
+ * if the annotation attribute {@code singleton} is true then multiple usages of
+ * the annotation within a single bundle generates an error.
+ * <p>
+ * The {@code value} attribute can use the following macro values:
+ * <ul>
+ * <li>$&#123;&#64;class&#125; adds the FQN of the target type</li>
+ * <li>$&#123;&#64;class-simple&#125; adds the short name of the target
+ * type</li>
+ * <li>$&#123;&#64;package&#125; adds the FQN of the target type's package</li>
+ * </ul>
+ * The default value is $&#123;&#64;class&#125;.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+	ElementType.ANNOTATION_TYPE, ElementType.TYPE
+})
+public @interface BundleHeader {
+
+	/**
+	 * The name of the bundle manifest header. Must not be empty and should
+	 * begin with an upper-case character (otherwise it will be omitted from the
+	 * generated manifest).
+	 */
+	String name();
+
+	/**
+	 * The value of the generated manifest header, which may be parameterized
+	 * with macros as described above. Defaults to the FQN of the type to which
+	 * the annotation is attached.
+	 */
+	String value() default "${@class}";
+
+	/**
+	 * Whether this header should be a singleton within the scope of the bundle.
+	 */
+	boolean singleton() default false;
+
+}

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/headers/packageinfo
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/headers/packageinfo
@@ -1,2 +1,2 @@
-version 1.1
+version 1.2
  

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/MetaAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/MetaAnnotationHeadersTest.java
@@ -1,0 +1,102 @@
+package test.annotationheaders;
+
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+
+import aQute.bnd.annotation.headers.BundleHeader;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Builder;
+import aQute.lib.io.IO;
+import junit.framework.TestCase;
+
+public class MetaAnnotationHeadersTest extends TestCase {
+
+	@BundleHeader(name = "Foo-Bundle-Activator")
+	@interface FooActivatorHeader {}
+
+	@FooActivatorHeader
+	class A {}
+
+	@BundleHeader(name = "Foo-Multi-Header")
+	@interface MultiBundleHeader {}
+
+	@MultiBundleHeader
+	class B {}
+
+	@MultiBundleHeader
+	class C {}
+
+	@BundleHeader(name = "Foo-Package-Header", value = "${@package}")
+	@interface PackageHeader {}
+
+	@PackageHeader
+	class D {}
+
+	@PackageHeader
+	class E {}
+
+	@Test
+	public void testBasic() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders");
+			b.build();
+			assertTrue(b.check());
+
+			Manifest manifest = b.getJar()
+				.getManifest();
+			assertEquals(A.class.getName(), manifest.getMainAttributes()
+				.getValue("Foo-Bundle-Activator"));
+		}
+	}
+
+	@Test
+	public void testMultiValueHeader() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders");
+			b.build();
+			assertTrue(b.check());
+
+			Manifest manifest = b.getJar()
+				.getManifest();
+			String value = manifest.getMainAttributes()
+				.getValue("Foo-Multi-Header");
+			Parameters params = new Parameters(value);
+			assertTrue(params.containsKey(B.class.getName()));
+			assertTrue(params.containsKey(C.class.getName()));
+		}
+	}
+
+	@Test
+	public void testMergeRepeated() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders");
+			b.build();
+			assertTrue(b.check());
+
+			Manifest manifest = b.getJar()
+				.getManifest();
+			assertEquals(D.class.getPackage()
+				.getName(),
+				manifest.getMainAttributes()
+					.getValue("Foo-Package-Header"));
+		}
+	}
+
+	@Test
+	public void testSingleton() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin"));
+			b.setPrivatePackage("test.annotationheaders.singleton");
+			b.build();
+			assertFalse("bundle should be invalid due to repeated use of singleton header annotation", b.check());
+			assertTrue(b.getErrors()
+				.get(0)
+				.contains("Repeated use"));
+		}
+	}
+
+}

--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/singleton/AnnotatedTypes.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/singleton/AnnotatedTypes.java
@@ -1,0 +1,16 @@
+package test.annotationheaders.singleton;
+
+import aQute.bnd.annotation.headers.BundleHeader;
+
+public class AnnotatedTypes {
+
+	@BundleHeader(name = "Singleton-Bundle-Header", singleton = true)
+	public static @interface SingletonBundleHeader {}
+
+	@SingletonBundleHeader
+	public static class A {}
+
+	@SingletonBundleHeader
+	public static class B {}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -30,6 +30,7 @@ import aQute.bnd.annotation.headers.BundleContributors;
 import aQute.bnd.annotation.headers.BundleCopyright;
 import aQute.bnd.annotation.headers.BundleDevelopers;
 import aQute.bnd.annotation.headers.BundleDocURL;
+import aQute.bnd.annotation.headers.BundleHeader;
 import aQute.bnd.annotation.headers.BundleLicense;
 import aQute.bnd.annotation.headers.Category;
 import aQute.bnd.annotation.headers.ProvideCapability;
@@ -113,6 +114,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 	static final String				BUNDLE_DEVELOPERS	= "aQute.bnd.annotation.headers.BundleDevelopers";
 	static final String				BUNDLE_CONTRIBUTORS	= "aQute.bnd.annotation.headers.BundleContributors";
 	static final String				BUNDLE_COPYRIGHT	= "aQute.bnd.annotation.headers.BundleCopyright";
+	static final String				BUNDLE_HEADER		= "aQute.bnd.annotation.headers.BundleHeader";
 	static final String				STD_REQUIREMENT		= "org.osgi.annotation.bundle.Requirement";
 	static final String				STD_REQUIREMENTS	= "org.osgi.annotation.bundle.Requirements";
 	static final String				STD_CAPABILITY		= "org.osgi.annotation.bundle.Capability";
@@ -192,6 +194,9 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 				break;
 			case REQUIRE_CAPABILITY :
 				doRequireCapability(annotation);
+				break;
+			case BUNDLE_HEADER :
+				doBundleHeader(annotation);
 				break;
 			case STD_CAPABILITIES :
 				Capability[] capabilities = annotation.getAnnotation(Capabilities.class)
@@ -304,6 +309,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 				case BUNDLE_DEVELOPERS :
 				case BUNDLE_DOC_URL :
 				case BUNDLE_LICENSE :
+				case BUNDLE_HEADER :
 				case PROVIDE_CAPABILITY :
 				case REQUIRE_CAPABILITY :
 					// Bnd annotations support merging of child
@@ -538,6 +544,21 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 		}
 
 		add(Constants.REQUIRE_CAPABILITY, s);
+	}
+
+	/*
+	 * Arbitrary bundle header annotation
+	 */
+	private void doBundleHeader(Annotation a) throws Exception {
+		final BundleHeader annotation = a.getAnnotation(BundleHeader.class);
+		String headerName = annotation.name()
+			.trim();
+		if (headerName.isEmpty())
+			throw new IllegalArgumentException("Bundle header name may not be empty, on type " + current);
+		if (annotation.singleton() && headers.containsKey(headerName))
+			throw new IllegalArgumentException(
+				"Repeated use of singleton header " + headerName + " on type " + current);
+		add(headerName, annotation.value());
 	}
 
 	private void replaceParameters(Attrs attrs) throws IllegalArgumentException {


### PR DESCRIPTION
Example:

```java
@BundleHeader(name = "Bundle-Activator", singleton=true)
public @interface BundleActivatorHeader {}

package org.example;
@BundleActivatorHeader
public class ExampleActivator implements BundleActivator { ... }
```

Output:

```
Bundle-Activator: org.example.ExampleActivator;