### PR TITLE
[tester] Fragments & Lazy

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -250,7 +250,7 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 
 	void checkBundle(List<Bundle> queue, Bundle bundle) {
 		Bundle host = findHost(bundle);
-		if (host.getState() == Bundle.ACTIVE) {
+		if (host.getState() == Bundle.ACTIVE || host.getState() == Bundle.STARTING) {
 			String testcases = (String) bundle.getHeaders()
 				.get(aQute.bnd.osgi.Constants.TESTCASES);
 			if (testcases != null) {


### PR DESCRIPTION
This patch makes the tester handle the case that the
host of a fragment is lazy. The code did not take
STARTING hosts as active so it though the fragment host
was not alive yet.

There can be no confusion with a hanging activator
since the launcher would have reported that as an error.





Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>