### PR TITLE
gradle: Make Bnd less chatty on build output

### DIFF
--- a/aQute.libg/src/aQute/libg/reporter/slf4j/Slf4jReporter.java
+++ b/aQute.libg/src/aQute/libg/reporter/slf4j/Slf4jReporter.java
@@ -1,7 +1,5 @@
 package aQute.libg.reporter.slf4j;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,16 +53,14 @@ public class Slf4jReporter extends ReporterAdapter {
 	}
 
 	/**
-	 * @deprecated Use SLF4J
-	 *             Logger.info(aQute.libg.slf4j.GradleLogging.LIFECYCLE)
-	 *             instead.
+	 * @deprecated Use SLF4J Logger.info() instead.
 	 */
 	@Override
 	@Deprecated
 	public void progress(float progress, String format, Object... args) {
 		super.progress(progress, format, args);
-		if (logger.isInfoEnabled(LIFECYCLE)) {
-			logger.info(LIFECYCLE, "{}", Strings.format(format, args));
+		if (logger.isInfoEnabled()) {
+			logger.info("{}", Strings.format(format, args));
 		}
 	}
 

--- a/biz.aQute.bnd/src/aQute/bnd/ant/BaseTask.java
+++ b/biz.aQute.bnd/src/aQute/bnd/ant/BaseTask.java
@@ -1,7 +1,5 @@
 package aQute.bnd.ant;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -183,19 +181,17 @@ public class BaseTask extends Task implements Reporter {
 	}
 
 	/**
-	 * @deprecated Use SLF4J
-	 *             Logger.info(aQute.libg.slf4j.GradleLogging.LIFECYCLE)
-	 *             instead.
+	 * @deprecated Use SLF4J Logger.info() instead.
 	 */
 	@Override
 	@Deprecated
 	public void progress(float progress, String s, Object... args) {
-		if (logger.isInfoEnabled(LIFECYCLE)) {
+		if (logger.isInfoEnabled()) {
 			String message = Strings.format(s, args);
 			if (progress > 0)
-				logger.info(LIFECYCLE, "[{}] {}", (int) progress, message);
+				logger.info("[{}] {}", (int) progress, message);
 			else
-				logger.info(LIFECYCLE, "{}", message);
+				logger.info("{}", message);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/LoggingProgressPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/LoggingProgressPlugin.java
@@ -1,7 +1,5 @@
 package aQute.bnd.build;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,7 +11,7 @@ public class LoggingProgressPlugin implements ProgressPlugin {
 
 	@Override
 	public Task startTask(final String name, final int size) {
-		logger.info(LIFECYCLE, name); // log at Gradle LIFECYCLE level
+		logger.info(name);
 
 		return new Task() {
 			@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -1,6 +1,5 @@
 package aQute.bnd.http;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
@@ -198,8 +197,8 @@ public class HttpClient implements Closeable, URLConnector {
 				if (message == null) {
 					message = failure.toString();
 				}
-				logger.info(LIFECYCLE, "Retrying failed connection. url={}, message={}, delay={}, retries={}",
-					request.url, message, delay, retries, logFailure);
+				logger.info("Retrying failed connection. url={}, message={}, delay={}, retries={}", request.url,
+					message, delay, retries, logFailure);
 				Promise<T> delayed = (Promise<T>) failed.delay(delay);
 				// double delay for next retry; 10 minutes max delay
 				long nextDelay = (request.retryDelay == 0L) ? Math.min(delay * 2L, MAX_RETRY_DELAY) : delay;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDeploy.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDeploy.java
@@ -1,7 +1,5 @@
 package aQute.bnd.maven;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -65,7 +63,7 @@ public class MavenDeploy implements Deploy, Plugin {
 		if (maven == null)
 			return false; // we're not playing for this bundle
 
-		logger.info(LIFECYCLE, "deploying {} to Maven repo: {}", jarName, repository);
+		logger.info("deploying {} to Maven repo: {}", jarName, repository);
 		File target = project.getTarget();
 		File tmp = Processor.getFile(target, repository);
 		IO.mkdirs(tmp);
@@ -75,7 +73,7 @@ public class MavenDeploy implements Deploy, Plugin {
 			if (manifest == null)
 				project.error("Jar has no manifest: %s", original);
 			else {
-				logger.info(LIFECYCLE, "Writing pom.xml");
+				logger.info("Writing pom.xml");
 				PomResource pom = new PomResource(manifest);
 				pom.setProperties(maven);
 				File pomFile = write(tmp, pom, "pom.xml");
@@ -86,20 +84,20 @@ public class MavenDeploy implements Deploy, Plugin {
 						.getValue(Constants.EXPORT_PACKAGE));
 					File jdoc = new File(tmp, "jdoc");
 					IO.mkdirs(jdoc);
-					logger.info(LIFECYCLE, "Generating Javadoc for: {}", exports.keySet());
+					logger.info("Generating Javadoc for: {}", exports.keySet());
 					Jar javadoc = javadoc(jdoc, project, exports.keySet());
-					logger.info(LIFECYCLE, "Writing javadoc jar");
+					logger.info("Writing javadoc jar");
 					File javadocFile = write(tmp, new JarResource(javadoc), "javadoc.jar");
-					logger.info(LIFECYCLE, "Writing main file");
+					logger.info("Writing main file");
 					File mainFile = write(tmp, new JarResource(main), "main.jar");
-					logger.info(LIFECYCLE, "Writing sources file");
+					logger.info("Writing sources file");
 					File srcFile = write(tmp, new JarResource(main), "src.jar");
 
-					logger.info(LIFECYCLE, "Deploying main file");
+					logger.info("Deploying main file");
 					maven_gpg_sign_and_deploy(project, mainFile, null, pomFile);
-					logger.info(LIFECYCLE, "Deploying main sources file");
+					logger.info("Deploying main sources file");
 					maven_gpg_sign_and_deploy(project, srcFile, "sources", null);
-					logger.info(LIFECYCLE, "Deploying main javadoc file");
+					logger.info("Deploying main javadoc file");
 					maven_gpg_sign_and_deploy(project, javadocFile, "javadoc", null);
 
 				}

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDeployCmd.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDeployCmd.java
@@ -1,7 +1,5 @@
 package aQute.bnd.maven;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,7 +35,7 @@ public class MavenDeployCmd extends Processor {
 	/**
 	 * maven deploy [-url repo] [-passphrase passphrase] [-homedir homedir]
 	 * [-keyname keyname] bundle ...
-	 * 
+	 *
 	 * @param args
 	 * @param i
 	 * @throws Exception
@@ -96,7 +94,7 @@ public class MavenDeployCmd extends Processor {
 		if (maven == null)
 			return false; // we're not playing for this bundle
 
-		logger.info(LIFECYCLE, "deploying {} to Maven repo: {}", original, repository);
+		logger.info("deploying {} to Maven repo: {}", original, repository);
 		File target = project.getTarget();
 		File tmp = Processor.getFile(target, repository);
 		if (!tmp.exists() && !tmp.mkdirs()) {
@@ -107,7 +105,7 @@ public class MavenDeployCmd extends Processor {
 		if (manifest == null)
 			project.error("Jar has no manifest: %s", original);
 		else {
-			logger.info(LIFECYCLE, "Writing pom.xml");
+			logger.info("Writing pom.xml");
 			PomResource pom = new PomResource(manifest);
 			pom.setProperties(maven);
 			File pomFile = write(tmp, pom, "pom.xml");
@@ -118,20 +116,20 @@ public class MavenDeployCmd extends Processor {
 					.getValue(Constants.EXPORT_PACKAGE));
 				File jdoc = new File(tmp, "jdoc");
 				IO.mkdirs(jdoc);
-				logger.info(LIFECYCLE, "Generating Javadoc for: {}", exports.keySet());
+				logger.info("Generating Javadoc for: {}", exports.keySet());
 				Jar javadoc = javadoc(jdoc, project, exports.keySet());
-				logger.info(LIFECYCLE, "Writing javadoc jar");
+				logger.info("Writing javadoc jar");
 				File javadocFile = write(tmp, new JarResource(javadoc), "javadoc.jar");
-				logger.info(LIFECYCLE, "Writing main file");
+				logger.info("Writing main file");
 				File mainFile = write(tmp, new JarResource(main), "main.jar");
-				logger.info(LIFECYCLE, "Writing sources file");
+				logger.info("Writing sources file");
 				File srcFile = write(tmp, new JarResource(main), "src.jar");
 
-				logger.info(LIFECYCLE, "Deploying main file");
+				logger.info("Deploying main file");
 				maven_gpg_sign_and_deploy(project, mainFile, null, pomFile);
-				logger.info(LIFECYCLE, "Deploying main sources file");
+				logger.info("Deploying main sources file");
 				maven_gpg_sign_and_deploy(project, srcFile, "sources", null);
-				logger.info(LIFECYCLE, "Deploying main javadoc file");
+				logger.info("Deploying main javadoc file");
 				maven_gpg_sign_and_deploy(project, javadocFile, "javadoc", null);
 			}
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1,6 +1,5 @@
 package aQute.bnd.osgi;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
 import static java.lang.invoke.MethodHandles.publicLookup;
 import static java.lang.invoke.MethodType.methodType;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -378,20 +377,18 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	/**
-	 * @deprecated Use SLF4J
-	 *             Logger.info(aQute.libg.slf4j.GradleLogging.LIFECYCLE)
-	 *             instead.
+	 * @deprecated Use SLF4J Logger.info() instead.
 	 */
 	@Override
 	@Deprecated
 	public void progress(float progress, String format, Object... args) {
 		Logger l = getLogger();
-		if (l.isInfoEnabled(LIFECYCLE)) {
+		if (l.isInfoEnabled()) {
 			String message = formatArrays(format, args);
 			if (progress > 0)
-				l.info(LIFECYCLE, "[{}] {}", (int) progress, message);
+				l.info("[{}] {}", (int) progress, message);
 			else
-				l.info(LIFECYCLE, "{}", message);
+				l.info("{}", message);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/DefaultURLConnectionHandler.java
@@ -1,7 +1,5 @@
 package aQute.bnd.url;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashSet;
@@ -65,7 +63,7 @@ public class DefaultURLConnectionHandler implements URLConnectionHandler, Plugin
 
 	/**
 	 * Convenience method to make it easier to verify connections
-	 * 
+	 *
 	 * @param connection The connection to match
 	 * @return true if this connection should be handled.
 	 */
@@ -142,19 +140,17 @@ public class DefaultURLConnectionHandler implements URLConnectionHandler, Plugin
 	}
 
 	/**
-	 * @deprecated Use SLF4J
-	 *             Logger.info(aQute.libg.slf4j.GradleLogging.LIFECYCLE)
-	 *             instead.
+	 * @deprecated Use SLF4J Logger.info() instead.
 	 */
 	@Override
 	@Deprecated
 	public void progress(float progress, String format, Object... args) {
-		if (logger.isInfoEnabled(LIFECYCLE)) {
+		if (logger.isInfoEnabled()) {
 			String message = Strings.format(format, args);
 			if (progress > 0)
-				logger.info(LIFECYCLE, "[{}] {}", (int) progress, message);
+				logger.info("[{}] {}", (int) progress, message);
 			else
-				logger.info(LIFECYCLE, "{}", message);
+				logger.info("{}", message);
 		}
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/osgi/OSGiIndex.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/osgi/OSGiIndex.java
@@ -1,7 +1,6 @@
 package aQute.bnd.repository.osgi;
 
 import static aQute.lib.promise.PromiseCollectors.toPromise;
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
 import static java.util.stream.Collectors.toList;
 
 import java.io.BufferedInputStream;
@@ -76,7 +75,7 @@ class OSGiIndex {
 
 	/**
 	 * Return the bridge repository in {@link Promise} form.
-	 * 
+	 *
 	 * @return promise representing the repository
 	 */
 	Promise<BridgeRepository> getBridgeRepository() {
@@ -194,7 +193,7 @@ class OSGiIndex {
 				if (retries < 1) {
 					return null; // no recovery
 				}
-				logger.info(LIFECYCLE, "Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
+				logger.info("Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
 					.getMessage(), delay, retries);
 				return success.delay(delay)
 					.flatMap(tag -> get(url, file, remoteDigest, retries - 1,
@@ -212,7 +211,7 @@ class OSGiIndex {
 
 	/**
 	 * Check any of the URL indexes are stale.
-	 * 
+	 *
 	 * @return
 	 * @throws Exception
 	 */

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
@@ -3,7 +3,6 @@ package aQute.bnd.repository.p2.provider;
 import static aQute.bnd.osgi.repository.ResourcesRepository.toResourcesRepository;
 import static aQute.bnd.osgi.resource.ResourceUtils.toVersion;
 import static aQute.lib.promise.PromiseCollectors.toPromise;
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toMap;
 
@@ -194,8 +193,7 @@ class P2Indexer implements Closeable {
 						return rb.build();
 					})
 					.recover(failed -> {
-						logger.info(LIFECYCLE, "{}: Failed to create resource for {}", name, a.uri,
-							failed.getFailure());
+						logger.info("{}: Failed to create resource for {}", name, a.uri, failed.getFailure());
 						return RECOVERY;
 					});
 			})
@@ -218,7 +216,7 @@ class P2Indexer implements Closeable {
 					if (retries < 1) {
 						return null; // no recovery
 					}
-					logger.info(LIFECYCLE, "Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
+					logger.info("Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
 						.getMessage(), delay, retries);
 					return success.delay(delay)
 						.flatMap(tag -> fetch(a, retries - 1, Math.min(delay * 2L, TimeUnit.MINUTES.toMillis(10))));

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
@@ -1,7 +1,5 @@
 package aQute.maven.provider;
 
-import static aQute.libg.slf4j.GradleLogging.LIFECYCLE;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -94,7 +92,7 @@ public class MavenRemoteRepository extends MavenBackingRepository {
 					if (retries < 1) {
 						return null; // no recovery
 					}
-					logger.info(LIFECYCLE, "Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
+					logger.info("Retrying invalid download: {}. delay={}, retries={}", failed.getFailure()
 						.getMessage(), delay, retries);
 					return success.delay(delay)
 						.flatMap(


### PR DESCRIPTION
Primarily this is "Downloading" output. Gradle moved its downloading
messages from LIFECYCLE (a special, output-by-default log level of
Gradle) to INFO. So we do the same to limit chattiness of the build
output. Running gradle with --info will display these download messages.

When not using gradle, this change has no effect.
