### PR TITLE
gradle: Cease embedding dependencies in plugin jar

### DIFF
--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -25,10 +25,7 @@ pluginClasspath: ${p-buildpath;\\${pathseparator}}
 -includeresource: \
 	OSGI-OPT/src=src, \
 	resources, \
-	@${repo;biz.aQute.bndlib;latest}!/!META-INF/*, \
-	@${repo;biz.aQute.repository;latest}!/!META-INF/*, \
-	@${repo;biz.aQute.resolve;latest}!/!META-INF/*, \
-	embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;snapshot}
+	embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;latest}
 
 # Use groovydoc task generated doc for -javadoc.jar
 -maven-release: pom;path=JAR,javadoc;path=${target}/docs/groovydoc

--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -20,6 +20,8 @@ Bundle-Description: The bnd gradle plugin.
 	biz.aQute.resolve;version=latest, \
 	biz.aQute.repository;version=latest
 
+pluginClasspath: ${p-buildpath;\\${pathseparator}}
+
 -includeresource: \
 	OSGI-OPT/src=src, \
 	resources, \

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -35,3 +35,17 @@ test {
 release {
   dependsOn groovydoc
 }
+
+classes {
+    inputs.property('pluginClasspath', bnd('pluginClasspath'))
+    File pluginClasspathFile = new File(compileJava.destinationDir, 'plugin-under-test-metadata.properties')
+    outputs.file(pluginClasspathFile).withPropertyName('pluginClasspathFile')
+    doLast {
+        def pluginClasspath = project.files(new File(buildDir, "${project.name}.jar"), bnd('pluginClasspath').tokenize(File.pathSeparatorChar))
+        Properties properties = new Properties()
+        properties.setProperty('implementation-classpath', pluginClasspath.asPath)
+        pluginClasspathFile.withOutputStream {
+          properties.store(it, 'plugin-under-test-metadata')
+        }
+    }
+}

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBaselineTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBaselineTask.groovy
@@ -11,13 +11,6 @@ class TestBaselineTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Simple Bnd Baseline Task Test"() {
         given:
@@ -30,7 +23,7 @@ class TestBaselineTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'baseline', 'baselineSelf')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -58,7 +51,7 @@ class TestBaselineTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', 'echo')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -80,7 +73,7 @@ class TestBaselineTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', 'tasks', 'baseline')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -104,7 +97,7 @@ class TestBaselineTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'baseline')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -14,11 +14,17 @@ class TestBndPlugin extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    File plugin
+    String pluginClasspath
 
     def setup() {
-      plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
+      File propertiesFile = new File('bin/plugin-under-test-metadata.properties')
+      assert propertiesFile.isFile()
+      def properties = new Properties()
+      propertiesFile.withInputStream {
+        properties.load(it)
+      }
+      pluginClasspath = properties.'implementation-classpath'
+      assert pluginClasspath != null
     }
 
     def "Bnd Workspace Plugin"() {
@@ -30,7 +36,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'build', 'release')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'build', 'release')
             .forwardOutput()
             .build()
 
@@ -81,7 +87,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', 'echo', 'bndproperties', ':tasks')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', 'echo', 'bndproperties', ':tasks')
             .forwardOutput()
             .build()
 
@@ -100,7 +106,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--continue', ':test.simple:resolve', ':test.simple:resolve2')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--continue', ':test.simple:resolve', ':test.simple:resolve2')
             .forwardOutput()
             .buildAndFail()
 
@@ -163,7 +169,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--continue', ':test.simple:export', ':test.simple:runbundles', ':test.simple:export2')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--continue', ':test.simple:export', ':test.simple:runbundles', ':test.simple:export2')
             .forwardOutput()
             .build()
 
@@ -212,7 +218,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', ':tasks')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', ':tasks')
             .forwardOutput()
             .build()
 
@@ -229,7 +235,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'build', 'release')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'build', 'release')
             .forwardOutput()
             .build()
 
@@ -276,7 +282,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'build', 'release')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'build', 'release')
             .forwardOutput()
             .build()
 
@@ -323,7 +329,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'build', 'release')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'build', 'release')
             .forwardOutput()
             .build()
 
@@ -376,7 +382,7 @@ class TestBndPlugin extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'check', '--exclude-task', 'testrun.testOSGi2')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'check', '--exclude-task', 'testrun.testOSGi2')
             .forwardOutput()
             .build()
 
@@ -415,7 +421,7 @@ class TestBndPlugin extends Specification {
         when:
           result = TestHelper.getGradleRunner('4.6')
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'testrun.testOSGi2')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'testrun.testOSGi2')
             .forwardOutput()
             .buildAndFail()
 
@@ -425,7 +431,7 @@ class TestBndPlugin extends Specification {
         when:
           result = TestHelper.getGradleRunner('4.6')
             .withProjectDir(testProjectDir)
-            .withArguments("-Pbnd_plugin=${plugin}", '--stacktrace', '--debug', 'testrun.testOSGi2', '--tests=test.simple.Test')
+            .withArguments("-Pbnd_plugin=${pluginClasspath}", '--stacktrace', '--debug', 'testrun.testOSGi2', '--tests=test.simple.Test')
             .forwardOutput()
             .build()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -10,13 +10,6 @@ class TestBundlePlugin extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Simple Bnd Builder Plugin Test"() {
         given:
@@ -29,7 +22,7 @@ class TestBundlePlugin extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -116,7 +109,7 @@ class TestBundlePlugin extends Specification {
           result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestExportTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestExportTask.groovy
@@ -14,13 +14,6 @@ class TestExportTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Simple Bnd Export Task Executable Jar Test"() {
         given:
@@ -44,7 +37,7 @@ class TestExportTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -94,7 +87,7 @@ class TestExportTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -133,7 +126,7 @@ class TestExportTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestIndexTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestIndexTask.groovy
@@ -12,13 +12,6 @@ class TestIndexTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Simple Bnd Index Task Test"() {
         given:
@@ -31,7 +24,7 @@ class TestIndexTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build', 'indexer', 'indexer2')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -140,7 +133,7 @@ class TestIndexTask extends Specification {
           result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build', 'indexer', 'indexer2')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestResolveTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestResolveTask.groovy
@@ -14,13 +14,6 @@ class TestResolveTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Simple Bnd Resolve Task Generate -runbundles Test"() {
         given:
@@ -44,7 +37,7 @@ class TestResolveTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -77,7 +70,7 @@ class TestResolveTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -110,7 +103,7 @@ class TestResolveTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .buildAndFail()
 
@@ -144,7 +137,7 @@ class TestResolveTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', taskname)
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .buildAndFail()
 

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
@@ -11,13 +11,6 @@ class TestTestOSGiTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
-    List<File> pluginClasspath
-
-    def setup() {
-      File plugin = new File(buildDir, 'biz.aQute.bnd.gradle.jar').getCanonicalFile()
-      assert plugin.isFile()
-      pluginClasspath = Collections.singletonList(plugin)
-    }
 
     def "Bnd TestOSGi Task Basic Test"() {
         given:
@@ -31,7 +24,7 @@ class TestTestOSGiTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -104,7 +97,7 @@ class TestTestOSGiTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -153,7 +146,7 @@ class TestTestOSGiTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .build()
 
@@ -200,7 +193,7 @@ class TestTestOSGiTask extends Specification {
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments('--stacktrace', '--debug', '--continue', 'build')
-            .withPluginClasspath(pluginClasspath)
+            .withPluginClasspath()
             .forwardOutput()
             .buildAndFail()
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin1/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin1/settings.gradle
@@ -5,7 +5,7 @@
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
 }
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin2/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin2/settings.gradle
@@ -10,7 +10,7 @@ import aQute.bnd.osgi.Constants
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
   /* Pass bnd gradle plugin classpath to rootProject once created */
   def bndPlugin = files(configurations.classpath.files)

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin3/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin3/settings.gradle
@@ -10,7 +10,7 @@ import aQute.bnd.osgi.Constants
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
   /* Add bnd gradle plugin to buildscript classpath of rootProject */
   def bndPlugin = files(configurations.classpath.files)

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin4/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin4/build.gradle
@@ -7,7 +7,7 @@
 
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
 }
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin5/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin5/settings.gradle
@@ -5,7 +5,7 @@
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
 }
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin6/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin6/settings.gradle
@@ -5,7 +5,7 @@
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
   /* Pass bnd gradle plugin classpath to rootProject once created */
   def bndPlugin = files(configurations.classpath.files)

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin7/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin7/settings.gradle
@@ -5,7 +5,7 @@
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
   /* Pass bnd gradle plugin classpath to rootProject once created */
   def bndPlugin = files(configurations.classpath.files)

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin8/workspace/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin8/workspace/build.gradle
@@ -7,7 +7,7 @@
 
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
 }
 

