### PR TITLE
clazz: Add isInnerClass method

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ClazzTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ClazzTest.java
@@ -820,5 +820,26 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	public static class Nested {}
+
+	public class Inner {}
+
+	public void testNestedClass() throws Exception {
+		File file = IO.getFile("bin_test/test/ClazzTest$Nested.class");
+		try (Analyzer analyzer = new Analyzer()) {
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			clazz.parseClassFile();
+			assertThat(clazz.isInnerClass()).isFalse();
+		}
+	}
+
+	public void testInnerClass() throws Exception {
+		File file = IO.getFile("bin_test/test/ClazzTest$Inner.class");
+		try (Analyzer analyzer = new Analyzer()) {
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			clazz.parseClassFile();
+			assertThat(clazz.isInnerClass()).isTrue();
+		}
+	}
 }
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -411,9 +411,16 @@ public class Clazz {
 			type = analyzer.getTypeRef(classFile.this_class);
 		}
 
-		public String getSourceFile() {
+		String getSourceFile() {
 			return attribute(SourceFileAttribute.class).map(a -> a.sourcefile)
 				.orElse(null);
+		}
+
+		boolean isInnerClass() {
+			return attributes(InnerClassesAttribute.class).map(a -> a.classes)
+				.flatMap(Arrays::stream)
+				.anyMatch(
+					inner -> !Modifier.isStatic(inner.inner_access) && inner.inner_class.equals(type.getBinary()));
 		}
 
 		@Override
@@ -1803,6 +1810,10 @@ public class Clazz {
 
 	public TypeRef getClassName() {
 		return classDef.getType();
+	}
+
+	public boolean isInnerClass() {
+		return classDef.isInnerClass();
 	}
 
 	@Deprecated


### PR DESCRIPTION
This method uses the InnerClasses attribute of the class file to
determine if the receiver is an inner class.

Fixes https://github.com/bndtools/bnd/issues/2714