### PR TITLE
[launchpad] Fix sanity checking for bundleSymbolicName()

### DIFF
--- a/aQute.libg/src/aQute/lib/io/IO.java
+++ b/aQute.libg/src/aQute/lib/io/IO.java
@@ -892,7 +892,7 @@ public class IO {
 		}
 	}
 
-	public static Throwable close(Closeable in) {
+	public static Throwable close(AutoCloseable in) {
 		try {
 			if (in != null)
 				in.close();
@@ -900,6 +900,11 @@ public class IO {
 			return e;
 		}
 		return null;
+	}
+
+	// This method is required for binary backwards compatibility.
+	public static Throwable close(Closeable in) {
+		return close((AutoCloseable) in);
 	}
 
 	public static URL toURL(String s, File base) throws MalformedURLException {

--- a/aQute.libg/src/aQute/lib/io/packageinfo
+++ b/aQute.libg/src/aQute/lib/io/packageinfo
@@ -1,1 +1,1 @@
-version 3.2
+version 3.3

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleBuilder.java
@@ -15,7 +15,7 @@ import aQute.lib.io.IO;
 /**
  * Implementation class for building bundles on the remote workspace server.
  */
-public class BundleBuilder implements BundleSpecBuilder {
+public class BundleBuilder implements BundleSpecBuilder, AutoCloseable {
 
 	final Launchpad		ws;
 	final BuilderSpecification	spec		= new BuilderSpecification();
@@ -76,8 +76,9 @@ public class BundleBuilder implements BundleSpecBuilder {
 		closeables.add(closeable);
 	}
 
-	void close() {
-		closeables.forEach( IO::close);
+	@Override
+	public void close() {
+		closeables.forEach(IO::close);
 	}
 
 }

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,7 +22,8 @@ import aQute.lib.io.IO;
  * 
  */
 public interface BundleSpecBuilder {
-	final static String CONFIGURATION_JSON = "configuration/configuration.json";
+	final static String		CONFIGURATION_JSON	= "configuration/configuration.json";
+	final static Pattern	SYMBOLICNAME		= Pattern.compile("[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)*");
 
 	BundleBuilder x();
 
@@ -30,9 +32,15 @@ public interface BundleSpecBuilder {
 	 */
 	default BundleSpecBsn bundleSymbolicName(String name) {
 		BundleBuilder x = x();
+		if (name == null) {
+			throw new IllegalArgumentException("bsn cannot be null");
+		}
+		if (!SYMBOLICNAME.matcher(name)
+			.matches()) {
+			throw new IllegalArgumentException("invalid bsn: " + name);
+		}
+		x.spec.bundleSymbolicName.clear();
 		x.spec.bundleSymbolicName.put(name, new LinkedHashMap<>());
-		if (x.spec.bundleSymbolicName.size() > 1)
-			throw new IllegalArgumentException("You can only have one Bundle-SymbolicName");
 
 		return new BundleSpecBsn() {
 

--- a/biz.aQute.launchpad/test/aQute/launchpad/BundleBuilderTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/BundleBuilderTest.java
@@ -1,0 +1,80 @@
+package aQute.launchpad;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+import aQute.bnd.osgi.Verifier;
+import aQute.lib.io.IO;
+
+public class BundleBuilderTest {
+	LaunchpadBuilder	builder;
+	Launchpad			lp;
+	BundleBuilder 		bb;
+	
+	@Rule
+	public JUnitSoftAssertions	softly	= new JUnitSoftAssertions();
+
+
+	@Before
+	public void before() throws Exception {
+		builder = new LaunchpadBuilder();
+		try {
+			lp = builder.runfw("org.apache.felix.framework")
+				.create();
+		} catch (Exception e) {
+			builder.close();
+		}
+		bb = lp.bundle();
+	}
+
+	@After
+	public void after() throws Exception {
+		IO.close(bb);
+		IO.close(lp);
+		IO.close(builder);
+	}
+
+	@Test
+	public void bundleBuilder_shouldAllowManualOverrideOfBSN() throws Exception {
+		softly.assertThatCode(() -> bb.bundleSymbolicName("my.test.name"))
+			.as("set")
+			.doesNotThrowAnyException();
+		softly.assertThat(bb.install()
+			.getSymbolicName())
+			.as("bsn")
+			.isEqualTo("my.test.name");
+	}
+
+	@Test
+	public void bundleBuilder_shouldCreateUniqueLegalBSN() throws Exception {
+		final Bundle b1 = bb.install();
+		softly.assertThat(b1.getSymbolicName())
+			.as("bsn 1")
+			.isNotBlank()
+			.matches(Verifier.SYMBOLICNAME);
+		// Check that we don't get the same name.
+		final Bundle b2 = lp.bundle()
+			.install();
+		softly.assertThat(b2.getSymbolicName())
+			.as("bsn 2")
+			.isNotBlank()
+			.matches(Verifier.SYMBOLICNAME)
+			.isNotEqualTo(b1.getSymbolicName());
+	}
+
+	@Test
+	public void bundleBuilder_shouldNotAllowManualOverride_withInvalidBSN() throws Exception {
+		for (String invalid : new String[] {
+				null, "my&test.name", "   ", ""
+			}) {
+				softly.assertThatThrownBy(() -> bb.bundleSymbolicName(invalid))
+					.as("bsn: '" + invalid + '\'')
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining(invalid == null ? "null" : invalid);
+		}
+	}
+}


### PR DESCRIPTION
Instead of throwing an IllegalArgumentException if you try to set the BSN twice, this PR changes it so that the second set will simply override the first. This fixes #3019.

Also added some sanity checking using aQute.bnd.osgi.Verifier to make sure that you can't accidentally set an invalid BSN.