### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.build-scans.gradle
+++ b/.build-scans.gradle
@@ -1,8 +1,7 @@
 def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/bnd/gradle-scans-license-agree.txt")
 def env = System.getenv()
-boolean isCI = env.CI || env.TRAVIS
-boolean hasAccepted = isCI || env.GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
-boolean hasRefused = env.GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+boolean hasAccepted = env.BND_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.BND_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
 
 buildScan {
     if (hasAccepted) {
@@ -22,7 +21,7 @@ Please read
 
 and then:
 
-  - set the `GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - set the `BND_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
   - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
 
 And we'll not bother you again. Note that build scans are only made public if 

--- a/.build-scans.gradle
+++ b/.build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/bnd/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - "./mvnw --version"
 
 script:
-  - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy"
+  - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue --scan :build :maven:deploy"
 
 before_cache:
   - "git status"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - "./mvnw --version"
 
 script:
-  - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue --scan :build :maven:deploy"
+  - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy"
 
 before_cache:
   - "git status"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,13 @@
 
 import aQute.lib.io.IO
 
+apply plugin: 'com.gradle.build-scan'
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 if (JavaVersion.current().isJava9Compatible()) {
   ext.java9options = [
     '--add-opens=java.base/java.lang=ALL-UNNAMED', 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'com.gradle.build-scan'
 
 buildScan {
     termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
+    apply from: './.build-scans.gradle'
 }
 
 if (JavaVersion.current().isJava9Compatible()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,9 +11,13 @@ buildscript {
     maven {
       url uri(bnd_repourl)
     }
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
   }
   dependencies {
     classpath bnd_plugin
+    classpath 'com.gradle:build-scan-plugin:2.1'
   }
   /* Since the files in the repository change with each build, we need to recheck for changes */
   configurations.classpath {


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.