### PR TITLE
gradle: Use bnd version of build for biz.aQute.junit version in test

### DIFF
--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -1,5 +1,7 @@
 # Set javac settings from JDT prefs
--include: ${workspace}/cnf/includes/jdt.bnd
+# Include the gradle.properties to get the value of bnd_plugin which is used
+# for the bnd_version for the test cases.
+-include: ${workspace}/cnf/includes/jdt.bnd, ${workspace}/gradle.properties
 
 -dependson: biz.aQute.bnd.embedded-repo
 
@@ -21,6 +23,8 @@ Bundle-Description: The bnd gradle plugin.
 	biz.aQute.repository;version=latest
 
 pluginClasspath: ${p-buildpath;\\${pathseparator}}
+
+bnd_version: ${replace;${bnd_plugin};.*:(.*);$1}
 
 -includeresource: \
 	OSGI-OPT/src=src, \

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -21,6 +21,7 @@ if (JavaVersion.current().isJava9Compatible()) {
 
 tasks.named('test') {
     dependsOn 'jar'
+    systemProperty 'bnd_version', bnd('bnd_version')
     File source = project.file('testresources')
     File target = new File(project.buildDir, 'testresources')
     doFirst { // copy test resources into build dir

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
@@ -11,6 +11,7 @@ class TestTestOSGiTask extends Specification {
 
     File buildDir = new File('generated')
     File testResources = new File(buildDir, 'testresources')
+    String bnd_version = System.properties['bnd_version']
 
     def "Bnd TestOSGi Task Basic Test"() {
         given:
@@ -23,7 +24,7 @@ class TestTestOSGiTask extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'build')
+            .withArguments("-Pbnd_version=${bnd_version}", '--stacktrace', '--debug', 'build')
             .withPluginClasspath()
             .forwardOutput()
             .build()
@@ -96,7 +97,7 @@ class TestTestOSGiTask extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'build')
+            .withArguments("-Pbnd_version=${bnd_version}", '--stacktrace', '--debug', 'build')
             .withPluginClasspath()
             .forwardOutput()
             .build()
@@ -145,7 +146,7 @@ class TestTestOSGiTask extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', 'build')
+            .withArguments("-Pbnd_version=${bnd_version}", '--stacktrace', '--debug', 'build')
             .withPluginClasspath()
             .forwardOutput()
             .build()
@@ -192,7 +193,7 @@ class TestTestOSGiTask extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--stacktrace', '--debug', '--continue', 'build')
+            .withArguments("-Pbnd_version=${bnd_version}", '--stacktrace', '--debug', '--continue', 'build')
             .withPluginClasspath()
             .forwardOutput()
             .buildAndFail()

--- a/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'biz.aQute.bnd:biz.aQute.junit:+'
+    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     runtime 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 

--- a/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compile 'biz.aQute.bnd:biz.aQute.junit:+'
+    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     framework 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 

--- a/biz.aQute.bnd.gradle/testresources/testosgitask3/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask3/build.gradle
@@ -20,8 +20,8 @@ configurations {
 }
 
 dependencies {
-    compile 'biz.aQute.bnd:biz.aQute.junit:+'
-    bundles 'biz.aQute.bnd:biz.aQute.junit:+'
+    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
+    bundles "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     bundles 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 

--- a/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'biz.aQute.bnd:biz.aQute.junit:+'
+    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     runtime 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 


### PR DESCRIPTION
This is necessary for next to use the associated version of
biz.aQute.junit for the version of bnd being built.
