### PR TITLE
Avoid import of gradle logging package

### DIFF
--- a/aQute.libg/src/aQute/libg/slf4j/GradleLogging.java
+++ b/aQute.libg/src/aQute/libg/slf4j/GradleLogging.java
@@ -17,10 +17,11 @@ public class GradleLogging {
 	public final static Marker	QUIET;
 
 	static {
+		String gradleLogging = "org.gradle.api.logging.Logging";
 		Marker lifecycle = null;
 		Marker quiet = null;
 		try {
-			Class<?> logging = Class.forName("org.gradle.api.logging.Logging");
+			Class<?> logging = Class.forName(gradleLogging);
 			lifecycle = (Marker) logging.getField("LIFECYCLE")
 				.get(null);
 			quiet = (Marker) logging.getField("QUIET")


### PR DESCRIPTION
Use local var to hold class name for Class.forName. This avoids
ldc/invokestatic bytecode sequence which Bnd will find and generate an
import for the package.