### PR TITLE
launchpad: Deep clone runspec in LaunchpadBuilder()

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/specifications/RunSpecification.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/specifications/RunSpecification.java
@@ -46,7 +46,8 @@ public class RunSpecification implements Cloneable {
 			bin = spec.bin;
 		if (spec.bin_test != null)
 			bin_test = spec.bin_test;
-		runfw = spec.runfw;
+		runfw.clear();
+		runfw.addAll(spec.runfw);
 		runbundles.addAll(spec.runbundles);
 		runpath.addAll(spec.runpath);
 		putAll(extraSystemCapabilities, spec.extraSystemCapabilities);

--- a/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -45,13 +46,18 @@ public class LaunchpadBuilder implements AutoCloseable {
 
 		//
 		// We only want the raw setup and not the run spec since this
-		// makes it impossible to start a clean framework
+		// makes it impossible to start a clean framework. Make them
+		// immutable so that they can't be modified accidentally.
 		//
 
-		projectTestSetup.runbundles.clear();
-		projectTestSetup.runpath.clear();
-		projectTestSetup.properties.clear();
-		projectTestSetup.runfw.clear();
+		projectTestSetup.runbundles = Collections.emptyList();
+		projectTestSetup.runpath = Collections.emptyList();
+		projectTestSetup.properties = Collections.emptyMap();
+		projectTestSetup.runfw = Collections.emptyList();
+
+		projectTestSetup.extraSystemPackages = Collections.unmodifiableMap(projectTestSetup.extraSystemPackages);
+		projectTestSetup.extraSystemCapabilities = Collections
+			.unmodifiableMap(projectTestSetup.extraSystemCapabilities);
 
 		Runtime.getRuntime()
 			.addShutdownHook(new Thread(() -> {
@@ -74,7 +80,9 @@ public class LaunchpadBuilder implements AutoCloseable {
 	 * directory.
 	 */
 	public LaunchpadBuilder() {
-		local = projectTestSetup.clone();
+		// This ensures a deep clone.
+		local = new RunSpecification();
+		local.mergeWith(projectTestSetup);
 	}
 
 	public LaunchpadBuilder bndrun(File file) {
@@ -155,7 +163,7 @@ public class LaunchpadBuilder implements AutoCloseable {
 	}
 
 	public LaunchpadBuilder set(String key, String value) {
-		projectTestSetup.properties.put(key, value);
+		local.properties.put(key, value);
 		return this;
 	}
 

--- a/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadBuilderTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadBuilderTest.java
@@ -1,0 +1,72 @@
+package aQute.launchpad;
+
+import static aQute.launchpad.LaunchpadBuilder.projectTestSetup;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import aQute.bnd.service.specifications.RunSpecification;
+
+public class LaunchpadBuilderTest {
+	LaunchpadBuilder	builder;
+
+	@Rule
+	public JUnitSoftAssertions	softly	= new JUnitSoftAssertions();
+
+	@Before
+	public void before() throws Exception {
+		builder = new LaunchpadBuilder();
+	}
+
+	@After
+	public void after() throws Exception {
+		builder.close();
+	}
+
+	@Test
+	public void newInstance_deepClonesProjectSetup() {
+		final RunSpecification local = builder.local;
+		softly.assertThat(local)
+			.as("local")
+			.isNotSameAs(projectTestSetup);
+
+		softly.assertThat(local.runbundles)
+			.as("runbundles")
+			.isNotSameAs(projectTestSetup.runbundles);
+		softly.assertThat(local.runpath)
+			.as("runpath")
+			.isNotSameAs(projectTestSetup.runpath)
+			.isEmpty();
+		softly.assertThat(local.extraSystemCapabilities)
+			.as("extraSystemCapabilities")
+			.isNotSameAs(projectTestSetup.extraSystemCapabilities);
+		softly.assertThat(local.extraSystemPackages)
+			.as("extraSystemPackages")
+			.isNotSameAs(projectTestSetup.extraSystemPackages);
+		softly.assertThat(local.properties)
+			.as("properties")
+			.isNotSameAs(projectTestSetup.properties);
+		softly.assertThat(local.errors)
+			.as("errors")
+			.isNotSameAs(projectTestSetup.errors);
+		softly.assertThat(local.runfw)
+			.as("runfw")
+			.isNotSameAs(projectTestSetup.runfw);
+	}
+
+	@Test
+	public void newInstance_copiesProjectTestSetup() {
+		softly.assertThat(builder.local)
+			.isEqualToComparingFieldByField(projectTestSetup);
+	}
+
+	@Test
+	public void set_setsLocalProperties() {
+		builder.set("somekey", "somevalue");
+		softly.assertThat(builder.local.properties)
+			.containsEntry("somekey", "somevalue");
+	}
+}


### PR DESCRIPTION
Changes constructor to ensure that it deep clones projectTestSetup, to avoid making accidental changes to the master copy.

Defensive guarding of projectTestSetup to make it harder (though not impossible) for code to manipulate it accidentally.

Also ensures that LaunchpadBuilder.set() updates the instance runspec and not the static one.

Fixes #3026.