### PR TITLE
 pom: Use merged properties for -maven-dependencies 

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
@@ -330,7 +330,7 @@ public class PomResource extends WriteResource {
 			processor.warning("POM will not validate on Central due to missing Bundle-Developers header");
 		}
 
-		Parameters dependencies = new Parameters(processor.getProperty(Constants.MAVEN_DEPENDENCIES), processor);
+		Parameters dependencies = processor.getMergedParameters(Constants.MAVEN_DEPENDENCIES);
 		if (!dependencies.isEmpty()) {
 			Tag tdependencies = new Tag("dependencies");
 			dependencies.values()

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -1005,8 +1005,8 @@ public interface BundleSpecBuilder {
 
 	/**
 	 * Specify the install location of a bundle. This is the value that is
-	 * passed to {@link BundleContext#installBundle(String, InputStream} as the
-	 * location parameter.
+	 * passed to {@Link BundleContext#installBundle(String,
+	 * java.io.InputStream)} as the location parameter.
 	 * <p>
 	 * If not specified, the location will default to the string
 	 * <tt>bsn-bundleVersion</tt>.


### PR DESCRIPTION
This allows additional maven dependencies to be specified in the bnd
file to supplement any dependencies computed from the -buildpath.