### PR TITLE
azure: Publish test results for main job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,13 @@ jobs:
     env:
       JFROG_USERNAME: $(JFrog.Username)
       JFROG_PASSWORD: $(JFrog.Password)
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: |-
+        */generated/test-reports/test/TEST-*.xml
+        maven/*/target/surefire-reports/TEST-*.xml
+    condition: succeededOrFailed()
 
 - job: OpenJDK11
   pool:


### PR DESCRIPTION
Add Azure Pipelines task to publish the main job (OpenJDK8) test results. This will allow us more insight when a test case fails for an Azure build.