### PR TITLE
Fix docs manual for -pom instruction

### DIFF
--- a/docs/_instructions/diffignore.md
+++ b/docs/_instructions/diffignore.md
@@ -2,8 +2,7 @@
 layout: default
 class: Project
 title: -diffignore SELECTORS
-summary: Manifest header names
-and resource paths to ignore during baseline comparison.
+summary: Manifest header names and resource paths to ignore during baseline comparison.
 ---
 
 You can use the `-diffignore` instruction to specify manifest header names

--- a/docs/_instructions/pom.md
+++ b/docs/_instructions/pom.md
@@ -29,34 +29,36 @@ The `-pom` instruction will also attempt to convert the following headers to the
 * `Bundle-DocUrl`
 * `Bundle-Vendor`  – If the  value ends with a HTTP or HTTPS url then this URL is used as the organization URL and the name with be the part without the URL. Otherwise the whole value is used as the value for the organization name.
 * `Bundle-License`
-* `Bundle-Developer` – This is an unofficial header. The key must be the email. It consist of the following parameters:
+* `Bundle-Developers` – This is an unofficial header. The key must be the email. It consist of the following parameters:
 
-	email                      Email address mandatory
-	id                         A developer id (default address)
-	name                       Name of the developer
-	organization               Name of the organization
-	organizationUrl            URL of the organization
-	roles                      Roles of the developer (comma separated)
-	timezone                   Three letter time zone
-	
-	  Bundle-Developer: 
-	    Peter.Kriens@aQute.biz;
-	      name="Peter Kriens";
-	      organization=aQute;
-	      roles="programmer,gopher"
+|Parameters          |Default       |Description|
+|`email`             |              |Email address (mandatory)|
+|`id`                |email         |A developer id (defaults to email)|
+|`name`              |              |Name of the developer|
+|`organization`      |              |Name of the organization|
+|`organizationUrl`   |              |URL of the organization|
+|`roles`             |              |Roles of the developer (comma separated)|
+|`timezone`          |              |Three letter time zone|
+
+    Bundle-Developers: \
+      Peter.Kriens@aQute.biz; \
+        name="Peter Kriens"; \
+        organization=aQute; \
+        roles="programmer,gopher"
 	 
 * `Bundle-SCM` – This is an unofficial header. The key must be the It consists of the following parameters:
 
-    connection                 Read only connection
-    developerConnection        Developer connection
-    url                        The URL for a web front end to your SCM system.     
+|Parameters             |Default       |Description|
+|`connection`           |              |Read only connection|
+|`developerConnection`  |              |Developer connection|
+|`url`                  |              |The URL for a web front end to your SCM system.|
 
-	  Bundle-SCM: 
-	    url=https://github.com/bndtools,
-	    connection=scm:git:https://github.com/bndtools/bnd,
-	    developerConnection=scm:git:git@github.com/bndtools/bnd
+    Bundle-SCM: \
+        url=https://github.com/bndtools, \
+        connection=scm:git:https://github.com/bndtools/bnd, \
+        developerConnection=scm:git:git@github.com/bndtools/bnd
 
-## Example
+### Example
 
 The following example bnd file:
 
@@ -66,59 +68,57 @@ The following example bnd file:
 
 Generates the following pom in `pom.xml`:
 
-	<project 	xmlns="http://maven.apache.org/POM/4.0.0" 
-	  	xmlns:xsi="" 
-	  	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  	  <modelVersion>4.0.0</modelVersion>
-  	  <groupId>com.example</groupId>
-  	  <artifactId>foo</artifactId>
-  	  <version>1.2.3.qualifier</version>
-  	  <name>com.example.foo</name>
-	</project>
+    <project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="" 
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>foo</artifactId>
+                <version>1.2.3.qualifier</version>
+                <name>com.example.foo</name>
+    </project>
 
 You can override the different parts of the Maven coordinates:
 
 	Bundle-SymbolicName:          com.example.foo
 	Bundle-Version:               1.2.3.qualifier
-	Bundle-Developer:             Peter.Kriens@aQute.biz;
-	  name="Peter Kriens";
-	  organization=aQute;
+	Bundle-Developers:            Peter.Kriens@aQute.biz; \
+	  name="Peter Kriens"; \
+	  organization=aQute; \
 	  roles="programmer,gopher"
-	Bundle-SCM: url=https://github.com/bndtools,
-	  connection=scm:git:https://github.com/bndtools/bnd,
+	Bundle-SCM: url=https://github.com/bndtools, \
+	  connection=scm:git:https://github.com/bndtools/bnd, \
 	  developerConnection=scm:git:git@github.com/bndtools/bnd
-	-pom: groupid=com.example,
-	  where=META-INF/maven/pom.xml,
+	-pom: groupid=com.example, \
+	  where=META-INF/maven/pom.xml, \
 	  version=${versionmask;==;${Bundle-Version}}
 	
 Generates the following pom in `META-INF/maven/pom.xml`:
 
-	<project 	
-	  xmlns="http://maven.apache.org/POM/4.0.0" 
-	  xmlns:xsi="" 
-	  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
-	  	http://maven.apache.org/maven-v4_0_0.xsd">
-  	  <modelVersion>4.0.0</modelVersion>
-  	  <groupId>com.example</groupId>
-  	  <artifactId>com.example.foo</artifactId>
-  	  <version>1.2</version>
-  	  <name>com.example.foo</name>
-	  <scm>
-	    <url>https://github.com/bndtools</url>
-	    <connection>scm:git:https://github.com/bndtools/bnd</connection>
-	    <developerConnection>scm:git:git@github.com/bndtools/bnd</developerConnection>
-	  </scm>
-	  <developers>
-	    <developer>
-	      <id>Peter.Kriens@aQute.biz</id>
-	      <name>Peter Kriens</name>
-	      <organization>aQute</organization>
-	      <roles>
-	        <role>programmer</role>
-	        <role>gopher</role>
-	      </roles>
-	      <email>Peter.Kriens@aQute.biz</email>
-	    </developer>
-	  </developers>
-	</project>
+    <project xmlns="http://maven.apache.org/POM/4.0.0" 
+        xmlns:xsi=""
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>com.example.foo</artifactId>
+                <version>1.2</version>
+                <name>com.example.foo</name>
+                <scm>
+                    <url>https://github.com/bndtools</url>
+                    <connection>scm:git:https://github.com/bndtools/bnd</connection>
+                    <developerConnection>scm:git:git@github.com/bndtools/bnd</developerConnection>
+                </scm>
+                <developers>
+                    <developer>
+                        <id>Peter.Kriens@aQute.biz</id>
+                        <name>Peter Kriens</name>
+                        <organization>aQute</organization>
+                        <roles>
+                            <role>programmer</role>
+                            <role>gopher</role>
+                        </roles>
+                        <email>Peter.Kriens@aQute.biz</email>
+                    </developer>
+                </developers>
+    </project>
 


### PR DESCRIPTION
Fix Bundle-Developer to Bundle-Developers manifest header.
Fix warning on diffignore.md when processed by the jekyll.
Make -pom instruction more readable by introducing given parameters in a table view.