### PR TITLE
 analyzer: Fix -require-bnd instruction

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
@@ -15,6 +15,7 @@ import java.util.jar.Manifest;
 
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.About;
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Clazz;
@@ -395,21 +396,23 @@ public class AnalyzerTest extends BndTestCase {
 	 * @throws Exception
 	 */
 
-	public static void testRequire() throws Exception {
-		Builder b = new Builder();
-		try {
+	public static void testRequireFail() throws Exception {
+		try (Builder b = new Builder()) {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
 			b.setProperty("Private-Package", "org.osgi.framework");
-			b.setProperty("-require-bnd", "10000");
+			b.setProperty("-require-bnd", "\"(version=10000)\"");
 			b.build();
-			System.err.println(b.getErrors());
-			System.err.println(b.getWarnings());
-			assertEquals(1, b.getErrors()
-				.size());
-			assertEquals(0, b.getWarnings()
-				.size());
-		} finally {
-			b.close();
+			assertTrue(b.check("-require-bnd fails for filter \\(version=10000\\) values=\\{version=.*\\}"));
+		}
+	}
+
+	public static void testRequirePass() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("Private-Package", "org.osgi.framework");
+			b.setProperty("-require-bnd", "\"(version>=" + About.CURRENT + ")\"");
+			b.build();
+			assertTrue(b.check());
 		}
 	}
 

--- a/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
@@ -171,7 +171,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * The -removeheaders header can be used as a whitelist.
 	 */
 
-	public static void testRemoveheadersAsWhiteList() throws Exception {
+	public void testRemoveheadersAsWhiteList() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.addClasspath(IO.getFile("jar/asm.jar"));
@@ -208,7 +208,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Check if bnd detects references to private packages and gives a warning.
 	 */
 
-	public static void testExportReferencesToPrivatePackages() throws Exception {
+	public void testExportReferencesToPrivatePackages() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
@@ -227,7 +227,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Test basic functionality of he BCP
 	 */
 
-	public static void testBundleClasspath() throws Exception {
+	public void testBundleClasspath() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.setProperty(Constants.BUNDLE_CLASSPATH, "foo");
@@ -243,7 +243,7 @@ public class AnalyzerTest extends BndTestCase {
 
 	}
 
-	public static void testBundleClasspathWithVersionedExports() throws Exception {
+	public void testBundleClasspathWithVersionedExports() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.setBundleClasspath("foo");
@@ -267,7 +267,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Very basic sanity test
 	 */
 
-	public static void testSanity() throws Exception {
+	public void testSanity() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.setProperty("Export-Package", "thinlet;version=1.0");
@@ -294,7 +294,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * @throws Exception
 	 */
 
-	public static void testGenerateManifest() throws Exception {
+	public void testGenerateManifest() throws Exception {
 		Analyzer analyzer = new Analyzer();
 		try {
 			Jar bin = new Jar(IO.getFile("jar/osgi.jar"));
@@ -326,7 +326,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Bundle-Classpath are considered during import/export calculation.
 	 */
 
-	public static void testExportContentsDirectory() throws Exception {
+	public void testExportContentsDirectory() throws Exception {
 		Builder b = new Builder();
 		try {
 			File embedded = IO.getFile("bin_test/test/refer")
@@ -352,7 +352,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * @throws Exception
 	 */
 
-	public static void testUsesFiltering() throws Exception {
+	public void testUsesFiltering() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.setTrace(true);
@@ -396,7 +396,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * @throws Exception
 	 */
 
-	public static void testRequireFail() throws Exception {
+	public void testRequireFail() throws Exception {
 		try (Builder b = new Builder()) {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
 			b.setProperty("Private-Package", "org.osgi.framework");
@@ -406,7 +406,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testRequirePass() throws Exception {
+	public void testRequirePass() throws Exception {
 		try (Builder b = new Builder()) {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
 			b.setProperty("Private-Package", "org.osgi.framework");
@@ -416,7 +416,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testComponentImportReference() throws Exception {
+	public void testComponentImportReference() throws Exception {
 		Builder b = new Builder();
 		try {
 			b.addClasspath(IO.getFile("jar/osgi.jar"));
@@ -435,7 +435,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testFindClass() throws Exception {
+	public void testFindClass() throws Exception {
 		Builder a = new Builder();
 		try {
 			a.setProperty("Export-Package", "org.osgi.service.io");
@@ -451,7 +451,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testMultilevelInheritance() throws Exception {
+	public void testMultilevelInheritance() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			a.setJar(new File("bin_test"));
 			a.analyze();
@@ -464,7 +464,7 @@ public class AnalyzerTest extends BndTestCase {
 
 	}
 
-	public static void testClassQuery() throws Exception {
+	public void testClassQuery() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			a.setJar(IO.getFile("jar/osgi.jar"));
 			a.analyze();
@@ -477,7 +477,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testClassQuery_b() throws Exception {
+	public void testClassQuery_b() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			a.setJar(IO.getFile("jar/osgi.jar"));
 			a.analyze();
@@ -497,7 +497,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testEmptyHeader() throws Exception {
+	public void testEmptyHeader() throws Exception {
 		try (Builder a = new Builder()) {
 			a.setProperty("Bundle-Blueprint", "  <<EMPTY>> ");
 			a.setProperty("Export-Package", "org.osgi.framework");
@@ -523,7 +523,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Test name section.
 	 */
 
-	public static void testNameSection() throws Exception {
+	public void testNameSection() throws Exception {
 		Builder a = new Builder();
 		try {
 			a.setProperty("Export-Package", "org.osgi.service.event, org.osgi.service.io");
@@ -557,7 +557,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Test if mandatory attributes are augmented even when the version is not
 	 * set.
 	 */
-	public static void testMandatoryWithoutVersion() throws Exception {
+	public void testMandatoryWithoutVersion() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -585,7 +585,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Test Import-Packages marked with resolution:=dynamic are expanded, moved
 	 * to DynamicImport-Packages with no original DIP instruction.
 	 */
-	public static void testDynamicImportExpansionPackagesAreSet() throws Exception {
+	public void testDynamicImportExpansionPackagesAreSet() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -621,7 +621,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * Test Import-Packages marked with resolution:=dynamic are expanded, moved
 	 * to DynamicImport-Packages and added to the original DIP instruction.
 	 */
-	public static void testDynamicImportExpansionPackagesAreAdded() throws Exception {
+	public void testDynamicImportExpansionPackagesAreAdded() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -660,7 +660,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testPrivataBundleActivatorNotImported() throws Exception {
+	public void testPrivataBundleActivatorNotImported() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -690,7 +690,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorNotImported() throws Exception {
+	public void testBundleActivatorNotImported() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -719,7 +719,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorImport() throws Exception {
+	public void testBundleActivatorImport() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -754,7 +754,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorAbstract() throws Exception {
+	public void testBundleActivatorAbstract() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -781,7 +781,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorInterface() throws Exception {
+	public void testBundleActivatorInterface() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -809,7 +809,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorNoDefaultConstructor() throws Exception {
+	public void testBundleActivatorNoDefaultConstructor() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -837,7 +837,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorNotPublic() throws Exception {
+	public void testBundleActivatorNotPublic() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -867,7 +867,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testNotABundleActivator() throws Exception {
+	public void testNotABundleActivator() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -895,7 +895,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorNoType() throws Exception {
+	public void testBundleActivatorNoType() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -926,7 +926,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testBundleActivatorNotAType() throws Exception {
+	public void testBundleActivatorNotAType() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -958,7 +958,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testScanForABundleActivatorNoMatches() throws Exception {
+	public void testScanForABundleActivatorNoMatches() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -990,7 +990,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testScanForABundleActivatorMultipleMatches() throws Exception {
+	public void testScanForABundleActivatorMultipleMatches() throws Exception {
 		Builder a = new Builder();
 		try {
 			Properties p = new Properties();
@@ -1024,7 +1024,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * calculated.
 	 */
 
-	public static void testRemoveheaders() throws Exception {
+	public void testRemoveheaders() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			a.setJar(IO.getFile("jar/asm.jar"));
 			Manifest m = a.calcManifest();
@@ -1046,7 +1046,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws Exception
 	 */
-	public static void testExportForJar() throws Exception {
+	public void testExportForJar() throws Exception {
 		try (Analyzer an = new Analyzer()) {
 			Jar jar = new Jar("dot");
 			jar.putResource("target/aopalliance.jar", new FileResource(IO.getFile("jar/asm.jar")));
@@ -1071,7 +1071,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * @throws IOException
 	 */
 
-	public static void testVersion() throws IOException {
+	public void testVersion() throws IOException {
 		try (Analyzer a = new Analyzer()) {
 			String v = a.getBndVersion();
 			assertNotNull(v);
@@ -1081,7 +1081,7 @@ public class AnalyzerTest extends BndTestCase {
 	/**
 	 * asm is a simple library with two packages. No imports are done.
 	 */
-	public static void testAsm() throws Exception {
+	public void testAsm() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*");
 		base.put(Constants.EXPORT_PACKAGE, "*;-noimport:=true");
@@ -1113,7 +1113,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws IOException
 	 */
-	public static void testAsm2() throws Exception {
+	public void testAsm2() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*");
 		base.put(Constants.EXPORT_PACKAGE, "org.objectweb.asm;name=short, org.objectweb.asm.signature;name=long");
@@ -1135,7 +1135,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testDs() throws Exception {
+	public void testDs() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*");
 		base.put(Constants.EXPORT_PACKAGE, "*;-noimport:=true");
@@ -1159,7 +1159,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testDsSkipOsgiImport() throws Exception {
+	public void testDsSkipOsgiImport() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "!org.osgi.*, *");
 		base.put(Constants.EXPORT_PACKAGE, "*;-noimport:=true");
@@ -1186,7 +1186,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testDsNoExport() throws Exception {
+	public void testDsNoExport() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*");
 		base.put(Constants.EXPORT_PACKAGE, "!*");
@@ -1210,7 +1210,7 @@ public class AnalyzerTest extends BndTestCase {
 		}
 	}
 
-	public static void testClasspath() throws Exception {
+	public void testClasspath() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*");
 		base.put(Constants.EXPORT_PACKAGE, "*;-noimport:=true");
@@ -1241,7 +1241,7 @@ public class AnalyzerTest extends BndTestCase {
 	 * 
 	 * @throws IOException
 	 */
-	public static void testSuperfluous() throws Exception {
+	public void testSuperfluous() throws Exception {
 		Properties base = new Properties();
 		base.put(Constants.IMPORT_PACKAGE, "*, =com.foo, com.foo.bar.*");
 		base.put(Constants.EXPORT_PACKAGE, "*, com.bar, baz.*");

--- a/biz.aQute.bndlib.tests/test/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ProjectTest.java
@@ -19,6 +19,7 @@ import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectBuilder;
 import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.About;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
@@ -81,14 +82,24 @@ public class ProjectTest extends TestCase {
 	/**
 	 * Test require bnd
 	 */
-	public void testRequireBnd() throws Exception {
-		Workspace ws = getWorkspace(IO.getFile("testresources/ws"));
-		Project top = ws.getProject("p1");
-		top.setProperty("-resourceonly", "true");
-		top.setProperty("-includeresource", "a;literal=''");
-		top.setProperty("-require-bnd", "100000.0");
-		top.build();
-		assertTrue(top.check("-require-bnd fails for filter  values=\\{version="));
+	public void testRequireBndFail() throws Exception {
+		try (Workspace ws = getWorkspace(IO.getFile("testresources/ws")); Project top = ws.getProject("p1")) {
+			top.setProperty("-resourceonly", "true");
+			top.setProperty("-includeresource", "a;literal=''");
+			top.setProperty("-require-bnd", "\"(version=100000.0)\"");
+			top.build();
+			assertTrue(top.check("-require-bnd fails for filter \\(version=100000.0\\) values=\\{version=.*\\}"));
+		}
+	}
+
+	public void testRequireBndPass() throws Exception {
+		try (Workspace ws = getWorkspace(IO.getFile("testresources/ws")); Project top = ws.getProject("p1")) {
+			top.setProperty("-resourceonly", "true");
+			top.setProperty("-includeresource", "a;literal=''");
+			top.setProperty("-require-bnd", "\"(version>=" + About.CURRENT + ")\"");
+			top.build();
+			assertTrue(top.check());
+		}
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -586,7 +586,7 @@ public class Syntax implements Constants {
 			"-resolve.preferences=com.example.bundle.most.priority", "${packages}", null),
 
 		new Syntax(RUNTIMEOUT, "Specifies the test execution timeout.", RUNTIMEOUT + "=10000", null, null),
-		new Syntax(REQUIRE_BND, "Require a specific version of bnd.", REQUIRE_BND + "=4.1",
+		new Syntax(REQUIRE_BND, "Require a specific version of bnd.", REQUIRE_BND + "=\"(version>=4.1)\"",
 			"(FILTER ( ',' FILTER )* )?", null),
 
 		new Syntax(RESOURCEONLY,

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -43,7 +43,6 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -3044,15 +3043,15 @@ public class Analyzer extends Processor {
 		if (require == null || require.isEmpty())
 			return;
 
-		Hashtable<String, String> map = new Hashtable<>();
-		map.put(Constants.VERSION_FILTER, getBndVersion());
+		Map<String, Object> map = Collections.singletonMap(Constants.VERSION_FILTER,
+			Version.valueOf(getBndVersion()));
 
 		for (String filter : require.keySet()) {
 			try {
 				Filter f = new Filter(filter);
-				if (f.match(map))
+				if (f.matchMap(map))
 					continue;
-				error("%s fails for filter %s values=%s", REQUIRE_BND, require.get(filter), map);
+				error("%s fails for filter %s values=%s", REQUIRE_BND, filter, map);
 			} catch (Exception t) {
 				exception(t, "%s with value %s throws exception", REQUIRE_BND, require);
 			}

--- a/docs/_instructions/require_bnd.md
+++ b/docs/_instructions/require_bnd.md
@@ -2,30 +2,11 @@
 layout: default
 class: Project
 title: -require-bnd  (FILTER ( ',' FILTER )* )?
-summary: The filter can test aginst 'version', which will contain the bnd version. If it does not match, bnd will generate an error.  
+summary: The filter can test against 'version', which will contain the Bnd version. If it does not match, Bnd will generate an error.  
 ---
 
-	/**
-	 * Ensure that we are running on the correct bnd.
-	 */
-	void doRequireBnd() {
-		Attrs require = OSGiHeader.parseProperties(getProperty(REQUIRE_BND));
-		if (require == null || require.isEmpty())
-			return;
+Each specified filter must evaluate to true for the running version of Bnd in the `version` attribute. Since the values of the instruction are filter expressions, they need to quoted so the filter operators are not processed by Bnd.
 
-		Hashtable<String,String> map = new Hashtable<String,String>();
-		map.put(Constants.VERSION_FILTER, getBndVersion());
+This instruction can be useful when the workspace requires a feature of Bnd introduced in some version of Bnd. For example:
 
-		for (String filter : require.keySet()) {
-			try {
-				Filter f = new Filter(filter);
-				if (f.match(map))
-					continue;
-				error("%s fails %s", REQUIRE_BND, require.get(filter));
-			}
-			catch (Exception t) {
-				error("%s with value %s throws exception", t, REQUIRE_BND, require);
-			}
-		}
-	}
-
+    -require-bnd: "(version>=4.3.0)"


### PR DESCRIPTION
We now use a Version object in the map to the filter to get proper
version comparison semantics. We also fix the test methods and docs to
properly use filter expressions for `-require-bnd`.