### PR TITLE
Remove "Downloading" messages from maven build

### DIFF
--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -54,30 +54,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
-					<properties>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-					</properties>
 					<goals>
 						<goal>deploy</goal>
 					</goals>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -84,34 +84,6 @@
 						<scope>runtime</scope>
 					</dependency>
 				</dependencies>
-				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
-					<properties>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-					</properties>
-					<goals>
-						<goal>package</goal>
-					</goals>
-					<scriptVariables>
-						<bndVersion>${project.version}</bndVersion>
-					</scriptVariables>
-				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -76,14 +76,7 @@
 					</dependency>
 				</dependencies>
 				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
 					<preBuildHookScript>setup.groovy</preBuildHookScript>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
 					<scriptVariables>
 						<pluginBasedir>${project.basedir}</pluginBasedir>
 						<pluginBuildDirectory>${project.build.directory}</pluginBuildDirectory>
@@ -92,22 +85,8 @@
 						<jsse.enableSNIExtension>false</jsse.enableSNIExtension>
 						<!-- Used in the "no-dist-mgmt" deploy test -->
 						<altSnapshotDeploymentRepository>LocalSnapshotDeploy::default::file://${project.build.directory}/integration-test/projects/test/localsnapshotdeployrepo</altSnapshotDeploymentRepository>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
 					</properties>
-					<goals>
-						<goal>package</goal>
-					</goals>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -63,38 +63,4 @@
 			<artifactId>biz.aQute.bndlib</artifactId>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-invoker-plugin</artifactId>
-				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
-					<properties>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-					</properties>
-					<goals>
-						<goal>package</goal>
-					</goals>
-				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/maven/bnd-resolver-maven-plugin/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/pom.xml
@@ -85,34 +85,10 @@
 					</dependency>
 				</dependencies>
 				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
 					<properties>
 						<jsse.enableSNIExtension>false</jsse.enableSNIExtension>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
 					</properties>
-					<goals>
-						<goal>package</goal>
-					</goals>
-					<scriptVariables>
-						<bndVersion>${project.version}</bndVersion>
-					</scriptVariables>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-run-maven-plugin/pom.xml
+++ b/maven/bnd-run-maven-plugin/pom.xml
@@ -77,35 +77,11 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-invoker-plugin</artifactId>
 				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
-					<properties>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-					</properties>
 					<goals>
-						<goal>clean</goal>
 						<goal>install</goal>
 						<goal>bnd-run:run</goal>
 					</goals>
-					<scriptVariables>
-						<bndVersion>${project.version}</bndVersion>
-					</scriptVariables>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -85,33 +85,10 @@
 					</dependency>
 				</dependencies>
 				<configuration>
-					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
-					<cloneClean>true</cloneClean>
-					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
-					<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
-					<streamLogs>true</streamLogs>
-					<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
-					<postBuildHookScript>verify.groovy</postBuildHookScript>
-					<properties>
-						<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
-						<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-					</properties>
 					<goals>
 						<goal>integration-test</goal>
 					</goals>
-					<scriptVariables>
-						<bndVersion>${project.version}</bndVersion>
-					</scriptVariables>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>install</goal>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/maven/build.gradle
+++ b/maven/build.gradle
@@ -18,6 +18,7 @@ def deploy = tasks.register('deploy', Exec.class) {
     executable rootProject.file('mvnw')
   }
   args '--batch-mode'
+  args '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
   if (logger.isDebugEnabled()) {
     args '--debug'
   }
@@ -45,6 +46,7 @@ def deployOSSRH = tasks.register('deployOSSRH', Exec.class) {
     executable rootProject.file('mvnw')
   }
   args '--batch-mode'
+  args '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
   if (logger.isDebugEnabled()) {
     args '--debug'
   }
@@ -72,6 +74,7 @@ def deployJFrog = tasks.register('deployJFrog', Exec.class) {
     executable rootProject.file('mvnw')
   }
   args '--batch-mode'
+  args '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
   if (logger.isDebugEnabled()) {
     args '--debug'
   }

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -264,6 +264,7 @@
 						<properties>
 							<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
 							<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+							<org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>warn</org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener>
 						</properties>
 						<scriptVariables>
 							<bndVersion>${project.version}</bndVersion>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -253,6 +253,34 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-invoker-plugin</artifactId>
 					<version>3.2.0</version>
+					<configuration>
+						<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
+						<cloneClean>true</cloneClean>
+						<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
+						<settingsFile>src/test/resources/integration-test/settings.xml</settingsFile>
+						<streamLogs>true</streamLogs>
+						<localRepositoryPath>${project.build.directory}/integration-test/repo</localRepositoryPath>
+						<postBuildHookScript>verify.groovy</postBuildHookScript>
+						<properties>
+							<maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+							<maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+						</properties>
+						<scriptVariables>
+							<bndVersion>${project.version}</bndVersion>
+						</scriptVariables>
+						<goals>
+							<goal>package</goal>
+						</goals>
+					</configuration>
+					<executions>
+						<execution>
+							<id>integration-test</id>
+							<goals>
+								<goal>install</goal>
+								<goal>run</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
Found this nugget <https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output> which explained how to cleanup the build output! Now the CI build output is significantly shorter.