### PR TITLE
Exceptions: Add and use unrollCause method

### DIFF
--- a/aQute.libg/src/aQute/lib/aspects/Aspects.java
+++ b/aQute.libg/src/aQute/lib/aspects/Aspects.java
@@ -294,9 +294,7 @@ public class Aspects {
 
 					if (exceptions == null)
 						this.exceptions = (inv, exc) -> {
-							if (exc instanceof InvocationTargetException)
-								throw Exceptions.duck(((InvocationTargetException) exc).getTargetException());
-							throw Exceptions.duck(exc);
+							throw Exceptions.duck(Exceptions.unrollCause(exc, InvocationTargetException.class));
 						};
 
 					return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class[] {

--- a/aQute.libg/src/aQute/lib/consoleapp/AbstractConsoleApp.java
+++ b/aQute.libg/src/aQute/lib/consoleapp/AbstractConsoleApp.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import aQute.lib.collections.ExtList;
 import aQute.lib.env.Env;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.getopt.Arguments;
 import aQute.lib.getopt.CommandLine;
 import aQute.lib.getopt.Description;
@@ -141,10 +142,7 @@ public abstract class AbstractConsoleApp extends Env {
 			}
 
 		} catch (InvocationTargetException t) {
-			Throwable tt = t;
-			while (tt instanceof InvocationTargetException)
-				tt = ((InvocationTargetException) tt).getTargetException();
-
+			Throwable tt = Exceptions.unrollCause(t, InvocationTargetException.class);
 			exception(tt, "%s", tt);
 		} catch (Throwable t) {
 			exception(t, "Failed %s", t);

--- a/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
+++ b/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
@@ -1,5 +1,7 @@
 package aQute.lib.exceptions;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.StringJoiner;
@@ -21,6 +23,18 @@ public class Exceptions {
 		StringWriter sw = new StringWriter();
 		t.printStackTrace(new PrintWriter(sw));
 		return sw.toString();
+	}
+
+	public static Throwable unrollCause(Throwable t, Class<? extends Throwable> unrollType) {
+		requireNonNull(t);
+		for (Throwable cause; unrollType.isInstance(t) && ((cause = t.getCause()) != null);) {
+			t = cause;
+		}
+		return t;
+	}
+
+	public static Throwable unrollCause(Throwable t) {
+		return unrollCause(t, Throwable.class);
 	}
 
 	public static String causes(Throwable t) {

--- a/aQute.libg/src/aQute/lib/link/Link.java
+++ b/aQute.libg/src/aQute/lib/link/Link.java
@@ -190,10 +190,7 @@ public class Link<L, R> extends Thread implements Closeable {
 
 						return waitForResult(msgId, method.getGenericReturnType());
 					} catch (InvocationTargetException e) {
-						Throwable t = e;
-						while (t instanceof InvocationTargetException)
-							t = ((InvocationTargetException) t).getTargetException();
-						throw t;
+						throw Exceptions.unrollCause(e, InvocationTargetException.class);
 					} catch (InterruptedException e) {
 						interrupt();
 						throw e;
@@ -561,9 +558,7 @@ public class Link<L, R> extends Thread implements Closeable {
 					return;
 				}
 			} catch (Throwable t) {
-				while (t instanceof InvocationTargetException
-					&& ((InvocationTargetException) t).getTargetException() != null)
-					t = ((InvocationTargetException) t).getTargetException();
+				t = Exceptions.unrollCause(t, InvocationTargetException.class);
 				// t.printStackTrace();
 				try {
 					send(-id, null, new Object[] {

--- a/aQute.libg/src/aQute/libg/reporter/ReporterAdapter.java
+++ b/aQute.libg/src/aQute/libg/reporter/ReporterAdapter.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.strings.Strings;
 import aQute.libg.generics.Create;
 import aQute.service.reporter.Report;
@@ -149,11 +150,8 @@ public class ReporterAdapter implements Reporter, Report, Runnable {
 		errors.add(e);
 		trace("ERROR: %s", e);
 		if (isExceptions() || isTrace())
-			if (t instanceof InvocationTargetException)
-				t.getCause()
-					.printStackTrace(System.err);
-			else
-				t.printStackTrace(System.err);
+			Exceptions.unrollCause(t, InvocationTargetException.class)
+				.printStackTrace(System.err);
 		return location(e);
 	}
 

--- a/aQute.libg/test/aQute/lib/exceptions/ExceptionsTest.java
+++ b/aQute.libg/test/aQute/lib/exceptions/ExceptionsTest.java
@@ -1,0 +1,201 @@
+package aQute.lib.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Test;
+
+public class ExceptionsTest {
+
+	@Test
+	public void testDuck() {
+		IOException ioe = new IOException();
+		assertThatExceptionOfType(IOException.class).isThrownBy(() -> duck(ioe))
+			.isEqualTo(ioe);
+		assertThatExceptionOfType(Throwable.class).isThrownBy(() -> duck(new Throwable()));
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> duck(new RuntimeException()));
+		assertThatExceptionOfType(Error.class).isThrownBy(() -> duck(new Error()));
+	}
+
+	private void duck(Throwable t) {
+		throw Exceptions.duck(t);
+	}
+
+	@Test
+	public void testUnrollCause() {
+		IOException ioe1 = new IOException();
+		IOException ioe2 = new IOException(ioe1);
+		InvocationTargetException ite1 = new InvocationTargetException(ioe2);
+		InvocationTargetException ite2 = new InvocationTargetException(ite1);
+		assertThat(Exceptions.unrollCause(ite2)).isEqualTo(ioe1);
+		assertThat(Exceptions.unrollCause(ite2, Throwable.class)).isEqualTo(ioe1);
+		assertThat(Exceptions.unrollCause(ite2, InvocationTargetException.class)).isEqualTo(ioe2);
+		assertThat(Exceptions.unrollCause(ioe2, InvocationTargetException.class)).isEqualTo(ioe2);
+		assertThat(Exceptions.unrollCause(ioe1)).isEqualTo(ioe1);
+
+		assertThatNullPointerException().isThrownBy(() -> Exceptions.unrollCause(null));
+		assertThatNullPointerException()
+			.isThrownBy(() -> Exceptions.unrollCause(null, InvocationTargetException.class));
+		assertThatNullPointerException().isThrownBy(() -> Exceptions.unrollCause(ioe2, null));
+	}
+
+	@Test
+	public void testFunctionWithException() {
+		FunctionWithException<String, String> fwe = this::functionThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> fwe.orElseThrow()
+			.apply("hi"))
+			.withMessage("hi");
+		assertThat(fwe.orElse("aloha")
+			.apply("hi")).isEqualTo("aloha");
+		assertThat(fwe.orElseGet(() -> "aloha")
+			.apply("hi")).isEqualTo("aloha");
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> FunctionWithException.asFunction(fwe)
+			.apply("hi"))
+			.withMessage("hi");
+		assertThat(FunctionWithException.asFunctionOrElse(fwe, "aloha")
+			.apply("hi")).isEqualTo("aloha");
+		assertThat(FunctionWithException.asFunctionOrElseGet(fwe, () -> "aloha")
+			.apply("hi")).isEqualTo("aloha");
+	}
+
+	private <T, R> R functionThrows(T t) throws Exception {
+		throw new Exception(String.valueOf(t));
+	}
+
+	@Test
+	public void testBiFunctionWithException() {
+		BiFunctionWithException<String, String, String> bfwe = this::biFunctionThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> bfwe.orElseThrow()
+			.apply("hi", "hola"))
+			.withMessage("hihola");
+		assertThat(bfwe.orElse("aloha")
+			.apply("hi", "hola")).isEqualTo("aloha");
+		assertThat(bfwe.orElseGet(() -> "aloha")
+			.apply("hi", "hola")).isEqualTo("aloha");
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> BiFunctionWithException.asBiFunction(bfwe)
+			.apply("hi", "hola"))
+			.withMessage("hihola");
+		assertThat(BiFunctionWithException.asBiFunctionOrElse(bfwe, "aloha")
+			.apply("hi", "hola")).isEqualTo("aloha");
+		assertThat(BiFunctionWithException.asBiFunctionOrElseGet(bfwe, () -> "aloha")
+			.apply("hi", "hola")).isEqualTo("aloha");
+	}
+
+	private <T, U, R> R biFunctionThrows(T t, U u) throws Exception {
+		throw new Exception(String.valueOf(t) + String.valueOf(u));
+	}
+
+	@Test
+	public void testPredicateWithException() {
+		PredicateWithException<String> pwe = this::predicateThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> pwe.orElseThrow()
+			.test("hi"))
+			.withMessage("hi");
+		assertThat(pwe.orElse(false)
+			.test("hi")).isFalse();
+		assertThat(pwe.orElseGet(() -> false)
+			.test("hi")).isFalse();
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> PredicateWithException.asPredicate(pwe)
+			.test("hi"))
+			.withMessage("hi");
+		assertThat(PredicateWithException.asPredicateOrElse(pwe, false)
+			.test("hi")).isFalse();
+		assertThat(PredicateWithException.asPredicateOrElseGet(pwe, () -> false)
+			.test("hi")).isFalse();
+	}
+
+	private <T> boolean predicateThrows(T t) throws Exception {
+		throw new Exception(String.valueOf(t));
+	}
+
+	@Test
+	public void testSupplierWithException() {
+		SupplierWithException<String> swe = this::supplierThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> swe.orElseThrow()
+			.get())
+			.withMessage("hi");
+		assertThat(swe.orElse("aloha")
+			.get()).isEqualTo("aloha");
+		assertThat(swe.orElseGet(() -> "aloha")
+			.get()).isEqualTo("aloha");
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> SupplierWithException.asSupplier(swe)
+			.get())
+			.withMessage("hi");
+		assertThat(SupplierWithException.asSupplierOrElse(swe, "aloha")
+			.get()).isEqualTo("aloha");
+		assertThat(SupplierWithException.asSupplierOrElseGet(swe, () -> "aloha")
+			.get()).isEqualTo("aloha");
+	}
+
+	private <T> T supplierThrows() throws Exception {
+		throw new Exception("hi");
+	}
+
+	@Test
+	public void testConsumerWithException() {
+		ConsumerWithException<String> cwe = this::consumerThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> cwe.orElseThrow()
+			.accept("hi"))
+			.withMessage("hi");
+		cwe.ignoreException()
+			.accept("hi");
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> ConsumerWithException.asConsumer(cwe)
+			.accept("hi"))
+			.withMessage("hi");
+		ConsumerWithException.asConsumerIgnoreException(cwe)
+			.accept("hi");
+	}
+
+	private <T> void consumerThrows(T t) throws Exception {
+		throw new Exception(String.valueOf(t));
+	}
+
+	@Test
+	public void testBiConsumerWithException() {
+		BiConsumerWithException<String, String> bcwe = this::biConsumerThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> bcwe.orElseThrow()
+			.accept("hi", "hola"))
+			.withMessage("hihola");
+		bcwe.ignoreException()
+			.accept("hi", "hola");
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> BiConsumerWithException.asBiConsumer(bcwe)
+			.accept("hi", "hola"))
+			.withMessage("hihola");
+		BiConsumerWithException.asBiConsumerIgnoreException(bcwe)
+			.accept("hi", "hola");
+	}
+
+	private <T, U> void biConsumerThrows(T t, U u) throws Exception {
+		throw new Exception(String.valueOf(t) + String.valueOf(u));
+	}
+
+	@Test
+	public void testRunnableWithException() {
+		RunnableWithException rwe = this::runnableThrows;
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> rwe.orElseThrow()
+			.run())
+			.withMessage("hi");
+		rwe.ignoreException()
+			.run();
+
+		assertThatExceptionOfType(Exception.class).isThrownBy(() -> RunnableWithException.asRunnable(rwe)
+			.run())
+			.withMessage("hi");
+		RunnableWithException.asRunnableIgnoreException(rwe)
+			.run();
+	}
+
+	private void runnableThrows() throws Exception {
+		throw new Exception("hi");
+	}
+}

