### PR TITLE
java11 OutputStream has its own public nullOutputStream()

### DIFF
--- a/biz.aQute.remote/src/aQute/remote/agent/RedirectOutput.java
+++ b/biz.aQute.remote/src/aQute/remote/agent/RedirectOutput.java
@@ -32,13 +32,14 @@ public class RedirectOutput extends PrintStream {
 	}
 
 	public RedirectOutput(List<AgentServer> agents, PrintStream out, boolean err) {
-		super(out == null ? out = nullOutputStream() : out);
+		super(out == null ? out = newNullOutputStream() : out);
 		this.agents = agents;
 		this.out = out;
 		this.err = err;
 	}
 
-	private static PrintStream nullOutputStream() {
+	// TODO: java11 - use OutputStream.nullOutputStream()
+	private static PrintStream newNullOutputStream() {
 		return new PrintStream(new NullOutputStream());
 	}
 


### PR DESCRIPTION
In java 11 OutputStream has its own public nullOutputStream(),
we cannot reduce the visibility of the inherited method

https://hg.openjdk.java.net/jdk/jdk11/file/1ddf9a99e4ad/src/java.base/share/classes/java/io/OutputStream.java

Signed-off-by: stbischof stbischof@bipolis.org