### PR TITLE
http: Delay on current thread when using inline executor

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -184,6 +184,10 @@ public class HttpClient implements Closeable, URLConnector {
 				// double delay for next retry; 10 minutes max delay
 				long nextDelay = (request.retryDelay == 0L) ? Math.min(delay * 2L, TimeUnit.MINUTES.toMillis(10))
 					: delay;
+				if (factory == inlinePromiseFactory()) {
+					delayed.getFailure(); // wait on the current thread
+					return sendRetry(request, retries - 1, nextDelay, factory);
+				}
 				return delayed.recoverWith(f -> sendRetry(request, retries - 1, nextDelay, factory));
 			});
 	}


### PR DESCRIPTION
If we use recoverWith on the delayed promise while using the inline
executor we end up moving work onto the scheduled executors thread.
Since we have only a limited number of schedule executor threads, we
want to avoid long term use. So when using the inline executor, we wait
for the delay to expire on the current thread. This should keep all work
on the current thread when using the inline executor.
