### PR TITLE
methodhandles: Avoid object creation for non-static invocation

### DIFF
--- a/aQute.libg/src/aQute/lib/getopt/CommandLine.java
+++ b/aQute.libg/src/aQute/lib/getopt/CommandLine.java
@@ -154,10 +154,7 @@ public class CommandLine {
 			m.setAccessible(true);
 			try {
 				MethodHandle mh = publicLookup().unreflect(m);
-				if (!Modifier.isStatic(m.getModifiers())) {
-					mh = mh.bindTo(target);
-				}
-				result = mh.invoke(options);
+				result = Modifier.isStatic(m.getModifiers()) ? mh.invoke(options) : mh.invoke(target, options);
 			} catch (Error | Exception e) {
 				throw e;
 			} catch (Throwable e) {

--- a/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
+++ b/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -198,10 +199,11 @@ public class DomDTOParser {
 	private static void setField(Field f, Object targetObject, Object value) throws Exception {
 		try {
 			MethodHandle mh = publicLookup().unreflectSetter(f);
-			if (!Modifier.isStatic(f.getModifiers())) {
-				mh = mh.bindTo(targetObject);
+			if (isStatic(f)) {
+				mh.invoke(value);
+			} else {
+				mh.invoke(targetObject, value);
 			}
-			mh.invoke(value);
 		} catch (Error | Exception e) {
 			throw e;
 		} catch (Throwable e) {
@@ -212,10 +214,7 @@ public class DomDTOParser {
 	private static <T> T getField(Field f, Object targetObject) throws Exception {
 		try {
 			MethodHandle mh = publicLookup().unreflectGetter(f);
-			if (!Modifier.isStatic(f.getModifiers())) {
-				mh = mh.bindTo(targetObject);
-			}
-			return (T) mh.invoke();
+			return isStatic(f) ? (T) mh.invoke() : (T) mh.invoke(targetObject);
 		} catch (Error | Exception e) {
 			throw e;
 		} catch (Throwable e) {
@@ -223,4 +222,7 @@ public class DomDTOParser {
 		}
 	}
 
+	private static boolean isStatic(Member m) {
+		return Modifier.isStatic(m.getModifiers());
+	}
 }

--- a/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
+++ b/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
@@ -387,16 +387,13 @@ public class ReplacerAdapter extends ReporterAdapter implements Replacer {
 			MethodHandle mh;
 			try {
 				mh = publicLookup().unreflect(m);
-				if (!Modifier.isStatic(m.getModifiers())) {
-					mh = mh.bindTo(target);
-				}
 			} catch (Exception e) {
 				reporter.warning("Exception in replace: %s method=%s", e, method);
 				e.printStackTrace();
 				return null;
 			}
 			try {
-				Object result = mh.invoke(args);
+				Object result = Modifier.isStatic(m.getModifiers()) ? mh.invoke(args) : mh.invoke(target, args);
 				return "" + result;
 			} catch (Error e) {
 				throw e;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -364,15 +364,12 @@ public class Macro {
 			MethodHandle mh;
 			try {
 				mh = publicLookup().unreflect(m);
-				if (!Modifier.isStatic(m.getModifiers())) {
-					mh = mh.bindTo(target);
-				}
 			} catch (Exception e) {
 				domain.warning("Exception in replace: method=%s %s ", method, Exceptions.toString(e));
 				return NULLVALUE;
 			}
 			try {
-				Object result = mh.invoke(args);
+				Object result = Modifier.isStatic(m.getModifiers()) ? mh.invoke(args) : mh.invoke(target, args);
 				return result == null ? NULLVALUE : result.toString();
 			} catch (Error e) {
 				throw e;

--- a/biz.aQute.repository/src/aQute/p2/provider/XML.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/XML.java
@@ -103,10 +103,11 @@ public class XML {
 	private static void setField(Field f, Object targetObject, Object value) throws Exception {
 		try {
 			MethodHandle mh = publicLookup().unreflectSetter(f);
-			if (!Modifier.isStatic(f.getModifiers())) {
-				mh = mh.bindTo(targetObject);
+			if (Modifier.isStatic(f.getModifiers())) {
+				mh.invoke(value);
+			} else {
+				mh.invoke(targetObject, value);
 			}
-			mh.invoke(value);
 		} catch (Error | Exception e) {
 			throw e;
 		} catch (Throwable e) {


### PR DESCRIPTION
Change to call invoke differently for static or non-static members
rather than bind which creates objects we can easily avoid.