### PR TITLE
this is just a question

### DIFF
--- a/aQute.libg/src/aQute/libg/glob/AntGlob.java
+++ b/aQute.libg/src/aQute/libg/glob/AntGlob.java
@@ -14,7 +14,7 @@ public class AntGlob extends Glob {
 		super(globString, toPattern(globString, flags));
 	}
 
-	// match forward slash or back slash (windows)
+	// match forward slash or back slash (windows)? what about linux?
 	private static final String	SLASHY		= "[/\\\\]";
 	private static final String	NOT_SLASHY	= "[^/\\\\]";
 


### PR DESCRIPTION
this works like a charm on windows..
but it failed with this : (?:.*[/\\]|)[^/\\]*\.
pattern at my customer's linux machine... some character class error ,
it thinks we are skipping brackets or something..
can you make it work for linux too?