### PR TITLE
Improve TYPE_USE support of annotations

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/ClazzTest.java
+++ b/biz.aQute.bndlib.tests/src/test/ClazzTest.java
@@ -1,12 +1,16 @@
 package test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.Serializable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import org.xml.sax.SAXException;
@@ -18,6 +22,7 @@ import aQute.bnd.osgi.Annotation;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.ClassDataCollector;
 import aQute.bnd.osgi.Clazz;
+import aQute.bnd.osgi.Clazz.FieldDef;
 import aQute.bnd.osgi.Clazz.MethodDef;
 import aQute.bnd.osgi.Clazz.QUERY;
 import aQute.bnd.osgi.Descriptors;
@@ -401,11 +406,21 @@ public class ClazzTest extends TestCase {
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
+				int	target_index;
+				int	target_type;
+
+				@Override
+				public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+					this.target_type = target_type;
+					this.target_index = target_index;
+				}
+
 				@Override
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case TYPE_USE :
-							assertEquals(Annotation.TARGET_INDEX_EXTENDS, annotation.getTargetIndex());
+							assertEquals(0x10, target_type);
+							assertEquals(Clazz.TYPEUSE_TARGET_INDEX_EXTENDS, target_index);
 							break;
 						default :
 							fail("Didn't fine @TypeUse annotation");
@@ -422,11 +437,21 @@ public class ClazzTest extends TestCase {
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
+				int	target_index;
+				int	target_type;
+
+				@Override
+				public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+					this.target_type = target_type;
+					this.target_index = target_index;
+				}
+
 				@Override
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case TYPE_USE :
-							assertEquals(0, annotation.getTargetIndex());
+							assertEquals(0x10, target_type);
+							assertEquals(0, target_index);
 							break;
 						default :
 							fail("Didn't fine @TypeUse annotation");
@@ -444,11 +469,21 @@ public class ClazzTest extends TestCase {
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
+				int	target_index;
+				int	target_type;
+
+				@Override
+				public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+					this.target_type = target_type;
+					this.target_index = target_index;
+				}
+
 				@Override
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case TYPE_USE :
-							assertEquals(1, annotation.getTargetIndex());
+							assertEquals(0x10, target_type);
+							assertEquals(1, target_index);
 							break;
 						default :
 							fail("Didn't fine @TypeUse annotation");
