### PR TITLE
3109 modify launcher

### DIFF
--- a/biz.aQute.bndall.tests/keep_notrace.bndrun
+++ b/biz.aQute.bndall.tests/keep_notrace.bndrun
@@ -1,0 +1,9 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=demo)'
+-runfw: org.apache.felix.framework;version='[5.6.10,6)'
+-runee: JavaSE-1.8
+-runbundles: \
+	demo;version=snapshot,\
+	org.apache.servicemix.bundles.junit;version='[4.11.0,5)'
+	
+-runkeep: true
+-runstorage: generated/keepfw

--- a/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
+++ b/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
@@ -15,6 +15,7 @@ public class LauncherConstants {
 	public final static String		DEFAULT_LAUNCHER_PROPERTIES	= "launcher.properties";
 	public final static String		LAUNCHER_ARGUMENTS			= "launcher.arguments";
 	public final static String		LAUNCHER_READY				= "launcher.ready";
+	public final static String		LAUNCH_TRACE				= "launch.trace";
 
 	// MUST BE ALIGNED WITH ProjectLauncher! Do not want to create coupling
 	// so cannot refer.
@@ -37,7 +38,6 @@ public class LauncherConstants {
 	final static String				LAUNCH_RUNBUNDLES			= "launch.bundles";
 	final static String				LAUNCH_SYSTEMPACKAGES		= "launch.system.packages";
 	final static String				LAUNCH_SYSTEMCAPABILITIES	= "launch.system.capabilities";
-	final static String				LAUNCH_TRACE				= "launch.trace";
 	final static String				LAUNCH_TIMEOUT				= "launch.timeout";
 	final static String				LAUNCH_ACTIVATORS			= "launch.activators";
 	final static String				LAUNCH_EMBEDDED				= "launch.embedded";


### PR DESCRIPTION
I may have gone a bit far with the verbose stuff, but It really helped during developement. The new run Method in the Embedded Launcher allows the equinox native executables to trigger the bnd launcher.

- the different ways of intializing that have been spread over the
Constructor and the main method have been moved to init(), run() and
runWithoutInit()
- adds a run method to the EmbeddedLauncher
- the argument -v or -verbose triggers debug logging for the
EmbeddedLauncher and sets the Launcher into trace mode

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>