### PR TITLE
[Launchpad] Add ability to exclude system packages

### DIFF
--- a/biz.aQute.launchpad.tests/test/aQute/launchpad/LaunchpadBuilderTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/launchpad/LaunchpadBuilderTest.java
@@ -2,11 +2,15 @@ package aQute.launchpad;
 
 import static aQute.launchpad.LaunchpadBuilder.projectTestSetup;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.osgi.framework.Constants;
 
 import aQute.bnd.service.specifications.RunSpecification;
 
@@ -68,5 +72,49 @@ public class LaunchpadBuilderTest {
 		builder.set("somekey", "somevalue");
 		softly.assertThat(builder.local.properties)
 			.containsEntry("somekey", "somevalue");
+	}
+
+	@Test
+	public void excludePackages_filtersSystemPackages() throws Exception {
+		addPackage("m.n.o.p", "3.2.1");
+		addPackage("my.pkg1", "1.2");
+		addPackage("my.pkg.pkg2", "1.3");
+		addPackage("our.other", "2.3");
+		addPackage("our.other.pkg2", "2.3");
+		builder.excludePackages("my.*", "our.other")
+			.runfw("org.apache.felix.framework");
+		try (Launchpad lp = builder.create()) {
+			softly.assertThat(builder.local.properties.get(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA))
+				.doesNotContain("my.pkg1;")
+				.doesNotContain("my.pkg.pkg2;")
+				.doesNotContain("our.other;")
+				.contains("our.other.pkg2;")
+				.contains("m.n.o.p;");
+		}
+	}
+
+	@Test
+	public void excludePackages_withPredicates_filtersSystemPackages() throws Exception {
+		addPackage("m.n.o.p", "3.2.1");
+		addPackage("my.pkg1", "1.2");
+		addPackage("my.pkg.pkg2", "1.3");
+		addPackage("our.other", "2.3");
+		addPackage("our.other.pkg2", "2.3");
+		builder.excludePackages(x -> x.startsWith("my"), y -> y.equals("our.other"))
+			.runfw("org.apache.felix.framework");
+		try (Launchpad lp = builder.create()) {
+			softly.assertThat(builder.local.properties.get(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA))
+				.doesNotContain("my.pkg1;")
+				.doesNotContain("my.pkg.pkg2;")
+				.doesNotContain("our.other;")
+				.contains("our.other.pkg2;")
+				.contains("m.n.o.p;");
+		}
+	}
+
+	protected void addPackage(String bsn, String version) {
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("version", version);
+		builder.local.extraSystemPackages.put(bsn, attrs);
 	}
 }


### PR DESCRIPTION
Proposed implementation of #3081.

Adds ability to filter the package list that is exported into the `SYSTEMPACKAGES_EXTRA` property, before it is actually used to generate the framework.

Can filter either by `Predicate<String>`(s), or by a plain string(s). If plain strings are used, ending with a ".*" indicates that it will exclude all subpackages also, whereas without this on the end an exact match is required. Hopefully this is a pretty good combination of flexibility and simplicity to cover most situations.

Feedback welcome.