### PR TITLE
[command] Additional commands for xref and repo

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/XRefCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/XRefCommand.java
@@ -1,0 +1,197 @@
+package aQute.bnd.main;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Clazz;
+import aQute.bnd.osgi.Descriptors;
+import aQute.bnd.osgi.Descriptors.PackageRef;
+import aQute.bnd.osgi.Descriptors.TypeRef;
+import aQute.bnd.osgi.Instructions;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.collections.SortedList;
+import aQute.lib.getopt.Arguments;
+import aQute.lib.getopt.Description;
+import aQute.lib.getopt.Options;
+import aQute.lib.strings.Strings;
+import aQute.libg.generics.Create;
+
+public class XRefCommand {
+	private final bnd bnd;
+
+	@Description("Show a cross references for all classes in a set of jars.")
+	@Arguments(arg = {
+			"<jar path>", "[...]"
+	})
+	interface xrefOptions extends Options {
+		@Description("Show classes instead of packages")
+		boolean classes();
+
+		@Description("Show references to other classes/packages (>)")
+		boolean to();
+
+		@Description("Show references from other classes/packages (<)")
+		boolean from();
+
+		@Description("Match source types")
+		List<String> source();
+
+		@Description("Match destination types")
+		List<String> destination();
+
+		@Description("Filter for class names, a globbing expression")
+		List<String> match();
+
+		@Description("Output list of package/class names that have been referred to")
+		String referrredTo();
+
+	}
+
+	static public class All {
+		public Map<TypeRef,List<TypeRef>>		classes		= new HashMap<Descriptors.TypeRef,List<TypeRef>>();
+		public Map<PackageRef,List<PackageRef>>	packages	= new HashMap<Descriptors.PackageRef,List<PackageRef>>();
+	}
+
+	XRefCommand(aQute.bnd.main.bnd bnd) {
+		this.bnd = bnd;
+	}
+
+	void xref(xrefOptions options) throws FileNotFoundException {
+		Analyzer analyzer = new Analyzer();
+		final MultiMap<TypeRef,TypeRef> table = new MultiMap<TypeRef,TypeRef>();
+		final MultiMap<PackageRef,PackageRef> packages = new MultiMap<PackageRef,PackageRef>();
+		Set<TypeRef> set = Create.set();
+
+		Instructions filter = new Instructions(options.match());
+		Instructions source = new Instructions(options.source());
+		Instructions destination = new Instructions(options.destination());
+		bnd.getLogger().info(" sources {}", source);
+
+		for (String arg : options._arguments()) {
+			try {
+				File file = bnd.getFile(arg);
+				try (Jar jar = new Jar(file.getName(), file)) {
+					for (Map.Entry<String,Resource> entry : jar.getResources().entrySet()) {
+						String key = entry.getKey();
+						Resource r = entry.getValue();
+						if (key.endsWith(".class")) {
+							TypeRef ref = analyzer.getTypeRefFromPath(key);
+							String fqn = ref.getFQN();
+
+							if (filter.matches(fqn) && source.matches(fqn)) {
+								bnd.getLogger().info("# include {}", fqn);
+								set.add(ref);
+
+								try (InputStream in = r.openInputStream()) {
+									Clazz clazz = new Clazz(analyzer, key, r);
+
+									// TODO use the proper bcp instead
+									// of using the default layout
+
+									Set<TypeRef> s = clazz.parseClassFile();
+									for (Iterator<TypeRef> t = s.iterator(); t.hasNext();) {
+										TypeRef tr = t.next();
+										while (tr.isArray())
+											tr = tr.getComponentTypeRef();
+
+										if (!destination.matches(tr.getFQN()) || tr.isJava() || tr.isPrimitive())
+											t.remove();
+										else {
+											packages.add(ref.getPackageRef(), tr.getPackageRef());
+										}
+									}
+									if (!s.isEmpty()) {
+										table.addAll(ref, s);
+										set.addAll(s);
+									}
+								}
+							}
+						}
+					}
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+
+		boolean to = options.to();
+		boolean from = options.from();
+		if (to == false && from == false && !"--".equals(options.referrredTo()))
+			to = from = true;
+
+		if (options.classes()) {
+			if (options.referrredTo() != null) {
+				printReferred(options.referrredTo(), Strings.join("\n",
+						flatten(table)));
+			}
+
+			if (to)
+				printxref(table, ">");
+			if (from)
+				printxref(table.transpose(), "<");
+		} else {
+			if (options.referrredTo() != null) {
+				printReferred(options.referrredTo(), Strings.join("\n",
+						flatten(packages)));
+			}
+			if (to)
+				printxref(packages, ">");
+			if (from)
+				printxref(packages.transpose(), "<");
+		}
+	}
+
+	private <T> Set<T> flatten(final MultiMap<T,T> packages) {
+		return new TreeSet<>(packages.values().stream().flatMap(l -> l.stream()).collect(Collectors.toSet()));
+	}
+
+	private void printReferred(String referrredTo, String joined) throws FileNotFoundException {
+		PrintStream out = bnd.out;
+		boolean toConsole = referrredTo.equals("--");
+		if (!toConsole) {
+			File file = bnd.getFile(referrredTo);
+			if (!file.getParentFile().mkdirs()) {
+				bnd.error("Cannot make parent directory for referred output file %s", referrredTo);
+			}
+			out = new PrintStream(file);
+		}
+		out.println(joined);
+		if (!toConsole)
+			out.close();
+	}
+
+	private void printxref(MultiMap< ? , ? > map, String direction) {
+		SortedList< ? > labels = new SortedList<Object>(map.keySet(), null);
+		for (Object element : labels) {
+			List< ? > e = map.get(element);
+			if (e == null) {
+				// ignore
+			} else {
+				Set<Object> set = new LinkedHashSet<Object>(e);
+				set.remove(element);
+				Iterator< ? > row = set.iterator();
+				String first = "";
+				if (row.hasNext())
+					first = row.next().toString();
+				bnd.out.printf("%50s %s %s\n", element, direction, first);
+				while (row.hasNext()) {
+					bnd.out.printf("%50s   %s\n", "", row.next());
+				}
+			}
+		}
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -73,6 +73,8 @@ public class Descriptors {
 
 		String getDottedOnly();
 
+		boolean isArray();
+
 	}
 
 	public static class PackageRef implements Comparable<PackageRef> {
@@ -276,6 +278,11 @@ public class Descriptors {
 			return super.hashCode();
 		}
 
+		@Override
+		public boolean isArray() {
+			return false;
+		}
+
 	}
 
 	private static class ArrayRef implements TypeRef {
@@ -379,6 +386,11 @@ public class Descriptors {
 				return name;
 
 			return name.substring(n + 1);
+		}
+
+		@Override
+		public boolean isArray() {
+			return true;
 		}
 
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.osgi.framework.namespace.AbstractWiringNamespace;
@@ -38,6 +39,7 @@ import org.osgi.resource.Namespace;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.service.repository.ContentNamespace;
+import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.header.Attrs;
@@ -520,5 +522,31 @@ public class ResourceUtils {
 		Attrs attribs = new Attrs();
 		attribs.put(Constants.VERSION_ATTRIBUTE, versionString);
 		return new VersionedClause(identity, attribs);
+	}
+
+	static <T> T requireNonNull(T obj) {
+		if (obj != null) {
+			return obj;
+		}
+		throw new NullPointerException();
+	}
+
+	static Collection<Requirement> all = Collections.singleton(createWildcardRequirement());
+
+	/**
+	 * Return all resources from a repository as returned by the wildcard
+	 * requirement, see {@link #createWildcardRequirement()}
+	 * 
+	 * @param repository the repository to use
+	 * @return a set of resources from the repository.
+	 */
+	public static Set<Resource> getAllResources(Repository repository) {
+		Set<Capability> capabilities = repository.findProviders(all)
+			.values()
+			.stream()
+			.flatMap(l -> l.stream())
+			.collect(Collectors.toSet());
+		return getResources(capabilities);
+
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/packageinfo
@@ -1,1 +1,1 @@
-version 3.0
+version 3.1

--- a/biz.aQute.bndlib/src/aQute/bnd/service/progress/ProgressToOutput.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/progress/ProgressToOutput.java
@@ -1,0 +1,68 @@
+package aQute.bnd.service.progress;
+
+import java.io.Flushable;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProgressToOutput implements ProgressPlugin {
+	final static Logger	logger	= LoggerFactory.getLogger(ProgressToOutput.class);
+	final Object	lock	= new Object();
+	final Appendable	appendable;
+	final String	eol;
+
+	public ProgressToOutput(Appendable appendable, String eol) {
+		this.appendable = appendable;
+		if (eol == null) {
+			if ("ansi".equalsIgnoreCase(System.getenv("TERM"))) {
+				eol = "\u001B[0K .\r";
+			} else
+				eol = "\n";
+		}
+		this.eol = eol;
+	}
+
+	private synchronized void log(String msg, boolean nl, Object... args) {
+		try {
+			String out = String.format(msg + (nl ? "%n" : eol), args);
+			if (out.length() > 100) {
+				out = out.substring(0, 50) + ".." + out.substring(out.length() - 50);
+			}
+			appendable.append(out);
+			if (appendable instanceof Flushable)
+				((Flushable) appendable).flush();
+		} catch (IOException e) {
+			logger.error("sending output for progress ", e);
+		}
+	}
+
+	@Override
+	public Task startTask(String name, int size) {
+		return new Task() {
+
+			@Override
+			public void worked(int units) {
+				log("work : %02d %s", false, (units * 100 + size / 2) / size, name);
+			}
+
+			@Override
+			public void done(String message, Throwable e) {
+				if (e != null) {
+					log("error:    %s %s", true, name, e.getMessage());
+				} else {
+					log("done :    %s", false, name);
+				}
+			}
+
+			@Override
+			public boolean isCanceled() {
+				return false;
+			}
+		};
+	}
+
+	public void clear() {
+		log("", false);
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/progress/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/progress/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
bnd
- dependencies - show all used dependencies in the workspace
- collect - extract a set of resources from a set of jars and copy to an output jar
- classtoresource - Convert class names to resource path
- packagetoresource - Convert package to resource path

repo
- repo copy
- repo sync
- repo index

xref
A lot of filtering options to analyze large setups



Signed-off-by: Peter Kriens <peter.kriens@aqute.biz>