### PR TITLE
[libg] relocate Bnd home (~/.bnd)

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -83,6 +83,7 @@ import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.help.Syntax;
+import aQute.bnd.home.Home;
 import aQute.bnd.main.BaselineCommands.baseLineOptions;
 import aQute.bnd.main.BaselineCommands.schemaOptions;
 import aQute.bnd.main.DiffCommand.diffOptions;
@@ -155,7 +156,8 @@ public class bnd extends Processor {
 	private static Logger						logger					= LoggerFactory.getLogger(bnd.class);
 	static Pattern								ASSIGNMENT				= Pattern.compile(															//
 		"([^=]+) (= ( ?: (\"|'|) (.+) \\3 )? ) ?", Pattern.COMMENTS);
-	Settings									settings				= new Settings();
+	Settings									settings				= new Settings(
+		Home.getUserHomeBnd() + "/settings.json");
 	final PrintStream							err						= System.err;
 	final public PrintStream					out						= System.out;
 	Justif										justif					= new Justif(80, 40, 42, 70);

--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -23,10 +23,11 @@ Export-Package: \
 	aQute.bnd.service.*;-noimport:=true,\
 	aQute.bnd.help.*;-noimport:=true,\
 	aQute.bnd.header;-noimport:=true,\
+	aQute.bnd.home;-noimport:=true,\
 	aQute.bnd.version;-noimport:=true,\
 	aQute.bnd.filerepo;-noimport:=true,\
 	aQute.lib.deployer;-noimport:=true,\
-	aQute.bnd.junit,\
+	aQute.bnd.junit;-noimport:=true,\
 	aQute.bnd.properties;-noimport:=true,\
 	aQute.bnd.build.model;-noimport:=true,\
 	aQute.bnd.build.model.clauses;-noimport:=true,\
@@ -40,7 +41,7 @@ Export-Package: \
 	aQute.bnd.component.error;-noimport:=true,\
 	org.osgi.service.log;-split-package:=first,\
 	org.osgi.service.repository;-split-package:=first,\
-	org.osgi.util.promise;-split-package:=first, \
+	org.osgi.util.promise;-split-package:=first,\
 	org.osgi.util.function;-split-package:=first
 
 -conditionalpackage: \

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -51,6 +51,7 @@ import aQute.bnd.exporter.runbundles.RunbundlesExporter;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.home.Home;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.maven.support.Maven;
 import aQute.bnd.osgi.About;
@@ -84,7 +85,7 @@ import aQute.service.reporter.Reporter;
 
 public class Workspace extends Processor {
 	private final static Logger	logger							= LoggerFactory.getLogger(Workspace.class);
-	public static final File	BND_DEFAULT_WS					= IO.getFile("~/.bnd/default-ws");
+	public static final File	BND_DEFAULT_WS					= IO.getFile(Home.getUserHomeBnd() + "/default-ws");
 	public static final String	BND_CACHE_REPONAME				= "bnd-cache";
 	public static final String	EXT								= "ext";
 	public static final String	BUILDFILE						= "build.bnd";
@@ -107,7 +108,8 @@ public class Workspace extends Processor {
 	final Map<String, Action>									commands		= newMap();
 	final Maven													maven			= new Maven(Processor.getExecutor());
 	private final AtomicBoolean									offline			= new AtomicBoolean();
-	Settings													settings		= new Settings();
+	Settings													settings		= new Settings(
+		Home.getUserHomeBnd() + "/settings.json");
 	WorkspaceRepository											workspaceRepo	= new WorkspaceRepository(this);
 	static String												overallDriver	= "unset";
 	static Parameters											overallGestalt	= new Parameters();
@@ -575,7 +577,7 @@ public class Workspace extends Processor {
 			}
 
 			resourceRepositoryImpl = new ResourceRepositoryImpl();
-			resourceRepositoryImpl.setCache(IO.getFile(getProperty(CACHEDIR, "~/.bnd/caches/shas")));
+			resourceRepositoryImpl.setCache(IO.getFile(getProperty(CACHEDIR, Home.getUserHomeBnd() + "/caches/shas")));
 			resourceRepositoryImpl.setExecutor(getExecutor());
 			resourceRepositoryImpl.setIndexFile(getFile(getBuildDir(), "repo.json"));
 			resourceRepositoryImpl.setURLConnector(new MultiURLConnectionHandler(this));

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.home.Home;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Processor.FileLine;
@@ -56,7 +57,8 @@ public class ConnectionSettings {
 	public static final String					M2_SETTINGS_SECURITY_XML		= "~/.m2/settings-security.xml";
 	public static final String					M2_SETTINGS_SECURITY_PROPERTY	= "settings.security";
 	private static final String					M2_SETTINGS_XML					= "~/.m2/settings.xml";
-	private static final String					BND_CONNECTION_SETTINGS_XML		= "~/.bnd/connection-settings.xml";
+	private static final String					BND_CONNECTION_SETTINGS_XML		= Home.getUserHomeBnd()
+		+ "/connection-settings.xml";
 	private static final String					CONNECTION_SETTINGS				= "-connection-settings";
 	private final Processor						processor;
 	private final HttpClient					client;

--- a/biz.aQute.bndlib/src/aQute/bnd/home/Home.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/home/Home.java
@@ -1,0 +1,10 @@
+package aQute.bnd.home;
+public class Home {
+	public static final String	USER_HOME_BND_DEFAULT		= "~/.bnd";
+	public static final String	USER_HOME_BND_SYSTEM_PROP	= "bnd.home.dir";
+
+	public static final String getUserHomeBnd() {
+		return System.getProperty(USER_HOME_BND_SYSTEM_PROP, USER_HOME_BND_DEFAULT);
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/home/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/home/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package aQute.bnd.home;

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.connection.settings.ConnectionSettings;
+import aQute.bnd.home.Home;
 import aQute.bnd.http.URLCache.Info;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.Registry;
@@ -85,7 +86,8 @@ public class HttpClient implements Closeable, URLConnector {
 	private ThreadLocal<PasswordAuthentication>	passwordAuthentication	= new ThreadLocal<>();
 	private boolean								inited;
 	private static JSONCodec					codec					= new JSONCodec();
-	private URLCache							cache					= new URLCache(IO.getFile("~/.bnd/urlcache"));
+	private URLCache							cache					= new URLCache(
+		IO.getFile(Home.getUserHomeBnd() + "/urlcache"));
 	private Registry							registry				= null;
 	private Reporter							reporter;
 	private volatile AtomicBoolean				offline;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenCommand.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenCommand.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.home.Home;
 import aQute.bnd.maven.support.CachedPom;
 import aQute.bnd.maven.support.Maven;
 import aQute.bnd.maven.support.Pom;
@@ -49,7 +50,7 @@ import aQute.libg.command.Command;
 
 public class MavenCommand extends Processor {
 	private final static Logger	logger		= LoggerFactory.getLogger(MavenCommand.class);
-	final Settings				settings	= new Settings();
+	final Settings				settings	= new Settings(Home.getUserHomeBnd() + "/settings.json");
 	File						temp;
 
 	public MavenCommand() {}

--- a/biz.aQute.remote/src/aQute/remote/main/Main.java
+++ b/biz.aQute.remote/src/aQute/remote/main/Main.java
@@ -3,6 +3,7 @@ package aQute.remote.main;
 import java.io.File;
 import java.io.IOException;
 
+import aQute.bnd.home.Home;
 import aQute.lib.collections.ExtList;
 import aQute.lib.getopt.CommandLine;
 import aQute.lib.getopt.Options;
@@ -68,7 +69,7 @@ public class Main extends ReporterAdapter {
 		int port = options.port(Agent.DEFAULT_PORT);
 		String network = options.network(options.all() ? "0.0.0.0" : "localhost");
 
-		File cache = IO.getFile(options.cache("~/.bnd/remote/cache"));
+		File cache = IO.getFile(options.cache(Home.getUserHomeBnd() + "/remote/cache"));
 		File storage = IO.getFile(options.storage("storage"));
 
 		dispatcher = new EnvoyDispatcher(this, cache, storage, network, port);


### PR DESCRIPTION
**Status**
- [ ] IN DEVELOPMENT
- [x] READY
- [ ] HOLD

**Description**
in some cases it might be necessary to relocate ~/.bnd by setting a env. property.

e.g. gitlab-ci could not cache directories in~/
https://gitlab.com/gitlab-org/gitlab-runner/issues/327
in most cases like mvn and gradle they relocate the dir.
```
export GRADLE_USER_HOME=`pwd`/.gradle
MAVEN_OPTS: "-Dmaven.repo.local=.m2"
```

bnd should also be able to to relocate the ~/.bnd folder.

**Checklist**
- [ ] You have added unit tests
- [ ] Documentation `please paste url`
- [x] Squash changes, related to a single issue, into a separate commit `git rebase -i` and `git push -f`
- [x] Tag commit-message [exporter,wab,cli,libg,...]
- [x] Sign-off every commit message `Signed-off-by: Joe Smith <joe.smith@email.com>` or use `git commit -s`
- [ ] Related Spec:`none`
- [ ] Reference Issues: Fixes #2661
- [ ] Backward compatibility conflicts:
 * none
- [ ] Known open Issues:
 * none

**Questions**

none
