### PR TITLE
[launchpad] Rename literals and comments.

### DIFF
--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -478,8 +478,7 @@ public interface BundleSpecBuilder {
 
 			/*
 			 * (non-Javadoc)
-			 * 
-			 * @see aQute.bnd.remote.junit.BundleSpecBuilder#x()
+			 * @see aQute.launchpad.BundleSpecBuilder#x()
 			 */
 			@Override
 			public BundleBuilder x() {

--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -93,10 +93,10 @@ public class Launchpad implements AutoCloseable {
 	PrintStream									out						= System.err;
 	ServiceTracker<FindHook, FindHook>			hooks;
 
-	Launchpad(LaunchpadBuilder jUnitFrameworkBuilder, Framework framework) {
+	Launchpad(LaunchpadBuilder launchpadBuilder, Framework framework) {
 		try {
-			this.builder = jUnitFrameworkBuilder;
-			this.debug = jUnitFrameworkBuilder.debug;
+			this.builder = launchpadBuilder;
+			this.debug = launchpadBuilder.debug;
 			this.framework = framework;
 			this.framework.init();
 			this.injector = new Injector<>(makeConverter(), this::getService, Service.class);
@@ -561,9 +561,9 @@ public class Launchpad implements AutoCloseable {
 
 	/**
 	 * Hide a service by registering a hook. This should in general be done
-	 * before you let others look. In general, the JUnit Framework should be
-	 * started in {@link LaunchpadBuilder#nostart()} mode. This initializes
-	 * the OSGi framework making it possible to register a service before
+	 * before you let others look. In general, the Launchpad should be started
+	 * in {@link LaunchpadBuilder#nostart()} mode. This initializes the OSGi
+	 * framework making it possible to register a service before
 	 */
 
 	public Closeable hide(Class<?> type) {
@@ -597,7 +597,7 @@ public class Launchpad implements AutoCloseable {
 
 				@Override
 				public String toString() {
-					return "JUnitFramework[" + reason + "]";
+					return "Launchpad[" + reason + "]";
 				}
 			}, null);
 
@@ -614,7 +614,7 @@ public class Launchpad implements AutoCloseable {
 
 				@Override
 				public String toString() {
-					return "JUnitFramework[" + reason + "]";
+					return "Launchpad[" + reason + "]";
 				}
 
 			}, null);

--- a/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
@@ -171,7 +171,7 @@ public class LaunchpadBuilder implements AutoCloseable {
 
 	public Launchpad create() {
 		try {
-			File storage = IO.getFile(new File(local.target), "junit-fw-" + counter.incrementAndGet());
+			File storage = IO.getFile(new File(local.target), "launchpad-" + counter.incrementAndGet());
 			IO.delete(storage);
 
 			String extraPackages = toString(local.extraSystemPackages);
@@ -186,22 +186,22 @@ public class LaunchpadBuilder implements AutoCloseable {
 			Framework framework = getFramework();
 
 			@SuppressWarnings("resource")
-			Launchpad jUnitFramework = new Launchpad(this, framework);
+			Launchpad launchpad = new Launchpad(this, framework);
 
-			jUnitFramework.report("Extra system packages %s", local.extraSystemPackages.keySet()
+			launchpad.report("Extra system packages %s", local.extraSystemPackages.keySet()
 				.stream()
 				.collect(Collectors.joining("\n")));
-			jUnitFramework.report("Extra system capabilities %s", local.extraSystemCapabilities.keySet()
+			launchpad.report("Extra system capabilities %s", local.extraSystemCapabilities.keySet()
 				.stream()
 				.collect(Collectors.joining("\n")));
-			jUnitFramework.report("Storage %s", storage.getAbsolutePath());
-			jUnitFramework.report("Runpath %s", local.runpath);
+			launchpad.report("Storage %s", storage.getAbsolutePath());
+			launchpad.report("Runpath %s", local.runpath);
 
 			if (start) {
-				jUnitFramework.start();
+				launchpad.start();
 			}
 
-			return jUnitFramework;
+			return launchpad;
 		} catch (Exception e) {
 			throw Exceptions.duck(e);
 		}

--- a/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
@@ -367,7 +367,7 @@ public class LaunchpadTest {
 			fail();
 		} catch (TimeoutException toe) {
 			System.out.println(toe);
-			assertThat(toe.getMessage()).contains("Hidden (FindHook)", "JUnitFramework[hide]");
+			assertThat(toe.getMessage()).contains("Hidden (FindHook)", "Launchpad[hide]");
 		}
 	}
 
@@ -412,7 +412,7 @@ public class LaunchpadTest {
 	// wait a bit until this is supported by gradle and Eclipse
 	// @Test(expected = IllegalArgumentException.class)
 	// public void testMissingBundle() throws Exception {
-	// try (JUnitFramework fw = builder.bndrun("missing.bndrun")
+	// try (Launchpad lp = builder.bndrun("missing.bndrun")
 	// .create()) {}
 	// }
 


### PR DESCRIPTION
Further fix for #2957. Some literals, comments and variables were missed in the original rename.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>