### PR TITLE
[httpclient] Report failing to parse settings

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/CommunicationCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/CommunicationCommands.java
@@ -38,7 +38,11 @@ public class CommunicationCommands extends Processor {
 		this.options = options;
 		this.workspace = bnd.getWorkspace((String) null);
 		this.httpClient = workspace.getPlugin(HttpClient.class);
-		this.cache = httpClient.cache();
+		if (this.httpClient == null) {
+			error("No http client");
+			this.cache = null;
+		} else
+			this.cache = httpClient.cache();
 	}
 
 	@Arguments(arg = "url...")

--- a/biz.aQute.bnd/src/aQute/bnd/main/GraphCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/GraphCommand.java
@@ -34,7 +34,7 @@ public class GraphCommand implements AutoCloseable {
 	GraphCommand(bnd bnd, GraphOptions options) throws Exception {
 		this.bnd = bnd;
 		this.options = options;
-		this.workspace = bnd.getWorkspace((String) null);
+		this.workspace = bnd.getWorkspace();
 	}
 
 	@Description("Find the roots in a set of bundles. A root is a resource that is present but not dependent on by any other resource in the set")

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -462,6 +462,8 @@ public class bnd extends Processor {
 		err.flush();
 		if (ws != null)
 			getInfo(ws);
+		if (workspace != null)
+			getInfo(workspace);
 
 		if (!check(options.ignore())) {
 			err.flush();
@@ -3929,6 +3931,7 @@ public class bnd extends Processor {
 
 			out.printf("%03d %s%n", n++, s);
 		}
+		getInfo(ws);
 
 	}
 
@@ -3974,7 +3977,7 @@ public class bnd extends Processor {
 		}
 
 		out.println(justif.wrap());
-
+		getInfo(ws);
 	}
 
 	/**
@@ -4714,12 +4717,18 @@ public class bnd extends Processor {
 	@Description("Commands to verify the bnd communications setup")
 	public void _com(CommunicationCommands.CommunicationOptions options) throws Exception {
 		try (CommunicationCommands cc = new CommunicationCommands(this, options)) {
-			String help = options._command()
-				.subCmd(options, cc);
-			if (help != null)
-				out.println(help);
+			if (cc.isOk() && isWorkspaceOk()) {
+				String help = options._command()
+					.subCmd(options, cc);
+				if (help != null)
+					out.println(help);
+			}
 			getInfo(cc);
 		}
+	}
+
+	private boolean isWorkspaceOk() {
+		return ws == null || ws.isOk();
 	}
 
 	@Description("Commands to inspect a dependency graph of a set of bundles")

--- a/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/invalid.xml
+++ b/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/invalid.xml
@@ -1,0 +1,9 @@
+
+<settings >
+	<servers>
+		<server>
+			<id>httpbin.org</id>
+			<username>user</username>
+			<password>passwd</password>
+		</server>
+</settings>

--- a/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/valid.xml
+++ b/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/valid.xml
@@ -1,0 +1,21 @@
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<localRepository />
+	<interactiveMode />
+	<usePluginRegistry />
+	<offline />
+	<pluginGroups />
+	<servers>
+		<server>
+			<id>http://httpbin.org</id>
+			<username>user</username>
+			<password>passwd</password>
+		</server>
+	</servers>
+	<mirrors />
+	<profiles />
+	<activeProfiles />
+</settings>

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -112,9 +112,10 @@ public class Workspace extends Processor {
 	private final static Map<File, WeakReference<Workspace>>	cache				= newHashMap();
 	static Processor											defaults			= null;
 	final Map<String, Action>									commands			= newMap();
-	final Maven													maven			= new Maven(Processor.getExecutor());
+	final Maven													maven				= new Maven(
+		Processor.getExecutor());
 	private final AtomicBoolean									offline				= new AtomicBoolean();
-	Settings													settings		= new Settings(
+	Settings													settings			= new Settings(
 		Home.getUserHomeBnd() + "/settings.json");
 	WorkspaceRepository											workspaceRepo		= new WorkspaceRepository(this);
 	static String												overallDriver		= "unset";
@@ -620,16 +621,16 @@ public class Workspace extends Processor {
 			list.add(new ExecutableJarExporter());
 			list.add(new RunbundlesExporter());
 
+			HttpClient client = new HttpClient();
 			try {
-				HttpClient client = new HttpClient();
 				client.setOffline(getOffline());
 				client.setRegistry(this);
 				client.readSettings(this);
 
-				list.add(client);
 			} catch (Exception e) {
 				exception(e, "Failed to load the communication settings");
 			}
+			list.add(client);
 
 		} catch (RuntimeException e) {
 			throw e;

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXParseException;
 
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
@@ -418,42 +419,45 @@ public class ConnectionSettings {
 	}
 
 	private void parse(File file) throws Exception {
-		assert file != null : "File must be set";
-		assert file.isFile() : "File must be a file and exist";
-		parsed.add(file.getAbsolutePath());
-		SettingsParser parser = new SettingsParser(file);
+		try {
+			assert file != null : "File must be set";
+			assert file.isFile() : "File must be a file and exist";
+			parsed.add(file.getAbsolutePath());
+			SettingsParser parser = new SettingsParser(file);
 
-		SettingsDTO settings = parser.getSettings();
-		for (ProxyDTO proxyDTO : settings.proxies) {
-			if (isActive(proxyDTO)) {
+			SettingsDTO settings = parser.getSettings();
+			for (ProxyDTO proxyDTO : settings.proxies) {
+				if (isActive(proxyDTO)) {
 
-				add(proxyDTO);
-			}
-		}
-		ServerDTO deflt = null;
-		for (ServerDTO serverDTO : settings.servers) {
-			serverDTO.trust = makeAbsolute(file.getParentFile(), serverDTO.trust);
-
-			if (MavenPasswordObfuscator.isObfuscatedPassword(serverDTO.password)) {
-				String masterPassphrase = mavenMasterPassphrase.get();
-				if (masterPassphrase != null) {
-					try {
-						serverDTO.password = MavenPasswordObfuscator.decrypt(serverDTO.password, masterPassphrase);
-					} catch (Exception e) {
-						processor.exception(e, "Could not decrypt the password for server %s", serverDTO.id);
-					}
+					add(proxyDTO);
 				}
 			}
-			if ("default".equals(serverDTO.id))
-				deflt = serverDTO;
-			else {
-				add(serverDTO);
+			ServerDTO deflt = null;
+			for (ServerDTO serverDTO : settings.servers) {
+				serverDTO.trust = makeAbsolute(file.getParentFile(), serverDTO.trust);
+
+				if (MavenPasswordObfuscator.isObfuscatedPassword(serverDTO.password)) {
+					String masterPassphrase = mavenMasterPassphrase.get();
+					if (masterPassphrase != null) {
+						try {
+							serverDTO.password = MavenPasswordObfuscator.decrypt(serverDTO.password, masterPassphrase);
+						} catch (Exception e) {
+							processor.exception(e, "Could not decrypt the password for server %s", serverDTO.id);
+						}
+					}
+				}
+				if ("default".equals(serverDTO.id))
+					deflt = serverDTO;
+				else {
+					add(serverDTO);
+				}
 			}
+
+			if (deflt != null)
+				add(deflt);
+		} catch (SAXParseException e) {
+			processor.error("Invalid XML in connection settings for file : %s: %s", file, e.getMessage());
 		}
-
-		if (deflt != null)
-			add(deflt);
-
 	}
 
 	final static String	IPNR_PART_S	= "([01]\\d\\d)|(2[0-4]\\d)|(25[0-5])";


### PR DESCRIPTION
Parsing an invalid XML file caused an NPE

This patch ensures there is always an Http Client
even if the parse fails. The error is now better
reported on the workspace.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>