### PR TITLE
[launchpad] LaunchpadRule to gracefully handle non-creation of Launchpad

### DIFF
--- a/biz.aQute.launchpad/src/aQute/launchpad/junit/LaunchpadRule.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/junit/LaunchpadRule.java
@@ -26,6 +26,9 @@ public class LaunchpadRule extends TestWatcher {
 	@Override
 	protected void finished(Description description) {
 		super.finished(description);
+		if (launchpad == null) {
+			return;
+		}
 		try {
 			this.launchpad.close();
 		} catch (Exception e) {

--- a/biz.aQute.launchpad/test/aQute/launchpad/JunitRuleTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/JunitRuleTest.java
@@ -25,4 +25,8 @@ public class JunitRuleTest {
 			assertThat(fw.getClassName()).isEqualTo(JunitRuleTest.class.getName());
 		}
 	}
+
+	@Test
+	public void whenGetLaunchpadIsNotCalled_thenDontTryToCloseIt() {
+	}
 }


### PR DESCRIPTION
If you have a `LaunchpadRule` attached to your JUnit 4 test class, and you happen to not call `getLaunchpad()` in one of the tests in that class, then you'll get a `NullPointerException` when that test ends.

This PR fixes that problem.