### PR TITLE
Fix misspellings of "Launch"

### DIFF
--- a/biz.aQute.bnd.runtime/test/aQute/bnd/runtime/snapshot/SnapshotTest.java
+++ b/biz.aQute.bnd.runtime/test/aQute/bnd/runtime/snapshot/SnapshotTest.java
@@ -7,14 +7,14 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 
-import aQute.launchpad.LauchpadBuilder;
+import aQute.launchpad.LaunchpadBuilder;
 import aQute.launchpad.Launchpad;
 import aQute.launchpad.Service;
 import exported_not_imported.ExportedNotImported;
 
 public class SnapshotTest {
 
-	LauchpadBuilder builder = new LauchpadBuilder().bundles(
+	LaunchpadBuilder builder = new LaunchpadBuilder().bundles(
 		"biz.aQute.bnd.runtime.snapshot, org.apache.felix.log, org.apache.felix.configadmin, org.apache.felix.scr, biz.aQute.bnd.runtime.gogo");
 
 	@Test

--- a/biz.aQute.bnd.runtime/test/biz/aQute/bnd/diagnostics/gogo/DSDiagTest.java
+++ b/biz.aQute.bnd.runtime/test/biz/aQute/bnd/diagnostics/gogo/DSDiagTest.java
@@ -5,12 +5,12 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 
-import aQute.launchpad.LauchpadBuilder;
+import aQute.launchpad.LaunchpadBuilder;
 import aQute.launchpad.Launchpad;
 
 public class DSDiagTest {
 
-	LauchpadBuilder	builder	= new LauchpadBuilder().bndrun("run.bndrun");
+	LaunchpadBuilder	builder	= new LaunchpadBuilder().bndrun("run.bndrun");
 	Launchpad			fw		= builder.create();
 
 	interface IA {}

--- a/biz.aQute.bnd.runtime/test/biz/aQute/bnd/diagnostics/gogo/DiagnosticsTest.java
+++ b/biz.aQute.bnd.runtime/test/biz/aQute/bnd/diagnostics/gogo/DiagnosticsTest.java
@@ -4,19 +4,19 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import aQute.bnd.build.Workspace;
-import aQute.launchpad.LauchpadBuilder;
+import aQute.launchpad.LaunchpadBuilder;
 import aQute.lib.io.IO;
 
 public class DiagnosticsTest {
 	static Workspace				workspace;
-	static LauchpadBuilder	builder;
+	static LaunchpadBuilder	builder;
 
 	@SuppressWarnings("resource")
 	@BeforeClass
 	public static void before() throws Exception {
 		Workspace.remoteWorkspaces = true;
 		workspace = Workspace.findWorkspace(IO.work);
-		builder = new LauchpadBuilder()
+		builder = new LaunchpadBuilder()
 			.runfw("org.apache.felix.framework")
 			.gogo()
 			.bundles("biz.aQute.bnd.diagnostics.gogo");

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
@@ -141,7 +141,7 @@ public class About {
 		"Added ${versionmask} macro that is identical to ${version} but can be used when you want to use the version macro for yourself",
 		"Manifest Annotations use any defined methods as attributes from the annotation they are applied to",
 		"Made many more headers merged headers", "Added several support methods so bnd can generate a pom",
-		"Laucher moved to Java 6", "Always read bnd files with UTF-8 with a fallback to ISO-8859-1",
+		"Launcher moved to Java 6", "Always read bnd files with UTF-8 with a fallback to ISO-8859-1",
 		"Full Java 8 support", "Added life cycle plugin that can interact with workspace/project creation/deletion",
 		"Allow includes in bnd files to specify a URL", "Support for Gradle plugin", "Support Travis builds",
 		"Added support for gestalt, allows build tools to communicate out what the environment they run in supports. See -bnd-driver",

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleBuilder.java
@@ -24,7 +24,7 @@ public class BundleBuilder implements BundleSpecBuilder {
 	BundleBuilder(Launchpad ws) {
 		this.ws = ws;
 		spec.classpath.add(ws.builder.local.bin_test);
-		bundleSymbolicName("t-" + LauchpadBuilder.counter.incrementAndGet());
+		bundleSymbolicName("t-" + LaunchpadBuilder.counter.incrementAndGet());
 	}
 
 	/**

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -926,7 +926,7 @@ public interface BundleSpecBuilder {
 	}
 
 	default Bundle install() throws Exception {
-		byte[] build = LauchpadBuilder.workspace.build(LauchpadBuilder.projectDir.getAbsolutePath(),
+		byte[] build = LaunchpadBuilder.workspace.build(LaunchpadBuilder.projectDir.getAbsolutePath(),
 				x().spec);
 		String name = x().spec.bundleSymbolicName.toString();
 		ByteArrayInputStream bin = new ByteArrayInputStream(build);

--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -1,6 +1,6 @@
 package aQute.launchpad;
 
-import static aQute.launchpad.LauchpadBuilder.projectDir;
+import static aQute.launchpad.LaunchpadBuilder.projectDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -81,7 +81,7 @@ public class Launchpad implements AutoCloseable {
 
 	final Framework								framework;
 	final List<ServiceTracker<?, ?>>			trackers				= new ArrayList<>();
-	final LauchpadBuilder					builder;
+	final LaunchpadBuilder					builder;
 	final List<FrameworkEvent>					frameworkEvents			= new CopyOnWriteArrayList<FrameworkEvent>();
 	final Injector<Service>						injector;
 	final Map<Class<?>, ServiceTracker<?, ?>>	injectedDoNotClose		= new HashMap<>();
@@ -93,7 +93,7 @@ public class Launchpad implements AutoCloseable {
 	PrintStream									out						= System.err;
 	ServiceTracker<FindHook, FindHook>			hooks;
 
-	Launchpad(LauchpadBuilder jUnitFrameworkBuilder, Framework framework) {
+	Launchpad(LaunchpadBuilder jUnitFrameworkBuilder, Framework framework) {
 		try {
 			this.builder = jUnitFrameworkBuilder;
 			this.debug = jUnitFrameworkBuilder.debug;
@@ -219,7 +219,7 @@ public class Launchpad implements AutoCloseable {
 	 */
 	public List<Bundle> bundles(String specification) {
 		try {
-			return LauchpadBuilder.workspace.getLatestBundles(projectDir.getAbsolutePath(), specification)
+			return LaunchpadBuilder.workspace.getLatestBundles(projectDir.getAbsolutePath(), specification)
 				.stream()
 				.map(File::new)
 				.map(this::bundle)
@@ -562,7 +562,7 @@ public class Launchpad implements AutoCloseable {
 	/**
 	 * Hide a service by registering a hook. This should in general be done
 	 * before you let others look. In general, the JUnit Framework should be
-	 * started in {@link LauchpadBuilder#nostart()} mode. This initializes
+	 * started in {@link LaunchpadBuilder#nostart()} mode. This initializes
 	 * the OSGi framework making it possible to register a service before
 	 */
 
@@ -576,7 +576,7 @@ public class Launchpad implements AutoCloseable {
 	 * all bundles _except_ the testbundle. Notice that bundles that already
 	 * obtained a references are not affected. If you use this facility it is
 	 * best to not start the framework before you hide a service. You can
-	 * indicate this to the build with {@link LauchpadBuilder#nostart()}.
+	 * indicate this to the build with {@link LaunchpadBuilder#nostart()}.
 	 * The framework can be started after creation with {@link #start()}. Notice
 	 * that services through the testbundle remain visible for this hide.
 	 * 

--- a/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
@@ -31,7 +31,7 @@ import aQute.lib.strings.Strings;
 /**
  * This class is a builder for frameworks that can be used in JUnit testing.
  */
-public class LauchpadBuilder implements AutoCloseable {
+public class LaunchpadBuilder implements AutoCloseable {
 
 	final static ExecutorService	executor	= Executors.newCachedThreadPool();
 	final static File				projectDir	= IO.work;
@@ -73,11 +73,11 @@ public class LauchpadBuilder implements AutoCloseable {
 	 * Start a framework assuming the current working directory is the project
 	 * directory.
 	 */
-	public LauchpadBuilder() {
+	public LaunchpadBuilder() {
 		local = projectTestSetup.clone();
 	}
 
-	public LauchpadBuilder bndrun(File file) {
+	public LaunchpadBuilder bndrun(File file) {
 		RunSpecification setup = workspace.getRun(file.getAbsolutePath());
 		if (!setup.errors.isEmpty()) {
 			throw new IllegalArgumentException(
@@ -91,32 +91,32 @@ public class LauchpadBuilder implements AutoCloseable {
 		return this;
 	}
 
-	public LauchpadBuilder bndrun(String path) {
+	public LaunchpadBuilder bndrun(String path) {
 		return bndrun(IO.getFile(projectDir, path));
 	}
 
-	public LauchpadBuilder project() {
+	public LaunchpadBuilder project() {
 		return bndrun(projectDir);
 	}
 
-	public LauchpadBuilder gogo() {
+	public LaunchpadBuilder gogo() {
 		bundles("org.apache.felix.gogo.runtime,org.apache.felix.gogo.command,org.apache.felix.gogo.shell");
 		return this;
 	}
 
-	public LauchpadBuilder bundles(String specification) {
+	public LaunchpadBuilder bundles(String specification) {
 		List<String> config = workspace.getLatestBundles(projectDir.getAbsolutePath(), specification);
 		config.forEach(local.runbundles::add);
 		return this;
 	}
 
-	public LauchpadBuilder runpath(String specification) {
+	public LaunchpadBuilder runpath(String specification) {
 		List<String> config = workspace.getLatestBundles(projectDir.getAbsolutePath(), specification);
 		config.forEach(local.runpath::add);
 		return this;
 	}
 
-	public LauchpadBuilder bundles(File... files) {
+	public LaunchpadBuilder bundles(File... files) {
 		Stream.of(files)
 			.map(File::getAbsolutePath)
 			.forEach(local.runpath::add);
@@ -124,7 +124,7 @@ public class LauchpadBuilder implements AutoCloseable {
 		return this;
 	}
 
-	public LauchpadBuilder runpath(File... files) {
+	public LaunchpadBuilder runpath(File... files) {
 		Stream.of(files)
 			.map(File::getAbsolutePath)
 			.forEach(local.runpath::add);
@@ -132,39 +132,39 @@ public class LauchpadBuilder implements AutoCloseable {
 		return this;
 	}
 
-	public LauchpadBuilder nostart() {
+	public LaunchpadBuilder nostart() {
 		this.start = false;
 		return this;
 	}
 
-	public LauchpadBuilder notestbundle() {
+	public LaunchpadBuilder notestbundle() {
 		this.testbundle = false;
 		return this;
 	}
 
-	public LauchpadBuilder runfw(File file) {
+	public LaunchpadBuilder runfw(File file) {
 		local.runfw.clear();
 		local.runfw.add(file.getAbsolutePath());
 
 		return this;
 	}
 
-	public LauchpadBuilder runfw(String specification) {
+	public LaunchpadBuilder runfw(String specification) {
 		local.runfw = workspace.getLatestBundles(projectDir.getAbsolutePath(), specification);
 		return this;
 	}
 
-	public LauchpadBuilder set(String key, String value) {
+	public LaunchpadBuilder set(String key, String value) {
 		projectTestSetup.properties.put(key, value);
 		return this;
 	}
 
-	public LauchpadBuilder closeTimeout(long ms) {
+	public LaunchpadBuilder closeTimeout(long ms) {
 		this.closeTimeout = ms;
 		return this;
 	}
 
-	public LauchpadBuilder debug() {
+	public LaunchpadBuilder debug() {
 		this.debug = true;
 		return this;
 	}
@@ -324,7 +324,7 @@ public class LauchpadBuilder implements AutoCloseable {
 	}
 
 	private ClassLoader getMyClassLoader() {
-		return LauchpadBuilder.class.getClassLoader();
+		return LaunchpadBuilder.class.getClassLoader();
 	}
 
 	private URL toURL(File file) {

--- a/biz.aQute.launchpad/test/aQute/launchpad/BeforeAfterTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/BeforeAfterTest.java
@@ -8,12 +8,12 @@ import org.junit.Test;
 
 public class BeforeAfterTest {
 
-	LauchpadBuilder builder;
+	LaunchpadBuilder builder;
 	Launchpad			framework;
 
 	@Before
 	public void before() {
-		builder = new LauchpadBuilder();
+		builder = new LaunchpadBuilder();
 		framework = builder.runfw("org.apache.felix.framework")
 			.create();
 	}

--- a/biz.aQute.launchpad/test/aQute/launchpad/HelloTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/HelloTest.java
@@ -18,7 +18,7 @@ import aQute.lib.io.IO;
 
 public class HelloTest {
 	static Workspace		ws;
-	LauchpadBuilder	builder;
+	LaunchpadBuilder	builder;
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {
@@ -27,7 +27,7 @@ public class HelloTest {
 
 	@Before
 	public void before() throws Exception {
-		builder = new LauchpadBuilder();
+		builder = new LaunchpadBuilder();
 	}
 
 	@After

--- a/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
@@ -40,7 +40,7 @@ import aQute.lib.io.IO;
 
 public class LaunchpadTest {
 	static Workspace		ws;
-	LauchpadBuilder	builder;
+	LaunchpadBuilder	builder;
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {
@@ -49,7 +49,7 @@ public class LaunchpadTest {
 
 	@Before
 	public void before() throws Exception {
-		builder = new LauchpadBuilder();
+		builder = new LaunchpadBuilder();
 	}
 
 	@After

--- a/biz.aQute.launchpad/test/aQute/launchpad/RuleTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/RuleTest.java
@@ -12,7 +12,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class RuleTest {
 
-	LauchpadBuilder builder = new LauchpadBuilder();
+	LaunchpadBuilder builder = new LaunchpadBuilder();
 
 	@Rule
 	public TemporaryFolder	folder	= new TemporaryFolder();


### PR DESCRIPTION
Started trying to work with Peter Kriens' newly-renamed "Launchpad" (see #2957). Wondered why the compiler couldn't find LaunchpadBuilder even after I added it to the build path and imported it.

Turns out it was misspelled as "Lauchpad". The joys of automated refactoring means that this typo propagated through the whole repository while still compiling. This patch fixes the spelling.

I also had the thought to search the workspace for other similar misspellings of "launch", which is an easy enough mistake to make. Found one in a message in biz.aQute.bndlib/src/aQute/bnd/osgi/About.java which I have also fixed in this patch.