### PR TITLE
[launchpad] Launchpad imported too much

### DIFF
--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -50,8 +50,6 @@ import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.util.tracker.ServiceTracker;
 
-import aQute.bnd.header.Parameters;
-import aQute.bnd.osgi.Builder;
 import aQute.lib.converter.Converter;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.inject.Injector;
@@ -67,12 +65,12 @@ import aQute.libg.glob.Glob;
  * will ensure that. Once the framework is up and running it will be possible to
  * add bundles to it. There are a number of ways that this can be achieved:
  * <ul>
- * <li>Build a bundle – A bnd {@link Builder} is provided to create a bundle and
- * install it. This makes it possible to add classes from the src or test
- * directories or resources. See {@link #bundle()}. Convenience methods are
- * added to get services, see {@link #getService(Class)} et. al. Notice that
- * this framework starts in the same process as that the JUnit code runs. This
- * is normally a separately started VM.
+ * <li>Build a bundle – A bnd Builder is provided to create a bundle and install
+ * it. This makes it possible to add classes from the src or test directories or
+ * resources. See {@link #bundle()}. Convenience methods are added to get
+ * services, see {@link #getService(Class)} et. al. Notice that this framework
+ * starts in the same process as that the JUnit code runs. This is normally a
+ * separately started VM.
  */
 public class Launchpad implements AutoCloseable {
 

--- a/biz.aQute.launchpad/src/aQute/launchpad/Parameters.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Parameters.java
@@ -1,0 +1,72 @@
+package aQute.launchpad;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import aQute.libg.qtokens.QuotedTokenizer;
+
+public class Parameters extends LinkedHashMap<String, Map<String, String>> {
+	private static final long serialVersionUID = 1L;
+
+	public Parameters(String headers) {
+		if (headers == null)
+			return;
+		parse(headers);
+	}
+
+	enum Mode {
+
+	}
+
+	private void parse(String headers) {
+		QuotedTokenizer qt = new QuotedTokenizer(headers, ";=,", false);
+		Set<String> keys = new HashSet<>();
+
+		do {
+			keys.clear();
+			do {
+				String token = qt.nextToken(";=,");
+
+				switch (qt.getSeparator()) {
+					case ';' :
+						keys.add(token.trim());
+						break;
+					case ',' :
+						keys.forEach(k -> put(k, null));
+						break;
+
+					case '=' :
+						Map<String, String> attrs = new LinkedHashMap<>();
+						do {
+							String key = token.trim();
+							if (qt.getSeparator() == '=') {
+								String value = qt.nextToken(";,");
+								attrs.put(key, value.trim());
+							}
+							if (qt.getSeparator() == ';')
+								token = qt.nextToken(";=,");
+						} while (qt.getSeparator() == '=');
+						keys.forEach(k -> put(k, attrs));
+				}
+			} while (qt.getSeparator() == ';');
+		} while (qt.getSeparator() == ',');
+
+		String token = qt.nextToken();
+		if (token != null && !token.trim()
+			.isEmpty()) {
+			throw new IllegalArgumentException("Parsing header: '" + headers + "' has trailing " + qt);
+		}
+	}
+
+	public Map<String, String> put(String key, Map<String, String> attrs) {
+		while (this.containsKey(key)) {
+			key += "~";
+		}
+		if (attrs == null)
+			attrs = new LinkedHashMap<String, String>();
+		super.put(key, attrs);
+		return null;
+	}
+}

--- a/biz.aQute.launchpad/test/aQute/launchpad/ParametersTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/ParametersTest.java
@@ -1,0 +1,27 @@
+package aQute.launchpad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ParametersTest {
+
+	@Test
+	public void testParameters() {
+		Parameters parameters = new Parameters("   foo    ;  \tbar ; abc = \"abc  x\"; def=def,    foo; bar2 = bar2");
+
+		assertThat(parameters.keySet()).containsExactlyInAnyOrder("foo", "bar", "foo~");
+
+		Map<String, String> attrs = parameters.get("foo");
+
+		assertThat(attrs).isEqualTo(parameters.get("bar"));
+
+		assertThat(attrs.get("abc")).isEqualTo("abc  x");
+		assertThat(attrs.get("def")).isEqualTo("def");
+
+		assertThat(parameters.get("foo~")
+			.get("bar2")).isEqualTo("bar2");
+	}
+}


### PR DESCRIPTION
Included OSGiHeaders but this included too many
dependencies and these were not even properly 
conditionally included.

Created a simple Parameters class that assumes the
header is correct and does not try to analyze 
what might be wrong.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>