--- a/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/gogo/Activator.java
+++ b/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/gogo/Activator.java
@@ -100,7 +100,7 @@ public class Activator implements BundleActivator {
 			});
 
 		} catch (InvocationTargetException e) {
-			e.getTargetException()
+			Exceptions.unrollCause(e, InvocationTargetException.class)
 				.printStackTrace();
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/biz.aQute.bnd/src/aQute/bnd/main/Shell.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/Shell.java
@@ -139,8 +139,7 @@ public class Shell implements AutoCloseable {
 								if (!(t instanceof Exception)) {
 									throw Exceptions.duck(t);
 								}
-								while (t instanceof InvocationTargetException)
-									t = ((InvocationTargetException) t).getTargetException();
+								t = Exceptions.unrollCause(t, InvocationTargetException.class);
 								bnd.exception(t, "%s", t);
 							}
 						} else {

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -122,6 +122,7 @@ import aQute.lib.base64.Base64;
 import aQute.lib.collections.ExtList;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.collections.SortedList;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.filter.Filter;
 import aQute.lib.getopt.Arguments;
 import aQute.lib.getopt.CommandLine;
@@ -454,8 +455,7 @@ public class bnd extends Processor {
 				settings.load(password);
 			}
 		} catch (Throwable t) {
-			while (t instanceof InvocationTargetException)
-				t = t.getCause();
+			t = Exceptions.unrollCause(t, InvocationTargetException.class);
 			exception(t, "%s", t);
 		}
 		out.flush();

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2845,7 +2845,7 @@ public class Project extends Processor {
 								return (constructor.getParameterCount() == 1) ? constructor.newInstance(this)
 									: constructor.newInstance(this, c);
 							} catch (InvocationTargetException e) {
-								throw Exceptions.duck(e.getCause());
+								throw Exceptions.duck(Exceptions.unrollCause(e, InvocationTargetException.class));
 							}
 						}
 					}

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -57,6 +57,7 @@ import aQute.bnd.service.url.TaggedData;
 import aQute.bnd.service.url.URLConnectionHandler;
 import aQute.bnd.service.url.URLConnector;
 import aQute.bnd.util.home.Home;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.lib.json.JSONCodec;
 import aQute.libg.reporter.ReporterAdapter;