@@ -471,6 +506,12 @@ public class ClazzTest extends TestCase {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
 				MethodDef member;
+				int			parameter;
+
+				@Override
+				public void parameter(int p) {
+					parameter = p;
+				}
 
 				@Override
 				public void method(MethodDef member) {
@@ -485,7 +526,7 @@ public class ClazzTest extends TestCase {
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case PARAMETER :
-							assertEquals(0, annotation.getTargetIndex());
+							assertEquals(0, parameter);
 							assertEquals("bindChars", member.getName());
 							break;
 						default :
@@ -506,6 +547,12 @@ public class ClazzTest extends TestCase {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
 				MethodDef member;
+				int			parameter;
+
+				@Override
+				public void parameter(int p) {
+					parameter = p;
+				}
 
 				@Override
 				public void method(MethodDef member) {
@@ -520,7 +567,7 @@ public class ClazzTest extends TestCase {
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case PARAMETER :
-							assertEquals(1, annotation.getTargetIndex());
+							assertEquals(1, parameter);
 							assertEquals("bindChars", member.getName());
 							break;
 						default :
@@ -541,6 +588,12 @@ public class ClazzTest extends TestCase {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
 				MethodDef member;
+				int			parameter;
+
+				@Override
+				public void parameter(int p) {
+					parameter = p;
+				}
 
 				@Override
 				public void method(MethodDef member) {
@@ -555,7 +608,7 @@ public class ClazzTest extends TestCase {
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case PARAMETER :
-							assertEquals(0, annotation.getTargetIndex());
+							assertEquals(0, parameter);
 							assertEquals("<init>", member.getName());
 							break;
 						default :
@@ -576,6 +629,12 @@ public class ClazzTest extends TestCase {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFileWithCollector(new ClassDataCollector() {
 				MethodDef member;
+				int			parameter;
+
+				@Override
+				public void parameter(int p) {
+					parameter = p;
+				}
 
 				@Override
 				public void method(MethodDef member) {
@@ -590,7 +649,7 @@ public class ClazzTest extends TestCase {
 				public void annotation(Annotation annotation) throws Exception {
 					switch (annotation.getElementType()) {
 						case PARAMETER :
-							assertEquals(1, annotation.getTargetIndex());
+							assertEquals(1, parameter);
 							assertEquals("<init>", member.getName());
 							break;
 						default :
@@ -601,4 +660,170 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	/**
+	 * See 4.7.20.2 in JVMS spec.
+	 */
+	public void testTypeUseTypePath() throws Exception {
+		File file = IO.getFile("bin/test/typeuse/TypePath.class");
+		try (Analyzer analyzer = new Analyzer()) {
+			List<String> tested = new ArrayList<>();
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			clazz.parseClassFileWithCollector(new ClassDataCollector() {
+				FieldDef member;
+				byte[] type_path;
+
+				@Override
+				public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+					this.type_path = type_path;
+				}
+				@Override
+				public void field(FieldDef member) {
+					this.member = member;
+				}
+				@Override
+				public void memberEnd() {
+					member = null;
+				}
+
+				@Override
+				public void annotation(Annotation annotation) throws Exception {
+					switch (annotation.getElementType()) {
+						case TYPE_USE :
+							switch (member.getName()) {
+								case "b" :
+									switch (annotation.getName()
+										.getBinary()) {
+										case "test/typeuse/A" :
+											assertThat(type_path).hasSize(0);
+											break;
+										case "test/typeuse/B" :
+											assertThat(type_path).hasSize(2)
+												.containsExactly(3, 0);
+											break;
+										case "test/typeuse/C" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(3, 0, 2, 0);
+											break;
+										case "test/typeuse/D" :
+											assertThat(type_path).hasSize(2)
+												.containsExactly(3, 1);
+											break;
+										case "test/typeuse/E" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(3, 1, 3, 0);
+											break;
+										default :
+											fail("Unexpected annotation " + annotation);
+									}
+									break;
+								case "c" :
+									switch (annotation.getName()
+										.getBinary()) {
+										case "test/typeuse/F" :
+											assertThat(type_path).hasSize(0);
+											break;
+										case "test/typeuse/G" :
+											assertThat(type_path).hasSize(2)
+												.containsExactly(0, 0);
+											break;
+										case "test/typeuse/H" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(0, 0, 0, 0);
+											break;
+										case "test/typeuse/I" :
+											assertThat(type_path).hasSize(6)
+												.containsExactly(0, 0, 0, 0, 0, 0);
+											break;
+										default :
+											fail("Unexpected annotation " + annotation);
+									}
+									break;
+								case "d" :
+									switch (annotation.getName()
+										.getBinary()) {
+										case "test/typeuse/A" :
+											assertThat(type_path).hasSize(0);
+											break;
+										case "test/typeuse/B" :
+											assertThat(type_path).hasSize(2)
+												.containsExactly(3, 0);
+											break;
+										case "test/typeuse/C" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(3, 0, 3, 0);
+											break;
+										case "test/typeuse/D" :
+											assertThat(type_path).hasSize(6)
+												.containsExactly(3, 0, 3, 0, 0, 0);
+											break;
+										case "test/typeuse/E" :
+											assertThat(type_path).hasSize(8)
+												.containsExactly(3, 0, 3, 0, 0, 0, 0, 0);
+											break;
+										case "test/typeuse/F" :
+											assertThat(type_path).hasSize(10)
+												.containsExactly(3, 0, 3, 0, 0, 0, 0, 0, 0, 0);
+											break;
+										default :
+											fail("Unexpected annotation " + annotation);
+									}
+									break;
+								case "e" :
+									switch (annotation.getName()
+										.getBinary()) {
+										case "test/typeuse/A" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(1, 0, 1, 0);
+											break;
+										case "test/typeuse/B" :
+											assertThat(type_path).hasSize(2)
+												.containsExactly(1, 0);
+											break;
+										case "test/typeuse/C" :
+											assertThat(type_path).hasSize(0);
+											break;
+										default :
+											fail("Unexpected annotation " + annotation);
+									}
+									break;
+								case "f" :
+									switch (annotation.getName()
+										.getBinary()) {
+										case "test/typeuse/A" :
+											assertThat(type_path).hasSize(6)
+												.containsExactly(1, 0, 1, 0, 3, 0);
+											break;
+										case "test/typeuse/B" :
+											assertThat(type_path).hasSize(8)
+												.containsExactly(1, 0, 1, 0, 3, 0, 0, 0);
+											break;
+										case "test/typeuse/C" :
+											assertThat(type_path).hasSize(6)
+												.containsExactly(1, 0, 3, 0, 1, 0);
+											break;
+										case "test/typeuse/D" :
+											assertThat(type_path).hasSize(4)
+												.containsExactly(1, 0, 3, 0);
+											break;
+										default :
+											fail("Unexpected annotation " + annotation);
+									}
+									break;
+								default :
+									break;
+							}
+							tested.add(member.getName() + "|" + annotation.getName()
+								.getShortName());
+							break;
+						default :
+							fail("Didn't find TYPE_USE annotation");
+					}
+				}
+			});
+			assertThat(tested).containsExactlyInAnyOrder("b|A", "b|B", "b|C", "b|D", "b|E", "c|F", "c|G", "c|H", "c|I",
+				"d|A", "d|B", "d|C", "d|D", "d|E", "d|F", "e|A", "e|B", "e|C", "f|A", "f|B", "f|C", "f|D");
+		}
+	}
+
 }
+

--- a/biz.aQute.bndlib.tests/src/test/typeuse/A.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/A.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface A {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/B.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/B.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface B {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/C.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/C.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface C {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/D.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/D.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface D {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/E.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/E.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface E {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/F.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/F.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface F {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/G.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/G.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface G {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/H.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/H.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface H {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/I.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/I.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface I {}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/OuterE.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/OuterE.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+public class OuterE {
+	public class Middle {
+		public class Inner {}
+	}
+}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/OuterF.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/OuterF.java
@@ -1,0 +1,7 @@
+package test.typeuse;
+
+public class OuterF {
+	public class Middle<S> {
+		public class Inner<T> {}
+	}
+}

--- a/biz.aQute.bndlib.tests/src/test/typeuse/TypePath.java
+++ b/biz.aQute.bndlib.tests/src/test/typeuse/TypePath.java
@@ -1,0 +1,20 @@
+package test.typeuse;
+
+import java.util.List;
+import java.util.Map;
+
+public class TypePath {
+	@A
+	Map<@B ? extends @C String, @D List<@E Object>>		b;
+
+	@I
+	String @F [] @G [] @H []							c;
+
+	@A
+	List<@B Comparable<@F Object @C [] @D [] @E []>>	d;
+
+	@C
+	OuterE.@B Middle.@A Inner									e;
+
+	OuterF.Middle<@D OuterE.@C Middle>.Inner<@B String @A []>	f;
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -20,10 +20,6 @@ import aQute.lib.converter.Converter;
  * BND_ANNOTATION_CLASS_NAME
  */
 public class Annotation {
-
-	public static final int			TARGET_INDEX_EXTENDS	= 65535;
-	public static final int			TARGET_INDEX_NONE		= -1;
-
 	private static final Converter CONVERTER;
 
 	static {
@@ -43,19 +39,12 @@ public class Annotation {
 	private Map<String, Object>		elements;
 	private final ElementType		member;
 	private final RetentionPolicy	policy;
-	private final int				targetIndex;
 
 	public Annotation(TypeRef name, Map<String, Object> elements, ElementType member, RetentionPolicy policy) {
-		this(name, elements, member, policy, TARGET_INDEX_NONE);
-	}
-
-	public Annotation(TypeRef name, Map<String, Object> elements, ElementType member, RetentionPolicy policy,
-		int targetIndex) {
 		this.name = requireNonNull(name);
 		this.elements = elements;
 		this.member = requireNonNull(member);
 		this.policy = requireNonNull(policy);
-		this.targetIndex = targetIndex;
 	}
 
 	public TypeRef getName() {
@@ -68,10 +57,6 @@ public class Annotation {
 
 	public RetentionPolicy getRetentionPolicy() {
 		return policy;
-	}
-
-	public int getTargetIndex() {
-		return targetIndex;
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollector.java
@@ -88,4 +88,6 @@ public class ClassDataCollector {
 	public void annotationDefault(Clazz.MethodDef last, Object value) {
 		annotationDefault(last);
 	}
+
+	public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollectorRecorder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollectorRecorder.java
@@ -148,4 +148,9 @@ class ClassDataCollectorRecorder extends ClassDataCollector {
 	public void annotationDefault(Clazz.MethodDef last, Object value) {
 		actions.add(cdc -> cdc.annotationDefault(last, value));
 	}
+
+	@Override
+	public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+		actions.add(cdc -> cdc.typeuse(target_type, target_index, target_info, type_path));
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollectors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClassDataCollectors.java
@@ -319,5 +319,16 @@ class ClassDataCollectors implements Closeable {
 				}
 			}
 		}
+
+		@Override
+		public void typeuse(int target_type, int target_index, byte[] target_info, byte[] type_path) {
+			for (ClassDataCollector cd : shortlist) {
+				try {
+					cd.typeuse(target_type, target_index, target_info, type_path);
+				} catch (Exception e) {
+					reporter.exception(e, "Failure for %s on call typeuse[%s]", clazz, cd);
+				}
+			}
+		}
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -1,6 +1,5 @@
 package aQute.bnd.osgi;
 
-import static aQute.bnd.osgi.Annotation.TARGET_INDEX_NONE;
 import static java.util.Objects.requireNonNull;
 
 import java.io.DataInput;
@@ -514,6 +513,9 @@ public class Clazz {
 
 	private Map<String, Object>				defaults;
 
+	public static final int					TYPEUSE_INDEX_NONE				= -1;
+	public static final int					TYPEUSE_TARGET_INDEX_EXTENDS	= 65535;
+
 	public Clazz(Analyzer analyzer, String path, Resource resource) {
 		this.path = path;
 		this.resource = resource;
@@ -973,10 +975,10 @@ public class Clazz {
 				doDeprecated(in, member);
 				break;
 			case "RuntimeVisibleAnnotations" :
-				doAnnotations(in, member, RetentionPolicy.RUNTIME, access_flags, TARGET_INDEX_NONE);
+				doAnnotations(in, member, RetentionPolicy.RUNTIME, access_flags);
 				break;
 			case "RuntimeInvisibleAnnotations" :
-				doAnnotations(in, member, RetentionPolicy.CLASS, access_flags, TARGET_INDEX_NONE);
+				doAnnotations(in, member, RetentionPolicy.CLASS, access_flags);
 				break;
 			case "RuntimeVisibleParameterAnnotations" :
 				doParameterAnnotations(in, ElementType.PARAMETER, RetentionPolicy.RUNTIME, access_flags);
@@ -1403,17 +1405,26 @@ public class Clazz {
 
 	private void doParameterAnnotations(DataInput in, ElementType member, RetentionPolicy policy, int access_flags)
 		throws Exception {
+		boolean collect = cd != null;
 		int num_parameters = in.readUnsignedByte();
 		for (int p = 0; p < num_parameters; p++) {
-			if (cd != null)
-				cd.parameter(p);
-			doAnnotations(in, member, policy, p, access_flags);
+			int num_annotations = in.readUnsignedShort(); // # of annotations
+			if (num_annotations > 0) {
+				if (collect) {
+					cd.parameter(p);
+				}
+				for (int a = 0; a < num_annotations; a++) {
+					Annotation annotation = doAnnotation(in, member, policy, collect, access_flags);
+					if (collect) {
+						cd.annotation(annotation);
+					}
+				}
+			}
 		}
 	}
 
 	private void doTypeAnnotations(DataInput in, ElementType member, RetentionPolicy policy, int access_flags)
 		throws Exception {
-		boolean collect = false;
 		int num_annotations = in.readUnsignedShort();
 		for (int p = 0; p < num_annotations; p++) {
 
@@ -1442,7 +1453,8 @@ public class Clazz {
 			// Table 4.7.20-A. Interpretation of target_type values (Part 1)
 
 			int target_type = in.readUnsignedByte();
-			int target_index = TARGET_INDEX_NONE;
+			byte[] target_info;
+			int target_index;
 			switch (target_type) {
 				case 0x00 : // type parameter declaration of generic class or
 							// interface
@@ -1452,7 +1464,9 @@ public class Clazz {
 					// type_parameter_target {
 					// u1 type_parameter_index;
 					// }
-					in.skipBytes(1);
+					target_info = new byte[1];
+					in.readFully(target_info);
+					target_index = Byte.toUnsignedInt(target_info[0]);
 					break;
 
 				case 0x10 : // type in extends clause of class or interface
@@ -1462,9 +1476,9 @@ public class Clazz {
 					// supertype_target {
 					// u2 supertype_index;
 					// }
-
-					collect = cd != null;
-					target_index = in.readUnsignedShort();
+					target_info = new byte[2];
+					in.readFully(target_info);
+					target_index = (Byte.toUnsignedInt(target_info[0]) << 8) | Byte.toUnsignedInt(target_info[1]);
 					break;
 
 				case 0x11 : // type in bound of type parameter declaration of
@@ -1475,13 +1489,17 @@ public class Clazz {
 					// u1 type_parameter_index;
 					// u1 bound_index;
 					// }
-					in.skipBytes(2);
+					target_info = new byte[2];
+					in.readFully(target_info);
+					target_index = Byte.toUnsignedInt(target_info[0]);
 					break;
 
 				case 0x13 : // type in field declaration
 				case 0x14 : // return type of method, or type of newly
 							// constructed object
 				case 0x15 : // receiver type of method or constructor
+					target_info = new byte[0];
+					target_index = TYPEUSE_INDEX_NONE;
 					break;
 
 				case 0x16 : // type in formal parameter declaration of method,
@@ -1489,14 +1507,18 @@ public class Clazz {
 					// formal_parameter_target {
 					// u1 formal_parameter_index;
 					// }
-					in.skipBytes(1);
+					target_info = new byte[1];
+					in.readFully(target_info);
+					target_index = Byte.toUnsignedInt(target_info[0]);
 					break;
 
 				case 0x17 : // type in throws clause of method or constructor
 					// throws_target {
 					// u2 throws_type_index;
 					// }
-					in.skipBytes(2);
+					target_info = new byte[2];
+					in.readFully(target_info);
+					target_index = (Byte.toUnsignedInt(target_info[0]) << 8) | Byte.toUnsignedInt(target_info[1]);
 					break;
 
 				case 0x40 : // type in local variable declaration
@@ -1509,14 +1531,18 @@ public class Clazz {
 					// } table[table_length];
 					// }
 					int table_length = in.readUnsignedShort();
-					in.skipBytes(table_length * 6);
+					target_info = new byte[table_length * 6];
+					in.readFully(target_info);
+					target_index = TYPEUSE_INDEX_NONE;
 					break;
 
 				case 0x42 : // type in exception parameter declaration
 					// catch_target {
 					// u2 exception_table_index;
 					// }
-					in.skipBytes(2);
+					target_info = new byte[2];
+					in.readFully(target_info);
+					target_index = (Byte.toUnsignedInt(target_info[0]) << 8) | Byte.toUnsignedInt(target_info[1]);
 					break;
 
 				case 0x43 : // type in instanceof expression
@@ -1527,7 +1553,9 @@ public class Clazz {
 					// offset_target {
 					// u2 offset;
 					// }
-					in.skipBytes(2);
+					target_info = new byte[2];
+					in.readFully(target_info);
+					target_index = TYPEUSE_INDEX_NONE;
 					break;
 
 				case 0x47 : // type in cast expression
@@ -1545,9 +1573,12 @@ public class Clazz {
 					// u2 offset;
 					// u1 type_argument_index;
 					// }
-					in.skipBytes(3);
+					target_info = new byte[3];
+					in.readFully(target_info);
+					target_index = Byte.toUnsignedInt(target_info[2]);
 					break;
-
+				default :
+					throw new IllegalArgumentException("Unknown target_type: " + target_type);
 			}
 
 			// The value of the target_path item denotes precisely which part of
@@ -1562,26 +1593,29 @@ public class Clazz {
 			// }
 
 			int path_length = in.readUnsignedByte();
-			in.skipBytes(path_length * 2);
+			byte[] type_path = new byte[path_length * 2];
+			in.readFully(type_path);
 
 			//
 			// Rest is identical to the normal annotations
-			Annotation annotation = doAnnotation(in, member, policy, target_index, collect, access_flags);
-			if (cd != null && annotation != null) {
+			if (cd != null) {
+				cd.typeuse(target_type, target_index, target_info, type_path);
+				Annotation annotation = doAnnotation(in, member, policy, true, access_flags);
 				cd.annotation(annotation);
+			} else {
+				doAnnotation(in, member, policy, false, access_flags);
 			}
 		}
 	}
 
-	private void doAnnotations(DataInput in, ElementType member, RetentionPolicy policy, int targetIndex,
-		int access_flags)
+	private void doAnnotations(DataInput in, ElementType member, RetentionPolicy policy, int access_flags)
 		throws Exception {
 		int num_annotations = in.readUnsignedShort(); // # of annotations
 		for (int a = 0; a < num_annotations; a++) {
 			if (cd == null)
-				doAnnotation(in, member, policy, targetIndex, false, access_flags);
+				doAnnotation(in, member, policy, false, access_flags);
 			else {
-				Annotation annotation = doAnnotation(in, member, policy, targetIndex, true, access_flags);
+				Annotation annotation = doAnnotation(in, member, policy, true, access_flags);
 				cd.annotation(annotation);
 			}
 		}
@@ -1596,7 +1630,7 @@ public class Clazz {
 	// element_value_pairs[num_element_value_pairs];
 	// }
 
-	private Annotation doAnnotation(DataInput in, ElementType member, RetentionPolicy policy, int targetIndex,
+	private Annotation doAnnotation(DataInput in, ElementType member, RetentionPolicy policy,
 		boolean collect, int access_flags) throws IOException {
 		int type_index = in.readUnsignedShort();
 		if (annotations == null)
@@ -1627,7 +1661,7 @@ public class Clazz {
 			}
 		}
 		if (collect)
-			return new Annotation(typeRef, elements, member, policy, targetIndex);
+			return new Annotation(typeRef, elements, member, policy);
 		return null;
 	}
 
@@ -1677,7 +1711,7 @@ public class Clazz {
 				return name;
 
 			case '@' : // Annotation type
-				return doAnnotation(in, member, policy, TARGET_INDEX_NONE, collect, access_flags);
+				return doAnnotation(in, member, policy, collect, access_flags);
 
 			case '[' : // Array
 				int num_values = in.readUnsignedShort();


### PR DESCRIPTION
We were only handling some usage cases (target_types 0x00-0x17). We now
support all scenarios. We use a new visitor method to supply type use
information before calling the visitor method with the annotation.