### PR TITLE
[bndrun] Order the bundles of a resolution in dependency order

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -648,6 +648,9 @@ public class Syntax implements Constants {
 			RUNJDB + ": 10001", null, null),
 		new Syntax(RUNKEEP, "Decides to keep the framework storage directory between launching.", RUNKEEP + ": true",
 			"true,false", Verifier.TRUEORFALSEPATTERN),
+		new Syntax(RUNORDER, "After a resolver order the " + RUNBUNDLES
+			+ " by their wiring dependencies. That is, general utilities are started before application code and likely the application last. If not set or false, the order is random",
+			RUNORDER + "=true", null, Verifier.BOOLEANPATTERN),
 		new Syntax(RUNPATH, "Additional JARs for the VM path, can include a framework",
 			RUNPATH + "=org.eclipse.osgi;version=3.5", null, null, path_version),
 		new Syntax(RUNNOREFERENCES,

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -204,6 +204,7 @@ public interface Constants {
 	String								RUNSYSTEMPACKAGES							= "-runsystempackages";
 	String								RUNSYSTEMCAPABILITIES						= "-runsystemcapabilities";
 	String								RUNPROVIDEDCAPABILITIES						= "-runprovidedcapabilities";
+	String								RUNORDER									= "-runorder";
 
 	String								RUNBUNDLES									= "-runbundles";
 	String								AUGMENT										= "-augment";
@@ -281,7 +282,7 @@ public interface Constants {
 		JAVA_DEBUG, EXPORTTYPE, RUNREMOTE, TESTER, AUGMENT, REQUIRE_BND, GROUPID, STANDALONE, IGNORE_STANDALONE,
 		RUNREPOS, INIT, MAVEN_RELEASE, BUILDREPO, CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE,
 		REPRODUCIBLE, INCLUDEPACKAGE, CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK,
-		MAVEN_SCOPE
+		MAVEN_SCOPE, RUNORDER
 
 	};
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/packageinfo
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0


### PR DESCRIPTION
Although OSGi does not have ordering because you can
dynamically install/uninstall bundles this patch orders
the -runbundles out of a resolution by looking at their dependencies.
If a bundle depends on another bundle then it is tried to start
after it. If there are circular dependencies then of course
this not work well.

To activate:

   -runorder true

If not set we get a more or less random order

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>