### PR TITLE
Avoid duplicate DS extender for DS version 1.4+

### DIFF
--- a/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/src/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -43,7 +43,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.get("filter:")
 				.contains("(a=b)"));
 			assertTrue(p.get("filter:")
-				.contains("(&(version>=1.0.0)(!(version>=2.0.0)))"));
+				.contains("(version>=1.0.0)(!(version>=2.0.0))"));
 			assertTrue(p.get("filter:")
 				.contains("(require=Required)"));
 			assertFalse(p.containsKey("foo"));
@@ -54,7 +54,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.get("filter:")
 				.contains("(a=b)"));
 			assertTrue(p.get("filter:")
-				.contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
+				.contains("(version>=2.0.0)(!(version>=3.0.0))"));
 			assertTrue(p.get("filter:")
 				.contains("(require=Required2)"));
 			assertEquals("direct", p.get("foo"));
@@ -106,7 +106,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.containsKey("filter:"));
 			String filter = p.get("filter:");
 			assertTrue(filter, filter.contains("(a=b)"));
-			assertTrue(filter, filter.contains("(&(version>=1.0.0)(!(version>=2.0.0)))"));
+			assertTrue(filter, filter.contains("(version>=1.0.0)(!(version>=2.0.0))"));
 			assertTrue(filter, filter.contains("(require=Indirectly-Required)"));
 
 			p = req.get("require" + DUPLICATE_MARKER);
@@ -114,7 +114,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.containsKey("filter:"));
 			filter = p.get("filter:");
 			assertTrue(filter, filter.contains("(a=b)"));
-			assertTrue(filter, filter.contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
+			assertTrue(filter, filter.contains("(version>=2.0.0)(!(version>=3.0.0))"));
 			assertTrue(filter, filter.contains("(require=Indirectly-Required2)"));
 
 			Header cap = Header.parseHeader(mainAttributes.getValue(Constants.PROVIDE_CAPABILITY));
@@ -139,7 +139,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.containsKey("filter:"));
 			filter = p.get("filter:");
 			assertTrue(filter, filter.contains("(a=b)"));
-			assertTrue(filter, filter.contains("(&(version>=1.0.0)(!(version>=2.0.0)))"));
+			assertTrue(filter, filter.contains("(version>=1.0.0)(!(version>=2.0.0))"));
 			assertTrue(filter, filter.contains("(require=Required)"));
 			assertTrue(p.containsKey("open"));
 			assertEquals("sesame", p.get("open"));
@@ -162,7 +162,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertTrue(p.containsKey("filter:"));
 			filter = p.get("filter:");
 			assertTrue(filter, filter.contains("(a=b)"));
-			assertTrue(filter, filter.contains("(&(version>=2.0.0)(!(version>=3.0.0)))"));
+			assertTrue(filter, filter.contains("(version>=2.0.0)(!(version>=3.0.0))"));
 			assertTrue(filter, filter.contains("(require=Required2)"));
 			assertTrue(p.containsKey("open"));
 			assertEquals("sesame", p.get("open"));
