### PR TITLE
[parameters] There shouldn't be "Duplicate name..." warnings with ped…

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -50,6 +50,25 @@ import aQute.service.reporter.Report.Location;
 public class BuilderTest extends BndTestCase {
 
 	/**
+	 * There shouldn't be "Duplicate name..." warnings with pedantic flag set to
+	 * true #2803 https://github.com/bndtools/bnd/issues/2803
+	 * 
+	 * @throws Exception
+	 */
+
+	public void testNoDuplicateWarningForHeadersThatAllowDuplicates() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setPedantic(true);
+			b.addClasspath(IO.getFile("bin_test"));
+			b.set("Export-Package", "a;version=1,a;version=2");
+			b.set("Require-Capability", "ns;filter:='(foo=1)',ns;filter:='(foo=2)',ns;filter:='(foo=1)'");
+			b.set("Provide-Capability", "ns;foo=1,ns;foo=2");
+			Jar build = b.build();
+			b.check();
+		}
+	}
+
+	/**
 	 * Duplicate Export-Package clause exports second and later package with
 	 * bundle version #2864 https://github.com/bndtools/bnd/issues/2864
 	 */

--- a/biz.aQute.bndlib/src/aQute/bnd/header/OSGiHeader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/OSGiHeader.java
@@ -94,7 +94,7 @@ public class OSGiHeader {
 				// add a number of "~" to make it unique.
 				for (String clauseName : aliases) {
 					if (result.containsKey(clauseName)) {
-						if (logger != null && logger.isPedantic())
+						if (logger != null && logger.isPedantic() && !result.allowDuplicateAttributes())
 							logger.warning(
 								"Duplicate name %s used in header: '%s'. Duplicate names are specially marked in Bnd with a ~ at the end (which is stripped at printing time).",
 								clauseName, value);

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Parameters.java
@@ -27,11 +27,15 @@ public class Parameters implements Map<String, Attrs> {
 	}
 
 	public Parameters(String header) {
-		this(header, null);
+		this(header, null, false);
 	}
 
 	public Parameters(String header, Reporter reporter) {
-		this(false);
+		this(header, reporter, false);
+	}
+
+	public Parameters(String header, Reporter reporter, boolean duplicates) {
+		this(duplicates);
 		OSGiHeader.parseHeader(header, reporter, this);
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -972,8 +972,8 @@ public class Analyzer extends Processor {
 
 			// ----- Require/Capabilities section
 
-			Parameters requirements = new Parameters(annotationHeaders.getHeader(REQUIRE_CAPABILITY), this);
-			Parameters capabilities = new Parameters(annotationHeaders.getHeader(PROVIDE_CAPABILITY), this);
+			Parameters requirements = new Parameters(annotationHeaders.getHeader(REQUIRE_CAPABILITY), this, true);
+			Parameters capabilities = new Parameters(annotationHeaders.getHeader(PROVIDE_CAPABILITY), this, true);
 
 			//
 			// Do any contracts contracts

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
@@ -188,6 +188,10 @@ public abstract class Domain implements Iterable<String> {
 		return new Parameters(get(key));
 	}
 
+	public Parameters getParameters(String key, boolean allowDuplicates) {
+		return new Parameters(get(key), null, allowDuplicates);
+	}
+
 	public Parameters getParameters(String key, String deflt) {
 		return new Parameters(get(key, deflt));
 	}
@@ -205,7 +209,7 @@ public abstract class Domain implements Iterable<String> {
 	}
 
 	public Parameters getExportPackage() {
-		return getParameters(EXPORT_PACKAGE);
+		return getParameters(EXPORT_PACKAGE, true);
 	}
 
 	public Parameters getBundleClassPath() {
@@ -230,7 +234,7 @@ public abstract class Domain implements Iterable<String> {
 	}
 
 	public Parameters getExportContents() {
-		return getParameters(EXPORT_CONTENTS);
+		return getParameters(EXPORT_CONTENTS, true);
 	}
 
 	public String getBundleActivator() {
@@ -428,11 +432,11 @@ public abstract class Domain implements Iterable<String> {
 	}
 
 	public Parameters getRequireCapability() {
-		return getParameters(Constants.REQUIRE_CAPABILITY);
+		return getParameters(Constants.REQUIRE_CAPABILITY, true);
 	}
 
 	public Parameters getProvideCapability() {
-		return getParameters(Constants.PROVIDE_CAPABILITY);
+		return getParameters(Constants.PROVIDE_CAPABILITY, true);
 	}
 
 	public static Domain domain(File file) throws IOException {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -615,7 +615,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 * @param pluginString
 	 */
 	protected void loadPlugins(Set<Object> instances, String pluginString, String pluginPathString) {
-		Parameters plugins = new Parameters(pluginString, this);
+		Parameters plugins = new Parameters(pluginString, this, true);
 		CL loader = getLoader();
 
 		// First add the plugin-specific paths from their path: directives
@@ -2842,5 +2842,10 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			return parent.isInteractive();
 		}
 		return false;
+	}
+
+	@Override
+	public Parameters getParameters(String key, boolean allowDuplicates) {
+		return new Parameters(get(key), this, allowDuplicates);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0


### PR DESCRIPTION
…antic flag set to true #2803

This message spams the warnings as soon as you set -pedantic: true. It would be nice if you don't have to use -fixupmessages Duplicate name in order to get rid of those warnings as those duplicates seem to be common.

Set the `allowDuplicates` flag in the parameters used for headers that actually allow duplicates. This should remove any warnings for duplicated keys in Export-Package, -export-contents, require-capability and provide-capabality.

Fixes #2803


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>