### PR TITLE
httpclient: Refactor for better handling of TimeoutException

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
@@ -38,10 +38,10 @@ public class HttpClientTest extends TestCase {
 
 	@Override
 	protected void tearDown() throws Exception {
-		super.tearDown();
-		httpServer.close();
-		httpsServer.close();
+		IO.close(httpServer);
+		IO.close(httpsServer);
 		IO.delete(tmp);
+		super.tearDown();
 	}
 
 	public static class TestServer extends Httpbin {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -99,6 +99,8 @@ public class HttpClient implements Closeable, URLConnector {
 	private volatile AtomicBoolean				offline;
 	private final PromiseFactory				promiseFactory;
 	private ConnectionSettings					connectionSettings;
+	int											retries					= 3;
+	long										retryDelay				= 0L;
 
 	public HttpClient() {
 		promiseFactory = Processor.getPromiseFactory();
@@ -319,6 +321,16 @@ public class HttpClient implements Closeable, URLConnector {
 		if (connectionSettings != null) {
 			connectionSettings.report(out);
 		}
+	}
+
+	public HttpClient retries(int retries) {
+		this.retries = retries;
+		return this;
+	}
+
+	public HttpClient retryDelay(int retryDelay) {
+		this.retryDelay = TimeUnit.SECONDS.toMillis(retryDelay);
+		return this;
 	}
 
 	class HttpConnection<T> implements Callable<T> {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
@@ -1,7 +1,5 @@
 package aQute.bnd.http;
 
-import static aQute.bnd.http.HttpClient.getValue;
-
 import java.io.File;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
@@ -188,7 +186,8 @@ public class HttpRequest<T> {
 	}
 
 	public T go(URL url) throws Exception {
-		return getValue(async(url));
+		this.url = url;
+		return client.send(this);
 	}
 
 	public T go(URI url) throws Exception {
@@ -202,7 +201,7 @@ public class HttpRequest<T> {
 
 	public Promise<T> async(URL url) {
 		this.url = url;
-		return client.async(this);
+		return client.sendAsync(this);
 	}
 
 	public Promise<T> async(URI uri) {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
@@ -40,11 +40,13 @@ public class HttpRequest<T> {
 	Reporter			reporter;
 	File				useCacheFile;
 	boolean				updateTag;
-	int					retries		= 3;
-	long				retryDelay	= 0L;
+	int					retries;
+	long				retryDelay;
 
 	HttpRequest(HttpClient client) {
 		this.client = client;
+		this.retries = client.retries;
+		this.retryDelay = client.retryDelay;
 	}
 
 	/**

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
@@ -194,7 +194,8 @@ class P2Indexer implements Closeable {
 						return rb.build();
 					})
 					.recover(failed -> {
-						logger.info(LIFECYCLE, "{}: Failed to create resource for {}", name, a, failed.getFailure());
+						logger.info(LIFECYCLE, "{}: Failed to create resource for {}", name, a.uri,
+							failed.getFailure());
 						return RECOVERY;
 					});
 			})

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
@@ -39,89 +39,91 @@ public class P2IndexerTest extends TestCase {
 	}
 
 	public void testEclipseP2Repo() throws Exception {
-		HttpClient client = new HttpClient();
-		client.setCache(IO.getFile(tmp, "cache"));
+		try (HttpClient client = new HttpClient()) {
+			client.setCache(IO.getFile(tmp, "cache"));
 
-		try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
-			new URI("https://download.eclipse.org/egit/updates-4.7.1/"), getName())) {
-			List<String> bsns = p2.list(null);
-			System.out.println(bsns);
-			assertThat(bsns).contains("org.kohsuke.args4j", "org.slf4j.api", "org.apache.httpcomponents.httpclient",
-				"org.eclipse.egit.ui.source", "org.eclipse.jgit.archive", "org.eclipse.jgit.pgm.source",
-				"org.eclipse.egit", "org.eclipse.egit.ui", "org.eclipse.egit.mylyn.ui.source", "org.eclipse.jgit.pgm",
-				"org.apache.commons.compress", "org.eclipse.egit.gitflow.ui", "org.slf4j.impl.log4j12",
-				"org.eclipse.jgit.ui", "javaewah", "org.apache.httpcomponents.httpcore", "org.eclipse.jgit.source",
-				"org.eclipse.jgit.http.apache", "org.eclipse.egit.gitflow.source", "org.eclipse.jgit",
-				"org.eclipse.egit.core.source", "org.eclipse.egit.gitflow.ui.source", "org.eclipse.egit.mylyn.ui",
-				"org.eclipse.jgit.lfs", "org.eclipse.egit.gitflow", "org.eclipse.egit.core",
-				"org.eclipse.egit.ui.smartimport", "org.eclipse.jgit.lfs.server", "org.eclipse.egit.doc",
-				"org.apache.log4j", "com.google.gson", "com.jcraft.jsch");
+			try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
+				new URI("https://download.eclipse.org/egit/updates-4.7.1/"), getName())) {
+				List<String> bsns = p2.list(null);
+				System.out.println(bsns);
+				assertThat(bsns).contains("org.kohsuke.args4j", "org.slf4j.api", "org.apache.httpcomponents.httpclient",
+					"org.eclipse.egit.ui.source", "org.eclipse.jgit.archive", "org.eclipse.jgit.pgm.source",
+					"org.eclipse.egit", "org.eclipse.egit.ui", "org.eclipse.egit.mylyn.ui.source",
+					"org.eclipse.jgit.pgm", "org.apache.commons.compress", "org.eclipse.egit.gitflow.ui",
+					"org.slf4j.impl.log4j12", "org.eclipse.jgit.ui", "javaewah", "org.apache.httpcomponents.httpcore",
+					"org.eclipse.jgit.source", "org.eclipse.jgit.http.apache", "org.eclipse.egit.gitflow.source",
+					"org.eclipse.jgit", "org.eclipse.egit.core.source", "org.eclipse.egit.gitflow.ui.source",
+					"org.eclipse.egit.mylyn.ui", "org.eclipse.jgit.lfs", "org.eclipse.egit.gitflow",
+					"org.eclipse.egit.core", "org.eclipse.egit.ui.smartimport", "org.eclipse.jgit.lfs.server",
+					"org.eclipse.egit.doc", "org.apache.log4j", "com.google.gson", "com.jcraft.jsch");
+			}
 		}
 	}
 
 	public void testURI() throws Exception {
-		HttpClient client = new HttpClient();
-		client.setCache(IO.getFile(tmp, "cache"));
+		try (HttpClient client = new HttpClient()) {
+			client.setCache(IO.getFile(tmp, "cache"));
 
-		try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
-			new URI("https://dl.bintray.com/bndtools/bndtools/3.5.0/"), getName())) {
-			List<String> bsns = p2.list(null);
-			System.out.println(bsns);
-			assertThat(bsns).contains("javax.xml", "org.bndtools.templating.gitrepo",
-				"org.bndtools.headless.build.manager", "javax.xml.stream", "org.bndtools.templating", "org.slf4j.api",
-				"bndtools.api", "bndtools.jareditor", "org.bndtools.versioncontrol.ignores.plugin.git", "bndtools.m2e",
-				"org.bndtools.embeddedrepo", "biz.aQute.resolve", "org.bndtools.versioncontrol.ignores.manager",
-				"bndtools.builder", "bndtools.core", "biz.aQute.repository",
-				"org.bndtools.headless.build.plugin.gradle", "bndtools.release",
-				"org.bndtools.headless.build.plugin.ant", "org.osgi.impl.bundle.repoindex.lib", "biz.aQute.bndlib");
+			try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
+				new URI("https://dl.bintray.com/bndtools/bndtools/3.5.0/"), getName())) {
+				List<String> bsns = p2.list(null);
+				System.out.println(bsns);
+				assertThat(bsns).contains("javax.xml", "org.bndtools.templating.gitrepo",
+					"org.bndtools.headless.build.manager", "javax.xml.stream", "org.bndtools.templating",
+					"org.slf4j.api", "bndtools.api", "bndtools.jareditor",
+					"org.bndtools.versioncontrol.ignores.plugin.git", "bndtools.m2e", "org.bndtools.embeddedrepo",
+					"biz.aQute.resolve", "org.bndtools.versioncontrol.ignores.manager", "bndtools.builder",
+					"bndtools.core", "biz.aQute.repository", "org.bndtools.headless.build.plugin.gradle",
+					"bndtools.release", "org.bndtools.headless.build.plugin.ant", "org.osgi.impl.bundle.repoindex.lib",
+					"biz.aQute.bndlib");
+			}
 		}
 	}
 
 	public void testFile() throws Throwable {
-		HttpClient client = new HttpClient();
-		client.setCache(IO.getFile(tmp, "cache"));
+		try (HttpClient client = new HttpClient()) {
+			client.setCache(IO.getFile(tmp, "cache"));
 
-		File input = IO.getFile("testdata/p2/macbadge");
-		assertThat(input).as("%s must be dir", input)
+			File input = IO.getFile("testdata/p2/macbadge");
+			assertThat(input).as("%s must be dir", input)
 			.isDirectory();
 
-		try (
-			P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(),
+			try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(),
 				getName())) {
-			List<String> bsns = p2.list(null);
-			assertThat(bsns).containsExactly("name.njbartlett.eclipse.macbadge");
+				List<String> bsns = p2.list(null);
+				assertThat(bsns).containsExactly("name.njbartlett.eclipse.macbadge");
 
-			System.out.println(bsns);
+				System.out.println(bsns);
 
-			assertThat(p2.versions("name.njbartlett.eclipse.macbadge"))
+				assertThat(p2.versions("name.njbartlett.eclipse.macbadge"))
 				.containsExactly(new Version("1.0.0.201110100042"));
 
-			File f = p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
-			assertThat(f).isNotNull()
+				File f = p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
+				assertThat(f).isNotNull()
 				.hasName("name.njbartlett.eclipse.macbadge-1.0.0.201110100042.jar");
-			assertThat(f.length()).isEqualTo(4672);
+				assertThat(f.length()).isEqualTo(4672);
 
-			String sha256 = SHA256.digest(f)
-				.asHex();
+				String sha256 = SHA256.digest(f)
+					.asHex();
 
-			Repository repository = p2.getBridge()
-				.getRepository();
-			RequirementBuilder rb = new RequirementBuilder("osgi.content");
+				Repository repository = p2.getBridge()
+					.getRepository();
+				RequirementBuilder rb = new RequirementBuilder("osgi.content");
 
-			rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
+				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
 
-			Requirement req = rb.synthetic();
-			Collection<Capability> collection = repository.findProviders(Collections.singleton(req))
-				.get(req);
-			Set<Resource> resources = ResourceUtils.getResources(collection);
+				Requirement req = rb.synthetic();
+				Collection<Capability> collection = repository.findProviders(Collections.singleton(req))
+					.get(req);
+				Set<Resource> resources = ResourceUtils.getResources(collection);
 
-			assertThat(resources).hasSize(1);
+				assertThat(resources).hasSize(1);
 
-			final AtomicReference<Throwable> result = new AtomicReference<>();
-			final Semaphore sem = new Semaphore(0);
+				final AtomicReference<Throwable> result = new AtomicReference<>();
+				final Semaphore sem = new Semaphore(0);
 
-			p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null,
-				new RepositoryPlugin.DownloadListener() {
+				p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null,
+					new RepositoryPlugin.DownloadListener() {
 
 					@Override
 					public void success(File file) throws Exception {
@@ -149,90 +151,92 @@ public class P2IndexerTest extends TestCase {
 					}
 				});
 
-			sem.acquire();
-			if (result.get() != null)
-				throw result.get();
+				sem.acquire();
+				if (result.get() != null)
+					throw result.get();
 
-		} catch (InvocationTargetException ite) {
-			Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
-			t.printStackTrace();
-			throw t;
-		}
+			} catch (InvocationTargetException ite) {
+				Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
+				t.printStackTrace();
+				throw t;
+			}
 
-		try (
-			P2Indexer p3 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(), "test")) {
-			File f = p3.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
-			assertThat(f).isNotNull()
+			try (P2Indexer p3 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(),
+				"test")) {
+				File f = p3.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
+				assertThat(f).isNotNull()
 				.hasName("name.njbartlett.eclipse.macbadge-1.0.0.201110100042.jar");
-			assertThat(f.length()).isEqualTo(4672);
+				assertThat(f.length()).isEqualTo(4672);
+			}
 		}
-
 	}
 
 	public void testRefresh() throws Exception {
-		HttpClient client = new HttpClient();
-		client.setCache(IO.getFile(tmp, "cache"));
+		try (HttpClient client = new HttpClient()) {
+			client.setCache(IO.getFile(tmp, "cache"));
 
-		try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
-			new URI("https://dl.bintray.com/bndtools/bndtools/3.5.0/"), getName())) {
+			try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
+				new URI("https://dl.bintray.com/bndtools/bndtools/3.5.0/"), getName())) {
 
-			assertThat(p2.versions("bndtools.core")).hasSize(1);
+				assertThat(p2.versions("bndtools.core")).hasSize(1);
 
-			p2.refresh();
+				p2.refresh();
 
-			assertThat(p2.versions("bndtools.core")).hasSize(1);
+				assertThat(p2.versions("bndtools.core")).hasSize(1);
+			}
 		}
 	}
 
 	public void testTargetPlatform() throws Throwable {
-		HttpClient client = new HttpClient();
-		client.setCache(IO.getFile(tmp, "cache"));
+		try (HttpClient client = new HttpClient()) {
+			client.setCache(IO.getFile(tmp, "cache"));
 
-		File input = IO.getFile("testdata/p2/macbadge/");
-		File targetFile = new File("testdata/targetplatform/macbadge.target");
-		String content = IO.collect(targetFile);
-		content = content.replaceAll("\\$\\{repo\\}", input.toURI()
-			.toString());
-		targetFile = new File(tmp, "macbadge.target");
-		IO.store(content, targetFile);
+			File input = IO.getFile("testdata/p2/macbadge/");
+			File targetFile = new File("testdata/targetplatform/macbadge.target");
+			String content = IO.collect(targetFile);
+			content = content.replaceAll("\\$\\{repo\\}", input.toURI()
+				.toString());
+			targetFile = new File(tmp, "macbadge.target");
+			IO.store(content, targetFile);
 
-		try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, targetFile.getAbsoluteFile()
+			try (P2Indexer p2 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client,
+				targetFile.getAbsoluteFile()
 				.toURI(),
-			getName())) {
-			List<String> bsns = p2.list(null);
-			assertThat(bsns).containsExactly("name.njbartlett.eclipse.macbadge");
+				getName())) {
+				List<String> bsns = p2.list(null);
+				assertThat(bsns).containsExactly("name.njbartlett.eclipse.macbadge");
 
-			System.out.println(bsns);
+				System.out.println(bsns);
 
-			assertThat(p2.versions("name.njbartlett.eclipse.macbadge"))
+				assertThat(p2.versions("name.njbartlett.eclipse.macbadge"))
 				.containsExactly(new Version("1.0.0.201110100042"));
 
-			File f = p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
-			assertThat(f).isNotNull()
+				File f = p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
+				assertThat(f).isNotNull()
 				.hasName("name.njbartlett.eclipse.macbadge-1.0.0.201110100042.jar");
-			assertThat(f.length()).isEqualTo(4672);
+				assertThat(f.length()).isEqualTo(4672);
 
-			String sha256 = SHA256.digest(f)
-				.asHex();
+				String sha256 = SHA256.digest(f)
+					.asHex();
 
-			Repository repository = p2.getBridge()
-				.getRepository();
-			RequirementBuilder rb = new RequirementBuilder("osgi.content");
+				Repository repository = p2.getBridge()
+					.getRepository();
+				RequirementBuilder rb = new RequirementBuilder("osgi.content");
 
-			rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
+				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
 
-			Requirement req = rb.synthetic();
-			Collection<Capability> collection = repository.findProviders(Collections.singleton(req))
-				.get(req);
-			Set<Resource> resources = ResourceUtils.getResources(collection);
+				Requirement req = rb.synthetic();
+				Collection<Capability> collection = repository.findProviders(Collections.singleton(req))
+					.get(req);
+				Set<Resource> resources = ResourceUtils.getResources(collection);
 
-			assertThat(resources).hasSize(1);
+				assertThat(resources).hasSize(1);
 
-			final AtomicReference<Throwable> result = new AtomicReference<>();
-			final Semaphore sem = new Semaphore(0);
+				final AtomicReference<Throwable> result = new AtomicReference<>();
+				final Semaphore sem = new Semaphore(0);
 
-			p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null,
-				new RepositoryPlugin.DownloadListener() {
+				p2.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null,
+					new RepositoryPlugin.DownloadListener() {
 
 					@Override
 					public void success(File file) throws Exception {
@@ -260,23 +264,23 @@ public class P2IndexerTest extends TestCase {
 					}
 				});
 
-			sem.acquire();
-			if (result.get() != null)
-				throw result.get();
+				sem.acquire();
+				if (result.get() != null)
+					throw result.get();
 
-		} catch (InvocationTargetException ite) {
-			Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
-			t.printStackTrace();
-			throw t;
-		}
+			} catch (InvocationTargetException ite) {
+				Throwable t = Exceptions.unrollCause(ite, InvocationTargetException.class);
+				t.printStackTrace();
+				throw t;
+			}
 
-		try (P2Indexer p3 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(),
-			getName())) {
-			File f = p3.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
-			assertThat(f).isNotNull()
+			try (P2Indexer p3 = new P2Indexer(new Slf4jReporter(P2IndexerTest.class), tmp, client, input.toURI(),
+				getName())) {
+				File f = p3.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
+				assertThat(f).isNotNull()
 				.hasName("name.njbartlett.eclipse.macbadge-1.0.0.201110100042.jar");
-			assertThat(f.length()).isEqualTo(4672);
+				assertThat(f.length()).isEqualTo(4672);
+			}
 		}
-
 	}
 }


### PR DESCRIPTION
We now set the TimeoutException stack trace to that of the "stuck"
request thread for some better diagnostic information. We also attempt
to close the input stream and delete the file of the TaggedData if there
is one for the request thread.

We also set the temporarily set the thread name to the URL of the
request. This can be quite useful in debugging and thread dumps.