### PR TITLE
demo: Use felix framework version supporting the gogo version

### DIFF
--- a/demo/x.bndrun
+++ b/demo/x.bndrun
@@ -1,7 +1,7 @@
 Bundle-Version: 1.0.0
 
--runfw: org.apache.felix.framework;version='[4,5)'
--runee: JavaSE-1.6
+-runfw: org.apache.felix.framework
+-runee: JavaSE-1.8
 -runsystemcapabilities: ${native_capability}
 -resolve.effective: active
 


### PR DESCRIPTION
The bndrun file did not successfully launch since the gogo bundles
required a later version of felix than specified.
