### PR TITLE
[fragments] No Import of host

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/fragments/FragmentTest.java
+++ b/biz.aQute.bndlib.tests/src/test/fragments/FragmentTest.java
@@ -1,0 +1,67 @@
+package test.fragments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.lib.io.IO;
+
+public class FragmentTest {
+
+	Builder init() throws IOException {
+		Builder b = new Builder();
+		b.addClasspath(IO.getFile("bin"));
+		b.addClasspath(IO.getFile("jar/osgi.jar"));
+		b.setExportPackage("test.fragments.imports");
+		return b;
+	}
+
+	@Test
+	public void simple() throws Exception {
+		try (Builder b = init()) {
+			b.setProperty(Constants.FRAGMENT_HOST, "osgi;bundle-version=4");
+			b.build();
+			assertTrue(b.check());
+
+			assertThat(b.getImports()
+				.keySet()).containsExactly(b.getPackageRef("javax.net.ssl"));
+		}
+	}
+
+	@Test
+	public void unmatchedVersion() throws Exception {
+		try (Builder b = init()) {
+			b.setProperty(Constants.FRAGMENT_HOST, "osgi;bundle-version=5");
+			b.build();
+			assertTrue(b.check("Host osgi=bundle-version=5"));
+			assertThat(b.getImports()
+				.keySet()).containsExactly(b.getPackageRef("javax.net.ssl"), b.getPackageRef("org.osgi.framework"));
+		}
+	}
+
+	@Test
+	public void noVersion() throws Exception {
+		try (Builder b = init()) {
+			b.setProperty(Constants.FRAGMENT_HOST, "osgi");
+			b.build();
+			assertTrue(b.check());
+			assertThat(b.getImports()
+				.keySet()).containsExactly(b.getPackageRef("javax.net.ssl"));
+		}
+	}
+
+	@Test
+	public void notAFragment() throws Exception {
+		try (Builder b = init()) {
+			b.build();
+			assertTrue(b.check());
+			assertThat(b.getImports()
+				.keySet()).containsExactly(b.getPackageRef("javax.net.ssl"), b.getPackageRef("org.osgi.framework"));
+		}
+	}
+}

--- a/biz.aQute.bndlib.tests/src/test/fragments/imports/ImportFramework.java
+++ b/biz.aQute.bndlib.tests/src/test/fragments/imports/ImportFramework.java
@@ -1,0 +1,10 @@
+package test.fragments.imports;
+
+import javax.net.ssl.TrustManager;
+
+import org.osgi.framework.ServiceEvent;
+
+public class ImportFramework {
+	ServiceEvent	se;
+	TrustManager	manager;
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
@@ -247,4 +247,17 @@ public class VersionRange {
 		return high == Version.HIGHEST;
 	}
 
+	public static VersionRange likeOSGi(String version) {
+		if (version == null) {
+			return new VersionRange(Version.LOWEST, Version.HIGHEST);
+		}
+
+		if (Version.isVersion(version)) {
+			return new VersionRange(new Version(version), Version.HIGHEST);
+		}
+		if (isVersionRange(version)) {
+			return new VersionRange(version);
+		}
+		return null;
+	}
 }

--- a/docs/_heads/fragment_host.md
+++ b/docs/_heads/fragment_host.md
@@ -4,19 +4,11 @@ class: Header
 title: Fragment-Host       ::= bundle-description 
 summary: The Fragment-Host header defines the host bundles for this fragment.
 ---
-	
-	The Fragment-Host manifest header links the fragment to its potential hosts. It must conform to the following syntax:
-Fragment-Host       ::= bundle-description
-bundle-description  ::= symbolic-name
-                            ( ';' parameter )* // See 1.3.2
-The following directives are architected by the Framework for Fragment-Host:
-• extension - Indicates this extension is a system or boot class path extension. It is only applica- ble when the Fragment-Host is the System Bundle. This is discussed in Extension Bundles on page 85. The following values are supported:
-• framework - The fragment bundle is a Framework extension bundle (default).
-• bootclasspath - The fragment bundle is a boot class path extension bundle.
-The fragment must be the bundle symbolic name of the implementation specific system bundle or the alias system.bundle. The Framework should fail to install an extension bundle when the bundle symbolic name is not referring to the system bundle.
-The following attributes are architected by the Framework for Fragment-Host:
-• bundle-version - The version range to select the host bundle. If a range is used, then the frag- ment can attach to multiple hosts. See Semantic Versioning on page 54. The default value is [0.0.0,∞).
-The Fragment-Host header can assert arbitrary attributes that must be matched before a host is eligi- ble.
-	
-	
-		verifyDirectives(Constants.FRAGMENT_HOST, "extension:", SYMBOLICNAME, "bsn");
+
+The Fragment-Host manifest header links the fragment to its potential _hosts_. A fragment bundle is loaded in the 
+same class loader as the _host_ that it will be attached to in runtime. When a fragment is attached to its host,
+then some headers are _merged_. One of those headers is the Import Package header.
+
+bnd will calculate the references without taking the host into account. If the fragment uses packages from the host, 
+quite likely, then these would result in imports. For this reason, bnd will subtract any package that can be found
+in the host from the import.


### PR DESCRIPTION
A fragment is loaded in the same class loader
as the host. It is therefore wrong to import
any package that is defined in the host of
a fragment.

This change will subtract all host packages from the references.


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>