### PR TITLE
bndcontainer: Use project as source path for runtime class path

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -114,7 +114,7 @@ public class BndContainer implements IClasspathContainer, Serializable {
                                         output = javaProject.getOutputLocation();
                                     }
                                     if (seen.add(output)) {
-                                        runtime.add(JavaRuntime.newArchiveRuntimeClasspathEntry(output, raw.getSourceAttachmentPath(), raw.getSourceAttachmentRootPath(), raw.getAccessRules(), raw.getExtraAttributes(), false));
+                                        runtime.add(JavaRuntime.newArchiveRuntimeClasspathEntry(output, cpe.getPath(), null, cpe.getAccessRules(), cpe.getExtraAttributes(), false));
                                     }
                                 }
                             }


### PR DESCRIPTION
When adding a project's output folder to the runtime class path, use
the project as the source attatchement path for the output folder.