### PR TITLE
Use -maven-scope instruction to simplify some -buildpaths

### DIFF
--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -25,7 +25,7 @@ pluginClasspath: ${p-buildpath;\\${pathseparator}}
 -includeresource: \
 	OSGI-OPT/src=src, \
 	resources, \
-	embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;latest}
+	embedded-repo.jar=${repo;biz.aQute.bnd.embedded-repo;snapshot}
 
 -builderignore: testresources
 

--- a/biz.aQute.bnd.runtime/bnd.bnd
+++ b/biz.aQute.bnd.runtime/bnd.bnd
@@ -2,7 +2,7 @@
 -include: ${workspace}/cnf/includes/jdt.bnd
 
 -buildpath: \
-    osgi.annotation;version=latest, \
+    osgi.annotation;version=latest;maven-scope=provided, \
     aQute.libg;version=project,\
     osgi.core;version=@6;maven-scope=provided,\
     org.osgi.service.coordinator;maven-scope=provided,\

--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -52,24 +52,26 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
 
 -dependson: biz.aQute.bnd.embedded-repo
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.core;version=latest;maven-scope=provided,\
-	org.osgi.service.log;version=latest;maven-scope=provided,\
-	org.osgi.service.repository;version=latest;maven-scope=provided,\
-	aQute.libg;version=project, \
-	biz.aQute.bndlib;version=latest;maven-scope=provided, \
-	biz.aQute.resolve;version=latest;maven-scope=provided, \
-	biz.aQute.repository;version=latest;maven-scope=provided, \
-	biz.aQute.bnd.exporters;version=latest;maven-scope=provided, \
- 	biz.aQute.bnd.reporter;version=latest;maven-scope=provided,\
+	osgi.core;version=latest,\
+	org.osgi.service.log;version=latest,\
+	org.osgi.service.repository;version=latest,\
+	aQute.libg;version=project,\
+	biz.aQute.bndlib;version=latest,\
+	biz.aQute.resolve;version=latest,\
+	biz.aQute.repository;version=latest,\
+	biz.aQute.bnd.exporters;version=latest,\
+ 	biz.aQute.bnd.reporter;version=latest,\
 	biz.aQute.bnd.annotation;version=project,\
-	org.apache.ant:ant;version=latest;maven-scope=provided,\
-	biz.aQute.remote.api;version=latest;maven-scope=provided,\
-	org.yaml.snakeyaml;version=latest;maven-scope=provided,\
-	slf4j.api;version=latest;maven-scope=provided,\
-	slf4j.simple;version=latest;maven-scope=provided, \
-	jline;maven-scope=provided, \
-	biz.aQute.launchpad;version=latest;maven-scope=provided
+	org.apache.ant:ant;version=latest,\
+	biz.aQute.remote.api;version=latest,\
+	org.yaml.snakeyaml;version=latest,\
+	slf4j.api;version=latest,\
+	slf4j.simple;version=latest,\
+	jline, \
+	biz.aQute.launchpad;version=latest
 
 -testpath: \
 	${junit},\

--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -60,20 +60,22 @@ Import-Package: junit.framework;resolution:=optional,\
 
 -includeresource: ${workspace}/LICENSE, img/=img/, {readme.md}
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.annotation;version=latest;maven-scope=provided,\
-	osgi.core;version=latest;maven-scope=provided,\
-	org.osgi.namespace.contract;version=latest;maven-scope=provided,\
-	org.osgi.namespace.extender;version=latest;maven-scope=provided,\
-	org.osgi.namespace.implementation;version=latest;maven-scope=provided,\
-	org.osgi.namespace.service;version=latest;maven-scope=provided,\
-	org.osgi.service.log;version=latest;maven-scope=provided,\
-	org.osgi.service.repository;version=latest;maven-scope=provided,\
-	org.osgi.util.function;version=latest;maven-scope=provided,\
-	org.osgi.util.promise;version=latest;maven-scope=provided,\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	org.osgi.namespace.contract;version=latest,\
+	org.osgi.namespace.extender;version=latest,\
+	org.osgi.namespace.implementation;version=latest,\
+	org.osgi.namespace.service;version=latest,\
+	org.osgi.service.log;version=latest,\
+	org.osgi.service.repository;version=latest,\
+	org.osgi.util.function;version=latest,\
+	org.osgi.util.promise;version=latest,\
 	aQute.libg;version=project, \
 	biz.aQute.bnd.annotation;version=project,\
-	slf4j.api;version=latest
+	slf4j.api;version=latest;maven-scope=compile
 
 Bundle-Icon: img/bnd-64.png;size=64
 Bundle-Developers: peter.kriens@aQute.biz, njbartlett@gmail.com

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -1,12 +1,14 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/includes/jdt.bnd
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.core;version=@4;maven-scope=provided,\
-	osgi.cmpn;version=@4;maven-scope=provided,\
+	osgi.core;version=@4,\
+	osgi.cmpn;version=@4,\
 	aQute.libg;version=project,\
-	biz.aQute.bndlib;version=latest;maven-scope=provided,\
-    ${replacelist;${list;junit};$;\\;maven-scope=provided}
+	biz.aQute.bndlib;version=latest,\
+    ${junit}
 
 Tester-Plugin: aQute.junit.plugin.ProjectTesterImpl
 

