### PR TITLE
build: Update repos to use Eclipse Luna 4.4.2 site

### DIFF
--- a/biz.aQute.bnd.diagnostics.gogo/bnd.bnd
+++ b/biz.aQute.bnd.diagnostics.gogo/bnd.bnd
@@ -11,8 +11,8 @@ Bundle-Activator: biz.aQute.bnd.diagnostics.gogo.osgi.Activator
     org.osgi.service.component;version='[1.3,1.4)', \
     org.osgi.service.component.annotations;version='[1.3,1.4)';maven-scope=provided, \
 	biz.aQute.bndlib;version=latest;packages=*;maven-scope=provided,\
-	org.apache.felix.gogo.runtime;version=0.12,\
-	org.apache.felix.gogo.command
+	org.apache.felix.gogo.runtime;version=latest,\
+	org.apache.felix.gogo.command;version=latest
 
 -testpath: \
 	${junit}, \

--- a/biz.aQute.bnd.remote.junit/bnd.bnd
+++ b/biz.aQute.bnd.remote.junit/bnd.bnd
@@ -32,6 +32,6 @@ Import-Package: \
     slf4j.api
 
 -runbundles: \
-    org.apache.felix.gogo.shell
+    org.apache.felix.gogo.shell;version=latest
 
 -runfw: org.apache.felix.framework

--- a/cnf/bnd.bnd
+++ b/cnf/bnd.bnd
@@ -2,14 +2,3 @@
 -include: ${workspace}/cnf/includes/jdt.bnd
 
 -nobundles = true
-
--runfw: org.apache.felix.framework;version=@4.0.0
--runee: JavaSE-1.8
--runsystemcapabilities: ${native_capability}
-
--runbundles:\
-	org.apache.felix.gogo.runtime,\
-	org.apache.felix.gogo.shell,\
-	org.apache.felix.gogo.command
-
--runtrace: true

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -1,5 +1,5 @@
 releaserepo:            ${workspace}/dist/bundles
-baselinerepo:           https://dl.bintray.com/bnd/dist/${baseline.version}
+baselinerepo:           https://dl.bintray.com/bnd/dist/${baseline.version}/index.xml.gz
 
 -plugin:\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\
@@ -31,29 +31,26 @@ baselinerepo:           https://dl.bintray.com/bnd/dist/${baseline.version}
         releaseUrl="https://bndtools.jfrog.io/bndtools/libs-release-local/";\
         snapshotUrl="https://bndtools.jfrog.io/bndtools/libs-snapshot-local/";\
         noupdateOnRelease=true,\
-    aQute.bnd.signing.JartoolSigner,\
-    aQute.bnd.repository.osgi.OSGiRepository;\
-        name="Eclipse IDE for Eclipse Committers 4.4.2";\
-        locations=https://dl.bintray.com/bndtools/eclipse-repo/4.4.2/index.xml.gz;\
-        poll.time=-1;\
-        cache=${workspace}/cnf/cache/stable/EclipseIDE,\
-    aQute.bnd.repository.osgi.OSGiRepository;\
-        name="Eclipse Orbit 4.4.2";\
-        locations=http://download.eclipse.org/tools/orbit/downloads/drops/R20150124073747/repository/index.xml.gz;\
-        poll.time=-1;\
-        cache=${workspace}/cnf/cache/stable/EclipseOrbit,\
+    aQute.bnd.repository.p2.provider.P2Repository;\
+        name="Eclipse Luna 4.4.2";\
+        url="https://download.eclipse.org/eclipse/updates/4.4/R-4.4.2-201502041700/";\
+        location=${workspace}/cnf/cache/stable/Eclipse,\
+    aQute.bnd.repository.p2.provider.P2Repository;\
+        name="Eclipse EGit 4.4.1";\
+        url="https://download.eclipse.org/egit/updates-4.4.1/";\
+        location=${workspace}/cnf/cache/stable/EclipseEGit,\
      aQute.bnd.repository.p2.provider.P2Repository;\
         name="Eclipse m2e 1.6.2";\
-        url="http://download.eclipse.org/technology/m2e/releases/1.6/1.6.2.20150902-0002/";\
+        url="https://download.eclipse.org/technology/m2e/releases/1.6/1.6.2.20150902-0002/";\
         location=${workspace}/cnf/cache/stable/EclipseM2E,\
      aQute.bnd.repository.maven.pom.provider.BndPomRepository;\
-        name="m2e Deps";\
+        name="Eclipse m2e Dependencies";\
         revision="org.apache.maven:maven-core:3.3.3,org.sonatype.plexus:plexus-build-api:0.0.7";\
         releaseUrls='https://repo.maven.apache.org/maven2';\
-        location=${workspace}/cnf/cache/stable/m2eDeps/index.xml,\
+        location=${workspace}/cnf/cache/stable/EclipseM2EDeps/index.xml,\
     aQute.bnd.repository.osgi.OSGiRepository;\
         name='Baseline';\
-        locations=${baselinerepo}/index.xml.gz;\
+        locations="${baselinerepo}";\
         poll.time=-1;\
         cache=${workspace}/cnf/cache/stable/Baseline
 
@@ -61,11 +58,11 @@ baselinerepo:           https://dl.bintray.com/bnd/dist/${baseline.version}
 #-plugin.m2e.debug:\
 #    aQute.bnd.repository.p2.provider.P2Repository; \
 #        name="Eclipse EMF 2.13"; \
-#        url="http://download.eclipse.org/modeling/emf/emf/builds/release/2.13";\
+#        url="https://download.eclipse.org/modeling/emf/emf/builds/release/2.13";\
 #        location=${workspace}/cnf/cache/stable/EclipseEMF,\
 #    aQute.bnd.repository.p2.provider.P2Repository; \
 #        name="Eclipse Webtools 3.6.3"; \
-#        url="http://download.eclipse.org/webtools/downloads/drops/R3.6.3/R-3.6.3-20150216091848/repository/";\
+#        url="https://download.eclipse.org/webtools/downloads/drops/R3.6.3/R-3.6.3-20150216091848/repository/";\
 #        location=${workspace}/cnf/cache/stable/Webtools363,\
 
 -buildrepo: Local


### PR DESCRIPTION
This replaces our bespoke update site on bintray.
