### PR TITLE
bndlib: Replace URLConnection usage with Resource.fromURL w/ HttpClient

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
@@ -1,10 +1,14 @@
 package aQute.bnd.comm.tests;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -14,6 +18,7 @@ import org.osgi.util.promise.Promise;
 import aQute.bnd.connection.settings.ConnectionSettings;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.progress.ProgressPlugin;
 import aQute.bnd.service.url.State;
 import aQute.bnd.service.url.TaggedData;
@@ -232,6 +237,19 @@ public class HttpClientTest extends TestCase {
 				.go(httpServer.getBaseURI("get"));
 			assertNotNull(text);
 			assertTrue(text.startsWith("{"));
+		}
+	}
+
+	public void testURLResource() throws Exception {
+		try (HttpClient hc = new HttpClient()) {
+			URL url = httpServer.getBaseURI("get")
+				.toURL();
+			try (Resource resource = Resource.fromURL(url, hc)) {
+				ByteBuffer bb = resource.buffer();
+				assertThat(bb).isNotNull();
+				String text = IO.collect(bb, UTF_8);
+				assertThat(text).startsWith("{");
+			}
 		}
 	}
 

--- a/biz.aQute.bndlib.tests/test/test/PluginTest.java
+++ b/biz.aQute.bndlib.tests/test/test/PluginTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import java.awt.MenuContainer;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +10,7 @@ import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.Plugin;
+import aQute.lib.io.IO;
 import aQute.service.reporter.Reporter;
 import junit.framework.TestCase;
 
