### PR TITLE
[component] Service-Component & wildcards

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/component/WildcardComponents.java
+++ b/biz.aQute.bndlib.tests/src/test/component/WildcardComponents.java
@@ -1,0 +1,92 @@
+package test.component;
+
+import java.io.File;
+import java.util.jar.Manifest;
+
+import org.osgi.service.component.annotations.Component;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import aQute.lib.io.IO;
+import junit.framework.TestCase;
+
+/**
+ * The Service-Component header is cleaned up when it contains wildcards. The
+ * wildcards are matched against the actual file paths. If they overlap, the
+ * actual file paths are removed. If the Service-Component header is not set
+ * then the names are not touched.
+ */
+public class WildcardComponents extends TestCase {
+	@Component
+	static class WildcardTestComponent {}
+
+	/**
+	 * Test to see if we ignore scala.ScalaObject as interface
+	 * 
+	 * @throws Exception
+	 */
+	public void testWildcardSpecMatchingOldStyleComponents() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/com.test.scala.jar"));
+			b.setProperty("Service-Component", "OSGI-INF/*.xml,not.matching.path.xml,com.test.scala.Service");
+			b.setIncludeResource("not.matching.path.xml;literal=''");
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String value = m.getMainAttributes()
+				.getValue("Service-Component");
+			assertEquals("OSGI-INF/*.xml,not.matching.path.xml", value);
+		}
+	}
+
+	public void testAnnotationsAndNoHeader() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.DSANNOTATIONS, "test.component.*WildcardTestComponent");
+			b.setProperty("Private-Package", "test.component");
+			b.addClasspath(new File("bin"));
+
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			String value = jar.getManifest()
+				.getMainAttributes()
+				.getValue("Service-Component");
+			assertEquals("OSGI-INF/test.component.WildcardComponents$WildcardTestComponent.xml", value);
+		}
+	}
+
+	public void testWildcardWithAnnotations() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.DSANNOTATIONS, "test.component.*WildcardTestComponent");
+			b.setProperty("Private-Package", "test.component");
+			b.setProperty(Constants.SERVICE_COMPONENT, "OSGI-INF/*.xml");
+			b.addClasspath(new File("bin"));
+
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			String value = jar.getManifest()
+				.getMainAttributes()
+				.getValue("Service-Component");
+			assertEquals("OSGI-INF/*.xml", value);
+		}
+	}
+
+	public void testWildcardNotMatching() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/com.test.scala.jar"));
+			b.setProperty("Service-Component", "BLABLA/*.xml,foo.bar.xml,com.test.scala.Service");
+			b.setIncludeResource("foo.bar.xml;literal=''");
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String value = m.getMainAttributes()
+				.getValue("Service-Component");
+			assertEquals("BLABLA/*.xml,foo.bar.xml,OSGI-INF/com.test.scala.Service.xml", value);
+		}
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
@@ -171,11 +171,29 @@ public class DSAnnotations implements AnalyzerPlugin {
 			maxVersion = ComponentDef.max(maxVersion, AnnotationReader.V1_3);
 			addExtenderRequirement(requires, maxVersion);
 		}
+		names = removeOverlapInServiceComponentHeader(names);
 		sc = Processor.append(names.toArray(new String[0]));
 		analyzer.setProperty(Constants.SERVICE_COMPONENT, sc);
 		updateHeader(analyzer, Constants.REQUIRE_CAPABILITY, requires);
 		updateHeader(analyzer, Constants.PROVIDE_CAPABILITY, provides);
 		return false;
+	}
+
+	public static List<String> removeOverlapInServiceComponentHeader(Collection<String> names) {
+		List<String> wildcards = new ArrayList<>(names);
+		wildcards.removeIf(name -> !name.contains("*"));
+
+		Instructions wildcardedPaths = new Instructions(wildcards);
+		if (wildcardedPaths.isEmpty())
+			return new ArrayList<>(names);
+
+		List<String> actual = new ArrayList<>();
+		for (String name : names) {
+			if (!name.contains("*") && wildcardedPaths.matches(name))
+				continue;
+			actual.add(name);
+		}
+		return actual;
 	}
 
 	private void addServiceCapability(String[] objectClass, Set<String> provides) {

--- a/biz.aQute.bndlib/src/aQute/bnd/make/component/ServiceComponent.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/component/ServiceComponent.java
@@ -4,10 +4,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Pattern;
 
+import aQute.bnd.component.DSAnnotations;
 import aQute.bnd.component.HeaderReader;
 import aQute.bnd.component.TagResource;
 import aQute.bnd.header.Attrs;
@@ -21,6 +24,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.osgi.Verifier;
 import aQute.bnd.service.AnalyzerPlugin;
+import aQute.lib.strings.Strings;
 import aQute.lib.tag.Tag;
 
 /**
@@ -36,9 +40,12 @@ public class ServiceComponent implements AnalyzerPlugin {
 
 		ComponentMaker m = new ComponentMaker(analyzer);
 
-		Map<String, Map<String, String>> l = m.doServiceComponent();
+		Set<String> l = m.doServiceComponent()
+			.keySet();
 
-		analyzer.setProperty(Constants.SERVICE_COMPONENT, Processor.printClauses(l));
+		List<String> names = DSAnnotations.removeOverlapInServiceComponentHeader(l);
+
+		analyzer.setProperty(Constants.SERVICE_COMPONENT, Strings.join(names));
 
 		analyzer.getInfo(m, Constants.SERVICE_COMPONENT + ": ");
 		m.close();


### PR DESCRIPTION
PDE projects tend to have a Service-Component
header like "OSGI-INF/*.xml", which is valid
SCR header. However, this clashes with the bnd
generation since it will append the xml file paths
to the end of this header. SCR will then see 
components twice. Once matched by the wildcard
and once literal.

Unfortunately, many PDE projects are in progress
to moving the annotations based components so they 
have a hybrid situation. This makes it impossible 
for them to remove the Service-Component wildcard 
since then no longer the hardcoded files are found.

Rock and a hard place.

So this patch will match the calculated paths
in the old ServiceComponent class  and the more
modern DSAnnotations class against any wildcard
patterns. The static method that does this is located
in DSAnnotations.

Sucks but after trying to find alternatives this turned
out to be the best solution.



Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>