### PR TITLE
[launchpad] BundleSpecBuilder to allow multiple versions of a bundle

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/specifications/BuilderSpecification.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/specifications/BuilderSpecification.java
@@ -27,6 +27,7 @@ public class BuilderSpecification {
 	 */
 	public List<String>						parent				= new ArrayList<>();
 	public List<String>						classpath			= new ArrayList<>();
+	public String							location;
 	public Map<String, Map<String, String>>	bundleSymbolicName	= new LinkedHashMap<>();
 	public String							bundleVersion;
 	public String							bundleActivator;

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -917,11 +917,21 @@ public interface BundleSpecBuilder {
 	}
 
 	default Bundle install() throws Exception {
-		byte[] build = LaunchpadBuilder.workspace.build(LaunchpadBuilder.projectDir.getAbsolutePath(), x().spec);
-		String name = x().spec.bundleSymbolicName.toString();
+		BuilderSpecification spec = x().spec;
+		byte[] build = LaunchpadBuilder.workspace.build(LaunchpadBuilder.projectDir.getAbsolutePath(), spec);
+		String location;
+		if (spec.location == null) {
+			String name = spec.bundleSymbolicName.toString();
+			String version = spec.bundleVersion;
+			version = (version == null) ? "0" : version;
+			location = name + '-' + version;
+		} else {
+			location = spec.location;
+		}
+
 		ByteArrayInputStream bin = new ByteArrayInputStream(build);
 		return x().ws.getBundleContext()
-			.installBundle(name, bin);
+			.installBundle(location, bin);
 	}
 
 	default Bundle start() {
@@ -993,4 +1003,19 @@ public interface BundleSpecBuilder {
 		return this;
 	}
 
+	/**
+	 * Specify the install location of a bundle. This is the value that is
+	 * passed to {@link BundleContext#installBundle(String, InputStream} as the
+	 * location parameter.
+	 * <p>
+	 * If not specified, the location will default to the string
+	 * <tt>bsn-bundleVersion</tt>.
+	 * 
+	 * @param location the location string to use for this bundle.
+	 * @return The builder object for chained invocations.
+	 */
+	default BundleSpecBuilder location(String location) {
+		x().spec.location = location;
+		return this;
+	}
 }


### PR DESCRIPTION
Original implementation used the BSN as the bundle key ("location") when installing the bundle. This means you can't install two bundles in the same Launchpad with the same BSN, even if they have different versions, which means you can't use Launchpad to test the full gamut of OSGi situations.

This patch changes `BundleSpecBuilder` so that it uses BSN + bundle version as the bundle key rather than just the BSN, which allows the Launchpad to install multiple versions of the same bundle with the same BSN.