### PR TITLE
Bnd runtests fix

### DIFF
--- a/aQute.libg/src/aQute/lib/io/FileTree.java
+++ b/aQute.libg/src/aQute/lib/io/FileTree.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -28,6 +29,9 @@ public class FileTree {
 	 *            {@link #getFiles(File, String)}.
 	 */
 	protected void addFile(File file) {
+		if (file == null) {
+			return;
+		}
 		if (!files.contains(file)) {
 			files.add(file);
 		}
@@ -36,43 +40,68 @@ public class FileTree {
 	/**
 	 * Add an Ant-style glob to the include patterns.
 	 * 
-	 * @param include Add an Ant-style glob
+	 * @param includes Add an Ant-style glob
 	 */
-	public void addInclude(String include) {
-		includes.add(AntGlob.toPattern(include));
+	public void addIncludes(List<String> includes) {
+		if (includes == null) {
+			return;
+		}
+		for (String include : includes) {
+			if (include == null) {
+				continue;
+			}
+			this.includes.add(AntGlob.toPattern(include));
+		}
 	}
 
 	/**
 	 * Add an Ant-style glob to the include patterns.
 	 * 
-	 * @param addIncludes Add an Ant-style glob
+	 * @param includes Add an Ant-style glob
 	 */
-	public void addIncludes(List<String> addIncludes) {
-		for (String include : addIncludes) {
-
-			includes.add(AntGlob.toPattern(include));
+	public void addIncludes(String... includes) {
+		if (includes == null) {
+			return;
+		}
+		for (String include : includes) {
+			if (include == null) {
+				continue;
+			}
+			this.includes.add(AntGlob.toPattern(include));
 		}
 	}
 
 	/**
 	 * Add an Ant-style glob to the exclude patterns.
 	 * 
-	 * @param exclude Add an Ant-style glob
+	 * @param excludes Add an Ant-style glob
 	 */
-	public void addExclude(String exclude) {
-		excludes.add(AntGlob.toPattern(exclude));
+	public void addExcludes(String... excludes) {
+		if (excludes == null) {
+			return;
+		}
+		for (String exclude : excludes) {
+			if (exclude == null) {
+				continue;
+			}
+			this.excludes.add(AntGlob.toPattern(exclude));
+		}
 	}
 
 	/**
 	 * Add an Ant-style glob to the exclude patterns.
 	 * 
-	 * @param addExcludes Add an Ant-style glob
+	 * @param excludes Add an Ant-style glob
 	 */
-	public void addExcludes(List<String> addExcludes) {
-
-		for (String exclude : addExcludes) {
-
-			excludes.add(AntGlob.toPattern(exclude));
+	public void addExcludes(List<String> excludes) {
+		if (excludes == null) {
+			return;
+		}
+		for (String exclude : excludes) {
+			if (exclude == null) {
+				continue;
+			}
+			this.excludes.add(AntGlob.toPattern(exclude));
 		}
 	}
 
@@ -86,22 +115,44 @@ public class FileTree {
 	 * @return A list of files.
 	 * @throws IOException If an exception occurs.
 	 */
-	public List<File> getFiles(File baseDir, List<String> defaultIncludes) throws IOException {
-
-		List<Pattern> includePatterns = includes.isEmpty() && files.isEmpty() && (defaultIncludes != null)
-			? defaultIncludes.stream()
-				.map(AntGlob::toPattern)
-				.collect(toList())
-			: includes;
-		if (includePatterns.isEmpty()) {
-			return files;
+	public List<File> getFiles(File baseDir, String... defaultIncludes) throws IOException {
+		if (includes.isEmpty() && files.isEmpty() && (defaultIncludes != null) && (defaultIncludes.length > 0)) {
+			return getFiles(baseDir, toPatterns(Stream.of(defaultIncludes)), excludes);
 		}
-		List<Pattern> excludePatterns = excludes;
+		return getFiles(baseDir, includes, excludes);
+	}
 
+	private List<Pattern> toPatterns(Stream<String> globs) {
+		return globs.filter(Objects::nonNull)
+			.map(AntGlob::toPattern)
+			.collect(toList());
+	}
+
+	/**
+	 * Return a list of files using the specified baseDir and the configured
+	 * include and exclude Ant-style glob expressions.
+	 * 
+	 * @param baseDir The base directory for locating files.
+	 * @param defaultIncludes The default include patterns to use if no include
+	 *            patterns were configured.
+	 * @return A list of files.
+	 * @throws IOException If an exception occurs.
+	 */
+	public List<File> getFiles(File baseDir, List<String> defaultIncludes) throws IOException {
+		if (includes.isEmpty() && files.isEmpty() && (defaultIncludes != null) && !defaultIncludes.isEmpty()) {
+			return getFiles(baseDir, toPatterns(defaultIncludes.stream()), excludes);
+		}
+		return getFiles(baseDir, includes, excludes);
+	}
+
+	private List<File> getFiles(File baseDir, List<Pattern> includePatterns, List<Pattern> excludePatterns)
+		throws IOException {
+		if (includePatterns.isEmpty()) {
+			return new ArrayList<>(files);
+		}
 		Path basePath = baseDir.toPath();
 		try (Stream<Path> walker = Files.walk(basePath)
 			.skip(1)) {
-
 			List<File> result = Stream.concat(files.stream(), //
 				walker.filter(p -> {
 					String path = basePath.relativize(p)

--- a/biz.aQute.bnd/src/aQute/bnd/main/ResolveCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/ResolveCommand.java
@@ -1,7 +1,6 @@
 package aQute.bnd.main;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -261,7 +260,7 @@ public class ResolveCommand extends Processor {
 	@Description("Resolve a bndrun file")
 	public void _resolve(ResolveOptions options) throws Exception {
 
-		HandledProjectWorkspaceOptions hwpo = bnd.handleOptions(options, Arrays.asList(aQute.bnd.main.bnd.BNDRUN_ALL));
+		HandledProjectWorkspaceOptions hwpo = bnd.handleOptions(options, aQute.bnd.main.bnd.BNDRUN_ALL);
 
 		for (File f : hwpo.files()) {
 			if (options.verbose()) {

--- a/biz.aQute.bnd/test/aQute/bnd/main/testrules/WatchedTemporaryFolder.java
+++ b/biz.aQute.bnd/test/aQute/bnd/main/testrules/WatchedTemporaryFolder.java
@@ -3,6 +3,7 @@ package aQute.bnd.main.testrules;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -23,6 +24,20 @@ public class WatchedTemporaryFolder extends TemporaryFolder implements WatchedFo
 	private Map<Path, String>		snapshotData	= Collections.unmodifiableMap(new HashMap<>());
 
 	private Function<Path, String>	snapshotFunc	= p -> "";
+
+	public WatchedTemporaryFolder() {
+		super(getParent());
+	}
+
+	private static File getParent() {
+		File parent = new File("generated/tmp/test").getAbsoluteFile();
+		try {
+			IO.mkdirs(parent);
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		return parent;
+	}
 
 	@Override
 	public Path getRootPath() {

--- a/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -118,7 +118,7 @@ public class BaselineMojo extends AbstractMojo {
 							"The baselining check failed when checking {} against {} but the bnd-baseline-maven-plugin is configured not to fail the build.",
 							artifact, artifactResult.getArtifact());
 					} else {
-						throw new MojoExecutionException("The baselining plugin detected versioning errors");
+						throw new MojoFailureException("The baselining plugin detected versioning errors");
 					}
 				} else {
 					logger.info("Baselining check succeeded checking {} against {}", artifact,
@@ -126,13 +126,13 @@ public class BaselineMojo extends AbstractMojo {
 				}
 			} else {
 				if (failOnMissing) {
-					throw new MojoExecutionException("Unable to locate a previous version of the artifact");
+					throw new MojoFailureException("Unable to locate a previous version of the artifact");
 				} else {
 					logger.warn("No previous version of {} could be found to baseline against", artifact);
 				}
 			}
 		} catch (RepositoryException re) {
-			throw new MojoExecutionException("Unable to locate a previous version of the artifact", re);
+			throw new MojoFailureException("Unable to locate a previous version of the artifact", re);
 		} catch (Exception e) {
 			throw new MojoExecutionException("An error occurred while calculating the baseline", e);
 		}

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -127,7 +127,7 @@ public class ExportMojo extends AbstractMojo {
 		}
 
 		if (errors > 0)
-			throw new MojoExecutionException(errors + " errors found");
+			throw new MojoFailureException(errors + " errors found");
 	}
 
 	private void export(File runFile, FileSetRepository fileSetRepository, Processor processor) throws Exception {

--- a/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -105,7 +105,7 @@ public class ExportMojo extends AbstractMojo {
 				system);
 
 			FileSetRepository fileSetRepository = dependencyResolver.getFileSetRepository(project.getName(),
-				bundles.getFiles(project.getBasedir(), null),
+				bundles.getFiles(project.getBasedir()),
 				useMavenDependencies);
 
 			if (exporter == null) {

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -211,7 +211,7 @@ public class IndexerMojo extends AbstractMojo {
 			throw new MojoExecutionException(e.getMessage(), e);
 		}
 		if (fail) {
-			throw new MojoExecutionException("One or more URI lookups failed");
+			throw new MojoFailureException("One or more URI lookups failed");
 		}
 		attach(outputFile, "osgi-index", "xml");
 

--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/LocalIndexerMojo.java
@@ -72,11 +72,9 @@ public class LocalIndexerMojo extends AbstractMojo {
 		logger.debug("Producing additional gzip index: {}", includeGzip);
 		logger.debug("URI paths will be relative to: {}", baseFile);
 
-		List<File> toIndex = indexFiles.getFiles(inputDir, "**/*.jar");
-
-		logger.debug("Included files: {}", toIndex);
-
 		try {
+			List<File> toIndex = indexFiles.getFiles(inputDir, "**/*.jar");
+			logger.debug("Included files: {}", toIndex);
 			IO.mkdirs(outputFile.getParentFile());
 			new SimpleIndexer().files(toIndex)
 				.base(baseFile.toURI())

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -39,6 +39,7 @@ import org.apache.maven.model.PluginManagement;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -135,7 +136,7 @@ public class BndMavenPlugin extends AbstractMojo {
 	private File									propertiesFile;
 
 	@Override
-	public void execute() throws MojoExecutionException {
+	public void execute() throws MojoExecutionException, MojoFailureException {
 		if (skip) {
 			logger.debug("skip project as configured");
 			return;
@@ -280,7 +281,7 @@ public class BndMavenPlugin extends AbstractMojo {
 
 			// Finally, report
 			reportErrorsAndWarnings(builder);
-		} catch (MojoExecutionException e) {
+		} catch (MojoExecutionException | MojoFailureException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new MojoExecutionException("bnd error: " + e.getMessage(), e);
@@ -378,7 +379,7 @@ public class BndMavenPlugin extends AbstractMojo {
 		return new Xpp3Dom("configuration");
 	}
 
-	private void reportErrorsAndWarnings(Builder builder) throws MojoExecutionException {
+	private void reportErrorsAndWarnings(Builder builder) throws MojoFailureException {
 		@SuppressWarnings("unchecked")
 		Collection<File> markedFiles = (Collection<File>) buildContext.getValue(MARKED_FILES);
 		if (markedFiles == null) {
@@ -419,9 +420,9 @@ public class BndMavenPlugin extends AbstractMojo {
 		buildContext.setValue(MARKED_FILES, markedFiles);
 		if (!builder.isOk()) {
 			if (errors.size() == 1)
-				throw new MojoExecutionException(errors.get(0));
+				throw new MojoFailureException(errors.get(0));
 			else
-				throw new MojoExecutionException("Errors in bnd processing, see log for details.");
+				throw new MojoFailureException("Errors in bnd processing, see log for details.");
 		}
 	}
 

--- a/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -101,7 +101,7 @@ public class ResolverMojo extends AbstractMojo {
 		}
 
 		if (errors > 0)
-			throw new MojoExecutionException(errors + " errors found");
+			throw new MojoFailureException(errors + " errors found");
 	}
 
 	private void resolve(File runFile, FileSetRepository fileSetRepository, Processor processor) throws Exception {

--- a/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
+++ b/maven/bnd-shared-maven-lib/src/main/java/aQute/bnd/maven/lib/configuration/FileTree.java
@@ -1,39 +1,9 @@
 package aQute.bnd.maven.lib.configuration;
 
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
+public class FileTree extends aQute.lib.io.FileTree {
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-
-import org.apache.maven.plugin.MojoExecutionException;
-
-import aQute.libg.glob.AntGlob;
-
-public class FileTree {
-	private List<File>		files		= new ArrayList<>();
-	private List<Pattern>	includes	= new ArrayList<>();
-	private List<Pattern>	excludes	= new ArrayList<>();
-
-	public FileTree() {}
-
-	/**
-	 * Can be used by subclasses to add specific files to the return value of
-	 * {@link #getFiles(File, String)}.
-	 * 
-	 * @param file A file to include in the return value of
-	 *            {@link #getFiles(File, String)}.
-	 */
-	protected void addFile(File file) {
-		if (!files.contains(file)) {
-			files.add(file);
-		}
+	public FileTree() {
+		super();
 	}
 
 	/**
@@ -42,7 +12,7 @@ public class FileTree {
 	 * @param include Add an Ant-style glob
 	 */
 	public void setInclude(String include) {
-		includes.add(AntGlob.toPattern(include));
+		addIncludes(include);
 	}
 
 	/**
@@ -51,49 +21,7 @@ public class FileTree {
 	 * @param exclude Add an Ant-style glob
 	 */
 	public void setExclude(String exclude) {
-		excludes.add(AntGlob.toPattern(exclude));
+		addExcludes(exclude);
 	}
 
-	/**
-	 * Return a list of files using the specified baseDir and the configured
-	 * include and exclude Ant-style glob expressions.
-	 * 
-	 * @param baseDir The base directory for locating files.
-	 * @param defaultInclude The default include pattern to use of no include
-	 *            patterns were configured.
-	 * @return A list of files.
-	 * @throws MojoExecutionException If an exception occurs.
-	 */
-	public List<File> getFiles(File baseDir, String defaultInclude) throws MojoExecutionException {
-		List<Pattern> includePatterns = includes.isEmpty() && files.isEmpty() && (defaultInclude != null)
-			? singletonList(AntGlob.toPattern(defaultInclude))
-			: includes;
-		if (includePatterns.isEmpty()) {
-			return files;
-		}
-		List<Pattern> excludePatterns = excludes;
-
-		Path basePath = baseDir.toPath();
-		try (Stream<Path> walker = Files.walk(basePath)
-			.skip(1)) { // skip basePath itself
-			List<File> result = Stream.concat(files.stream(), //
-				walker.filter(p -> {
-					String path = basePath.relativize(p)
-						.toString();
-					return includePatterns.stream()
-						.anyMatch(i -> i.matcher(path)
-							.matches())
-						&& !excludePatterns.stream()
-							.anyMatch(e -> e.matcher(path)
-								.matches());
-				})
-					.sorted()
-					.map(Path::toFile))
-				.distinct()
-				.collect(toList());
-			return result;
-		} catch (IOException ioe) {
-			throw new MojoExecutionException(ioe.getMessage(), ioe);
-		}
-	}
 }

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -139,7 +139,7 @@ public class TestingMojo extends AbstractMojo {
 		}
 
 		if (errors > 0)
-			throw new MojoExecutionException(errors + " errors found");
+			throw new MojoFailureException(errors + " errors found");
 	}
 
 	private List<String> getTests() {


### PR DESCRIPTION
The `bnd runtests` command was broken for the OSGi CT execution. runtests must not require or search for a "real" workspace folder. It must either use the specified folder or the current working directory for the workspace. 

This PR also includes a number of other fixes/improvements made concurrently with fixing runtests behavior.