### PR TITLE
Fix Verifier to properly verify Jars

### DIFF
--- a/aQute.libg/src/aQute/libg/glob/AntGlob.java
+++ b/aQute.libg/src/aQute/libg/glob/AntGlob.java
@@ -15,8 +15,8 @@ public class AntGlob extends Glob {
 	}
 
 	// match forward slash or back slash (windows)
-	private static final String	SLASHY		= "[/\\\\]";
-	private static final String	NOT_SLASHY	= "[^/\\\\]";
+	private static final String	SLASHY		= "[\\\\/]";
+	private static final String	NOT_SLASHY	= "[^\\\\/]";
 
 	public static Pattern toPattern(String line) {
 		return toPattern(line, 0);

--- a/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
+++ b/aQute.libg/src/aQute/libg/sed/ReplacerAdapter.java
@@ -52,7 +52,7 @@ import aQute.service.reporter.Reporter;
  */
 public class ReplacerAdapter extends ReporterAdapter implements Replacer {
 	static final Random	random		= new Random();
-	static Pattern		WILDCARD	= Pattern.compile("[*?|[\\\\]\\(\\)]");
+	static Pattern		WILDCARD	= Pattern.compile("[*?|({\\[]");
 	Domain				domain;
 	List<Object>		targets		= new ArrayList<>();
 	boolean				flattening;

--- a/aQute.libg/src/aQute/libg/uri/URIUtil.java
+++ b/aQute.libg/src/aQute/libg/uri/URIUtil.java
@@ -6,7 +6,7 @@ import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
 public final class URIUtil {
-	private static final Pattern WINDOWS_FILE_PATTERN = Pattern.compile("(?:[a-zA-Z]:[/\\\\]|\\\\\\\\|//)");
+	private static final Pattern WINDOWS_FILE_PATTERN = Pattern.compile("(?:[a-zA-Z]:[\\\\/]|\\\\\\\\|//)");
 
 	/**
 	 * Resolves a URI reference against a base URI. Work-around for bugs in

--- a/biz.aQute.bnd/src/aQute/bnd/main/RemoteCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/RemoteCommand.java
@@ -296,19 +296,22 @@ class RemoteCommand extends Processor {
 			if (opts.vendor() != null)
 				main.putValue(Constants.BUNDLE_VENDOR, opts.vendor());
 
-			Jar jar = new Jar("distro");
-			jar.setManifest(m);
+			try (Jar jar = new Jar("distro")) {
+				jar.setManifest(m);
 
-			Verifier v = new Verifier(jar);
-			v.setProperty(Constants.FIXUPMESSAGES, "osgi.* namespace must not be specified with generic capabilities");
-			v.verify();
-			v.getErrors();
+				try (Verifier v = new Verifier(jar)) {
+					v.setProperty(Constants.FIXUPMESSAGES,
+						"osgi.* namespace must not be specified with generic capabilities");
+					v.verify();
+					v.getErrors();
 
-			if (isFailOk() || v.isOk()) {
-				jar.updateModified(System.currentTimeMillis(), "Writing distro jar");
-				jar.write(output);
-			} else
-				getInfo(v);
+					if (isFailOk() || v.isOk()) {
+						jar.updateModified(System.currentTimeMillis(), "Writing distro jar");
+						jar.write(output);
+					} else
+						getInfo(v);
+				}
+			}
 		}
 
 	}

--- a/biz.aQute.bnd/src/aQute/bnd/main/RepoCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/RepoCommand.java
@@ -442,11 +442,12 @@ public class RepoCommand {
 				logger.debug("bsn {} version {}", bsn, jar.getVersion());
 
 				if (!opts.force()) {
-					Verifier v = new Verifier(jar);
-					v.setTrace(true);
-					v.setExceptions(true);
-					v.verify();
-					bnd.getInfo(v);
+					try (Verifier v = new Verifier(jar)) {
+						v.setTrace(true);
+						v.setExceptions(true);
+						v.verify();
+						bnd.getInfo(v);
+					}
 				}
 
 				if (bnd.isOk()) {

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -1996,10 +1996,11 @@ public class bnd extends Processor {
 
 	private void doPrint(Jar jar, int options, printOptions po) throws ZipException, IOException, Exception {
 		if ((options & VERIFY) != 0) {
-			Verifier verifier = new Verifier(jar);
-			verifier.setPedantic(isPedantic());
-			verifier.verify();
-			getInfo(verifier);
+			try (Verifier verifier = new Verifier(jar)) {
+				verifier.setPedantic(isPedantic());
+				verifier.verify();
+				getInfo(verifier);
+			}
 		}
 		if ((options & MANIFEST) != 0) {
 			Manifest manifest = jar.getManifest();
@@ -2617,15 +2618,15 @@ public class bnd extends Processor {
 			if (!f.isFile()) {
 				error("No such file: %s", f);
 			} else {
-				Jar jar = new Jar(f);
-				if (jar.getManifest() == null || jar.getBsn() == null)
-					error("Not a bundle %s", f);
-				else {
-					Verifier v = new Verifier(jar);
-					getInfo(v, f.getName());
-					v.close();
+				try (Jar jar = new Jar(f)) {
+					if (jar.getManifest() == null || jar.getBsn() == null)
+						error("Not a bundle %s", f);
+					else {
+						try (Verifier v = new Verifier(jar)) {
+							getInfo(v, f.getName());
+						}
+					}
 				}
-				jar.close();
 			}
 		}
 	}

--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -504,8 +504,7 @@ public class BuilderTest extends BndTestCase {
 	 */
 
 	public void testRemovedImportWithRequireBundle() throws Exception {
-		Builder b = new Builder();
-		try {
+		try (Builder b = new Builder()) {
 			b.addClasspath(new File("bin_test"));
 			b.addClasspath(new File("jar/osgi.core.jar"));
 			b.setPedantic(true);
@@ -520,11 +519,10 @@ public class BuilderTest extends BndTestCase {
 			assertThat(b.getImports()
 				.keySet()).containsExactlyInAnyOrder(b.getPackageRef("javax.swing"));
 
-			Verifier v = new Verifier(b.getJar());
-			v.verify();
-			assertTrue(v.check());
-		} finally {
-			b.close();
+			try (Verifier v = new Verifier(b.getJar())) {
+				v.verify();
+				assertTrue(v.check("Host .* for this fragment"));
+			}
 		}
 	}
 
@@ -535,8 +533,7 @@ public class BuilderTest extends BndTestCase {
 	 */
 
 	public void testMissingImportsWithDynamicImport() throws Exception {
-		Builder b = new Builder();
-		try {
+		try (Builder b = new Builder()) {
 			b.addClasspath(new File("bin_test"));
 			b.setPedantic(true);
 			b.setExportPackage("test.classreference;version=1");
@@ -545,15 +542,10 @@ public class BuilderTest extends BndTestCase {
 			b.build();
 			assertTrue(b.check());
 
-			Verifier v = new Verifier(b.getJar());
-			try {
+			try (Verifier v = new Verifier(b.getJar())) {
 				v.verify();
 				assertTrue(v.check("Unresolved references to \\[javax.swing\\] by class\\(es\\)"));
-			} finally {
-				v.close();
 			}
-		} finally {
-			b.close();
 		}
 	}
 
@@ -564,8 +556,7 @@ public class BuilderTest extends BndTestCase {
 	 */
 
 	public void testMissingImportsWithoutDynamicImport() throws Exception {
-		Builder b = new Builder();
-		try {
+		try (Builder b = new Builder()) {
 			b.addClasspath(new File("bin_test"));
 			b.setPedantic(true);
 			b.setExportPackage("test.classreference;version=1");
@@ -573,15 +564,10 @@ public class BuilderTest extends BndTestCase {
 			b.build();
 			assertTrue(b.check());
 
-			Verifier v = new Verifier(b.getJar());
-			try {
+			try (Verifier v = new Verifier(b.getJar())) {
 				v.verify();
 				assertTrue(v.check("Unresolved references to \\[javax.swing\\] by class\\(es\\)"));
-			} finally {
-				v.close();
 			}
-		} finally {
-			b.close();
 		}
 
 	}
@@ -3288,12 +3274,11 @@ public class BuilderTest extends BndTestCase {
 
 	public void testVerify() throws Exception {
 		System.err.println("Erroneous bundle: tb1.jar");
-		Jar jar = new Jar("test", getClass().getResourceAsStream("tb1.jar"));
-		Verifier verifier = new Verifier(jar);
-		verifier.verify();
-		assertTrue(verifier.check());
-		jar.close();
-		verifier.close();
+		try (Jar jar = new Jar("test", getClass().getResourceAsStream("tb1.jar"));
+			Verifier verifier = new Verifier(jar)) {
+			verifier.verify();
+			assertTrue(verifier.check());
+		}
 	}
 
 	public static void report(String title, Analyzer builder, Jar jar) {

--- a/biz.aQute.bndlib.tests/test/test/VerifierTest.java
+++ b/biz.aQute.bndlib.tests/test/test/VerifierTest.java
@@ -20,14 +20,15 @@ import junit.framework.TestCase;
 public class VerifierTest extends TestCase {
 
 	public void testExports() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(b.getFile("bin_test"));
-		b.setExportPackage("test,\u00A0bar.foo");
-		b.setImportPackage("\u2007bar.foo, \u2007bar.foo, \u202F bar.foo");
-		b.build();
-		assertTrue(b.check("Invalid package name: '\\\\u00A0bar.foo' in Export-Package",
-			"Invalid package name: '\\\\u2007bar.foo' in Import-Package",
-			"Invalid package name: '\\\\u202F bar.foo' in Import-Package"));
+		try (Builder b = new Builder()) {
+			b.addClasspath(b.getFile("bin_test"));
+			b.setExportPackage("test,\u00A0bar.foo");
+			b.setImportPackage("\u2007bar.foo, \u2007bar.foo, \u202F bar.foo");
+			b.build();
+			assertTrue(b.check("Invalid package name: '\\\\u00A0bar.foo' in Export-Package",
+				"Invalid package name: '\\\\u2007bar.foo' in Import-Package",
+				"Invalid package name: '\\\\u202F bar.foo' in Import-Package"));
+		}
 	}
 
 	public void testFQN() {
@@ -52,13 +53,14 @@ public class VerifierTest extends TestCase {
 	 * Verify that an invalid namespace error is actually an error
 	 */
 	public void verifyNamespace() throws Exception {
-		Builder b = new Builder();
-		b.setProperty("Require-Capability", "+++,bla.bla");
-		b.setProperty("Provide-Capability", "===,bla.bla");
-		b.setIncludeResource("foo;literal='foo'");
-		Jar inner = b.build();
-		assertTrue(b.check("The Require-Capability with namespace \\+\\+\\+ is not a symbolic name",
-			"The Provide-Capability with namespace === is not a symbolic name"));
+		try (Builder b = new Builder()) {
+			b.setProperty("Require-Capability", "+++,bla.bla");
+			b.setProperty("Provide-Capability", "===,bla.bla");
+			b.setIncludeResource("foo;literal='foo'");
+			Jar inner = b.build();
+			assertTrue(b.check("The Require-Capability with namespace \\+\\+\\+ is not a symbolic name",
+				"The Provide-Capability with namespace === is not a symbolic name"));
+		}
 	}
 
 	/**
@@ -68,20 +70,23 @@ public class VerifierTest extends TestCase {
 	 */
 
 	public void verifyMetaPersistence() throws Exception {
-		Builder b = new Builder();
-		b.setIncludeResource("foo.xml;literal='I exist'");
-		Jar inner = b.build();
-		assertTrue(b.check());
+		try (Builder b = new Builder()) {
+			b.setIncludeResource("foo.xml;literal='I exist'");
+			Jar inner = b.build();
+			assertTrue(b.check());
 
-		Jar outer = new Jar("x");
-		outer.putResource("foo.jar", new JarResource(inner));
-		Manifest m = new Manifest();
-		m.getMainAttributes()
-			.putValue(Constants.META_PERSISTENCE, "foo.jar, foo.jar!/foo.xml, absent.xml");
-		outer.setManifest(m);
-		Verifier v = new Verifier(outer);
-		v.verifyMetaPersistence();
-		assertTrue(v.check("Meta-Persistence refers to resources not in the bundle: \\[absent.xml\\]"));
+			try (Jar outer = new Jar("x")) {
+				outer.putResource("foo.jar", new JarResource(inner));
+				Manifest m = new Manifest();
+				m.getMainAttributes()
+					.putValue(Constants.META_PERSISTENCE, "foo.jar, foo.jar!/foo.xml, absent.xml");
+				outer.setManifest(m);
+				try (Verifier v = new Verifier(outer)) {
+					v.verifyMetaPersistence();
+					assertTrue(v.check("Meta-Persistence refers to resources not in the bundle: \\[absent.xml\\]"));
+				}
+			}
+		}
 	}
 
 	/**
@@ -113,8 +118,7 @@ public class VerifierTest extends TestCase {
 	}
 
 	private void testFilePath(String path, String pattern, boolean good) throws Exception {
-		Builder b = new Builder();
-		try {
+		try (Builder b = new Builder()) {
 			b.setProperty("-includeresource", path + ";literal='x'");
 			if (pattern != null)
 				b.setProperty(Constants.INVALIDFILENAMES, pattern);
@@ -124,8 +128,6 @@ public class VerifierTest extends TestCase {
 				assertTrue(b.check());
 			else
 				assertTrue(b.check("Invalid file/directory"));
-		} finally {
-			b.close();
 		}
 	}
 
@@ -136,23 +138,24 @@ public class VerifierTest extends TestCase {
 	 */
 
 	public void testInvalidFilterOnRequirement() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.setExportPackage("org.osgi.framework");
-		b.setProperty("Require-Capability", "test; filter:=\"(&(test=aName)(version>=1.1.0))\", "
-			+ " test; filter:=\"(&(version>=1.1)(string~=astring))\", "
-			+ " test; filter:=\"(&(version>=1.1)(long>=99))\", "
-			+ " test; filter:=\"(&(version>=1.1)(double>=1.0))\",  "
-			+ " test; filter:=\"(&(version>=1.1)(version.list=1.0)(version.list=1.1)(version.list=1.2))\", "
-			+ " test; filter:=\"(&(version>=1.1)(long.list=1)(long.list=2)(long.list=3)(long.list=4))\", "
-			+ " test; filter:=\"(&(version>=1.1)(double.list=1.001)(double.list=1.002)(double.list=1.003)(double.list<=1.3))\", "
-			+ " test; filter:=\"(&(version>=1.1)(string.list~=astring)(string.list~=bstring)(string.list=cString))\", "
-			+ " test; filter:=\"(&(version>=1.1)(string.list2=a\\\"quote)(string.list2=a\\,comma)(string.list2= aSpace )(string.list2=\\\"start)(string.list2=\\,start)(string.list2=end\\\")(string.list2=end\\,))\", "
-			+ " test; filter:=\"(&(version>=1.1)(string.list3= aString )(string.list3= bString )(string.list3= cString ))\", "
-			+ " test.effective; effective:=\"active\"; filter:=\"(willResolve=false)\", test.no.attrs");
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setExportPackage("org.osgi.framework");
+			b.setProperty("Require-Capability", "test; filter:=\"(&(test=aName)(version>=1.1.0))\", "
+				+ " test; filter:=\"(&(version>=1.1)(string~=astring))\", "
+				+ " test; filter:=\"(&(version>=1.1)(long>=99))\", "
+				+ " test; filter:=\"(&(version>=1.1)(double>=1.0))\",  "
+				+ " test; filter:=\"(&(version>=1.1)(version.list=1.0)(version.list=1.1)(version.list=1.2))\", "
+				+ " test; filter:=\"(&(version>=1.1)(long.list=1)(long.list=2)(long.list=3)(long.list=4))\", "
+				+ " test; filter:=\"(&(version>=1.1)(double.list=1.001)(double.list=1.002)(double.list=1.003)(double.list<=1.3))\", "
+				+ " test; filter:=\"(&(version>=1.1)(string.list~=astring)(string.list~=bstring)(string.list=cString))\", "
+				+ " test; filter:=\"(&(version>=1.1)(string.list2=a\\\"quote)(string.list2=a\\,comma)(string.list2= aSpace )(string.list2=\\\"start)(string.list2=\\,start)(string.list2=end\\\")(string.list2=end\\,))\", "
+				+ " test; filter:=\"(&(version>=1.1)(string.list3= aString )(string.list3= bString )(string.list3= cString ))\", "
+				+ " test.effective; effective:=\"active\"; filter:=\"(willResolve=false)\", test.no.attrs");
 
-		b.build();
-		assertTrue(b.check());
+			b.build();
+			assertTrue(b.check());
+		}
 	}
 
 	/**
@@ -162,47 +165,49 @@ public class VerifierTest extends TestCase {
 	 */
 
 	public void testValidDirectivesOnRequirement() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.setExportPackage("org.osgi.framework");
-		b.setProperty("Require-Capability",
-			"test; resolution:=mandatory, " + " test; resolution:=optional, " + " test; cardinality:=single, "
-				+ " test; cardinality:=multiple, " + " test; effective:=foo, "
-				+ " test; filter:=\"(&(version>=1.1) (long.list=1)(long.list=2) )\", " + " test; x-custom:=bar, ");
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setExportPackage("org.osgi.framework");
+			b.setProperty("Require-Capability",
+				"test; resolution:=mandatory, " + " test; resolution:=optional, " + " test; cardinality:=single, "
+					+ " test; cardinality:=multiple, " + " test; effective:=foo, "
+					+ " test; filter:=\"(&(version>=1.1) (long.list=1)(long.list=2) )\", " + " test; x-custom:=bar, ");
 
-		b.build();
-		assertTrue(b.check());
+			b.build();
+			assertTrue(b.check());
+		}
 	}
 
 	/**
 	 * Test the strict flag
 	 */
 	public void testStrict() throws Exception {
-		Builder bmaker = new Builder();
-		bmaker.addClasspath(IO.getFile("jar/osgi.jar"));
-		bmaker.addClasspath(new File("bin_test"));
-		bmaker.setProperty("Export-Package",
-			"org.osgi.service.eventadmin;version='[1,2)',org.osgi.framework;version=x13,test;-remove-attribute:=version,test.lib;specification-version=12,test.split");
-		bmaker.setProperty("Import-Package",
-			"foo;version=1,bar;version='[1,x2)',baz;version='[2,1)',baz2;version='(1,1)',*");
-		bmaker.setProperty("-strict", "true");
-		bmaker.setProperty("-fixupmessages", "^Exception: ");
-		Jar jar = bmaker.build();
-		assertTrue(bmaker.check("\\QInvalid syntax for version: x13, for cmd: range, arguments; [range, [==,+)]\\E",
-			"\\QImport Package org.osgi.framework has an invalid version range syntax ${range;[==,+)}\\E",
-			"\\QNo translation found for macro: range;[==,+)\\E",
-			"\\QExport-Package or -exportcontents refers to missing package 'org.osgi.service.eventadmin'\\E",
-			"Import Package clauses without version range \\(excluding javax\\.\\*\\):",
-			"Import Package bar has an invalid version range syntax \\[1,x2\\)",
-			"Import Package baz2 has an empty version range syntax \\(1,1\\), likely want to use \\[1.0.0,1.0.0\\]",
-			"Import Package baz has an invalid version range syntax \\[2,1\\): Low Range is higher than High Range: 2.0.0-1.0.0",
-			"Import Package clauses which use a version instead of a version range. This imports EVERY later package and not as many expect until the next major number: \\[foo\\]",
-			"Export Package org.osgi.framework version has invalid syntax: x13",
-			"Export Package test.lib uses deprecated specification-version instead of version",
-			"Export Package org.osgi.service.eventadmin version is a range: \\[1,2\\); Exports do not allow for ranges."));
+		try (Builder bmaker = new Builder()) {
+			bmaker.addClasspath(IO.getFile("jar/osgi.jar"));
+			bmaker.addClasspath(new File("bin_test"));
+			bmaker.setProperty("Export-Package",
+				"org.osgi.service.eventadmin;version='[1,2)',org.osgi.framework;version=x13,test;-remove-attribute:=version,test.lib;specification-version=12,test.split");
+			bmaker.setProperty("Import-Package",
+				"foo;version=1,bar;version='[1,x2)',baz;version='[2,1)',baz2;version='(1,1)',*");
+			bmaker.setProperty("-strict", "true");
+			bmaker.setProperty("-fixupmessages", "^Exception: ");
+			Jar jar = bmaker.build();
+			assertTrue(bmaker.check("\\QInvalid syntax for version: x13, for cmd: range, arguments; [range, [==,+)]\\E",
+				"\\QImport Package org.osgi.framework has an invalid version range syntax ${range;[==,+)}\\E",
+				"\\QNo translation found for macro: range;[==,+)\\E",
+				"\\QExport-Package or -exportcontents refers to missing package 'org.osgi.service.eventadmin'\\E",
+				"Import Package clauses without version range \\(excluding javax\\.\\*\\):",
+				"Import Package bar has an invalid version range syntax \\[1,x2\\)",
+				"Import Package baz2 has an empty version range syntax \\(1,1\\), likely want to use \\[1.0.0,1.0.0\\]",
+				"Import Package baz has an invalid version range syntax \\[2,1\\): Low Range is higher than High Range: 2.0.0-1.0.0",
+				"Import Package clauses which use a version instead of a version range. This imports EVERY later package and not as many expect until the next major number: \\[foo\\]",
+				"Export Package org.osgi.framework version has invalid syntax: x13",
+				"Export Package test.lib uses deprecated specification-version instead of version",
+				"Export Package org.osgi.service.eventadmin version is a range: \\[1,2\\); Exports do not allow for ranges."));
+		}
 	}
 
-	public static void testCapability() throws Exception {
+	public void testCapability() throws Exception {
 
 		Parameters h = OSGiHeader.parseHeader(
 			"test; version.list:List < Version > = \"1.0, 1.1, 1.2\"; effective:=\"resolve\"; test =\"aName\";version : Version=\"1.0\"; long :Long=\"100\"; "
@@ -230,30 +235,29 @@ public class VerifierTest extends TestCase {
 			.getType("version.list"));
 	}
 
-	public static void testFailedOSGiJar() throws Exception {
-		Jar jar = new Jar("jar/osgi.residential-4.3.0.jar");
-		Verifier v = new Verifier(jar);
-		assertTrue(v.check());
+	public void testFailedOSGiJar() throws Exception {
+		try (Jar jar = new Jar("jar/osgi.residential-4.3.0.jar"); Verifier v = new Verifier(jar)) {
+			assertTrue(v.check());
+		}
 	}
 
-	public static void testnativeCode() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(new File("bin_test"));
-		b.setProperty("-resourceonly", "true");
-		b.setProperty("Include-Resource", "native/win32/NTEventLogAppender-1.2.dll;literal='abc'");
-		b.setProperty("Bundle-NativeCode", "native/win32/NTEventLogAppender-1.2.dll; osname=Win32; processor=x86");
-		b.build();
-		Verifier v = new Verifier(b);
-
-		v.verifyNative();
-		System.err.println(v.getErrors());
-		assertEquals(0, v.getErrors()
-			.size());
-		v.close();
-		b.close();
+	public void testnativeCode() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("-resourceonly", "true");
+			b.setProperty("Include-Resource", "native/win32/NTEventLogAppender-1.2.dll;literal='abc'");
+			b.setProperty("Bundle-NativeCode", "native/win32/NTEventLogAppender-1.2.dll; osname=Win32; processor=x86");
+			b.build();
+			try (Verifier v = new Verifier(b)) {
+				v.verifyNative();
+				System.err.println(v.getErrors());
+				assertEquals(0, v.getErrors()
+					.size());
+			}
+		}
 	}
 
-	public static void testFilter() {
+	public void testFilter() {
 
 		testFilter("(&(a=b)(c=1))");
 		testFilter("(&(a=b)(!(c=1))(&(c=1))(c=1)(c=1)(c=1)(c=1)(c=1)(c=1)(c=1)(c=1))");
@@ -362,7 +366,7 @@ public class VerifierTest extends TestCase {
 		testFilter("(booleanValue =t*ue) ");
 	}
 
-	private static void testFilter(String string) {
+	private void testFilter(String string) {
 		int index = Verifier.verifyFilter(string, 0);
 		while (index < string.length() && Character.isWhitespace(string.charAt(index)))
 			index++;
@@ -371,79 +375,85 @@ public class VerifierTest extends TestCase {
 			throw new IllegalArgumentException("Characters after filter");
 	}
 
-	private static void testInvalidFilter(String string) {
+	private void testInvalidFilter(String string) {
 		try {
 			testFilter(string);
 			fail("Invalid filter");
 		} catch (Exception e) {}
 	}
 
-	public static void testBundleActivationPolicyNone() throws Exception {
-		Builder v = new Builder();
-		v.setProperty("Private-Package", "test.activator");
-		v.addClasspath(new File("bin_test"));
-		v.build();
-		assertTrue(v.check());
+	public void testBundleActivationPolicyNone() throws Exception {
+		try (Builder v = new Builder()) {
+			v.setProperty("Private-Package", "test.activator");
+			v.addClasspath(new File("bin_test"));
+			v.build();
+			assertTrue(v.check());
+		}
 	}
 
-	public static void testBundleActivationPolicyBad() throws Exception {
-		Builder v = new Builder();
-		v.setProperty("Private-Package", "test.activator");
-		v.addClasspath(new File("bin_test"));
-		v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "eager");
-		v.build();
-		assertTrue(v.check("Bundle-ActivationPolicy set but is not set to lazy: eager"));
+	public void testBundleActivationPolicyBad() throws Exception {
+		try (Builder v = new Builder()) {
+			v.setProperty("Private-Package", "test.activator");
+			v.addClasspath(new File("bin_test"));
+			v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "eager");
+			v.build();
+			assertTrue(v.check("Bundle-ActivationPolicy set but is not set to lazy: eager"));
+		}
 	}
 
-	public static void testBundleActivationPolicyGood() throws Exception {
-		Builder v = new Builder();
-		v.setProperty("Private-Package", "test.activator");
-		v.addClasspath(new File("bin_test"));
-		v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "lazy   ;   hello:=1");
-		v.build();
-		assertTrue(v.check());
+	public void testBundleActivationPolicyGood() throws Exception {
+		try (Builder v = new Builder()) {
+			v.setProperty("Private-Package", "test.activator");
+			v.addClasspath(new File("bin_test"));
+			v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "lazy   ;   hello:=1");
+			v.build();
+			assertTrue(v.check());
+		}
 	}
 
-	public static void testBundleActivationPolicyMultiple() throws Exception {
-		Builder v = new Builder();
-		v.setProperty("Private-Package", "test.activator");
-		v.addClasspath(new File("bin_test"));
-		v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "lazy;hello:=1,2");
-		v.build();
-		assertTrue(v.check("Bundle-ActivationPolicy has too many arguments lazy;hello:=1,2"));
+	public void testBundleActivationPolicyMultiple() throws Exception {
+		try (Builder v = new Builder()) {
+			v.setProperty("Private-Package", "test.activator");
+			v.addClasspath(new File("bin_test"));
+			v.setProperty(Constants.BUNDLE_ACTIVATIONPOLICY, "lazy;hello:=1,2");
+			v.build();
+			assertTrue(v.check("Bundle-ActivationPolicy has too many arguments lazy;hello:=1,2"));
+		}
 	}
 
-	public static void testInvalidCaseForHeader() throws Exception {
+	public void testInvalidCaseForHeader() throws Exception {
 		Properties p = new Properties();
 		p.put("Export-package", "org.apache.mina.*");
 		p.put("Bundle-Classpath", ".");
-		Analyzer analyzer = new Analyzer();
-		analyzer.setProperties(p);
-		analyzer.getProperties();
-		System.err.println("Errors   " + analyzer.getErrors());
-		System.err.println("Warnings " + analyzer.getWarnings());
-		assertEquals(0, analyzer.getErrors()
-			.size());
-		assertEquals(2, analyzer.getWarnings()
-			.size());
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setProperties(p);
+			analyzer.getProperties();
+			System.err.println("Errors   " + analyzer.getErrors());
+			System.err.println("Warnings " + analyzer.getWarnings());
+			assertEquals(0, analyzer.getErrors()
+				.size());
+			assertEquals(2, analyzer.getWarnings()
+				.size());
+		}
 	}
 
-	public static void testSimple() throws Exception {
-		Builder bmaker = new Builder();
-		bmaker.addClasspath(IO.getFile("jar/mina.jar"));
-		bmaker.set("Export-Package", "org.apache.mina.*;version=1");
-		bmaker.set("DynamicImport-Package", "org.slf4j");
-		Jar jar = bmaker.build();
-		assertTrue(bmaker.check());
+	public void testSimple() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			bmaker.addClasspath(IO.getFile("jar/mina.jar"));
+			bmaker.set("Export-Package", "org.apache.mina.*;version=1");
+			bmaker.set("DynamicImport-Package", "org.slf4j");
+			Jar jar = bmaker.build();
+			assertTrue(bmaker.check());
 
-		Manifest m = jar.getManifest();
-		m.write(System.err);
-		assertTrue(m.getMainAttributes()
-			.getValue("Import-Package")
-			.contains("org.slf4j"));
-		assertTrue(m.getMainAttributes()
-			.getValue("DynamicImport-Package")
-			.contains("org.slf4j"));
+			Manifest m = jar.getManifest();
+			m.write(System.err);
+			assertTrue(m.getMainAttributes()
+				.getValue("Import-Package")
+				.contains("org.slf4j"));
+			assertTrue(m.getMainAttributes()
+				.getValue("DynamicImport-Package")
+				.contains("org.slf4j"));
+		}
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/ADDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/ADDef.java
@@ -89,7 +89,7 @@ public class ADDef extends ExtensionDef {
 		return ad;
 	}
 
-	private static final Pattern escapes = Pattern.compile("[ ,\\\\]");
+	private static final Pattern escapes = Pattern.compile("[\\\\ ,]");
 
 	private void escape(String defaultValue, StringBuffer b) {
 		Matcher m = escapes.matcher(defaultValue);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -307,13 +307,12 @@ public class Verifier extends Processor {
 	private boolean				frombuilder;
 
 	public Verifier(Jar jar) throws Exception {
-		this.analyzer = new Analyzer(this);
-		this.analyzer.use(this);
-		addClose(analyzer);
-		this.analyzer.setJar(jar);
-		this.manifest = this.analyzer.calcManifest();
-		this.main = Domain.domain(manifest);
+		super(new Analyzer(jar));
+		this.analyzer = (Analyzer) getParent();
 		this.dot = jar;
+		this.manifest = analyzer.calcManifest();
+		this.main = Domain.domain(manifest);
+		addClose(analyzer);
 		getInfo(analyzer);
 	}
 

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/Printer.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/Printer.java
@@ -66,10 +66,11 @@ public class Printer extends Processor {
     private void doPrint(File file, int options) throws ZipException, IOException, Exception {
         try (Jar jar = new Jar(file.getName(), file)) {
             if ((options & VERIFY) != 0) {
-                Verifier verifier = new Verifier(jar);
-                verifier.setPedantic(isPedantic());
-                verifier.verify();
-                getInfo(verifier);
+                try (Verifier verifier = new Verifier(jar)) {
+                    verifier.setPedantic(isPedantic());
+                    verifier.verify();
+                    getInfo(verifier);
+                }
             }
             if ((options & MANIFEST) != 0) {
                 Manifest manifest = jar.getManifest();


### PR DESCRIPTION
The Verifier previously ignored the manifest in the Jar which may hold necessary information, such as Bundle-ClassPath, for proper verification.