### PR TITLE
builderignore: Avoid repetitive ignore values computation

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -253,7 +253,7 @@ public class BndPlugin implements Plugin<Project> {
           t.archiveName = it.name /* use first artifact as archiveName */
         }
         /* Additional excludes for projectDir inputs */
-        t.ext.projectDirInputsExcludes = Strings.split(bnd(Constants.BUILDERIGNORE)).collect { it.concat('/') }
+        t.ext.projectDirInputsExcludes = Strings.split(bndMerge(Constants.BUILDERIGNORE)).collect { it.concat('/') }
         /* all other files in the project like bnd and resources */
         t.inputs.files({
           project.fileTree(projectDir) { tree ->

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
@@ -21,6 +21,9 @@ class BndPluginConvention {
   String bnd(String name) {
     return project.bnd.get(name)
   }
+  String bndMerge(String name) {
+    return project.bnd.merge(name)
+  }
   Object bnd(String name, Object defaultValue) {
     return project.bnd.get(name, defaultValue)
   }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndProperties.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndProperties.groovy
@@ -32,6 +32,10 @@ class BndProperties {
     return trimmed(defaultValue)
   }
 
+  def merge(String name) {
+    return trimmed(project.mergeProperties(name))
+  }
+
   def propertyMissing(String name) {
     if ((name == 'ext') || extensions.extraProperties.has(name) || extensions.findByName(name)) {
       throw new MissingPropertyException(name, String)


### PR DESCRIPTION
We only compute the ignore set once per delta visitor run in the
Bndtools builder.

Also, we support -builderignore as a merged property.
