### PR TITLE
analyzer: Exclude module-info.class from EE calculation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -241,9 +241,11 @@ public class Analyzer extends Processor {
 			//
 			// calculate class versions in use
 			//
-			for (Clazz c : classspace.values()) {
-				ees.add(c.getFormat());
-			}
+			classspace.values()
+				.stream()
+				.filter(c -> !c.isModule())
+				.map(Clazz::getFormat)
+				.forEach(ees::add);
 
 			if (since(About._2_3)) {
 				try (ClassDataCollectors cds = new ClassDataCollectors(this)) {


### PR DESCRIPTION
Since module-info classes are not used at runtime by OSGi, we can safely
exclude them from the EE calculation for a bundle.

Fixes https://github.com/bndtools/bnd/issues/3010
