### PR TITLE
baselining: Change log level to debug for pedantic message

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -273,7 +273,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 						"Unable to determine whether the meta annotation %s applied to type %s provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed",
 						fqn, current.getFQN());
 				} else {
-					logger.info(
+					logger.debug(
 						"Unable to determine whether the meta annotation {} applied to type {} provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed",
 						fqn, current.getFQN());
 				}


### PR DESCRIPTION
The log message is changed to debug since info would appear in normal
maven output of a baselining task. The message is just pedantic and
should never have been info level. For baselining, the message is
not of any value anyway.

Fixes https://github.com/bndtools/bnd/issues/2772