@@ -553,8 +554,7 @@ public class HttpClient implements Closeable, URLConnector {
 			in = createProgressWrappedStream(in, con.toString(), con.getContentLength(), task, request.timeout);
 			return new TaggedData(con, in, request.useCacheFile);
 		} catch (javax.net.ssl.SSLHandshakeException ste) {
-			task.done(ste.getCause()
-				.toString(), null);
+			task.done(Exceptions.causes(ste), null);
 			//
 			// 526 Invalid SSL Certificate
 			// Cloudflare could not validate the SSL/TLS certificate that the

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -409,10 +409,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (p.exceptions) {
 			printExceptionSummary(t, System.err);
 		}
-		// unwrap InvocationTargetException
-		while ((t instanceof InvocationTargetException) && (t.getCause() != null)) {
-			t = t.getCause();
-		}
+		// unroll InvocationTargetException
+		t = Exceptions.unrollCause(t, InvocationTargetException.class);
 		String s = formatArrays("Exception: %s", Exceptions.toString(t));
 		if (p.isFailOk()) {
 			p.warnings.add(s);

--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -664,11 +664,8 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 							Object o = objects[n++];
 							if (o instanceof Throwable) {
 								Throwable t = e = (Throwable) o;
-								while (t instanceof InvocationTargetException) {
-									Throwable cause = t.getCause();
-									if (cause == null) {
-										break;
-									}
+								for (Throwable cause; (t instanceof InvocationTargetException)
+									&& ((cause = t.getCause()) != null);) {
 									t = cause;
 								}
 								sb.append(t.getMessage());

--- a/biz.aQute.remote/src/aQute/remote/util/Link.java
+++ b/biz.aQute.remote/src/aQute/remote/util/Link.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.json.JSONCodec;
 
 /**
@@ -137,10 +138,7 @@ public class Link<L, R> extends Thread implements Closeable {
 
 						return waitForResult(msgId, method.getGenericReturnType());
 					} catch (InvocationTargetException e) {
-						Throwable t = e;
-						while (t instanceof InvocationTargetException)
-							t = ((InvocationTargetException) t).getTargetException();
-						throw t;
+						throw Exceptions.unrollCause(e, InvocationTargetException.class);
 					} catch (InterruptedException e) {
 						interrupt();
 						throw e;
@@ -360,9 +358,7 @@ public class Link<L, R> extends Thread implements Closeable {
 					return;
 				}
 			} catch (Throwable t) {
-				while (t instanceof InvocationTargetException
-					&& ((InvocationTargetException) t).getTargetException() != null)
-					t = ((InvocationTargetException) t).getTargetException();
+				t = Exceptions.unrollCause(t, InvocationTargetException.class);
 				// t.printStackTrace();
 				try {
 					send(-id, null, new Object[] {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -38,6 +38,7 @@ import aQute.bnd.osgi.resource.ResourceUtils.BundleCap;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.maven.api.Archive;
@@ -247,13 +248,7 @@ class IndexFile {
 	}
 
 	private String getMessage(Throwable failure) {
-		if (failure instanceof InvocationTargetException) {
-			Throwable targetException = ((InvocationTargetException) failure).getTargetException();
-			if (targetException == null)
-				return failure.toString();
-
-			return getMessage(targetException);
-		}
+		failure = Exceptions.unrollCause(failure, InvocationTargetException.class);
 		if (failure instanceof FileNotFoundException) {
 			return "Not found";
 		}
@@ -380,7 +375,7 @@ class IndexFile {
 		try {
 			return bridge.getValue();
 		} catch (InvocationTargetException e) {
-			reporter.exception(e.getTargetException(), "Getting bridge failed");
+			reporter.exception(Exceptions.unrollCause(e, InvocationTargetException.class), "Getting bridge failed");
 		} catch (InterruptedException e) {
 			logger.info("Interrupted");
 			Thread.currentThread()

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
@@ -22,6 +22,7 @@ import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.libg.cryptography.SHA256;
 import aQute.libg.reporter.slf4j.Slf4jReporter;
@@ -130,9 +131,9 @@ public class P2IndexerTest extends TestCase {
 				throw result.get();
 
 		} catch (InvocationTargetException ite) {
-			ite.getTargetException()
-				.printStackTrace();
-			throw ite.getTargetException();
+			Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
+			t.printStackTrace();
+			throw t;
 		}
 
 		try (
@@ -240,9 +241,9 @@ public class P2IndexerTest extends TestCase {
 				throw result.get();
 
 		} catch (InvocationTargetException ite) {
-			ite.getTargetException()
-				.printStackTrace();
-			throw ite.getTargetException();
+			Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
+			t.printStackTrace();
+			throw t;
 		}
 
 		try (P2Indexer p3 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(), "test")) {

--- a/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
+++ b/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
@@ -66,6 +66,7 @@ import org.osgi.framework.BundleActivator;
 import org.osgi.framework.Constants;
 
 import aQute.bnd.build.model.BndEditModel;
+import aQute.lib.exceptions.Exceptions;
 import bndtools.Plugin;
 import bndtools.UIConstants;
 import bndtools.editor.utils.ToolTips;
@@ -350,7 +351,7 @@ public class GeneralInfoPart extends SectionPart implements PropertyChangeListen
                 window.run(false, false, runnable);
                 return result;
             } catch (InvocationTargetException e) {
-                logger.logError("Error searching for BundleActivator types", e.getTargetException());
+                logger.logError("Error searching for BundleActivator types", Exceptions.unrollCause(e, InvocationTargetException.class));
                 return Collections.emptyList();
             } catch (InterruptedException e) {
                 Thread.currentThread()

--- a/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsProposalProvider.java
+++ b/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsProposalProvider.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
+import aQute.lib.exceptions.Exceptions;
 import bndtools.javamodel.IJavaSearchContext;
 import bndtools.utils.CachingContentProposalProvider;
 
@@ -114,7 +115,7 @@ public class PkgPatternsProposalProvider extends CachingContentProposalProvider 
             }
             return result;
         } catch (InvocationTargetException e) {
-            logger.logError("Error searching for packages.", e);
+            logger.logError("Error searching for packages.", Exceptions.unrollCause(e, InvocationTargetException.class));
             return Collections.emptyList();
         } catch (InterruptedException e) {
             Thread.currentThread()

--- a/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
@@ -194,7 +194,7 @@ public class RepositorySelectionPart extends BndEditorPart implements IResourceC
                     // let it go
                 } catch (InvocationTargetException e) {
                     ErrorDialog.openError(editor.getSite()
-                        .getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Save error", e.getTargetException()));
+                        .getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Save error", Exceptions.unrollCause(e, InvocationTargetException.class)));
                 }
             }
         });

--- a/bndtools.core/src/bndtools/model/repo/RepositoryEntry.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryEntry.java
@@ -20,6 +20,7 @@ import aQute.bnd.service.ResourceHandle;
 import aQute.bnd.service.ResourceHandle.Location;
 import aQute.bnd.service.Strategy;
 import aQute.bnd.version.Version;
+import aQute.lib.exceptions.Exceptions;
 
 abstract class VersionFinder {
     String versionSpec;
@@ -119,11 +120,7 @@ public abstract class RepositoryEntry implements IAdaptable {
             }
             return repo.get(bsn, version, Collections.emptyMap());
         } catch (Exception e) {
-            Throwable t = e;
-            for (Throwable cause; (t instanceof InvocationTargetException) && ((cause = t.getCause()) != null);) {
-                t = cause; // unwrap exception
-            }
-            logger.logError(MessageFormat.format("Failed to query repository {0} for bundle {1} version {2}.", repo.getName(), bsn, versionFinder), t);
+            logger.logError(MessageFormat.format("Failed to query repository {0} for bundle {1} version {2}.", repo.getName(), bsn, versionFinder), Exceptions.unrollCause(e, InvocationTargetException.class));
             return null;
         }
     }

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -109,6 +109,7 @@ import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RemoteRepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.lib.converter.Converter;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import bndtools.Plugin;
 import bndtools.central.Central;
@@ -615,9 +616,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
                             refreshAction.setEnabled(false);
                             Central.refreshPlugins();
                         } catch (Exception e) {
-                            Throwable t = e;
-                            while (t instanceof InvocationTargetException)
-                                t = ((InvocationTargetException) e).getTargetException();
+                            Throwable t = Exceptions.unrollCause(e, InvocationTargetException.class);
 
                             logger.logError("Unexpected error in refreshing plugns", t);
 

--- a/bndtools.core/src/bndtools/wizards/bndfile/EmptyBndFileWizard.java
+++ b/bndtools.core/src/bndtools/wizards/bndfile/EmptyBndFileWizard.java
@@ -31,6 +31,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 
+import aQute.lib.exceptions.Exceptions;
 import bndtools.Plugin;
 
 public class EmptyBndFileWizard extends Wizard implements INewWizard {
@@ -69,7 +70,7 @@ public class EmptyBndFileWizard extends Wizard implements INewWizard {
                 }
             });
         } catch (InvocationTargetException e) {
-            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "An error occurred while enabling sub-bundles", e.getCause()));
+            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "An error occurred while enabling sub-bundles", Exceptions.unrollCause(e, InvocationTargetException.class)));
             return false;
         } catch (InterruptedException e) {
             return false;

--- a/bndtools.core/src/bndtools/wizards/bndfile/ExecutableJarExportWizard.java
+++ b/bndtools.core/src/bndtools/wizards/bndfile/ExecutableJarExportWizard.java
@@ -11,6 +11,7 @@ import org.eclipse.jface.wizard.Wizard;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.model.BndEditModel;
+import aQute.lib.exceptions.Exceptions;
 import bndtools.Plugin;
 
 public class ExecutableJarExportWizard extends Wizard implements IRunDescriptionExportWizard {
@@ -44,7 +45,7 @@ public class ExecutableJarExportWizard extends Wizard implements IRunDescription
             getContainer().run(true, true, task);
             return true;
         } catch (InvocationTargetException e) {
-            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error occurred during export.", e.getTargetException()));
+            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error occurred during export.", Exceptions.unrollCause(e, InvocationTargetException.class)));
             return false;
         } catch (InterruptedException e) {
             return false;

--- a/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizard.java
+++ b/bndtools.core/src/bndtools/wizards/workspace/WorkspaceSetupWizard.java
@@ -41,6 +41,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 
 import aQute.bnd.build.Project;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import bndtools.Plugin;
 import bndtools.central.Central;
@@ -225,7 +226,7 @@ public class WorkspaceSetupWizard extends Wizard implements INewWizard {
             }
             return true;
         } catch (InvocationTargetException e) {
-            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error generating template output", e.getTargetException()));
+            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error generating template output", Exceptions.unrollCause(e, InvocationTargetException.class)));
             return false;
         } catch (Exception e) {
             ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error generating template output", e));

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
@@ -15,6 +15,7 @@ import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import aQute.bnd.build.model.BndEditModel;
+import aQute.lib.exceptions.Exceptions;
 import bndtools.Plugin;
 
 public class ResolutionResultsWizardPage extends WizardPage implements ResolutionResultPresenter {
@@ -85,7 +86,7 @@ public class ResolutionResultsWizardPage extends WizardPage implements Resolutio
 
             setResult(resolver.getResult());
         } catch (InvocationTargetException e) {
-            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Unexpected error", e));
+            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Unexpected error", Exceptions.unrollCause(e, InvocationTargetException.class)));
             setResult(null);
         } catch (InterruptedException e) {
             setResult(null);

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/jpm/AddJpmDependenciesWizard.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/jpm/AddJpmDependenciesWizard.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.wizard.Wizard;
 
 import aQute.bnd.service.repository.SearchableRepository;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
+import aQute.lib.exceptions.Exceptions;
 import bndtools.Plugin;
 
 public class AddJpmDependenciesWizard extends Wizard {
@@ -72,7 +73,7 @@ public class AddJpmDependenciesWizard extends Wizard {
 
             return true;
         } catch (InvocationTargetException e) {
-            MessageDialog.openError(getShell(), "Error", e.getCause()
+            MessageDialog.openError(getShell(), "Error", Exceptions.unrollCause(e, InvocationTargetException.class)
                 .getMessage());
             return false;
         } catch (InterruptedException e) {

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/jpm/JpmDependencyWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/jpm/JpmDependencyWizardPage.java
@@ -40,6 +40,7 @@ import org.eclipse.swt.widgets.Table;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.service.repository.SearchableRepository;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
+import aQute.lib.exceptions.Exceptions;
 import bndtools.central.Central;
 
 public class JpmDependencyWizardPage extends WizardPage {
@@ -240,7 +241,7 @@ public class JpmDependencyWizardPage extends WizardPage {
                 indirectResources = query.getIndirectResources();
                 selectedIndirectResources = new HashSet<ResourceDescriptor>();
             } catch (InvocationTargetException e) {
-                errorText = e.getCause()
+                errorText = Exceptions.unrollCause(e, InvocationTargetException.class)
                     .getMessage();
             } catch (InterruptedException e) {
                 // ignore

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -70,6 +70,7 @@ import org.osgi.service.component.ComponentConstants;
 import org.osgi.util.promise.Promise;
 
 import aQute.bnd.osgi.Processor;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.libg.tuple.Pair;
 import bndtools.Plugin;
@@ -383,8 +384,7 @@ public class TemplateSelectionWizardPage extends WizardPage {
             ProgressRunner.execute(true, new LoadTemplatesJob(shell, oldMessage), getContainer(), getContainer().getShell()
                 .getDisplay());
         } catch (InvocationTargetException e) {
-            Throwable exception = e.getTargetException();
-            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error loading templates.", exception));
+            ErrorDialog.openError(getShell(), "Error", null, new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error loading templates.", Exceptions.unrollCause(e, InvocationTargetException.class)));
         }
     }
 


### PR DESCRIPTION
This method will provide consistent unrolling of exception causes such as InvocationTargetException.

There many places where InvocationTargetException was unrolled and many of the places had bugs which could result in a null exception value result leading to NPEs.