### PR TITLE
Build jdk12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ buildfiles
 /.gradle/
 /reports/
 /generated/
+/install-jdk.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - name: "OpenJDK11"
       install:
         - "source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz"
+    - name: "OpenJDK12"
+      install:
+        - "source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12-linux_x64.tar.gz"
     - name: "Local rebuild"
       script: 
         - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 :biz.aQute.bnd.gradle:build :biz.aQute.bnd.gradle:releaseNeeded"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,19 @@ jobs:
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
     displayName: Build
 
+- job: OpenJDK12
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - bash: |
+      set -ev
+      curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
+      source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12-linux_x64.tar.gz
+      ./gradlew --no-daemon --version
+      ./mvnw --version
+      ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
+    displayName: Build
+
 - job: LocalRebuild
   pool:
     vmImage: 'ubuntu-16.04'
@@ -44,6 +57,7 @@ jobs:
       set -ev
       curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
       source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-linux_x64.tar.gz
+      ./gradlew --no-daemon --version
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 :biz.aQute.bnd.gradle:build :biz.aQute.bnd.gradle:releaseNeeded
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles :buildscriptDependencies :build
     displayName: Build

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
 if (JavaVersion.current().isJava9Compatible()) {
     tasks.withType(GroovyCompile.class).configureEach {
-        groovyOptions.fork 'jvmArgs': java9options
+        groovyOptions.fork 'jvmArgs': jpmsOptions
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@
 import aQute.lib.io.IO
 
 if (JavaVersion.current().isJava9Compatible()) {
-  ext.java9options = [
+  ext.jpmsOptions = [
+    '--illegal-access=warn',
     '--add-opens=java.base/java.lang=ALL-UNNAMED', 
     '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED', 
     '--add-opens=java.base/java.io=ALL-UNNAMED',
@@ -18,7 +19,13 @@ if (JavaVersion.current().isJava9Compatible()) {
     '--add-opens=java.base/java.util.jar=ALL-UNNAMED',
     '--add-opens=java.base/java.util.regex=ALL-UNNAMED',
     '--add-opens=java.base/java.util.zip=ALL-UNNAMED',
-    '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED'
+    '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED',
+    '--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED'
   ]
 }
 
@@ -40,8 +47,8 @@ subprojects {
         exceptionFormat 'full'
       }
       if (JavaVersion.current().isJava9Compatible()) {
-        jvmArgs java9options
-        environment 'JAVA_OPTS': java9options.join(' ')
+        jvmArgs jpmsOptions
+        environment 'JAVA_OPTS': jpmsOptions.join(' ')
       }
       inputs.files(fileTree(project.projectDir) {
         include 'testresources/', 'testdata/'

--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -50,6 +50,7 @@
 	<build>
 		<plugins>
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<configuration>
 					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -70,7 +70,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.1</version>
 					<configuration>
                         <archive>
                            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -73,6 +73,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -58,6 +58,7 @@
 	<build>
 		<plugins>
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/helloworld-for-indexer-testing/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/helloworld-for-indexer-testing/pom.xml
@@ -36,7 +36,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/include-jar/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/include-jar/pom.xml
@@ -22,7 +22,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder-includes-excludes/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder-includes-excludes/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.10</version>
+				<version>3.1.1</version>
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/index-folder/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.10</version>
+				<version>3.1.1</version>
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
@@ -12,7 +12,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -22,7 +22,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.8.2</version>
 				<executions>
 					<execution>
 						<id>deploy</id>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy/pom.xml
@@ -19,7 +19,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -29,7 +29,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.8.2</version>
 				<executions>
 					<execution>
 						<id>deploy</id>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -66,6 +66,7 @@
 	<build>
 		<plugins>
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<configuration>
 					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -56,7 +56,7 @@ Parent-Here: ${.}
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.1</version>
 				<configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-api-bundle/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -37,7 +37,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.0</version>
 			</plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-impl-bundle/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.0</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-in-build-pluginManagement-inheritance/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-in-build-pluginManagement-inheritance/pom.xml
@@ -48,7 +48,7 @@ Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.1.1</version>
 					<configuration>
 						<archive>
 							<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-in-build-pluginManagement-inheritance/test-inheriting-api-bundle/pom.xml
+++ b/maven/bnd-maven-plugin/src/test/resources/integration-test/test/test-in-build-pluginManagement-inheritance/test-inheriting-api-bundle/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -37,7 +37,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.1.0</version>
 			</plugin>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>

--- a/maven/bnd-resolver-maven-plugin/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/pom.xml
@@ -73,6 +73,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/maven/bnd-run-maven-plugin/pom.xml
+++ b/maven/bnd-run-maven-plugin/pom.xml
@@ -73,6 +73,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<configuration>
 					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>

--- a/maven/bnd-run-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-run-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -43,7 +43,9 @@
 				</executions>
 			</plugin>
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -73,6 +73,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<dependencies>
 					<dependency>

--- a/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -107,7 +107,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.1.1</version>
 					<configuration>
 						<archive>
 							<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -145,7 +145,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.10.0</version>
+				<version>3.12.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -182,7 +182,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
-					<version>3.5.2</version>
+					<version>3.6.0</version>
 					<executions>
 						<execution>
 							<id>default-descriptor</id>
@@ -203,7 +203,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.1.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -232,7 +232,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.1.0</version>
 					<executions>
 						<execution>
 							<id>attach-javadocs</id>
@@ -243,18 +243,15 @@
 						</execution>
 					</executions>
                 <configuration>
-                    <javaApiLinks>
-                        <property>
-                            <name>jdk11-workaround</name>
-                            <value>https://bugs.openjdk.java.net/browse/JDK-8212233</value>
-                        </property>
-                    </javaApiLinks>
+                    <detectJavaApiLink>
+                        false
+                    </detectJavaApiLink>
                 </configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-invoker-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -342,7 +339,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>flatten-maven-plugin</artifactId>
-					<version>1.0.1</version>
+					<version>1.1.0</version>
 					<configuration>
 						<flattenMode>oss</flattenMode>
 					</configuration>


### PR DESCRIPTION
Add CI build job for JDK 12. We keep the JDK 11 build job since JDK 11 is an LTS release.