### PR TITLE
Add support to use bundle-symbolic-name and bundle-version attributes for Import-Package

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -3263,4 +3263,29 @@ public class BuilderTest extends BndTestCase {
 		System.err.println("Imports     " + builder.getImports());
 	}
 
+	public void testImportBSN() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(new File("bin_test"));
+			b.addClasspath(new File("jar/ecj-4.7.3a.jar"));
+			b.addClasspath(new File("jar/org.eclipse.osgi-3.5.0.jar"));
+			b.setProperty("Export-Package", "test.activator");
+			b.setProperty("Import-Package",
+				"org.eclipse.jdt.core.compiler;org.eclipse.osgi.framework.util;"
+					+ "bundle-symbolic-name=\"${@bundlesymbolicname}\";"
+					+ "bundle-version=\"${range;[==,+0);${@bundleversion}}\"");
+			Jar jar = b.build();
+			assertTrue(b.check());
+			Manifest manifest = jar.getManifest();
+			manifest.write(System.err);
+			Domain d = Domain.domain(manifest);
+			Parameters imports = d.getImportPackage();
+			Attrs attrs = imports.get("org.eclipse.jdt.core.compiler");
+			assertEquals("org.eclipse.jdt.core.compiler.batch", attrs.get("bundle-symbolic-name"));
+			assertEquals("[3.13,4.0)", attrs.get("bundle-version"));
+			attrs = imports.get("org.eclipse.osgi.framework.util");
+			assertEquals("org.eclipse.osgi", attrs.get("bundle-symbolic-name"));
+			assertEquals("[3.5,4.0)", attrs.get("bundle-version"));
+		}
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1881,6 +1881,12 @@ public class Analyzer extends Processor {
 				Attrs defaultAttrs = new Attrs();
 				Attrs importAttributes = imports.get(packageRef);
 				Attrs exportAttributes = exports.get(packageRef, classpathExports.get(packageRef, defaultAttrs));
+				String bundlesymbolicname = exportAttributes.get(INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE);
+				if (bundlesymbolicname != null) {
+					setProperty(CURRENT_BUNDLESYMBOLICNAME, bundlesymbolicname);
+					String bundleversion = exportAttributes.get(INTERNAL_BUNDLEVERSION_DIRECTIVE);
+					setProperty(CURRENT_BUNDLEVERSION, (bundleversion != null) ? bundleversion : "0.0.0");
+				}
 
 				String exportVersion = exportAttributes.getVersion();
 				String importRange = importAttributes.getVersion();
@@ -1965,6 +1971,8 @@ public class Analyzer extends Processor {
 					noimports.add(packageRef);
 			} finally {
 				unsetProperty(CURRENT_PACKAGE);
+				unsetProperty(CURRENT_BUNDLESYMBOLICNAME);
+				unsetProperty(CURRENT_BUNDLEVERSION);
 			}
 		}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2008,7 +2008,7 @@ public class Analyzer extends Processor {
 
 	String applyVersionPolicy(String exportVersion, String importRange, boolean provider) {
 		try {
-			setProperty("@", exportVersion);
+			setProperty(CURRENT_VERSION, exportVersion);
 
 			if (importRange != null) {
 				importRange = cleanupVersion(importRange);
@@ -2017,7 +2017,7 @@ public class Analyzer extends Processor {
 				importRange = getVersionPolicy(provider);
 
 		} finally {
-			unsetProperty("@");
+			unsetProperty(CURRENT_VERSION);
 		}
 		return importRange;
 	}
@@ -2187,11 +2187,11 @@ public class Analyzer extends Processor {
 	 */
 
 	String calculateVersionRange(String version, boolean impl) {
-		setProperty("@", version);
+		setProperty(CURRENT_VERSION, version);
 		try {
 			return getVersionPolicy(impl);
 		} finally {
-			unsetProperty("@");
+			unsetProperty(CURRENT_VERSION);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -165,10 +165,9 @@ public class Analyzer extends Processor {
 			analyzer.setProperties(properties);
 			Manifest m = analyzer.calcManifest();
 			Properties result = new UTF8Properties();
-			for (Iterator<Object> i = m.getMainAttributes()
-				.keySet()
-				.iterator(); i.hasNext();) {
-				Attributes.Name name = (Attributes.Name) i.next();
+			for (Object key : m.getMainAttributes()
+				.keySet()) {
+				Attributes.Name name = (Attributes.Name) key;
 				result.put(name.toString(), m.getMainAttributes()
 					.getValue(name));
 			}
@@ -902,14 +901,8 @@ public class Analyzer extends Processor {
 			// to a resource in the JAR
 			//
 
-			for (Iterator<PackageRef> i = temp.keySet()
-				.iterator(); i.hasNext();) {
-				String binary = i.next()
-					.getBinary();
-				Resource r = dot.getResource(binary);
-				if (r != null)
-					i.remove();
-			}
+			temp.keySet()
+				.removeIf(packageRef -> dot.getResource(packageRef.getBinary()) != null);
 
 			if (!temp.isEmpty())
 				main.putValue(PRIVATE_PACKAGE, printClauses(temp));
@@ -1346,9 +1339,7 @@ public class Analyzer extends Processor {
 		String ddel = "";
 		StringBuilder sb = new StringBuilder();
 		Map<String, Map<String, Resource>> map = bundle.getDirectories();
-		for (Iterator<String> i = map.keySet()
-			.iterator(); i.hasNext();) {
-			String directory = i.next();
+		for (String directory : map.keySet()) {
 			if (directory.equals("META-INF") || directory.startsWith("META-INF/"))
 				continue;
 			if (directory.equals("OSGI-OPT") || directory.startsWith("OSGI-OPT/"))
@@ -1403,9 +1394,7 @@ public class Analyzer extends Processor {
 	 */
 	public Set<PackageRef> getUnreachable() {
 		Set<PackageRef> unreachable = new HashSet<>(uses.keySet()); // all
-		for (Iterator<PackageRef> r = exports.keySet()
-			.iterator(); r.hasNext();) {
-			PackageRef packageRef = r.next();
+		for (PackageRef packageRef : exports.keySet()) {
 			removeTransitive(packageRef, unreachable);
 		}
 		if (activator != null) {
@@ -1495,9 +1484,8 @@ public class Analyzer extends Processor {
 	public void mergeManifest(Manifest manifest) throws IOException {
 		if (manifest != null) {
 			Attributes attributes = manifest.getMainAttributes();
-			for (Iterator<Object> i = attributes.keySet()
-				.iterator(); i.hasNext();) {
-				Name name = (Name) i.next();
+			for (Object k : attributes.keySet()) {
+				Name name = (Name) k;
 				String key = name.toString();
 				// Dont want instructions
 				if (key.startsWith("-"))
@@ -1554,8 +1542,8 @@ public class Analyzer extends Processor {
 				error("Missing file on classpath: %s", IO.absolutePath(classpath[i]));
 			}
 		}
-		for (Iterator<Jar> i = list.iterator(); i.hasNext();) {
-			addClasspath(i.next());
+		for (Jar jar : list) {
+			addClasspath(jar);
 		}
 	}
 
@@ -1627,8 +1615,7 @@ public class Analyzer extends Processor {
 		Jar j = super.getJarFromName(name, from);
 		Glob g = new Glob(name);
 		if (j == null) {
-			for (Iterator<Jar> cp = getClasspath().iterator(); cp.hasNext();) {
-				Jar entry = cp.next();
+			for (Jar entry : getClasspath()) {
 				if (entry.getSource() == null)
 					continue;
 
@@ -1649,8 +1636,7 @@ public class Analyzer extends Processor {
 
 		Glob g = new Glob(name);
 		List<Jar> result = new ArrayList<>();
-		for (Iterator<Jar> cp = getClasspath().iterator(); cp.hasNext();) {
-			Jar entry = cp.next();
+		for (Jar entry : getClasspath()) {
 			if (entry.getSource() == null)
 				continue;
 
@@ -1669,10 +1655,8 @@ public class Analyzer extends Processor {
 	 */
 	private void merge(Manifest result, Manifest old) {
 		if (old != null) {
-			for (Iterator<Map.Entry<Object, Object>> e = old.getMainAttributes()
-				.entrySet()
-				.iterator(); e.hasNext();) {
-				Map.Entry<Object, Object> entry = e.next();
+			for (Map.Entry<Object, Object> entry : old.getMainAttributes()
+				.entrySet()) {
 				Attributes.Name name = (Attributes.Name) entry.getKey();
 				String value = (String) entry.getValue();
 				if (name.toString()
@@ -1687,9 +1671,7 @@ public class Analyzer extends Processor {
 			// do not overwrite existing entries
 			Map<String, Attributes> oldEntries = old.getEntries();
 			Map<String, Attributes> newEntries = result.getEntries();
-			for (Iterator<Map.Entry<String, Attributes>> e = oldEntries.entrySet()
-				.iterator(); e.hasNext();) {
-				Map.Entry<String, Attributes> entry = e.next();
+			for (Map.Entry<String, Attributes> entry : oldEntries.entrySet()) {
 				if (!newEntries.containsKey(entry.getKey())) {
 					newEntries.put(entry.getKey(), entry.getValue());
 				}
@@ -1706,9 +1688,8 @@ public class Analyzer extends Processor {
 	 */
 
 	void verifyManifestHeadersCase(Properties properties) {
-		for (Iterator<Object> i = properties.keySet()
-			.iterator(); i.hasNext();) {
-			String header = (String) i.next();
+		for (Object key : properties.keySet()) {
+			String header = (String) key;
 			for (int j = 0; j < headers.length; j++) {
 				if (!headers[j].equals(header) && headers[j].equalsIgnoreCase(header)) {
 					warning(
@@ -1791,8 +1772,7 @@ public class Analyzer extends Processor {
 
 		// Clean up attributes and generate result map
 		Packages result = new Packages();
-		for (Iterator<PackageRef> i = toBeImported.iterator(); i.hasNext();) {
-			PackageRef ep = i.next();
+		for (PackageRef ep : toBeImported) {
 			Attrs parameters = exports.get(ep);
 
 			String noimport = parameters == null ? null : parameters.get(NO_IMPORT_DIRECTIVE);
@@ -2170,13 +2150,9 @@ public class Analyzer extends Processor {
 		}
 
 		// Remove any ! valued attributes
-		for (Iterator<Entry<String, String>> i = attributes.entrySet()
-			.iterator(); i.hasNext();) {
-			String v = i.next()
-				.getValue();
-			if (v.equals("!"))
-				i.remove();
-		}
+		attributes.entrySet()
+			.removeIf(entry -> entry.getValue()
+				.equals("!"));
 	}
 
 	/**
@@ -2206,9 +2182,7 @@ public class Analyzer extends Processor {
 		if (isTrue(getProperty(NOUSES)))
 			return;
 
-		for (Iterator<PackageRef> i = exports.keySet()
-			.iterator(); i.hasNext();) {
-			PackageRef packageRef = i.next();
+		for (PackageRef packageRef : exports.keySet()) {
 			String packageName = packageRef.getFQN();
 			setProperty(CURRENT_PACKAGE, packageName);
 			try {
@@ -2216,7 +2190,6 @@ public class Analyzer extends Processor {
 			} finally {
 				unsetProperty(CURRENT_PACKAGE);
 			}
-
 		}
 	}
 
@@ -2249,8 +2222,7 @@ public class Analyzer extends Processor {
 
 			StringBuilder sb = new StringBuilder();
 			String del = "";
-			for (Iterator<PackageRef> u = sharedPackages.iterator(); u.hasNext();) {
-				PackageRef usedPackage = u.next();
+			for (PackageRef usedPackage : sharedPackages) {
 				if (!usedPackage.isJava()) {
 					sb.append(del);
 					sb.append(usedPackage.getFQN());
@@ -2298,8 +2270,7 @@ public class Analyzer extends Processor {
 
 		List<PackageRef> ref = uses.get(name);
 		if (ref != null) {
-			for (Iterator<PackageRef> r = ref.iterator(); r.hasNext();) {
-				PackageRef element = r.next();
+			for (PackageRef element : ref) {
 				removeTransitive(element, unreachable);
 			}
 		}
@@ -2364,8 +2335,7 @@ public class Analyzer extends Processor {
 		super.close();
 
 		if (classpath != null)
-			for (Iterator<Jar> j = classpath.iterator(); j.hasNext();) {
-				Jar jar = j.next();
+			for (Jar jar : classpath) {
 				jar.close();
 			}
 	}
@@ -2406,10 +2376,8 @@ public class Analyzer extends Processor {
 		String del = "";
 
 		Pattern expr = Pattern.compile(regexp);
-		for (Iterator<String> e = dot.getResources()
-			.keySet()
-			.iterator(); e.hasNext();) {
-			String path = e.next();
+		for (String path : dot.getResources()
+			.keySet()) {
 			if (!fullPathName) {
 				int n = path.lastIndexOf('/');
 				if (n >= 0) {
@@ -2431,9 +2399,7 @@ public class Analyzer extends Processor {
 	}
 
 	public void putAll(Map<String, String> additional, boolean force) {
-		for (Iterator<Map.Entry<String, String>> i = additional.entrySet()
-			.iterator(); i.hasNext();) {
-			Map.Entry<String, String> entry = i.next();
+		for (Map.Entry<String, String> entry : additional.entrySet()) {
 			if (force || getProperties().get(entry.getKey()) == null)
 				setProperty(entry.getKey(), entry.getValue());
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1820,12 +1820,19 @@ public class Analyzer extends Processor {
 			if (m != null) {
 				Domain domain = Domain.domain(m);
 				Parameters exported = domain.getExportPackage();
+				String bsn = jar.getBsn();
+				String version = jar.getVersion();
+				String bsn_version = bsn + "-" + version;
 				for (Entry<String, Attrs> e : exported.entrySet()) {
 					PackageRef ref = getPackageRef(e.getKey());
 					if (!classpathExports.containsKey(ref)) {
-						e.getValue()
-							.put(Constants.INTERNAL_EXPORTED_DIRECTIVE, jar.getBsn() + "-" + jar.getVersion());
 						Attrs attrs = e.getValue();
+						attrs.put(Constants.INTERNAL_EXPORTED_DIRECTIVE, bsn_version);
+						if (bsn != null) {
+							attrs.put(Constants.INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE, bsn);
+							attrs.put(Constants.INTERNAL_BUNDLEVERSION_DIRECTIVE,
+								(version != null) ? version : "0.0.0");
+						}
 
 						//
 						// Fixup any old style specification versions

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -289,6 +289,8 @@ public interface Constants {
 
 	char								DUPLICATE_MARKER							= '~';
 	String								INTERNAL_EXPORTED_DIRECTIVE					= "-internal-exported:";
+	String								INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE		= "-internal-bundlesymbolicname:";
+	String								INTERNAL_BUNDLEVERSION_DIRECTIVE			= "-internal-bundleversion:";
 	String								INTERNAL_SOURCE_DIRECTIVE					= "-internal-source:";
 	String								SPECIFICATION_VERSION						= "specification-version";
 	String								SPLIT_PACKAGE_DIRECTIVE						= "-split-package:";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -383,6 +383,8 @@ public interface Constants {
 
 	String								CURRENT_VERSION								= "@";
 	String								CURRENT_PACKAGE								= "@package";
+	String								CURRENT_BUNDLESYMBOLICNAME					= "@bundlesymbolicname";
+	String								CURRENT_BUNDLEVERSION						= "@bundleversion";
 
 	String								BUILDFILES									= "buildfiles";
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -943,7 +943,7 @@ public class Macro {
 
 	String version(Version version, String mask) {
 		if (version == null) {
-			String v = domain.getProperty("@");
+			String v = domain.getProperty(Constants.CURRENT_VERSION);
 			if (v == null) {
 				return LITERALVALUE;
 			}
@@ -1026,7 +1026,7 @@ public class Macro {
 
 			version = new Version(string);
 		} else {
-			String v = domain.getProperty("@");
+			String v = domain.getProperty(Constants.CURRENT_VERSION);
 			if (v == null)
 				return LITERALVALUE;
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1058,8 +1058,13 @@ public class Macro {
 		return sb.toString();
 	}
 
+	private static final String		LOCALTARGET_NAME	= "@[^${}\\[\\]()<>«»‹›]*";
+	private static final Pattern	LOCALTARGET_P	= Pattern
+		.compile("\\$(\\{" + LOCALTARGET_NAME + "\\}|\\[" + LOCALTARGET_NAME + "\\]|\\(" + LOCALTARGET_NAME + "\\)|<"
+			+ LOCALTARGET_NAME + ">|«" + LOCALTARGET_NAME + "»|‹" + LOCALTARGET_NAME + "›)");
 	boolean isLocalTarget(String string) {
-		return string.matches("\\$(\\{@\\}|\\[@\\]|\\(@\\)|<@>|«@»|‹@›)");
+		return LOCALTARGET_P.matcher(string)
+			.matches();
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1595,6 +1595,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			case PROVIDE_DIRECTIVE :
 			case SPLIT_PACKAGE_DIRECTIVE :
 			case FROM_DIRECTIVE :
+			case INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE :
+			case INTERNAL_BUNDLEVERSION_DIRECTIVE :
 				return true;
 			default :
 				return false;

--- a/docs/_heads/import_package.md
+++ b/docs/_heads/import_package.md
@@ -1,154 +1,40 @@
 ---
 layout: default
 class: Header
-title: Import-Package ::= import ( ',' import )* 
-summary: The Import-Package header declares the imported packages for this bundle. 
+title: Import-Package ::= import ( ',' import )*
+summary: The Import-Package header declares the imported packages for this bundle.
 ---
-The Import-Package header lists the packages that are required by the contained packages. The default for this header is "*", resulting in importing all referred packages. This header therefore rarely has to be specified. However, in certain cases there is an unwanted import. The import is caused by code that the author knows can never be reached. This import can be removed by using a negating pattern. A pattern is inserted in the import as an extra import when it contains no wildcards and there is no referral to that package. This can be used to add an import statement for a package that is not referred to by your code but is still needed, for example, because the class is loaded by name.
+The `Import-Package` header lists the packages that are required by the contained packages. The default for this header is `*`, resulting in importing all referred packages. This header therefore rarely has to be specified. However, in certain cases there is an unwanted import. The import is caused by code that the author knows can never be reached. This import can be removed by using a negating pattern. A pattern is inserted in the import as an extra import when it contains no wildcards and there is no referral to that package. This can be used to add an import statement for a package that is not referred to by your code but is still needed, for example, because the class is loaded by name.
 
 For example:
-  Import-Package: !org.apache.commons.log4j, com.acme.*,
+
+    Import-Package: !org.apache.commons.log4j, com.acme.*,\
      com.foo.extra
 
-During processing, bnd will attempt to find the exported version of imported packages. If no version or version range is specified on the import instruction, the exported version will then be used though the micro part and the qualifier are dropped. That is, when the exporter is `1.2.3.build123`, then the import version will be 1.2. If a specific version (range) is specified, this will override any found version. This default an be overridden with the [-versionpolicy][#versionpolicy] command.
+During processing, bnd will attempt to find the exported version of imported packages. If no version or version range is specified on the import instruction, the exported version will then be used though the micro part and the qualifier are dropped. That is, when the exporter is `1.2.3.build123`, then the import version will be 1.2. If a specific version (range) is specified, this will override any found version. This default an be overridden with the [-versionpolicy](../instructions/versionpolicy.html) instruction.
 
-If an explicit version is given, then ${@} can be used to substitute the found version in a range. In those cases, the version macro can be very useful to calculate ranges or drop specific parts of the version. For example:
+If an explicit version is given, then `${@}` can be used to substitute the found version in a range. In those cases, the [range](../macros/range.html) macro can be very useful to calculate ranges and drop specific parts of the version. For example:
 
-  Import-Package: org.osgi.framework;version="[1.3,2.0)"
-  Import-Package: org.osgi.framework;version=${@}
-  Import-Package: org.osgi.framework;version="[${versionmask;==;${@}},${versionmask;=+;${@}})"
+    Import-Package: org.osgi.framework;version="[1.3,2.0)"
+    Import-Package: org.osgi.framework;version="${@}"
+    Import-Package: org.osgi.framework;version="${range;[==,=+);${@}}"
 
-Packages with directive resolution:=dynamic will be removed from Import-Package and added to the DynamicImport-Package header after being processed like any other Import-Package entry. For example:
+You can reference the `Bundle-SymbolicName` and `Bundle-Version` of the exporter on the classpath by using the `${@bundlesymbolicname}` and `${@bundleversion}` values. In those cases, the [range](../macros/range.html) macro can be very useful to calculate ranges and drop specific parts of the bundle version. For example:
 
-  Import-Package: org.slf4j.*;resolution:=dynamic, *
+    Import-Package: org.eclipse.jdt.ui;bundle-symbolic-name="${@bundlesymbolicname}";\
+     bundle-version="${range;[==,+0);${@bundleversion}}"
 
-If an imported package uses mandatory attributes, then bnd will attempt to add those attributes to the import statement. However, in certain (bizarre!) cases this is not wanted. It is therefore possible to remove an attribute from the import clause. This is done with the `-remove-attribute:` directive or by setting the value of an attribute to !. The parameter of the `-remove-attribute` directive is an instruction and can use the standard options with !, *, ?, etc.
 
-  Import-Package: org.eclipse.core.runtime;-remove-attribute:common,*
+Packages with directive `resolution:=dynamic` will be removed from `Import-Package` and added to the `DynamicImport-Package` header after being processed like any other `Import-Package` entry. For example:
+
+    Import-Package: org.slf4j.*;resolution:=dynamic, *
+
+If an imported package uses mandatory attributes, then bnd will attempt to add those attributes to the import statement. However, in certain (bizarre!) cases this is not wanted. It is therefore possible to remove an attribute from the import clause. This is done with the `-remove-attribute:` directive or by setting the value of an attribute to `!`. The parameter of the `-remove-attribute` directive is an instruction and can use the standard options with `!`, `*`, `?`, etc.
+
+    Import-Package: org.eclipse.core.runtime;-remove-attribute:common,*
 
 Or
 
-  Import-Package: org.eclipse.core.runtime;common=!,*
+    Import-Package: org.eclipse.core.runtime;common=!,*
 
-Directives that are not part of the OSGi specification will give a warning unless they are prefixed with a 'x-'.
-
-	
-			//
-			// IMPORTS
-			// Imports MUST come after exports because we use information from
-			// the exports
-			//
-			{
-				// Add all exports that do not have an -noimport: directive
-				// to the imports.
-				Packages referredAndExported = new Packages(referred);
-				referredAndExported.putAll(doExportsToImports(exports));
-
-				removeDynamicImports(referredAndExported);
-
-				// Remove any Java references ... where are the closures???
-				for (Iterator<PackageRef> i = referredAndExported.keySet().iterator(); i.hasNext();) {
-					if (i.next().isJava())
-						i.remove();
-				}
-
-				Set<Instruction> unused = Create.set();
-				String h = getProperty(IMPORT_PACKAGE);
-				if (h == null) // If not set use a default
-					h = "*";
-
-				if (isPedantic() && h.trim().length() == 0)
-					warning("Empty " + Constants.IMPORT_PACKAGE + " header");
-
-				Instructions filter = new Instructions(h);
-				imports = filter(filter, referredAndExported, unused);
-				if (!unused.isEmpty()) {
-					// We ignore the end wildcard catch
-					if (!(unused.size() == 1 && unused.iterator().next().toString().equals("*")))
-						warning("Unused " + Constants.IMPORT_PACKAGE + " instructions: %s ", unused);
-				}
-
-				// See what information we can find to augment the
-				// imports. I.e. look in the exports
-				augmentImports(imports, exports);
-			}
-	
-	
-	
-	
-				// Checks
-			//
-			if (referred.containsKey(Descriptors.DEFAULT_PACKAGE)) {
-				error("The default package '.' is not permitted by the " + Constants.IMPORT_PACKAGE + " syntax. \n"
-						+ " This can be caused by compile errors in Eclipse because Eclipse creates \n"
-						+ "valid class files regardless of compile errors.\n"
-						+ "The following package(s) import from the default package "
-						+ uses.transpose().get(Descriptors.DEFAULT_PACKAGE));
-			}
-	
-	
-			verifyDirectives(Constants.IMPORT_PACKAGE, "resolution:", PACKAGEPATTERN, "package");
-	
-	
-		/**
-	 * Verify that the imports properly use version ranges.
-	 */
-	private void verifyImports() {
-		if (isStrict()) {
-			Parameters map = parseHeader(manifest.getMainAttributes().getValue(Constants.IMPORT_PACKAGE));
-			Set<String> noimports = new HashSet<String>();
-			Set<String> toobroadimports = new HashSet<String>();
-
-			for (Entry<String,Attrs> e : map.entrySet()) {
-				String version = e.getValue().get(Constants.VERSION_ATTRIBUTE);
-				if (version == null) {
-					if (!e.getKey().startsWith("javax.")) {
-						noimports.add(e.getKey());
-					}
-				} else {
-					if (!VERSIONRANGE.matcher(version).matches()) {
-						Location location = error("Import Package %s has an invalid version range syntax %s",
-								e.getKey(), version).location();
-						location.header = Constants.IMPORT_PACKAGE;
-						location.context = e.getKey();
-					} else {
-						try {
-							VersionRange range = new VersionRange(version);
-							if (!range.isRange()) {
-								toobroadimports.add(e.getKey());
-							}
-							if (range.includeHigh() == false && range.includeLow() == false
-									&& range.getLow().equals(range.getHigh())) {
-								Location location = error(
-										"Import Package %s has an empty version range syntax %s, likely want to use [%s,%s]",
-										e.getKey(), version, range.getLow(), range.getHigh()).location();
-								location.header = Constants.IMPORT_PACKAGE;
-								location.context = e.getKey();
-							}
-							// TODO check for exclude low, include high?
-						}
-						catch (Exception ee) {
-							Location location = error("Import Package %s has an invalid version range syntax %s:%s",
-									e.getKey(), version, ee.getMessage()).location();
-							location.header = Constants.IMPORT_PACKAGE;
-							location.context = e.getKey();
-						}
-					}
-				}
-			}
-
-			if (!noimports.isEmpty()) {
-				Location location = error("Import Package clauses without version range (excluding javax.*): %s",
-						noimports).location();
-				location.header = Constants.IMPORT_PACKAGE;
-			}
-			if (!toobroadimports.isEmpty()) {
-				Location location = error(
-						"Import Package clauses which use a version instead of a version range. This imports EVERY later package and not as many expect until the next major number: %s",
-						toobroadimports).location();
-				location.header = Constants.IMPORT_PACKAGE;
-			}
-		}
-	}
-
-	
+Directives that are not part of the OSGi specification will give a warning unless they are prefixed with `x-`.


### PR DESCRIPTION
Add @bundlesymbolicname and @bundleversion properties. For imported packages, @ properties are defined which reference the bundle symbolic name and bundle version of the exporter from the
classpath.