### PR TITLE
Switch to Azul JDK 10 binary to avoid current issues with AdoptOpenJDK JDK 10 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - name: "OpenJDK 10"
       before_install:
         - "curl -O -L --retry 3  https://github.com/sormuras/bach/raw/master/install-jdk.sh"
-        - "source install-jdk.sh --url \"https://github.com/AdoptOpenJDK/openjdk10-releases/releases/download/jdk-10.0.2%2B13/OpenJDK10_x64_Linux_jdk-10.0.2.13.tar.gz\""
+        - "source install-jdk.sh --url \"https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz\""
     - name: "Local rebuild"
       jdk: oraclejdk8
       script: 

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -461,6 +461,9 @@ public class Attrs implements Map<String, String> {
 	}
 
 	public static Type toType(String type) {
+		if (type == null) {
+			return null;
+		}
 		for (Type t : Type.values()) {
 			if (t.toString.equals(type))
 				return t;

--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -66,7 +66,6 @@
  					<goals>
 						<goal>deploy</goal>
 					</goals>
-					<debug>true</debug>
 				</configuration>
 				<executions>
 					<execution>

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -97,7 +97,6 @@
                     <goals>
                         <goal>package</goal>
                     </goals>
-                    <debug>true</debug>
                     <scriptVariables>
                       <bndVersion>${project.version}</bndVersion>
                     </scriptVariables>

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -96,7 +96,6 @@
 					<goals>
 						<goal>package</goal>
 					</goals>
-					<debug>true</debug>
 				</configuration>
 				<executions>
 					<execution>

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -82,7 +82,6 @@
 					<goals>
 						<goal>package</goal>
 					</goals>
-					<debug>true</debug>
 				</configuration>
 				<executions>
 					<execution>

--- a/maven/bnd-resolver-maven-plugin/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/pom.xml
@@ -98,7 +98,6 @@
                     <goals>
                         <goal>package</goal>
                     </goals>
-                    <debug>true</debug>
                     <scriptVariables>
                       <bndVersion>${project.version}</bndVersion>
                     </scriptVariables>

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -97,7 +97,6 @@
                     <goals>
                         <goal>integration-test</goal>
                     </goals>
-                    <debug>true</debug>
                     <scriptVariables>
                       <bndVersion>${project.version}</bndVersion>
                     </scriptVariables>


### PR DESCRIPTION
We also remove debug output for the maven-invoker-plugin execution to vastly shorten the build output.