### PR TITLE
[junit] Groovy test case method names

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.Vector;
 import java.util.regex.Pattern;
 
@@ -293,18 +292,8 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 
 			bundle = findHost(bundle);
 
-			List<String> names = new ArrayList<>();
-			StringTokenizer st = new StringTokenizer(testnames, " ,");
-
-			//
-			// Collect the test names and remove any duplicates
-			//
-
-			while (st.hasMoreTokens()) {
-				String token = st.nextToken();
-				if (!names.contains(token))
-					names.add(token);
-			}
+			List<String> names = Arrays.asList(testnames.trim()
+				.split(",\\s*"));
 
 			List<TestReporter> reporters = new ArrayList<>();
 			final TestResult result = new TestResult();


### PR DESCRIPTION
In Groovy it is possible (and stupid) to name
methods with a quoted string. 

Don't handle the case yet when the method name contains a comma ... Not sure how to handle that since the name 
comes from Eclipse JUnit so we can't escape as I recall.

Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>