@@ -132,5 +134,23 @@ public class PluginTest extends TestCase {
 		assertEquals("thinlet.Thinlet", plugins.get(0)
 			.getClass()
 			.getName());
+	}
+
+	public void testLoadPluginWithGlobalPluginPathURL() throws Exception {
+		File tmp = new File("generated/tmp/test/" + getName() + "/thinlet.jar").getAbsoluteFile();
+		IO.delete(tmp);
+		try (Builder p = new Builder()) {
+			p.setProperty(Constants.PLUGIN, "thinlet.Thinlet");
+			p.setProperty(Constants.PLUGINPATH,
+				tmp + ";url=file:jar/thinlet.jar;sha1=af7ec3a35b1825e678bfa80edeffe65836d55b17");
+
+			List<MenuContainer> plugins = p.getPlugins(MenuContainer.class);
+			assertEquals(0, p.getErrors()
+				.size());
+			assertEquals(1, plugins.size());
+			assertEquals("thinlet.Thinlet", plugins.get(0)
+				.getClass()
+				.getName());
+		}
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -56,6 +56,7 @@ import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.help.Syntax;
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.maven.support.Pom;
 import aQute.bnd.maven.support.ProjectPom;
 import aQute.bnd.osgi.About;
@@ -2387,7 +2388,7 @@ public class Project extends Processor {
 	}
 
 	public Jar getValidJar(URL url) throws Exception {
-		try (Resource resource = Resource.fromURL(url)) {
+		try (Resource resource = Resource.fromURL(url, getPlugin(HttpClient.class))) {
 			Jar jar = Jar.fromResource(url.getFile()
 				.replace('/', '.'), resource);
 			return getValidJar(jar, url.toString());

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/JUnitFramework.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/JUnitFramework.java
@@ -33,6 +33,7 @@ import aQute.bnd.build.Run;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Descriptors.PackageRef;
@@ -233,7 +234,7 @@ public class JUnitFramework implements AutoCloseable {
 		}
 
 		public BundleBuilder addResource(String path, URL url) throws IOException {
-			return addResource(path, Resource.fromURL(url));
+			return addResource(path, Resource.fromURL(url, getPlugin(HttpClient.class)));
 		}
 
 		public BundleBuilder addResource(String path, Resource resource) {

--- a/biz.aQute.bndlib/src/aQute/bnd/make/MakeCopy.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/MakeCopy.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.EmbeddedResource;
 import aQute.bnd.osgi.FileResource;
@@ -31,7 +32,7 @@ public class MakeCopy implements MakePlugin {
 			return new FileResource(f);
 		try {
 			URL url = new URL(from);
-			return Resource.fromURL(url);
+			return Resource.fromURL(url, builder.getPlugin(HttpClient.class));
 		} catch (MalformedURLException mfue) {
 			// We ignore this
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
@@ -132,6 +132,21 @@ class ActivelyClosingClassLoader extends URLClassLoader implements Closeable {
 						public InputStream getInputStream() throws IOException {
 							return new ByteBufferInputStream(data);
 						}
+
+						@Override
+						public int getContentLength() {
+							return data.length;
+						}
+
+						@Override
+						public long getContentLengthLong() {
+							return data.length;
+						}
+
+						@Override
+						public String getContentType() {
+							return "application/octet-stream";
+						}
 					};
 				}
 			});

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -69,6 +69,7 @@ import aQute.bnd.annotation.Export;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Clazz.JAVA;
 import aQute.bnd.osgi.Descriptors.Descriptor;
 import aQute.bnd.osgi.Descriptors.PackageRef;
@@ -2985,7 +2986,7 @@ public class Analyzer extends Processor {
 			getClass().getClassLoader();
 			URL url = ClassLoader.getSystemResource(typeRef.getPath());
 			if (url != null)
-				r = Resource.fromURL(url);
+				r = Resource.fromURL(url, getPlugin(HttpClient.class));
 		}
 		if (r != null) {
 			c = new Clazz(this, typeRef.getPath(), r);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -17,7 +17,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -67,6 +66,7 @@ import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.help.Syntax;
 import aQute.bnd.help.SyntaxAnnotation;
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.Registry;
 import aQute.bnd.service.RegistryDonePlugin;
@@ -712,78 +712,96 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 */
 	private void loadPluginPath(Set<Object> instances, String pluginPath, CL loader) {
 		Parameters pluginpath = new Parameters(pluginPath, this);
+		HttpClient client = null;
+		try {
+			nextClause: for (Entry<String, Attrs> entry : pluginpath.entrySet()) {
 
-		nextClause: for (Entry<String, Attrs> entry : pluginpath.entrySet()) {
+				File f = getFile(entry.getKey()).getAbsoluteFile();
+				if (!f.isFile()) {
 
-			File f = getFile(entry.getKey()).getAbsoluteFile();
-			if (!f.isFile()) {
+					//
+					// File does not exist! Check if we need to download
+					//
 
-				//
-				// File does not exist! Check if we need to download
-				//
+					String url = entry.getValue()
+						.get(PLUGINPATH_URL_ATTR);
+					if (url != null) {
+						try {
+							logger.debug("downloading {} to {}", url, f.getAbsoluteFile());
+							URL u = new URL(url);
+							if (client == null) {
+								@SuppressWarnings("resource")
+								HttpClient c = new HttpClient();
+								c.setRegistry(this);
+								c.readSettings(this);
 
-				String url = entry.getValue()
-					.get(PLUGINPATH_URL_ATTR);
-				if (url != null) {
-					try {
-
-						logger.debug("downloading {} to {}", url, f.getAbsoluteFile());
-						URL u = new URL(url);
-						URLConnection connection = u.openConnection();
-
-						//
-						// Allow the URLCOnnectionHandlers to interact with the
-						// connection so they can sign it or decorate it with
-						// a password etc.
-						//
-						for (Object plugin : instances) {
-							if (plugin instanceof URLConnectionHandler) {
-								URLConnectionHandler handler = (URLConnectionHandler) plugin;
-								if (handler.matches(u))
-									handler.handle(connection);
+								//
+								// Allow the URLCOnnectionHandlers to interact
+								// with the
+								// connection so they can sign it or decorate it
+								// with
+								// a password etc.
+								//
+								instances.stream()
+									.filter(URLConnectionHandler.class::isInstance)
+									.map(URLConnectionHandler.class::cast)
+									.forEach(c::addURLConnectionHandler);
+								client = c;
 							}
-						}
 
-						//
-						// Copy the url to the file
-						//
-						IO.mkdirs(f.getParentFile());
-						IO.copy(connection.getInputStream(), f);
-
-						//
-						// If there is a sha specified, we verify the download
-						// of the
-						// the file.
-						//
-						String digest = entry.getValue()
-							.get(PLUGINPATH_SHA1_ATTR);
-						if (digest != null) {
-							if (Hex.isHex(digest.trim())) {
-								byte[] sha1 = Hex.toByteArray(digest);
-								byte[] filesha1 = SHA1.digest(f)
-									.digest();
-								if (!Arrays.equals(sha1, filesha1)) {
-									error(
-										"Plugin path: %s, specified url %s and a sha1 but the file does not match the sha",
-										entry.getKey(), url);
+							//
+							// Copy the url to the file
+							//
+							IO.mkdirs(f.getParentFile());
+							try (Resource resource = Resource.fromURL(u, client)) {
+								try (OutputStream out = IO.outputStream(f)) {
+									resource.write(out);
 								}
-							} else {
-								error("Plugin path: %s, specified url %s and a sha1 '%s' but this is not a hexadecimal",
-									entry.getKey(), url, digest);
+								long lastModified = resource.lastModified();
+								if (lastModified > 0L) {
+									f.setLastModified(lastModified);
+								}
 							}
+
+							//
+							// If there is a sha specified, we verify the
+							// download
+							// of the
+							// the file.
+							//
+							String digest = entry.getValue()
+								.get(PLUGINPATH_SHA1_ATTR);
+							if (digest != null) {
+								if (Hex.isHex(digest.trim())) {
+									byte[] sha1 = Hex.toByteArray(digest);
+									byte[] filesha1 = SHA1.digest(f)
+										.digest();
+									if (!Arrays.equals(sha1, filesha1)) {
+										error(
+											"Plugin path: %s, specified url %s and a sha1 but the file does not match the sha",
+											entry.getKey(), url);
+									}
+								} else {
+									error(
+										"Plugin path: %s, specified url %s and a sha1 '%s' but this is not a hexadecimal",
+										entry.getKey(), url, digest);
+								}
+							}
+						} catch (Exception e) {
+							exception(e, "Failed to download plugin %s from %s, error %s", entry.getKey(), url, e);
+							continue nextClause;
 						}
-					} catch (Exception e) {
-						error("Failed to download plugin %s from %s, error %s", entry.getKey(), url, e);
+					} else {
+						error("No such file %s from %s and no 'url' attribute on the path so it can be downloaded",
+							entry.getKey(), this);
 						continue nextClause;
 					}
-				} else {
-					error("No such file %s from %s and no 'url' attribute on the path so it can be downloaded",
-						entry.getKey(), this);
-					continue nextClause;
 				}
+				logger.debug("Adding {} to loader for plugins", f);
+				loader.add(f);
 			}
-			logger.debug("Adding {} to loader for plugins", f);
-			loader.add(f);
+		} finally {
+			IO.close(client);
 		}
 	}
 
@@ -1143,7 +1161,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 								ext = value.substring(n);
 
 							Path tmp = Files.createTempFile("url", ext);
-							try (Resource resource = Resource.fromURL(url)) {
+							try (Resource resource = Resource.fromURL(url, getPlugin(HttpClient.class))) {
 								try (OutputStream out = IO.outputStream(tmp)) {
 									resource.write(out);
 								}
@@ -2689,18 +2707,19 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		try {
 			// Lets try a URL
 			URL url = new URL(name);
-			URLConnection connection = url.openConnection();
-			try (InputStream in = connection.getInputStream()) {
-				long lastModified = connection.getLastModified();
-				if (lastModified == 0L)
+			try (Resource resource = Resource.fromURL(url, getPlugin(HttpClient.class))) {
+				Jar jar = Jar.fromResource(fileName(url.getPath()), resource);
+				if (jar.lastModified() <= 0L) {
 					// We assume the worst :-(
-					lastModified = System.currentTimeMillis();
-				Jar jar = new Jar(fileName(url.getPath()), in, lastModified);
+					jar.updateModified(System.currentTimeMillis(), "use current time");
+				}
 				addClose(jar);
 				return jar;
 			}
 		} catch (IOException ee) {
 			// ignore
+		} catch (Exception ee) {
+			throw Exceptions.duck(ee);
 		}
 		return null;
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 
+import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.URLResource.JarURLUtil;
 
 public interface Resource extends Closeable {
@@ -28,6 +29,10 @@ public interface Resource extends Closeable {
 	ByteBuffer buffer() throws Exception;
 
 	static Resource fromURL(URL url) throws IOException {
+		return fromURL(url, null);
+	}
+
+	static Resource fromURL(URL url, HttpClient client) throws IOException {
 		if (url.getProtocol()
 			.equalsIgnoreCase("file")) {
 			URI uri = URI.create(url.toExternalForm());
@@ -51,6 +56,6 @@ public interface Resource extends Closeable {
 				return new ZipResource(path, entryName);
 			}
 		}
-		return new URLResource(url);
+		return new URLResource(url, client);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/URLResource.java
@@ -10,12 +10,15 @@ import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.util.jar.JarFile;
 
+import aQute.bnd.http.HttpClient;
+import aQute.bnd.service.url.TaggedData;
 import aQute.lib.io.IO;
 
 class URLResource implements Resource {
 	private static final ByteBuffer	CLOSED			= ByteBuffer.allocate(0);
 	private ByteBuffer				buffer;
 	private final URL				url;
+	private final HttpClient		client;
 	private String					extra;
 	private long					lastModified	= -1L;
 	private int						size			= -1;
@@ -26,8 +29,9 @@ class URLResource implements Resource {
 	 * 
 	 * @see Resource#fromURL(URL)
 	 */
-	URLResource(URL url) {
+	URLResource(URL url, HttpClient client) {
 		this.url = url;
+		this.client = client;
 	}
 
 	@Override
@@ -39,24 +43,33 @@ class URLResource implements Resource {
 		if (buffer != null) {
 			return buffer;
 		}
-		URLConnection conn = openConnection();
+		InputStream in = open();
 		if (size == -1) {
-			return buffer = ByteBuffer.wrap(IO.read(conn.getInputStream()));
+			return buffer = ByteBuffer.wrap(IO.read(in));
 		}
-		ByteBuffer bb = IO.copy(conn.getInputStream(), ByteBuffer.allocate(size));
+		ByteBuffer bb = IO.copy(in, ByteBuffer.allocate(size));
 		bb.flip();
 		return buffer = bb;
 	}
 
-	private URLConnection openConnection() throws Exception {
-		URLConnection conn = url.openConnection();
-		conn.connect();
+	private InputStream open() throws Exception {
+		URLConnection conn;
+		InputStream in;
+		if (client != null) {
+			TaggedData tag = client.connectTagged(url);
+			conn = tag.getConnection();
+			in = tag.getInputStream();
+		} else {
+			conn = url.openConnection();
+			conn.connect();
+			in = conn.getInputStream();
+		}
 		lastModified = conn.getLastModified();
 		int length = conn.getContentLength();
 		if (length != -1) {
 			size = length;
 		}
-		return conn;
+		return in;
 	}
 
 	@Override
@@ -74,7 +87,7 @@ class URLResource implements Resource {
 		if (buffer != null) {
 			IO.copy(buffer(), out);
 		} else {
-			IO.copy(openConnection().getInputStream(), out);
+			IO.copy(open(), out);
 		}
 	}
 


### PR DESCRIPTION
This allows -pluginpath URLs and -includeresource URLs to be handled by
HttpClient which utilizes connection settings to handle authentication
and proxies.