### PR TITLE
[launchpad] Add ability to specify a root classloader

### DIFF
--- a/biz.aQute.launchpad/bnd.bnd
+++ b/biz.aQute.launchpad/bnd.bnd
@@ -39,6 +39,7 @@ Import-Package: \
     
 
 -testpath: \
+    ${mockito}, \
     biz.aQute.repository, \
     slf4j.simple;version=latest, \
     slf4j.api

--- a/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/LaunchpadBuilder.java
@@ -90,6 +90,7 @@ public class LaunchpadBuilder implements AutoCloseable {
 	final Set<Class<?>>				hide			= new HashSet<>();
 	final List<Predicate<String>>	excludeExports	= new ArrayList<>();
 	final List<String>				exports			= new ArrayList<>();
+	ClassLoader						myClassLoader;
 
 	/**
 	 * Start a framework assuming the current working directory is the project
@@ -190,6 +191,11 @@ public class LaunchpadBuilder implements AutoCloseable {
 
 	public LaunchpadBuilder closeTimeout(long ms) {
 		this.closeTimeout = ms;
+		return this;
+	}
+
+	public LaunchpadBuilder usingClassLoader(ClassLoader loader) {
+		this.myClassLoader = loader;
 		return this;
 	}
 
@@ -372,7 +378,7 @@ public class LaunchpadBuilder implements AutoCloseable {
 	}
 
 	private ClassLoader getMyClassLoader() {
-		return LaunchpadBuilder.class.getClassLoader();
+		return myClassLoader == null ? LaunchpadBuilder.class.getClassLoader() : myClassLoader;
 	}
 
 	private URL toURL(File file) {


### PR DESCRIPTION
This is a simple patch to allow you to override the object returned by `LaunchpadBuilder.getMyClassLoader()`.

I had a use case where it was not sufficient for me to simply hide a package by excluding it from `-runsystempackages` - this makes the package invisible to all bundles except the system bundle. I needed a way to hide a class/package from the system bundle as well. This feature allows me to achieve this by interposing a custom excluding classloader between the framework and LaunchpadBuilder's own classloader.