@@ -277,7 +277,7 @@ public class StdAnnotationHeadersTest extends TestCase {
 			Props p = req.get("overriding");
 			assertNotNull(p);
 			assertTrue(p.containsKey("filter:"));
-			assertEquals("(&(overriding=foo)(&(version>=1.0.0)(!(version>=2.0.0))))", p.get("filter:"));
+			assertEquals("(&(overriding=foo)(version>=1.0.0)(!(version>=2.0.0)))", p.get("filter:"));
 			assertTrue(p.containsKey("foo:List<String>"));
 			assertEquals("foobar", p.get("foo:List<String>"));
 			assertTrue(p.containsKey("x-top-name:"));

--- a/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/DSAnnotationTest.java
@@ -1,5 +1,7 @@
 package test.component;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -26,6 +28,7 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentServiceObjects;
 import org.osgi.service.component.annotations.Activate;
@@ -57,6 +60,8 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.test.BndTestCase;
 import aQute.bnd.test.XmlTester;
+import aQute.bnd.version.Version;
+import aQute.lib.filter.Filter;
 import junit.framework.AssertionFailedError;
 
 /**
@@ -106,6 +111,25 @@ public class DSAnnotationTest extends BndTestCase {
 		r.write(System.err);
 	}
 
+	public void testDuplicateExtender() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.DSANNOTATIONS, "test.component.ds14.*");
+			b.setProperty("-includepackage", "test.component.ds14");
+			b.addClasspath(new File("bin"));
+			Jar jar = b.build();
+
+			if (!b.check())
+				fail();
+			String reqcap = jar.getManifest()
+				.getMainAttributes()
+				.getValue(Constants.REQUIRE_CAPABILITY);
+			Parameters reqs = new Parameters(reqcap);
+			System.out.println(reqs);
+			assertThat(reqs).containsOnlyKeys("osgi.extender", "osgi.ee");
+			assertThat(reqs.get("osgi.extender")).containsOnlyKeys("filter:");
+			checkExtenderVersion(reqs, ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
+		}
+	}
 	/**
 	 * Property test
 	 */
@@ -769,7 +793,8 @@ public class DSAnnotationTest extends BndTestCase {
 		// n.b. we should merge the 2 logService requires, so when we fix that
 		// we'll need to update this test.
 		// one is plain, other has cardinality multiple.
-		checkRequires(a, "1.3.0", LogService.class.getName(), LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName(),
+			LogService.class.getName());
 	}
 
 	private void verifyDS11VeryBasic(Jar jar, Class<?> clazz) throws Exception, XPathExpressionException {
@@ -1254,7 +1279,8 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	public void testInheritanceExtenderFlag() throws Exception {
-		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit,extender", "1.3.0");
+		testInheritance(Constants.DSANNOTATIONS_OPTIONS, "inherit,extender",
+			ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 	}
 
 	public void testInheritance(String key, String value, String extender) throws Exception {
@@ -1406,7 +1432,7 @@ public class DSAnnotationTest extends BndTestCase {
 	}
 
 	public void testBindsExtender() throws Exception {
-		testBinds("1.3.0");
+		testBinds(ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 	}
 
 	public void testBinds(String extender) throws Exception {
@@ -1500,7 +1526,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/" + CheckBinds13.class.getName() + ".xml");
 		assertNotNull(r);
@@ -1655,7 +1681,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$ref_on_comp.xml");
 		System.err.println(Processor.join(jar.getResources()
@@ -2058,9 +2084,9 @@ public class DSAnnotationTest extends BndTestCase {
 			checkProvides(a, provides);
 		}
 		if (requires == null) {
-			checkRequires(a, "1.3.0");
+			checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 		} else {
-			checkRequires(a, "1.3.0", requires);
+			checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, requires);
 		}
 		return jar;
 	}
@@ -2172,7 +2198,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 	}
 
 	public enum Foo {
@@ -2299,7 +2325,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, "1.3.0");
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 
 		// // Test 1.3 signature methods give 1.3 namespace
 		checkDS13Anno(jar, DS13anno_configTypes_activate.class.getName(), "");
@@ -2437,7 +2463,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, "1.3.0");
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 
 		checkDS13AnnoConfigNames(jar, DS13annoNames_config.class.getName());
 	}
@@ -2734,7 +2760,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a, SERIALIZABLE_RUNNABLE);
-		checkRequires(a, "1.3.0");
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION);
 
 		checkDS13AnnoOverride(jar, DS13annoOverride_a_a.class.getName());
 		checkDS13AnnoOverride(jar, DS13annoOverride_a_d.class.getName());
@@ -2817,7 +2843,7 @@ public class DSAnnotationTest extends BndTestCase {
 		assertOk(b);
 		Attributes a = getAttr(jar);
 		checkProvides(a);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/" + TestFieldInjection.class.getName() + ".xml");
 		assertNotNull(r);
@@ -2897,7 +2923,8 @@ public class DSAnnotationTest extends BndTestCase {
 			assertOk(b);
 			Attributes a = getAttr(jar);
 			checkProvides(a, SERIALIZABLE_RUNNABLE);
-			checkRequires(a, "1.3.0", LogService.class.getName(), Map.class.getName());
+			checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName(),
+				Map.class.getName());
 
 			Resource r = jar.getResource("OSGI-INF/" + TestFieldCollectionType.class.getName() + ".xml");
 			assertNotNull(r);
@@ -2972,11 +2999,29 @@ public class DSAnnotationTest extends BndTestCase {
 			assertTrue("objectClass not found: " + o, found);
 		}
 
+		checkExtenderVersion(header, extender);
+	}
+
+	private void checkExtenderVersion(Parameters header, String extender) {
 		if (extender != null) {
 			Attrs attr = header.get("osgi.extender");
-			assertNotNull(attr);
-			assertEquals("(&(osgi.extender=osgi.component)(version>=" + extender + ")(!(version>=2.0.0)))",
-				attr.get("filter:"));
+			assertThat(attr).as("osgi.extender namespace")
+				.isNotNull();
+			String filterString = attr.get("filter:");
+			assertThat(filterString).as("osgi.extender namespace filter directive")
+				.isNotNull();
+			Filter filter = new Filter(filterString);
+			Map<String, Object> map = new HashMap<>();
+			map.put("osgi.extender", "osgi.component");
+			map.put("version", Version.parseVersion(extender));
+			boolean matches = false;
+			try {
+				matches = filter.matchMap(map);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+			assertThat(matches).as("filter %s matches version %s", filter, extender)
+				.isTrue();
 		}
 	}
 
@@ -3440,7 +3485,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$VolatileField.xml");
 		System.err.println(Processor.join(jar.getResources()
@@ -3480,7 +3525,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$FinalDynamicCollectionField.xml");
 		System.err.println(Processor.join(jar.getResources()
@@ -3527,7 +3572,7 @@ public class DSAnnotationTest extends BndTestCase {
 		Jar jar = b.build();
 		assertOk(b);
 		Attributes a = getAttr(jar);
-		checkRequires(a, "1.3.0", LogService.class.getName());
+		checkRequires(a, ComponentConstants.COMPONENT_SPECIFICATION_VERSION, LogService.class.getName());
 
 		Resource r = jar.getResource("OSGI-INF/test.component.DSAnnotationTest$FieldCardinality.xml");
 		System.err.println(Processor.join(jar.getResources()

--- a/biz.aQute.bndlib.tests/src/test/component/PermissionGeneratorTest.java
+++ b/biz.aQute.bndlib.tests/src/test/component/PermissionGeneratorTest.java
@@ -88,6 +88,8 @@ public class PermissionGeneratorTest extends BndTestCase {
             "aQute.bnd.osgi",
             "aQute.bnd.service.diff",
             "aQute.bnd.test",
+            "aQute.bnd.version",
+            "aQute.lib.filter",
             "aQute.lib.io",
             "aQute.service.reporter",
             "javax.xml.namespace",
@@ -133,8 +135,7 @@ public class PermissionGeneratorTest extends BndTestCase {
 				new TreeSet<>(Arrays.asList("osgi.service")), 
 				providedCapabilities);
 		assertEquals("Required capabilities",
-				new TreeSet<>(Arrays.asList("osgi.extender",
-						"osgi.service")), 
+				new TreeSet<>(Arrays.asList("osgi.service")), 
 						requiredCapabilities);
 		/* @formatter:on */
 	}

--- a/biz.aQute.bndlib.tests/src/test/component/ds14/AnComponentDSFourteen.java
+++ b/biz.aQute.bndlib.tests/src/test/component/ds14/AnComponentDSFourteen.java
@@ -1,0 +1,10 @@
+package test.component.ds14;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component
+public class AnComponentDSFourteen implements MyInterface {
+    public String getName() {
+        return "Cristiano";
+    }
+}

--- a/biz.aQute.bndlib.tests/src/test/component/ds14/MyInterface.java
+++ b/biz.aQute.bndlib.tests/src/test/component/ds14/MyInterface.java
@@ -1,0 +1,5 @@
+package test.component.ds14;
+
+public interface MyInterface {
+    String getName();
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -366,10 +366,7 @@ public class Analyzer extends Processor {
 			// private
 			// packages, lets kill them as well.
 
-			for (Iterator<PackageRef> p = privatePackages.iterator(); p.hasNext();)
-				if (p.next()
-					.isJava())
-					p.remove();
+			privatePackages.removeIf(PackageRef::isJava);
 
 			for (PackageRef exported : exports.keySet()) {
 				List<PackageRef> used = uses.get(exported);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -663,7 +663,8 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 				int current = filter.lastIndexOf(")");
 
 				VersionRange range = new VersionRange(floor, floor.bumpMajor());
-				filter.append(range.toFilter());
+				String rangeFilter = range.toFilter();
+				filter.append(rangeFilter.substring(2, rangeFilter.length() - 1));
 
 				if (andAdded) {
 					filter.deleteCharAt(current)

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -838,30 +838,35 @@ public class Clazz {
 	}
 
 	void doInteger_info(CONSTANT tag, DataInput in, int poolIndex) throws IOException {
-		intPool[poolIndex] = in.readInt();
-		if (cd != null)
-			pool[poolIndex] = intPool[poolIndex];
+		int i = in.readInt();
+		intPool[poolIndex] = i;
+		if (cd != null) {
+			pool[poolIndex] = Integer.valueOf(i);
+		}
 	}
 
 	void doFloat_info(CONSTANT tag, DataInput in, int poolIndex) throws IOException {
-		if (cd != null)
-			pool[poolIndex] = in.readFloat(); // ALU
-		else
+		if (cd != null) {
+			pool[poolIndex] = Float.valueOf(in.readFloat()); // ALU
+		} else {
 			in.skipBytes(4);
+		}
 	}
 
 	void doLong_info(CONSTANT tag, DataInput in, int poolIndex) throws IOException {
 		if (cd != null) {
-			pool[poolIndex] = in.readLong();
-		} else
+			pool[poolIndex] = Long.valueOf(in.readLong());
+		} else {
 			in.skipBytes(8);
+		}
 	}
 
 	void doDouble_info(CONSTANT tag, DataInput in, int poolIndex) throws IOException {
-		if (cd != null)
-			pool[poolIndex] = in.readDouble();
-		else
+		if (cd != null) {
+			pool[poolIndex] = Double.valueOf(in.readDouble());
+		} else {
 			in.skipBytes(8);
+		}
 	}
 
 	void doClass_info(CONSTANT tag, DataInput in, int poolIndex) throws IOException {
@@ -1738,7 +1743,7 @@ public class Clazz {
 			case 'I' : // Integer
 			case 'S' : // Short
 				int const_value_index = in.readUnsignedShort();
-				return intPool[const_value_index];
+				return Integer.valueOf(intPool[const_value_index]);
 
 			case 'D' : // Double
 			case 'F' : // Float
@@ -1749,7 +1754,7 @@ public class Clazz {
 
 			case 'Z' : // Boolean
 				const_value_index = in.readUnsignedShort();
-				return pool[const_value_index] == null || pool[const_value_index].equals(0) ? false : true;
+				return Boolean.valueOf(intPool[const_value_index] != 0);
 
 			case 'e' : // enum constant
 				int type_name_index = in.readUnsignedShort();


### PR DESCRIPTION
This change checks if the `Component` annotation class in the analyzer
is itself annotated with `RequireServiceComponentRuntime`. If it is, then
that annotation will handle generating the requirement for the DS
extender and the DS annotation processing code will not emit the
extender requirement.