### PR TITLE
build: Avoid Sonatype OSGi group and use the repositories instead

### DIFF
--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -23,8 +23,8 @@ baseline:   aQute.libg,\
         readOnly=true,\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\
         name="OSGi Snapshots";\
-        releaseUrl="https://oss.sonatype.org/content/groups/osgi/";\
-        snapshotUrl="https://oss.sonatype.org/content/groups/osgi/";\
+        releaseUrl="https://oss.sonatype.org/content/repositories/osgi-releases/";\
+        snapshotUrl="https://oss.sonatype.org/content/repositories/osgi-snapshots/";\
         index="${.}/osgi-snapshots.mvn";\
         readOnly=true,\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\


### PR DESCRIPTION
See https://github.com/osgi/osgi.enroute/pull/98
