### PR TITLE
[properties parser] Quote escapes

### DIFF
--- a/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
+++ b/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
@@ -1,5 +1,10 @@
 package aQute.lib.utf8properties;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -7,18 +12,37 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Properties;
 
+import org.junit.Test;
+
 import aQute.lib.io.IO;
 import aQute.libg.reporter.ReporterAdapter;
 import aQute.service.reporter.Report.Location;
-import junit.framework.TestCase;
 
 /**
  * Test if we properly can read
  *
  * @author aqute
  */
-public class UTF8PropertiesTest extends TestCase {
+public class UTF8PropertiesTest {
 
+	@Test
+	public void testEscapedQuotesInQuotedStrings() throws IOException {
+		testProperty(
+			"Foo=foo;string.list2:List=\"a\\\\\"quote,a\\\\,comma, aSpace ,\\\\\"start,\\\\,start,end\\\\\",end\\\\,\"",
+			"Foo",
+			"foo;string.list2:List=\"a\\\"quote,a\\,comma, aSpace ,\\\"start,\\,start,end\\\",end\\,\"");
+		
+		testProperty("Foo=foo;foo=\"a\\'quote\"", "Foo", "foo;foo=\"a\'quote\"",
+			"Found backslash escaped quote character"); // foo;foo="a\'quote"
+		testProperty("Foo=foo;foo=\"a\\\\\"quote\"", "Foo", "foo;foo=\"a\\\"quote\""); // foo;foo="a\"quote"
+		testProperty("Foo=foo;foo=\"a\\\\\\\\\\\"quote\"", "Foo", "foo;foo=\"a\\\\\"quote\""); // foo;foo="a\\\"quote"
+		testProperty("Foo=foo;foo=\"a\\\\\\\\\"", "Foo", "foo;foo=\"a\\\\\""); // foo;foo="a\\\""
+		testProperty("Foo=foo;foo='a\\\\\"quote'", "Foo", "foo;foo='a\\\"quote'"); // foo;foo="a\"quote"
+		testProperty("Foo=foo;foo='a\"quote'", "Foo", "foo;foo='a\"quote'"); // foo;foo="a\"quote"
+
+	}
+
+	@Test
 	public void testNBSP() throws IOException {
 		testProperty("-instr: 'foo,\u202Fbar'", "-instr", "'foo,\u202Fbar'");
 		testProperty("-instr: \"foo,\u202Fbar\"", "-instr", "\"foo,\u202Fbar\"");
@@ -26,7 +50,6 @@ public class UTF8PropertiesTest extends TestCase {
 		testProperty("Bundle-Description: foo,\u202Fbar", "Bundle-Description", "foo,\u202Fbar");
 
 		testProperty("macro: foo,\u202Fbar", "macro", "foo,\u202Fbar");
-
 
 		testProperty("-exportcontents: foo,\u202Fbar", "-exportcontents", "foo,\u202Fbar",
 			"Non breaking space found \\[NARROW NO-BREAK SPACE");
@@ -38,6 +61,7 @@ public class UTF8PropertiesTest extends TestCase {
 			"Non breaking space found \\[NON BREAKING SPACE");
 	}
 
+	@Test
 	public void testMissingDelimeterAfterQuotedString() throws IOException {
 		assertError("-foo: bar='abc' ' '    ;", "-foo", 0,
 			"Found a quote ''' while expecting a delimeter. You should quote the whole values, you can use both single and double quotes:");
@@ -62,6 +86,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * Entries are generally expected to be a single line of the form, one of
 	 * the following: propertyName=propertyValue propertyName:propertyValue}
 	 */
+	@Test
 	public void testSpecificationAssignment() throws IOException {
 		testProperty("propertyName=propertyValue\n", "propertyName", "propertyValue");
 		testProperty("propertyName:propertyValue\n", "propertyName", "propertyValue");
@@ -72,6 +97,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * White space that appears between the property name and property value is
 	 * ignored, so the following are equivalent.
 	 */
+	@Test
 	public void testSpecificationValueSpaces() throws IOException {
 		testProperty("name=Stephen\n", "name", "Stephen");
 		testProperty("name = Stephen\n", "name", "Stephen");
@@ -82,6 +108,7 @@ public class UTF8PropertiesTest extends TestCase {
 	/*
 	 * White space at the beginning of the line is also ignored.
 	 */
+	@Test
 	public void testSpecificationKeySpaces() throws IOException {
 		testProperty("    name = Stephen\n", "name", "Stephen");
 		testProperty("    name = Stephen", "name", "Stephen");
@@ -91,6 +118,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * Lines that start with the comment characters ! or # are ignored. Blank
 	 * lines are also ignored.
 	 */
+	@Test
 	public void testSpecificationComments() throws IOException {
 		testProperty("\n\n# comment\n!comment\n\nfoo=bar", "foo", "bar");
 		testProperty("foo=bar\n# comment", "foo", "bar");
@@ -106,6 +134,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * lines are also ignored. Comments which end with \ must not continue to
 	 * next line.
 	 */
+	@Test
 	public void testSpecificationCommentContinuation() throws IOException {
 		testProperty("\n\n# comment\\\n!comment\\\n\nfoo=bar", "foo", "bar");
 		testProperty("foo=bar\n# comment\\", "foo", "bar");
@@ -121,6 +150,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * space following the property value is not ignored, and is treated as part
 	 * of the property value.
 	 */
+	@Test
 	public void testSpecificationWhitespaceValue() throws IOException {
 		testProperty("foo=bar ", "foo", "bar ");
 		testProperty("foo=bar \n", "foo", "bar ");
@@ -130,6 +160,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * A property value can span several lines if each line is terminated by a
 	 * backslash (‘\’) character. For example:
 	 */
+	@Test
 	public void testSpecificationContinutation() throws IOException {
 		testProperty("targetCities=\\\n" //
 			+ "        Detroit,\\\n" //
@@ -142,6 +173,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * The characters newline, carriage return, and tab can be inserted with
 	 * characters \n, \r, and \t, respectively.
 	 */
+	@Test
 	public void testSpecificationControlCharacters() throws IOException {
 		testProperty("control= \\t\\n\\r\n", "control", "\t\n\r");
 	}
@@ -150,6 +182,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * The backslash character must be escaped as a double backslash. For
 	 * example:
 	 */
+	@Test
 	public void testSpecificationBackslashes() throws IOException {
 		testProperty("path=c:\\\\docs\\\\doc1", "path", "c:\\docs\\doc1");
 	}
@@ -158,6 +191,7 @@ public class UTF8PropertiesTest extends TestCase {
 	 * UNICODE characters can be entered as they are in a Java program, using
 	 * the \\u prefix. For example, \u002c.
 	 */
+	@Test
 	public void testSpecificationUnicode() throws IOException {
 		testProperty("unicode=\\u002c\n", "unicode", ",");
 		testProperty("unicode=\\uFEF0\n", "unicode", "\uFEF0");
@@ -166,12 +200,14 @@ public class UTF8PropertiesTest extends TestCase {
 	/*
 	 * You can have control characters in keys
 	 */
+	@Test
 	public void testControlCharactersInKeys() throws IOException {
 		testProperty("key\\ key = value\n", "key key", "value", "Found |Invalid");
 		testProperty("key\\u002Ckey = value\n", "key,key", "value", "Found |Invalid");
 		testProperty("key\\:key = value\n", "key:key", "value", "Found |Invalid");
 	}
 
+	@Test
 	public void testEmptyContinuations() throws IOException {
 		testProperty("-plugin: \\\n\\\n\\\nabc", "-plugin", "abc");
 		testProperty("-plugin: \\\n\\\n\\\nabc\n", "-plugin", "abc");
@@ -179,6 +215,7 @@ public class UTF8PropertiesTest extends TestCase {
 		testProperty("-plugin: \\\n  \\\n  \\\n    abc\n", "-plugin", "abc");
 	}
 
+	@Test
 	public void testEmptyKey() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -189,6 +226,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testEmptySpace() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -198,6 +236,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testNewlineCr() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -208,6 +247,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testEscapedNewlinEmpty() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -217,6 +257,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testPackageinfo() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -226,6 +267,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testPackageinfoWithCrLf() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
@@ -235,6 +277,7 @@ public class UTF8PropertiesTest extends TestCase {
 
 	}
 
+	@Test
 	public void testErrorsInParsing() throws IOException {
 		assertError("\n\n\n\n\n\n\n" //
 			+ "a;b=9", "a;b", 7, "Invalid property key: `a;b`:");
@@ -254,54 +297,61 @@ public class UTF8PropertiesTest extends TestCase {
 		up.load(string, IO.getFile("foo"), ra);
 		assertNotNull("No '" + key + "' property found", up.getProperty(key));
 		if (check.length == 0)
-			assertEquals(0, ra.getErrors()
+			assertEquals(0, ra.getWarnings()
 				.size());
 		else {
-			assertTrue(ra.getErrors()
+			assertTrue(ra.getWarnings()
 				.size() > 0);
-			Location location = ra.getLocation(ra.getErrors()
+			Location location = ra.getLocation(ra.getWarnings()
 				.get(0));
 			assertEquals("Faulty line number", line, location.line);
 		}
 		assertTrue(ra.check(check));
 	}
 
+	@Test
 	public void testBackslashEncodingWithReader() throws IOException {
 		Properties p = new UTF8Properties();
 		p.load(new StringReader("x=abc \\\\ def\n"));
 		assertEquals("abc \\ def", p.get("x"));
 	}
 
+	@Test
 	public void testISO8859Encoding() throws IOException {
 		Properties p = new UTF8Properties();
 		p.load(new ByteArrayInputStream(("x=" + trickypart + "\n").getBytes("ISO-8859-1")));
 		assertEquals(trickypart, p.get("x"));
 	}
 
+	@Test
 	public void testUTF8Encoding() throws IOException {
 		Properties p = new UTF8Properties();
 		p.load(new ByteArrayInputStream(("x=" + trickypart + "\n").getBytes("UTF-8")));
 		assertEquals(trickypart, p.get("x"));
 	}
 
+	@Test
 	public void testShowUTF8PropertiesDoNotSkipBackslash() throws IOException {
 		Properties p = new UTF8Properties();
 		p.load(new ByteArrayInputStream("x=abc \\ def\n".getBytes("UTF-8")));
 		assertEquals("abc  def", p.get("x"));
 	}
 
+	@Test
 	public void testShowPropertiesSkipBackslash() throws IOException {
 		Properties p = new Properties();
 		p.load(new StringReader("x=abc \\ def\n"));
 		assertEquals("abc  def", p.get("x"));
 	}
 
+	@Test
 	public void testContinuation() throws IOException {
 		Properties p = new Properties();
 		p.load(new StringReader("x=abc \\\n        def\n"));
 		assertEquals("abc def", p.get("x"));
 	}
 
+	@Test
 	public void testWriteWithoutComment() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		p.put("Foo", "Foo");
@@ -313,6 +363,7 @@ public class UTF8PropertiesTest extends TestCase {
 		assertTrue("Foo should be in there", s.contains("Foo"));
 	}
 
+	@Test
 	public void testWrite() throws IOException {
 		UTF8Properties p = new UTF8Properties();
 		p.put("Foo", "Foo");
@@ -341,7 +392,7 @@ public class UTF8PropertiesTest extends TestCase {
 		UTF8Properties p = new UTF8Properties();
 		ReporterAdapter ra = new ReporterAdapter();
 		p.load(content, null, ra, new String[] {
-			"Export-Package", "Private-Package", "Import-Package"
+			"Export-Package", "Private-Package", "Import-Package", "Provide-Capability", "Foo"
 		});
 
 		if (check == null)

--- a/biz.aQute.bndlib.tests/src/test/PropertiesTest.java
+++ b/biz.aQute.bndlib.tests/src/test/PropertiesTest.java
@@ -115,16 +115,12 @@ public class PropertiesTest extends TestCase {
 		analyzer.setProperties(IO.getFile("src/test/badproperties.prop"));
 		String s = analyzer.getProperty(Constants.IMPORT_PACKAGE);
 		Parameters map = analyzer.parseHeader(s);
+		analyzer.check("This is allowed in a properties file but not in bnd to prevent mistakes:",
+			"No value specified for key: my.package",
+			"Empty clause, usually caused by repeating a comma without any name field or by having space");
 		assertEquals(2, map.size());
 		assertTrue(map.containsKey("org.osgi.service.cm"));
 		assertTrue(map.containsKey("org.osgi.util.tracker"));
-		assertEquals(1, analyzer.getWarnings()
-			.size());
-		System.err.println(analyzer.getWarnings());
-		assertTrue(analyzer.getWarnings()
-			.get(0)
-			.contains("Empty clause, usually caused by repeating a comma without"));
-		System.err.println(analyzer.getWarnings());
 	}
 
 	public static void testProperties() throws Exception {


### PR DESCRIPTION
- Fixed escaping quotes in quoted strings 
  the properties parser in test mode assumed
  that an unescaped quote always signals the end
  of the quoted string. However, if it is preceded
  by an odd number of backslashes in the output
  then it will be escaped by the OSGi header parser

- Moved test to JUnit 4


Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>