### PR TITLE
[component] Random DS schema version generation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -69,11 +69,11 @@ public class DSAnnotationReader extends ClassDataCollector {
 	private static final Logger					logger						= LoggerFactory
 		.getLogger(DSAnnotationReader.class);
 
-	public static final Version					V1_0						= new Version("1.0.0");			// "1.0.0"
-	public static final Version					V1_1						= new Version("1.1.0");			// "1.1.0"
-	public static final Version					V1_2						= new Version("1.2.0");			// "1.2.0"
-	public static final Version					V1_3						= new Version("1.3.0");			// "1.3.0"
-	public static final Version					V1_4						= new Version("1.4.0");			// "1.3.0"
+	public static final Version					V1_0						= new Version("1.0.0");
+	public static final Version					V1_1						= new Version("1.1.0");
+	public static final Version					V1_2						= new Version("1.2.0");
+	public static final Version					V1_3						= new Version("1.3.0");
+	public static final Version					V1_4						= new Version("1.4.0");
 	public static final Version					VMAX						= new Version("2.0.0");
 
 	private static final Pattern				BINDNAME					= Pattern


### PR DESCRIPTION
The DSAnnotations analyzer plugin is a singleton in bnd. However, the min (and later max versions) were kept as instance variables. If the build is ran in parallel then I suspect this caused problems. 

Moved the min/max version to a Version Settings object that is a local parameter and therefore not prone to parallel builds.

bnd is not designed to be used in parallel builds but I suspect when it happens we have a lock. Need to look how this works later.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>