### PR TITLE
httpclient: Rewrite retry logic using Promises

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/RetryException.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/RetryException.java
@@ -1,0 +1,24 @@
+package aQute.bnd.http;
+
+import static java.util.Objects.requireNonNull;
+
+import aQute.bnd.service.url.TaggedData;
+
+class RetryException extends Exception {
+	private static final long	serialVersionUID	= 1L;
+	private final TaggedData	tag;
+
+	RetryException(TaggedData tag, Throwable cause) {
+		super(cause);
+		this.tag = requireNonNull(tag);
+	}
+
+	RetryException(TaggedData tag, String message) {
+		super(message);
+		this.tag = requireNonNull(tag);
+	}
+
+	TaggedData getTag() {
+		return tag;
+	}
+}

--- a/biz.aQute.repository/test/aQute/bnd/deployer/http/HttpRedirectionTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/http/HttpRedirectionTest.java
@@ -77,7 +77,10 @@ public class HttpRedirectionTest extends TestCase {
 			public void run() {
 				try (HttpClient connector = new HttpClient()) {
 					try {
-						InputStream stream = connector.connect(new URL("http://localhost:" + httpd.getPort() + "/foo"));
+						InputStream stream = connector.build()
+							.retries(0)
+							.get(InputStream.class)
+							.go(new URL("http://localhost:" + httpd.getPort() + "/foo"));
 						IO.collect(stream);
 					} catch (Exception e) {
 						e.printStackTrace();
@@ -86,7 +89,7 @@ public class HttpRedirectionTest extends TestCase {
 			}
 		});
 		try {
-			future.get(1, TimeUnit.SECONDS);
+			future.get(5, TimeUnit.SECONDS);
 		} finally {
 			future.cancel(true);
 			executor.shutdownNow();


### PR DESCRIPTION
The retry logic is hoisted up around the send method to allow retries
when file caching fails when reading from the connection. This happens
sometimes on Eclipse p2 repos.

We also update the sha/md5 checks in p2 and maven repos.