--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin9/settings.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin9/settings.gradle
@@ -5,7 +5,7 @@
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
   dependencies {
-    classpath files(new File(bnd_plugin).canonicalFile)
+    classpath files(bnd_plugin.tokenize(File.pathSeparatorChar))
   }
   /* Pass bnd gradle plugin classpath to rootProject once created */
   def bndPlugin = files(configurations.classpath.files)

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -486,14 +486,20 @@ public class bnd extends Processor {
 				System.setProperty(DEFAULT_LOG_LEVEL_KEY, "warn");
 				level = org.slf4j.spi.LocationAwareLogger.WARN_INT;
 			}
-			Field field = org.slf4j.impl.SimpleLogger.class.getDeclaredField("DEFAULT_LOG_LEVEL");
+			Field field = org.slf4j.impl.SimpleLogger.class.getDeclaredField("CONFIG_PARAMS");
 			field.setAccessible(true);
-			field.set(null, level);
+			Object CONFIG_PARAMS = field.get(null);
+			field = org.slf4j.impl.SimpleLoggerConfiguration.class.getDeclaredField("defaultLogLevel");
+			field.setAccessible(true);
+			field.set(CONFIG_PARAMS, level);
+
+			field = org.slf4j.impl.SimpleLogger.class.getDeclaredField("currentLogLevel");
+			field.setAccessible(true);
+			field.set(logger, level);
 		} catch (Exception e) {
 			e.printStackTrace();
 			// ignore
 		}
