### PR TITLE
 annotations: Handle meta annotations in repeatable annotation containers 

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -1,8 +1,10 @@
 package test.annotationheaders;
 
 import static aQute.lib.env.Header.DUPLICATE_MARKER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
@@ -338,6 +340,30 @@ public class StdAnnotationHeadersTest extends TestCase {
 			assertEquals("foo", p.get("overriding"));
 			assertTrue(p.containsKey("version:Version"));
 			assertEquals("1.0.0", p.get("version:Version"));
+		}
+	}
+
+	/**
+	 * A Meta annotated class using Repeatable annotations
+	 * 
+	 * @throws Exception
+	 */
+	public void testStdRepeatableMetaAnnotated() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin_test"));
+			b.setPrivatePackage("test.annotationheaders.attrs.std.repeatable");
+			b.build();
+			assertTrue(b.check());
+			Manifest manifest = b.getJar()
+				.getManifest();
+			manifest.write(System.out);
+
+			Attributes mainAttributes = manifest.getMainAttributes();
+
+			Header repeated = Header.parseHeader(mainAttributes.getValue("Repeatable"));
+			assertThat(repeated).containsOnlyKeys("RepeatableAnnotation");
+			Header container = Header.parseHeader(mainAttributes.getValue("Container"));
+			assertThat(container).containsOnlyKeys("RepeatableAnnotations");
 		}
 	}
 

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/RepeatableAnnotation.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/RepeatableAnnotation.java
@@ -1,0 +1,11 @@
+package test.annotationheaders.attrs.std.repeatable;
+
+import java.lang.annotation.Repeatable;
+
+import org.osgi.annotation.bundle.Header;
+
+@Header(name = "Repeatable", value = "RepeatableAnnotation")
+@Repeatable(RepeatableAnnotations.class)
+public @interface RepeatableAnnotation {
+	int value();
+}

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/RepeatableAnnotations.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/RepeatableAnnotations.java
@@ -1,0 +1,8 @@
+package test.annotationheaders.attrs.std.repeatable;
+
+import org.osgi.annotation.bundle.Header;
+
+@Header(name = "Container", value = "RepeatableAnnotations")
+public @interface RepeatableAnnotations {
+	RepeatableAnnotation[] value();
+}

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/UsingRepeatableAnnotation.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/repeatable/UsingRepeatableAnnotation.java
@@ -1,0 +1,7 @@
+package test.annotationheaders.attrs.std.repeatable;
+
+@RepeatableAnnotation(1)
+@RepeatableAnnotation(2)
+public class UsingRepeatableAnnotation {
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/classfile/ConstantPool.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/classfile/ConstantPool.java
@@ -25,8 +25,8 @@ public class ConstantPool {
 
 	final Object[]			pool;
 
-	ConstantPool(int constant_pool_count) {
-		this.pool = new Object[constant_pool_count];
+	ConstantPool(Object[] pool) {
+		this.pool = pool;
 	}
 
 	public int size() {
@@ -88,8 +88,7 @@ public class ConstantPool {
 
 	static ConstantPool parseConstantPool(DataInput in) throws IOException {
 		int constant_pool_count = in.readUnsignedShort();
-		ConstantPool constant_pool = new ConstantPool(constant_pool_count);
-		Object[] pool = constant_pool.pool;
+		Object[] pool = new Object[constant_pool_count];
 		for (int index = 1; index < constant_pool_count; index++) {
 			int tag = in.readUnsignedByte();
 			switch (tag) {
@@ -175,7 +174,7 @@ public class ConstantPool {
 			}
 		}
 
-		return constant_pool;
+		return new ConstantPool(pool);
 	}
 
 	static String parseUtf8Info(DataInput in) throws IOException {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Annotation.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -92,7 +93,37 @@ public class Annotation {
 
 	@Override
 	public String toString() {
-		return name + ":" + member + ":" + policy + ":" + (elements == null ? "{}" : elements);
+		StringBuilder sb = new StringBuilder();
+		sb.append(name)
+			.append(':')
+			.append(member)
+			.append(':')
+			.append(policy)
+			.append(':')
+			.append('{');
+		if (elements != null) {
+			Iterator<Entry<String, Object>> i = elements.entrySet()
+				.iterator();
+			if (i.hasNext()) {
+				for (Entry<String, Object> e = i.next();; e = i.next()) {
+					sb.append(e.getKey())
+						.append('=');
+					Object v = e.getValue();
+					if (v instanceof Object[]) {
+						sb.append(Arrays.toString((Object[]) v));
+					} else {
+						sb.append(v);
+					}
+					if (!i.hasNext()) {
+						break;
+					}
+					sb.append(',')
+						.append(' ');
+				}
+			}
+		}
+		return sb.append('}')
+			.toString();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
We look to see if an annotation is a repeatable annotation container. If
it is, we processes the contained annotations as if they were on the
annotated type.

Fixes #2757