### PR TITLE
[workingsets] Ignore workings with non-java-id name

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/WorkingSetTracker.java
+++ b/bndtools.builder/src/org/bndtools/builder/WorkingSetTracker.java
@@ -15,6 +15,7 @@ import org.eclipse.ui.PlatformUI;
 import aQute.bnd.build.Project;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
 import aQute.lib.collections.ExtList;
 import aQute.service.reporter.Reporter.SetLocation;
@@ -39,7 +40,7 @@ public class WorkingSetTracker {
         IWorkbench workbench = PlatformUI.getWorkbench();
         final IWorkingSetManager workingSetManager = workbench.getWorkingSetManager();
 
-        String mergeProperties = model.mergeProperties("-workingset");
+        String mergeProperties = model.mergeProperties(Constants.WORKINGSET);
         if (mergeProperties == null)
             return;
 
@@ -47,6 +48,10 @@ public class WorkingSetTracker {
         IWorkingSet[] allWorkingSets = workingSetManager.getAllWorkingSets();
 
         for (IWorkingSet currentWorkingSet : allWorkingSets) {
+
+            if (!JAVAID_P.matcher(currentWorkingSet.getName())
+                .matches())
+                continue;
 
             Attrs attrs = memberShips.remove(currentWorkingSet.getName());
             boolean shouldBeMember = attrs != null && Processor.isTrue(attrs.get("member", "true"));

--- a/docs/_instructions/workingset.md
+++ b/docs/_instructions/workingset.md
@@ -35,3 +35,11 @@ As you could see in the syntax, you can also specify a `member` attribute on the
       test;member=${filter;${p};.*\.test}
 
 The feature will create working sets as demanded but will reuse existing working set with the matching name. If no `-workingset` instruction is given, the working sets are not touched in any way for that project. That is, they are then not removed from existing sets.
+
+## Manual Workingsets
+
+In some cases it is necessary to maintain a working set manual. Such a workingset is then stored in Eclipse and not shared with the team. To
+create a manual working set, use a name that is outside the specified NAME pattern. For example, use a name that starts with a 
+dot (`.`) like `.Private`. Since you cannot use these names in the `-workingset` instruction (they generate an error)
+bnd will never look at workingsets with such a name.
+


### PR DESCRIPTION
Some people want to maintain private working sets but
bnd would remove a project from a working set if
the -workingset was used in a project.

This change makes bnd ignore working sets that do
not follow the required naming pattern. Using such
a pattern for a workings therefore implies that the
user is on its own.

For example, a .Private working set will never be 
touched by bnd.

Fixes #3207

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>