-		logger = LoggerFactory.getLogger(bnd.class);
 		logger.debug("Setup logger");
 	}
 

--- a/biz.aQute.bnd/test/aQute/bnd/main/TestBndMain.java
+++ b/biz.aQute.bnd/test/aQute/bnd/main/TestBndMain.java
@@ -158,7 +158,7 @@ public class TestBndMain extends TestBndMainBase {
 
 		expectFileStatus(FileStatus.CREATED, "p2/bin/somepackage/SomeClass.class");
 		expectFileStatus(FileStatus.CREATED, "p3/bin/somepackage/SomeClass.class");
-		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotaionOne.class");
+		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotationOne.class");
 		expectFileStatus(FileStatus.CREATED, "p/generated/p.jar");
 		expectFileStatus(FileStatus.CREATED, "p2/generated/p2.jar");
 		expectFileStatus(FileStatus.CREATED, "p3/generated/p3.jar");
@@ -176,7 +176,7 @@ public class TestBndMain extends TestBndMainBase {
 
 		expectFileStatus(FileStatus.CREATED, "p2/bin/somepackage/SomeClass.class");
 		expectFileStatus(FileStatus.CREATED, "p3/bin/somepackage/SomeClass.class");
-		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotaionOne.class");
+		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotationOne.class");
 		expectFileStatus(FileStatus.UNMODIFIED_EXISTS, "p3/bin/somepackage/SomeOldClass.class");
 	}
 
@@ -188,7 +188,7 @@ public class TestBndMain extends TestBndMainBase {
 
 		expectNoError();
 
-		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotaionOne.class");
+		expectFileStatus(FileStatus.CREATED, "p4/bin/req/RequireAnnotationOne.class");
 	}
 
 	@Test

--- a/biz.aQute.bnd/testdata/workspace/p3/bnd.bnd
+++ b/biz.aQute.bnd/testdata/workspace/p3/bnd.bnd
@@ -4,6 +4,7 @@ Bundle-Name: SomeBundle
 Export-Package: somepackage
 
 -buildpath: \
-	p4;version=project
+	p4;version=project,\
+    osgi.cmpn;version=7.0
 	
 -dependson: p4

--- a/biz.aQute.bnd/testdata/workspace/p3/src/somepackage/SomeClass.java
+++ b/biz.aQute.bnd/testdata/workspace/p3/src/somepackage/SomeClass.java
@@ -1,8 +1,8 @@
 package somepackage;
 
-import req.RequireAnnotaionOne;
+import req.RequireAnnotationOne;
 
-@RequireAnnotaionOne
+@RequireAnnotationOne
 public class SomeClass {
 
 	public SomeClass() {

--- a/biz.aQute.bnd/testdata/workspace/p4/src/req/RequireAnnotationOne.java
+++ b/biz.aQute.bnd/testdata/workspace/p4/src/req/RequireAnnotationOne.java
@@ -17,6 +17,6 @@ import java.lang.annotation.Target;
 @Target({ TYPE, PACKAGE })
 
 @RequireConfigurator
-public @interface RequireAnnotaionOne {
+public @interface RequireAnnotationOne {
 
 }

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -68,8 +68,8 @@ org.assertj:assertj-core:3.10.0
 
 args4j:args4j:2.0.26
 
-org.slf4j:slf4j-api:1.7.13
-org.slf4j:slf4j-simple:1.7.13
+org.slf4j:slf4j-api:1.7.25
+org.slf4j:slf4j-simple:1.7.25
 
 org.yaml:snakeyaml:1.15
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,9 +9,6 @@ buildscript {
   repositories {
     mavenCentral()
     maven {
-      url 'https://oss.sonatype.org/content/groups/osgi/'
-    }
-    maven {
       url uri(bnd_repourl)
     }
   }


### PR DESCRIPTION
Using the new maven pom dependencies support, the gradle plugin jar
will no longer embed its dependencies and will rely upon gradle
downloading the dependencies from a repository and making them available
on the plugin's classpath.