### PR TITLE
[launchpad]

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2458,8 +2458,9 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 
 	@Override
 	public Location getLocation(String msg) {
+		assert msg != null : "Must provide message";
 		for (Location l : locations)
-			if ((l.message != null) && l.message.equals(msg))
+			if ((l.message != null) && msg.equals(l.message))
 				return l;
 
 		return null;

--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -742,7 +742,6 @@ public class Launchpad implements AutoCloseable {
 			fw.resolveBundles(toBeStarted);
 
 			Collections.sort(toBeStarted, this::startorder);
-			toBeStarted.forEach(this::start);
 
 			if (hasTestBundle)
 				testbundle();

--- a/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
@@ -262,12 +262,10 @@ public class LaunchpadBuilder implements AutoCloseable {
 			@SuppressWarnings("resource")
 			Launchpad launchpad = new Launchpad(framework, name, className, runspec, closeTimeout, debug, testbundle);
 
-			launchpad.report("Extra system packages %s", local.extraSystemPackages.keySet()
-				.stream()
-				.collect(Collectors.joining("\n")));
-			launchpad.report("Extra system capabilities %s", local.extraSystemCapabilities.keySet()
-				.stream()
-				.collect(Collectors.joining("\n")));
+			launchpad.report("ALL extra system packages\n     %s", toLines(local.extraSystemPackages.keySet()));
+			launchpad.report("Filtered extra system packages\n     %s", toLines(restrictedExports.keySet()));
+			launchpad.report("ALL extra system capabilities\n     %s", toLines(local.extraSystemCapabilities.keySet()));
+
 			launchpad.report("Storage %s", storage.getAbsolutePath());
 			launchpad.report("Runpath %s", local.runpath);
 
@@ -280,6 +278,12 @@ public class LaunchpadBuilder implements AutoCloseable {
 		} catch (Exception e) {
 			throw Exceptions.duck(e);
 		}
+	}
+
+	private String toLines(Collection<String> set) {
+		return set.stream()
+			.sorted()
+			.collect(Collectors.joining("\n     "));
 	}
 
 	// private Map<String, Map<String, String>> addUses(Map<String, Map<String,

--- a/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
@@ -143,6 +143,7 @@ public class LaunchpadTest {
 	public void testBundleActivatorCalled() throws Exception {
 
 		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+			.debug()
 			.create()) {
 
 			Bundle x = fw.bundle()
@@ -454,7 +455,7 @@ public class LaunchpadTest {
 							.create("foo", "bar");
 						l.add(fw);
 						Bundle bundle = fw.component(ExternalRefComp.class);
-						int sleep = Math.abs(r.nextInt() % 100) + 1;
+						int sleep = Math.abs(r.nextInt() % 100) + 30;
 						System.out.println(
 							fw.runspec.properties.get(org.osgi.framework.Constants.FRAMEWORK_STORAGE) + " " + sleep);
 						Thread.sleep(sleep);


### PR DESCRIPTION
Debug mode in launchpad builder now shows filter and all extra packages
Increase time out for stress test in launchpad

Fixes #3226

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>