### PR TITLE
[http] HttpClient's urlcache not updated on 404 #2098

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
@@ -197,4 +197,8 @@ public class URLCache {
 		return exists;
 	}
 
+	public boolean isCached(URI url) throws Exception {
+		return getCacheFileFor(url).isFile();
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.3.0")
+@Version("1.4.0")
 package aQute.bnd.http;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
@@ -29,6 +29,7 @@ public class TaggedData implements Closeable {
 	private final URI			url;
 	private final File			file;
 	private final String		message;
+	private final boolean		temporaryRedirected;
 
 	@Deprecated
 	public TaggedData(String tag, InputStream inputStream, int responseCode, long modified, URI url) {
@@ -50,7 +51,12 @@ public class TaggedData implements Closeable {
 	}
 
 	public TaggedData(URLConnection con, InputStream in, File file) throws Exception {
+		this(con, in, file, false);
+	}
+
+	public TaggedData(URLConnection con, InputStream in, File file, boolean temporaryRedirected) throws Exception {
 		this.con = con;
+		this.temporaryRedirected = temporaryRedirected;
 		this.responseCode = con instanceof HttpURLConnection ? ((HttpURLConnection) con).getResponseCode()
 			: (in != null ? 200 : -1);
 		this.in = in == null && con != null && (responseCode / 100 == 2) ? con.getInputStream() : in;
@@ -165,6 +171,7 @@ public class TaggedData implements Closeable {
 		this.responseCode = responseCode;
 		this.url = url;
 		this.message = null;
+		this.temporaryRedirected = false;
 	}
 
 	/**
@@ -237,6 +244,10 @@ public class TaggedData implements Closeable {
 
 	public boolean isNotFound() {
 		return responseCode == 404;
+	}
+
+	public boolean isTemporaryRedirected() {
+		return temporaryRedirected;
 	}
 
 	public File getFile() {

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0


### PR DESCRIPTION
HttpClient should not cache after a 302 response #2137

I have an OSGiRepository with poll.time=-1 and cache=${workspace}/cnf/cache/stable/baseline.
I delete the index on the http server.
The HttpClient have it's urlcache fixed at ~/.bnd/urlcache.
When HttpClient get a 404, the urlcache is not modified and the cached content is returned.
Is this the expected behavior?

Resolution: 
- 302 and 307 do not cache anymore
- 404 clears the cache

Fixes #2098
Fixes #2137

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>