### PR TITLE
[httpclient] HttpClient's urlcache not updated on 404 #2098

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -78,8 +78,8 @@ public class HttpClient implements Closeable, URLConnector {
 		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 	// These are not in HttpURLConnection
-	private static final int					HTTP_TEMPORARY_REDIRECT	= 307;											// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
-	private static final int					HTTP_PERMANENT_REDIRECT	= 308;											// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
+	private static final int					HTTP_TEMPORARY_REDIRECT	= 307;					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
+	private static final int					HTTP_PERMANENT_REDIRECT	= 308;					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
 
 	private final List<ProxyHandler>			proxyHandlers			= new ArrayList<>();
 	private final List<URLConnectionHandler>	connectionHandlers		= new ArrayList<>();
@@ -253,16 +253,22 @@ public class HttpClient implements Closeable, URLConnector {
 					}
 
 					TaggedData in = send0(request);
-					if (in.getState() == State.UPDATED) {
 
-						//
-						// update the cache from the input stream
-						//
+					if (in.getState() == State.NOT_FOUND) {
+						cache.clear(request.url.toURI());
 
-						info.update(in.getInputStream(), in.getTag(), in.getModified());
-					} else if (in.getState() == State.UNMODIFIED)
-						info.jsonFile.setLastModified(System.currentTimeMillis());
+					} else {
 
+						if (in.getState() == State.UPDATED) {
+
+							//
+							// update the cache from the input stream
+							//
+
+							info.update(in.getInputStream(), in.getTag(), in.getModified());
+						} else if (in.getState() == State.UNMODIFIED)
+							info.jsonFile.setLastModified(System.currentTimeMillis());
+					}
 					return in;
 
 				} else {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
@@ -197,4 +197,8 @@ public class URLCache {
 		return exists;
 	}
 
+	public boolean isCached(URI url) throws Exception {
+		return getCacheFileFor(url).isFile();
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.3.0")
+@Version("1.4.0")
 package aQute.bnd.http;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Clears the cache now when a cached call is made and we get
a 404.

Fixes #2098

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>