### PR TITLE
[launching] Error: Could not find or load main class aQute.launcher.L…

### DIFF
--- a/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
@@ -233,10 +233,31 @@ public abstract class AbstractOSGiLaunchDelegate extends JavaLaunchDelegate {
         super.launch(configuration, mode, launch, monitor);
     }
 
+    /*
+     * This method is deprecated in Eclipse 4.11 and no longer called there. Instead getClasspathAndModulepath is
+     * called. We need it here for older versions of Eclipse.
+     */
     @Override
     public String[] getClasspath(ILaunchConfiguration configuration) throws CoreException {
         Collection<String> paths = getProjectLauncher().getClasspath();
         return paths.toArray(new String[0]);
+    }
+
+    /*
+     * This method has taken over getClasspath in 4.11. See
+     * https://github.com/eclipse/eclipse.jdt.debug/commit/89530b29cb538a73f57f4b32cdf3f543258b9bc6#diff-
+     * 9010920d00bc21b4c2749643470ff0cfL95 See https://bugs.eclipse.org/bugs/show_bug.cgi?id=529435
+     * https://github.com/bndtools/bnd/issues/2947
+     */
+    @Override
+    public String[][] getClasspathAndModulepath(ILaunchConfiguration config) throws CoreException {
+        String[][] classpathAndModulepath = super.getClasspathAndModulepath(config);
+        if (classpathAndModulepath == null) {
+            classpathAndModulepath = new String[2][];
+            classpathAndModulepath[1] = new String[0];
+        }
+        classpathAndModulepath[0] = getClasspath(config);
+        return classpathAndModulepath;
     }
 
     @Override


### PR DESCRIPTION
…auncher #2947

Eclipse has deprecated getClasspath and replaced it with
a getClasspathAndModulePath, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=529435

However, the way they did this is not very backward compatible, see

https://github.com/eclipse/eclipse.jdt.debug/commit/89530b29cb538a73f57f4b32cdf3f543258b9bc6#diff-9010920d00bc21b4c2749643470ff0cfL95

I've overridden getClasspathAndModulepath() and ensure the first String[]
is the current classpath.

I've tested this on an older version and that works. When this is build I will
try this on the latest.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>