--- a/biz.aQute.launchpad/bnd.bnd
+++ b/biz.aQute.launchpad/bnd.bnd
@@ -16,14 +16,15 @@ Import-Package: \
 -conditionalpackage: \
     aQute.lib*
 
+-maven-scope: provided
 
 -buildpath: \
-    osgi.annotation;version=latest;maven-scope=provided, \
-    osgi.core;version=latest;maven-scope=provided, \
-    org.osgi.service.component;version='[1.3,1.4)';maven-scope=provided, \
-    org.osgi.service.component.annotations;version='[1.3,1.4)';maven-scope=provided, \
-    aQute.libg;version=project, \
-    biz.aQute.bndlib;version=latest;packages=*;maven-scope=provided, \
+    osgi.annotation;version=latest,\
+    osgi.core;version=latest,\
+    org.osgi.service.component;version='[1.3,1.4)',\
+    org.osgi.service.component.annotations;version='[1.3,1.4)',\
+    aQute.libg;version=project,\
+    biz.aQute.bndlib;version=latest;packages=*,\
     org.eclipse.jdt.annotation;version=@2
 
 -testpath: \

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -1,19 +1,21 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/includes/jdt.bnd
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.annotation;version=latest;maven-scope=provided,\
-	osgi.core;version=latest;maven-scope=provided,\
-	org.osgi.service.coordinator;version=latest;maven-scope=provided,\
+	osgi.annotation;version=latest,\
+	osgi.core;version=latest,\
+	org.osgi.service.coordinator;version=latest,\
 	org.osgi.service.log;version=latest,\
 	org.osgi.service.repository;version=latest,\
-	org.osgi.util.function;version=latest;maven-scope=provided,\
-	org.osgi.util.promise;version=latest;maven-scope=provided,\
+	org.osgi.util.function;version=latest,\
+	org.osgi.util.promise;version=latest,\
 	aQute.libg;version=project,\
 	biz.aQute.bnd.annotation;version=project,\
-	biz.aQute.bndlib;version=latest,\
-	slf4j.api;version=latest,\
-	org.tukaani.xz;version=latest;maven-scope=provided
+	biz.aQute.bndlib;version=latest;maven-scope=compile,\
+	slf4j.api;version=latest;maven-scope=compile,\
+	org.tukaani.xz;version=latest
 
 -testpath: \
 	${junit},\

--- a/biz.aQute.resolve/bnd.bnd
+++ b/biz.aQute.resolve/bnd.bnd
@@ -1,20 +1,22 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/includes/jdt.bnd
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.core;version=latest;maven-scope=provided,\
-	org.osgi.namespace.contract;version=latest;maven-scope=provided,\
-	org.osgi.namespace.service;version=latest;maven-scope=provided,\
-	org.osgi.service.log;version=latest;maven-scope=provided,\
+	osgi.core;version=latest,\
+	org.osgi.namespace.contract;version=latest,\
+	org.osgi.namespace.service;version=latest,\
+	org.osgi.service.log;version=latest,\
 	org.osgi.service.repository;version=latest,\
-	org.osgi.service.resolver;version=latest;maven-scope=provided, \
-	org.osgi.util.function;version=latest;maven-scope=provided,\
-	org.osgi.util.promise;version=latest;maven-scope=provided,\
+	org.osgi.service.resolver;version=latest, \
+	org.osgi.util.function;version=latest,\
+	org.osgi.util.promise;version=latest,\
 	aQute.libg;version=project,\
-	biz.aQute.bndlib;version=latest,\
-	biz.aQute.repository;version=latest,\
-	org.apache.felix.resolver;version=latest;packages=org.apache.felix.resolver.*;maven-scope=provided,\
-	slf4j.api;version=latest
+	biz.aQute.bndlib;version=latest;maven-scope=compile,\
+	biz.aQute.repository;version=latest;maven-scope=compile,\
+	org.apache.felix.resolver;version=latest;packages=org.apache.felix.resolver.*,\
+	slf4j.api;version=latest;maven-scope=compile
 
 -testpath: \
 	${junit},\

--- a/biz.aQute.tester/bnd.bnd
+++ b/biz.aQute.tester/bnd.bnd
@@ -30,10 +30,11 @@ Tester-Plugin: \
 
 -conditionalpackage: aQute.lib*
 
+-maven-scope: provided
+
 -buildpath: \
-	osgi.core;version=4.2;maven-scope=provided,\
-	biz.aQute.junit;version=latest;packages=aQute.junit.*;maven-scope=provided, \
-	biz.aQute.bndlib;version=latest;maven-scope=provided,\
-	${junit}
+	osgi.core;version=4.2,\
+	biz.aQute.junit;version=latest;packages=aQute.junit.*,\
+	biz.aQute.bndlib;version=latest
 
 -baseline: *


### PR DESCRIPTION
Some projects have many -buildpath entries with maven-scope=provided
attributes. For those projects, we set the instruction
-maven-scope=provided so the default scope for dependencies in generated
POMs is provided rather than the default of compile. This means that
some -buildpath entries will then need to specify maven-scope=compile
to make sure they are not provided.