### PR TITLE
[xmldtoparser] Removed dependency

### DIFF
--- a/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
+++ b/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
@@ -160,12 +160,6 @@ public class DomDTOParser {
 		if (xmlAttribute != null)
 			return xmlAttribute.name();
 
-		try {
-			javax.xml.bind.annotation.XmlAttribute xmlAttribute2 = field
-				.getAnnotation(javax.xml.bind.annotation.XmlAttribute.class);
-			if (xmlAttribute2 != null)
-				return xmlAttribute2.name();
-		} catch (Throwable cnfe) {}
 		return null;
 	}
 


### PR DESCRIPTION
This was introduced in 4.1 so we do not need to
be backward compatible.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>