### PR TITLE
Don't process SignatureAttribute on synthetic elements in class files

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -309,7 +309,7 @@ public class Clazz {
 		}
 
 		public boolean isSynthetic() {
-			return (access & ACC_SYNTHETIC) != 0;
+			return Clazz.isSynthetic(access);
 		}
 
 		public boolean isModule() {
@@ -1830,6 +1830,10 @@ public class Clazz {
 
 	public boolean isSynthetic() {
 		return classDef.isSynthetic();
+	}
+
+	static boolean isSynthetic(int access) {
+		return (access & ACC_SYNTHETIC) != 0;
 	}
 
 	public boolean isModule() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -1099,6 +1099,9 @@ public class Clazz {
 	}
 
 	private void processSignature(SignatureAttribute attribute, ElementType elementType, int access_flags) {
+		if (isSynthetic(access_flags)) {
+			return; // Ignore generic signatures on synthetic elements
+		}
 		String signature = attribute.signature;
 		Signature sig;
 		switch (elementType) {


### PR DESCRIPTION
ECJ can generate invalid signatures in SignatureAttributes on synthetic methods. See #3239. To avoid failing to process the class, we don't process SignatureAttributes on synthetic elements.
