### PR TITLE
metatype: Avoid instance variable for parallelism

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
@@ -75,7 +75,7 @@ public class DSAnnotations implements AnalyzerPlugin {
 
 		}
 
-		static void parseOption(Map.Entry<String, Attrs> entry, EnumSet<Options> options, VersionSettings state) {
+		static void parseOption(Map.Entry<String, Attrs> entry, Set<Options> options, VersionSettings state) {
 			String s = entry.getKey();
 			boolean negation = false;
 			if (s.startsWith("!")) {
@@ -113,7 +113,7 @@ public class DSAnnotations implements AnalyzerPlugin {
 		}
 
 		Parameters optionsHeader = OSGiHeader.parseHeader(analyzer.mergeProperties(Constants.DSANNOTATIONS_OPTIONS));
-		EnumSet<Options> options = EnumSet.noneOf(Options.class);
+		Set<Options> options = EnumSet.noneOf(Options.class);
 		for (Map.Entry<String, Attrs> entry : optionsHeader.entrySet()) {
 			try {
 				Options.parseOption(entry, options, settings);

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/MetatypeAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/MetatypeAnnotations.java
@@ -55,7 +55,7 @@ public class MetatypeAnnotations implements AnalyzerPlugin {
 
 		}
 
-		static void parseOption(Map.Entry<String, Attrs> entry, EnumSet<Options> options, VersionSettings state) {
+		static void parseOption(Map.Entry<String, Attrs> entry, Set<Options> options, VersionSettings state) {
 			String s = entry.getKey();
 			boolean negation = false;
 			if (s.startsWith("!")) {
@@ -90,7 +90,7 @@ public class MetatypeAnnotations implements AnalyzerPlugin {
 			return false;
 
 		Parameters optionsHeader = OSGiHeader.parseHeader(analyzer.getProperty(Constants.METATYPE_ANNOTATIONS_OPTIONS));
-		EnumSet<Options> options = EnumSet.noneOf(Options.class);
+		Set<Options> options = EnumSet.noneOf(Options.class);
 		for (Map.Entry<String, Attrs> entry : optionsHeader.entrySet()) {
 			try {
 				Options.parseOption(entry, options, settings);

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/OCDReader.java
@@ -3,7 +3,6 @@ package aQute.bnd.metatype;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,12 +32,12 @@ import aQute.bnd.xmlattribute.XMLAttributeFinder;
 class OCDReader {
 	final Analyzer				analyzer;
 	private final Clazz			clazz;
-	final EnumSet<Options>		options;
+	final Set<Options>			options;
 	private final Set<TypeRef>	analyzed	= new HashSet<>();;
 	private final OCDDef		ocd;
 	final XMLAttributeFinder	finder;
 
-	private OCDReader(Analyzer analyzer, Clazz clazz, EnumSet<Options> options, XMLAttributeFinder finder,
+	private OCDReader(Analyzer analyzer, Clazz clazz, Set<Options> options, XMLAttributeFinder finder,
 		MetatypeVersion minVersion) {
 		this.analyzer = analyzer;
 		this.clazz = clazz;
@@ -47,7 +46,7 @@ class OCDReader {
 		this.ocd = new OCDDef(finder, minVersion);
 	}
 
-	static OCDDef getOCDDef(Clazz c, Analyzer analyzer, EnumSet<Options> options, XMLAttributeFinder finder,
+	static OCDDef getOCDDef(Clazz c, Analyzer analyzer, Set<Options> options, XMLAttributeFinder finder,
 		MetatypeVersion minVersion) throws Exception {
 		OCDReader r = new OCDReader(analyzer, c, options, finder, minVersion);
 		return r.getDef();


### PR DESCRIPTION
Since the plugin instance is a singleton, we must avoid instance
variables that mutate for each invocation.

See #3209