### PR TITLE
[maven] custom scope for distros

### DIFF
--- a/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/Scope.java
+++ b/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/Scope.java
@@ -5,5 +5,10 @@ public enum Scope {
 	provided,
 	runtime,
 	system,
-	test;
+	test,
+
+	/**
+	 * Custom scope for isolating bnd distro artifacts
+	 */
+	distro;
 }


### PR DESCRIPTION
Maven allows custom scopes. However since bnd's maven support tries to validate a fixed set I'm proposing to add this non-standard one in order to at least have a bucket to put things in. This has no other effect beyond allowing the `bnd-*-maven-plugin`  `<scopes>` configuration to include, and search this custom scope.