### PR TITLE
Fix biz.aQute.junit build file during Gradle evaluation. Use replacel…

### DIFF
--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -6,7 +6,7 @@
 	osgi.cmpn;version=@4;maven-scope=provided,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest;maven-scope=provided,\
-    ${replace;${list;junit};$;\\;maven-scope=provided}
+    ${replacelist;${list;junit};$;\\;maven-scope=provided}
 
 Tester-Plugin: aQute.junit.plugin.ProjectTesterImpl
 


### PR DESCRIPTION
…ist instead of list macro.

An error occurs during Gradle evaluation with the following message:
A problem occurred evaluating settings 'bnd'.
> Failed to apply plugin [id 'biz.aQute.bnd.workspace']
   > Invalid syntax for version: [4.11;maven-scope=provided,5)

Signed-off-by: Stefan Georgiev <stefangeorgiev@outlook.com>