### PR TITLE
Issue #1930: Set refresh to true when refreshing

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/osgi/OSGiIndex.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/osgi/OSGiIndex.java
@@ -64,6 +64,15 @@ class OSGiIndex {
 		return bridge;
 	}
 
+	/**
+	 * Return the bridge repository in {@link Promise} form.
+	 * 
+	 * @return promise representing the repository
+	 */
+	Promise<BridgeRepository> getBridgeRepository() {
+		return this.repository;
+	}
+
 	private static File checkCache(File cache) throws Exception {
 		IO.mkdirs(cache);
 		if (!cache.isDirectory())


### PR DESCRIPTION
The refresh() method in OSGiRepository invoked getIndex with refresh set to false. This meant that the index was not updated even though it was changed. The current test tests whether or not refreshing the repository actually updates the index by checking their last modified times. Furthermore, the added tests checks whether refreshing notifies RepositoryListenerPlugin instances.