### PR TITLE
httpclient: Support retrying SocketException: Connection reset

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientProxyTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientProxyTest.java
@@ -1,5 +1,7 @@
 package aQute.bnd.comm.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
@@ -191,35 +193,25 @@ public class HttpClientProxyTest extends TestCase {
 	public void testSecureSocksAuthenticatingWithGoodUserSecure() throws Exception {
 		createSecureSocks5();
 		createSecureServer();
-		assertSocks5Proxy("good", true);
+		assertThat(assertSocks5Proxy("good", true)).isBetween(200, 299);
 	}
 
 	public void testSecureSocksAuthenticatingWithBadUserSecure() throws Exception {
-		try {
-			createSecureSocks5();
-			createSecureServer();
-			assertSocks5Proxy("bad", true);
-			fail("Expected the transfer to fail");
-		} catch (Exception e) {
-			// ok
-		}
+		createSecureSocks5();
+		createSecureServer();
+		assertThat(assertSocks5Proxy("bad", true)).isGreaterThanOrEqualTo(500);
 	}
 
 	public void testSecureSocksAuthenticatingWithGoodUser() throws Exception {
 		createSecureSocks5();
 		createUnsecureServer();
-		assertSocks5Proxy("good", true);
+		assertThat(assertSocks5Proxy("good", true)).isBetween(200, 299);
 	}
 
 	public void testSecureSocksAuthenticatingWithBadUser() throws Exception {
-		try {
-			createSecureSocks5();
-			createUnsecureServer();
-			assertSocks5Proxy("bad", true);
-			fail("Expected the transfer to fail");
-		} catch (Exception e) {
-			// ok
-		}
+		createSecureSocks5();
+		createUnsecureServer();
+		assertThat(assertSocks5Proxy("bad", true)).isGreaterThanOrEqualTo(500);
 	}
 
 	/*
@@ -470,7 +462,7 @@ public class HttpClientProxyTest extends TestCase {
 	}
 
 	@SuppressWarnings("resource")
-	void assertSocks5Proxy(String password, boolean authenticationCalled) throws MalformedURLException, Exception {
+	int assertSocks5Proxy(String password, boolean authenticationCalled) throws MalformedURLException, Exception {
 		try (Processor p = new Processor(); HttpClient hc = new HttpClient()) {
 			p.setProperty("-connectionsettings", "" + false);
 			ConnectionSettings cs = new ConnectionSettings(p, hc);
@@ -497,16 +489,23 @@ public class HttpClientProxyTest extends TestCase {
 			cs.add(server);
 
 			URL url = new URL(httpTestServer.getBaseURI() + "/get-tag/ABCDEFGH");
-			TaggedData tag = hc.connectTagged(url);
+			TaggedData tag = hc.build()
+				.get(TaggedData.class)
+				.retries(0)
+				.go(url);
 			assertNotNull(tag);
-			assertEquals("ABCDEFGH", tag.getTag());
-			String s = IO.collect(tag.getInputStream());
-			assertNotNull(s);
-			assertTrue(s.trim()
-				.startsWith("{"));
-			assertTrue(proxyCalled.get());
-			// assertTrue(this.authenticationCalled.get() ==
-			// authenticationCalled);
+			int code = tag.getResponseCode();
+			if (code / 100 == 2) {
+				assertEquals("ABCDEFGH", tag.getTag());
+				String s = IO.collect(tag.getInputStream());
+				assertNotNull(s);
+				assertTrue(s.trim()
+					.startsWith("{"));
+				assertTrue(proxyCalled.get());
+				// assertTrue(this.authenticationCalled.get() ==
+				// authenticationCalled);
+			}
+			return code;
 		}
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/CachingUriResourceHandle.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/CachingUriResourceHandle.java
@@ -14,6 +14,7 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import aQute.bnd.http.HttpRequestException;
 import aQute.bnd.service.ResourceHandle;
 import aQute.bnd.service.url.URLConnector;
 import aQute.lib.hex.Hex;
@@ -212,7 +213,7 @@ public class CachingUriResourceHandle implements ResourceHandle {
 			saveSHAFile(serverSHA);
 
 			return cachedFile;
-		} catch (IOException e) {
+		} catch (IOException | HttpRequestException e) {
 			if (sha == null) {
 				// Remote access failed, use the cache if it exists AND if the
 				// original SHA was not known.


### PR DESCRIPTION
When we get a SocketException, we convert to a 520 http response code.
This allows the retry support for 5xx response codes to retry.
