### PR TITLE
[builder] Duplicate Export-Package clause exports second and later pa…

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -50,6 +50,21 @@ import aQute.service.reporter.Report.Location;
 public class BuilderTest extends BndTestCase {
 
 	/**
+	 * Duplicate Export-Package clause exports second and later package with
+	 * bundle version #2864 https://github.com/bndtools/bnd/issues/2864
+	 */
+
+	public void testDuplicateExportPackageClauseExportsSecondAndLaterPackageWithBundleVersion() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("bin_test"));
+			b.setBundleVersion("20");
+			b.set("Export-Package", "a;version=1,a");
+			Jar build = b.build();
+			assertTrue(b.check("Export-Package duplicate package name \\(a\\) that uses the default version"));
+		}
+	}
+
+	/**
 	 * Test the detection of usage of old components: Invalid Service-Component
 	 * header
 	 */


### PR DESCRIPTION
…ckage with bundle version #2864

Assuming 1.0.0 in package-info.java/packageinfo in foo.bar, the manifest will add 2 exports. One for the package-info.java version and one for the bundle version. The version augment only handles the first clause and ignores the second clause that will then get the default bundle version.

Make a secondary and further export and error if no version is specified

Fix is reporting an error on later exports with identical package name but not version.

Fixes #2864

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>