### PR TITLE
maven repo: Use sources when specified for javadoc generation

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -70,8 +70,6 @@ class IndexFile {
 	final String[]						multi;
 	final String						source;
 
-	private long						lastModified;
-	private long						last		= 0L;
 	volatile Promise<BridgeRepository>	bridge;
 
 	/*
@@ -179,7 +177,6 @@ class IndexFile {
 	 * @throws Exception
 	 */
 	private synchronized Promise<BridgeRepository> load() throws Exception {
-		lastModified = indexFile.lastModified();
 		Set<Archive> toBeAdded = new HashSet<>();
 
 		if (indexFile.isFile()) {
@@ -335,7 +332,6 @@ class IndexFile {
 				}
 			}
 		}
-		last = System.currentTimeMillis();
 		this.bridge = load();
 		return true;
 	}
@@ -386,8 +382,6 @@ class IndexFile {
 				IO.mkdirs(indexFile.getParentFile());
 			IO.store(f.toString(), indexFile);
 		}
-
-		lastModified = indexFile.lastModified();
 	}
 
 	private Archive toArchive(String s, boolean macro) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.concurrent.ScheduledFuture;
@@ -358,11 +359,22 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 		Attrs javadoc = p.remove("javadoc");
 		if (javadoc != null) {
-			release.javadoc.path = javadoc.get("path");
+			release.javadoc.path = javadoc.remove("path");
 			if (NONE.equals(release.javadoc.path)) {
 				release.javadoc = null;
-			} else
+			} else {
+				String packages = javadoc.remove("packages");
+				if (packages != null) {
+					try {
+						release.javadoc.packages = JavadocPackages.valueOf(packages.toUpperCase(Locale.ROOT));
+					} catch (Exception e) {
+						reporter.warning(
+							"The -maven-release instruction contains unrecognized javadoc packages option: %s",
+							packages);
+					}
+				}
 				release.javadoc.options = javadoc;
+			}
 		}
 
 		Attrs sources = p.remove("sources");

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -201,22 +201,20 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 					releaser.add(binaryArchive, binaryFile);
 
 					if (!isLocal(instructions)) {
-
 						try (Tool tool = new Tool(options.context, binary)) {
+							if (instructions.sources != null) {
+								if (!NONE.equals(instructions.sources.path)) {
+									try (Jar jar = getSources(tool, options.context, instructions.sources.path)) {
+										save(releaser, pom.getRevision(), jar);
+									}
+								}
+							}
 
 							if (instructions.javadoc != null) {
 								if (!NONE.equals(instructions.javadoc.path)) {
 									try (Jar jar = getJavadoc(tool, options.context, instructions.javadoc.path,
 										instructions.javadoc.options,
 										instructions.javadoc.packages == JavadocPackages.EXPORT)) {
-										save(releaser, pom.getRevision(), jar);
-									}
-								}
-							}
-
-							if (instructions.sources != null) {
-								if (!NONE.equals(instructions.sources.path)) {
-									try (Jar jar = getSources(tool, options.context, instructions.sources.path)) {
 										save(releaser, pom.getRevision(), jar);
 									}
 								}
@@ -286,7 +284,9 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 	private Jar getSources(Tool tool, Processor context, String path) throws Exception {
 		Jar jar = toJar(context, path);
-		if (jar == null) {
+		if (jar != null) {
+			tool.setSources(jar);
+		} else {
 			jar = tool.doSource();
 		}
 		jar.ensureManifest();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
@@ -3,6 +3,7 @@ package aQute.bnd.repository.maven.provider;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -52,8 +53,10 @@ public class Tool extends Processor {
 					.substring(OSGI_OPT_SRC.length());
 				File out = IO.getFile(sources, path);
 				IO.mkdirs(out.getParentFile());
-				IO.copy(e.getValue()
-					.openInputStream(), out);
+				try (OutputStream os = IO.outputStream(out)) {
+					e.getValue()
+						.write(os);
+				}
 			}
 		}
 	}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
@@ -139,12 +139,11 @@ public class Tool extends Processor {
 			}
 		}
 
-		StringBuilder sb = new StringBuilder();
-		for (String arg : args) {
-			sb.append(arg);
-			sb.append('\n');
+		try (PrintWriter writer = IO.writer(javadocOptions)) {
+			for (String arg : args) {
+				writer.println(arg);
+			}
 		}
-		IO.store(sb, javadocOptions);
 
 		Command command = new Command();
 		command.add(getProperty("javadoc", "javadoc"));

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Tool.java
@@ -62,6 +62,20 @@ public class Tool extends Processor {
 		}
 	}
 
+	void setSources(Jar sourcesJar) throws Exception {
+		IO.delete(sources);
+		for (Entry<String, Resource> e : sourcesJar.getResources()
+			.entrySet()) {
+			String path = e.getKey();
+			File out = IO.getFile(sources, path);
+			IO.mkdirs(out.getParentFile());
+			try (OutputStream os = IO.outputStream(out)) {
+				e.getValue()
+					.write(os);
+			}
+		}
+	}
+
 	public boolean hasSources() {
 		return sources.isDirectory();
 	}

--- a/biz.aQute.repository/testresources/src/X.java
+++ b/biz.aQute.repository/testresources/src/X.java
@@ -1,0 +1,12 @@
+/**
+ * Some Javadoc!
+ *
+ * @author hargrave
+ */
+public class X {
+
+	/**
+	 * Constructor.
+	 */
+	public X() {}
+}


### PR DESCRIPTION
When the user supplies the sources option to -maven-releasse, use these
sources for the generated javadoc instead of any sources which may be in
the jar.