### PR TITLE
Initial support for bnd instructions via mvn <instructions> tag

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -540,7 +540,7 @@ public class BndMavenPlugin extends AbstractMojo {
 		Xpp3Dom bndElement = configuration.getChild("bnd");
 		if (bndElement != null) {
 			if (projectFile == null) {
-				if (!xppDomEqualsWithSubtitution(bndElement, tracker.get("bnd"), projectFile, builder)) {
+				if (!xppDomEqualsWithSubstitution(bndElement, tracker.get("bnd"), projectFile, builder)) {
 					tracker.put("bnd", bndElement);
 					bndUsed = true;
 					logger.debug("loading bnd properties from bnd element in pom: {}", pomProject);
@@ -589,7 +589,7 @@ public class BndMavenPlugin extends AbstractMojo {
 	 *         substitution.
 	 * @throws IOException If an IO exception occurs.
 	 */
-	private boolean xppDomEqualsWithSubtitution(Xpp3Dom d1, Xpp3Dom d2, File projectFile, Reporter reporter)
+	private boolean xppDomEqualsWithSubstitution(Xpp3Dom d1, Xpp3Dom d2, File projectFile, Reporter reporter)
 		throws IOException {
 		if (d1 == null && d2 == null)
 			return true;

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -13,10 +13,13 @@
 	</properties>
 
 	<modules>
+        <module>test-sub-parent</module>
 		<module>test-api-bundle</module>
 		<module>test-impl-bundle</module>
 		<module>test-wrapper-bundle</module>
 		<module>test-in-build-pluginManagement-inheritance</module>
+        <module>test-pom-instructions</module>
+        <module>test-pom-instructions2</module>
 	</modules>
 	
 	<build>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.2</version>
+	</parent>
+	<artifactId>test.pom.instructions</artifactId>
+    <name>Test POM Instructions</name>
+	<version>1.2.3</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.cmpn</artifactId>
+			<version>6.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+			<version>6.0.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+			</plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                     
+                    <instructions>
+                        <TestKey>testval</TestKey>
+                        <_exportcontents>org.example.api,org.example.types,blah</_exportcontents>
+                    </instructions>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/ExampleConsumerInterface.java
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/ExampleConsumerInterface.java
@@ -1,0 +1,10 @@
+package org.example.api;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+@ConsumerType
+public interface ExampleConsumerInterface {
+
+	void callbackMethod();
+
+}

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/ExampleProviderInterface.java
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/ExampleProviderInterface.java
@@ -1,0 +1,11 @@
+package org.example.api;
+
+import org.example.types.ThingyDTO;
+import org.osgi.annotation.versioning.ProviderType;
+
+@ProviderType
+public interface ExampleProviderInterface {
+
+	void doSomething(ThingyDTO thing);
+
+}

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/package-info.java
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/api/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("2.0.0")
+package org.example.api;

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/types/ThingyDTO.java
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/types/ThingyDTO.java
@@ -1,0 +1,5 @@
+package org.example.types;
+
+public class ThingyDTO {
+
+}

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/types/package-info.java
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/java/org/example/types/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.example.types;

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/resources/org/example/api/aresource.txt
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions/src/main/resources/org/example/api/aresource.txt
@@ -1,0 +1,1 @@
+This is a resource

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions2/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-pom-instructions2/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test-sub-parent</artifactId>
+		<version>0.0.1</version>
+        <relativePath>../test-sub-parent</relativePath>
+	</parent>
+	<artifactId>test.pom.instructions2</artifactId>
+    <name>Test POM Instructions 2</name>
+	<version>2.0.0</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.cmpn</artifactId>
+			<version>6.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+			<version>6.0.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+			</plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                    <bnd><![CDATA[Myotherkey: myothervalue]]></bnd>
+                </configuration>
+            </plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-sub-parent/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-sub-parent/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>biz.aQute.bnd-test</groupId>
+        <artifactId>test</artifactId>
+        <version>0.0.2</version>
+    </parent>
+	<artifactId>test-sub-parent</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Mykey>myvalue</Mykey>
+                    </instructions>
+                </configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -14,6 +14,10 @@ File wrapper_bundle = new File(basedir, 'test-wrapper-bundle/target/test-wrapper
 assert wrapper_bundle.isFile()
 File in_build_pluginManagement_api_bundle = new File(basedir, 'test-in-build-pluginManagement-inheritance/test-inheriting-api-bundle/target/test-inheriting-api-bundle-0.0.1.jar')
 assert in_build_pluginManagement_api_bundle.isFile()
+File pom_instr = new File(basedir, 'test-pom-instructions/target/test.pom.instructions-1.2.3.jar')
+assert pom_instr.isFile()
+File pom_instr2 = new File(basedir, 'test-pom-instructions2/target/test.pom.instructions2-2.0.0.jar')
+assert pom_instr2.isFile()
 
 // Load manifests
 JarFile api_jar = new JarFile(api_bundle)
@@ -24,21 +28,32 @@ JarFile wrapper_jar = new JarFile(wrapper_bundle)
 Attributes wrapper_manifest = wrapper_jar.getManifest().getMainAttributes()
 JarFile in_build_pluginManagement_api_jar = new JarFile(in_build_pluginManagement_api_bundle)
 Attributes in_build_pluginManagement_api_manifest = in_build_pluginManagement_api_jar.getManifest().getMainAttributes()
+JarFile pom_instr_jar = new JarFile(pom_instr)
+Attributes pom_instr_manifest = pom_instr_jar.getManifest().getMainAttributes()
+JarFile pom_instr_jar2 = new JarFile(pom_instr2)
+Attributes pom_instr_manifest2 = pom_instr_jar2.getManifest().getMainAttributes()
 
 // Basic manifest check
 assert api_manifest.getValue('Bundle-SymbolicName') == 'test.api.bundle'
 assert impl_manifest.getValue('Bundle-SymbolicName') == 'test-impl-bundle'
 assert wrapper_manifest.getValue('Bundle-SymbolicName') == 'test.wrapper.bundle'
+assert pom_instr_manifest.getValue('Bundle-SymbolicName') == 'test.pom.instructions'
 assert in_build_pluginManagement_api_manifest.getValue('Bundle-SymbolicName') == 'biz.aQute.bnd-test.test-inheriting-api-bundle'
 assert api_manifest.getValue('Bundle-Name') == 'Test API Bundle'
 assert impl_manifest.getValue('Bundle-Name') == 'Test Impl Bundle'
 assert wrapper_manifest.getValue('Bundle-Name') == 'test-wrapper-bundle'
+assert pom_instr_manifest.getValue('Bundle-Name') == 'Test POM Instructions'
 assert api_manifest.getValue('Bundle-Version') == '0.0.1.bndqual'
 assert impl_manifest.getValue('Bundle-Version') == '0.0.1.SNAPSHOT'
 assert wrapper_manifest.getValue('Bundle-Version') != '0.0.1.BUILD-SNAPSHOT'
 assert wrapper_manifest.getValue('Bundle-Version') =~ /^0\.0\.1\.BUILD-/
 assert in_build_pluginManagement_api_manifest.getValue('Bundle-Version') == '0.0.1'
+assert pom_instr_manifest.getValue('Bundle-Version') == '1.2.3'
+assert pom_instr_manifest.getValue('TestKey') == 'testval'
+assert pom_instr_manifest.getValue('Export-Package') =~ /blah/
 assert wrapper_manifest.getValue('Bundle-ClassPath') == '.,lib/osgi.annotation.jar'
+assert pom_instr_manifest2.getValue('Mykey') == 'myvalue'
+assert pom_instr_manifest2.getValue('Myotherkey') == 'myothervalue'
 
 // Check inheritance of properties in bnd.bnd from the parent project
 assert api_manifest.getValue('X-ParentProjectProperty') == 'it worked'
@@ -46,6 +61,7 @@ assert impl_manifest.getValue('X-ParentProjectProperty') == 'it worked'
 assert wrapper_manifest.getValue('X-ParentProjectProperty') == 'overridden'
 assert in_build_pluginManagement_api_manifest.getValue('X-ParentProjectProperty') == 'overridden'
 assert in_build_pluginManagement_api_manifest.getValue('X-ParentProjectProperty2') == 'it worked'
+assert pom_instr_manifest.getValue('X-ParentProjectProperty') == 'it worked'
 
 // Check -include of bnd files
 assert api_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
@@ -53,6 +69,7 @@ assert impl_manifest.getValue('X-IncludedParentProjectProperty') == 'Included vi
 assert wrapper_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
 assert wrapper_manifest.getValue('X-IncludedProperty') == 'Included via -include in project bnd.bnd file'
 assert impl_manifest.getValue('X-IncludedProjectProperty') == 'Included via -include in project bnd.bnd file'
+assert pom_instr_manifest.getValue('X-IncludedParentProjectProperty') == 'Included via -include in parent bnd.bnd file'
 
 // Check POM properties
 assert impl_manifest.getValue('Project-Build-OutputDirectory') == new File(basedir, 'test-impl-bundle/target/classes').absolutePath
@@ -68,20 +85,29 @@ assert impl_manifest.getValue('SomeParentVar') == 'parentValue'
 assert api_manifest.getValue('Project-Name') == 'Test API Bundle'
 assert impl_manifest.getValue('Project-Name') == 'test-impl-bundle'
 assert wrapper_manifest.getValue('Project-Name') == 'test-wrapper-bundle'
+assert pom_instr_manifest.getValue('Project-Name') == 'Test POM Instructions'
+assert pom_instr_manifest2.getValue('Project-Name') == 'Test POM Instructions 2'
 assert api_manifest.getValue('Project-Dir') == new File(basedir, 'test-api-bundle').absolutePath.replace(File.separatorChar, '/' as char)
 assert impl_manifest.getValue('Project-Dir') == new File(basedir, 'test-impl-bundle').absolutePath.replace(File.separatorChar, '/' as char)
 assert wrapper_manifest.getValue('Project-Dir') == new File(basedir, 'test-wrapper-bundle').absolutePath.replace(File.separatorChar, '/' as char)
+assert pom_instr_manifest.getValue('Project-Dir') == new File(basedir, 'test-pom-instructions').absolutePath.replace(File.separatorChar, '/' as char)
+assert pom_instr_manifest2.getValue('Project-Dir') == new File(basedir, 'test-pom-instructions2').absolutePath.replace(File.separatorChar, '/' as char)
 assert api_manifest.getValue('Project-Output') == new File(basedir, 'test-api-bundle/target').absolutePath
 assert impl_manifest.getValue('Project-Output') == new File(basedir, 'test-impl-bundle/target').absolutePath
 assert wrapper_manifest.getValue('Project-Output') == new File(basedir, 'test-wrapper-bundle/target').absolutePath
+assert pom_instr_manifest.getValue('Project-Output') == new File(basedir, 'test-pom-instructions/target').absolutePath
+assert pom_instr_manifest2.getValue('Project-Output') == new File(basedir, 'test-pom-instructions2/target').absolutePath
 assert api_manifest.getValue('Project-Buildpath')
 assert impl_manifest.getValue('Project-Buildpath')
 assert wrapper_manifest.getValue('Project-Buildpath')
+assert pom_instr_manifest.getValue('Project-Buildpath')
 assert api_manifest.getValue('Project-Sourcepath')
 assert impl_manifest.getValue('Project-Sourcepath')
 assert !wrapper_manifest.getValue('Project-Sourcepath')
+assert pom_instr_manifest.getValue('Project-Sourcepath')
 assert api_manifest.getValue('Here') == new File(basedir, 'test-api-bundle').absolutePath.replace(File.separatorChar, '/' as char)
 assert api_manifest.getValue('Parent-Here') == basedir.absolutePath.replace(File.separatorChar, '/' as char)
+assert pom_instr_manifest.getValue('Parent-Here') == basedir.absolutePath.replace(File.separatorChar, '/' as char)
 assert impl_manifest.getValue('Parent-Here') == basedir.absolutePath.replace(File.separatorChar, '/' as char)
 assert wrapper_manifest.getValue('Parent-Here') == basedir.absolutePath.replace(File.separatorChar, '/' as char)
 assert impl_manifest.getValue('Project-License') == 'Apache License, Version 2.0'
@@ -92,9 +118,15 @@ assert api_jar.getEntry('org/example/api/aresource.txt') != null
 assert api_jar.getInputStream(api_jar.getEntry('org/example/api/aresource.txt')).text =~ /This is a resource/
 assert api_jar.getEntry('org/example/types/') != null
 assert api_jar.getEntry('OSGI-OPT/src/') != null
+assert pom_instr_jar.getEntry('org/example/api/') != null
+assert pom_instr_jar.getEntry('org/example/api/aresource.txt') != null
+assert pom_instr_jar.getInputStream(api_jar.getEntry('org/example/api/aresource.txt')).text =~ /This is a resource/
+assert pom_instr_jar.getEntry('org/example/types/') != null
+assert pom_instr_jar.getEntry('OSGI-OPT/src/') == null
 assert impl_jar.getEntry('org/example/impl/') != null
 assert impl_jar.getEntry('OSGI-INF/org.example.impl.ExampleComponent.xml') != null
 assert impl_jar.getEntry('OSGI-INF/metatype/org.example.impl.Config.xml') != null
 assert wrapper_jar.getEntry('org/example/api/') != null
 assert wrapper_jar.getEntry('org/example/types/') != null
 assert wrapper_jar.getEntry('lib/osgi.annotation.jar') != null
+


### PR DESCRIPTION
Instructions that start with a dash '-' can be specified in the
<instructions> XML as starting with an underscore '_'.
This addresses #2769

Signed-off-by: David Bosschaert <david.bosschaert@gmail.com>