### PR TITLE
TemplateLoader: Race condition when loading templates

### DIFF
--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -306,12 +306,10 @@ public class TemplateSelectionWizardPage extends WizardPage {
                         label = String.format("Template Loader service ID " + templateLoaderSvcRef.getProperty(Constants.SERVICE_ID));
 
                     TemplateLoader templateLoader = context.getService(templateLoaderSvcRef);
-                    try {
-                        Promise<? extends Collection<Template>> promise = templateLoader.findTemplates(templateType, new Processor());
-                        promises.add(new Pair<String, Promise<? extends Collection<Template>>>(label, promise));
-                    } finally {
-                        context.ungetService(templateLoaderSvcRef);
-                    }
+
+                    Promise<? extends Collection<Template>> promise = templateLoader.findTemplates(templateType, new Processor());
+                    promise.onResolve(() -> context.ungetService(templateLoaderSvcRef));
+                    promises.add(new Pair<String, Promise<? extends Collection<Template>>>(label, promise));
                 }
 
                 // Force the promises in sequence


### PR DESCRIPTION
Because TemplateLoader.findTemplates() returns a collection of Promises, we don't want to release our service reference until after those Promises have finished, as they may still be using internal service state.

This fixes an issue where the list of available templates is sometimes not populated when trying to create a new project.

Signed-off-by: Sean Bright <sean.bright@gmail.com>