### PR TITLE
[launcher] Moved to 4.2 and changed startlevel handling

### DIFF
--- a/biz.aQute.bndall.tests/order-01.bndrun
+++ b/biz.aQute.bndall.tests/order-01.bndrun
@@ -1,0 +1,13 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=demo)'
+-runfw: org.apache.felix.framework;version='[5.6.10,6)'
+-runee: JavaSE-1.8
+-runbundles: \
+    org.apache.felix.log, \
+    demo;version=snapshot;startlevel=10,\
+    org.apache.servicemix.bundles.junit;version='[4.11.0,5)';startlevel=20, \
+    org.apache.felix.scr, \
+    org.apache.felix.configadmin;startlevel=5, \
+    org.apache.felix.inventory
+    
+    
+-runtrace: true

--- a/biz.aQute.bndall.tests/order-02.bndrun
+++ b/biz.aQute.bndall.tests/order-02.bndrun
@@ -1,0 +1,17 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=demo)'
+-runfw: org.apache.felix.framework;version='[5.6.10,6)'
+-runee: JavaSE-1.8
+-runbundles: \
+    org.apache.felix.log, \
+    demo;version=snapshot,\
+    org.apache.servicemix.bundles.junit;version='[4.11.0,5)', \
+    org.apache.felix.scr, \
+    org.apache.felix.configadmin, \
+    org.apache.felix.inventory
+
+-runbundles+: \
+    demo;startlevel=11,\
+    org.apache.servicemix.bundles.junit;startlevel=21, \
+    org.apache.felix.configadmin;startlevel=6
+    
+-runtrace: true

--- a/biz.aQute.bndall.tests/order-03.bndrun
+++ b/biz.aQute.bndall.tests/order-03.bndrun
@@ -1,0 +1,21 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=demo)'
+-runfw: org.apache.felix.framework;version='[5.6.10,6)'
+-runee: JavaSE-1.8
+-runbundles: \
+    org.apache.felix.log, \
+    demo;version=snapshot,\
+    org.apache.servicemix.bundles.junit;version='[4.11.0,5)', \
+    org.apache.felix.scr, \
+    org.apache.felix.configadmin, \
+    org.apache.felix.inventory
+    
+-runbundles+: \
+    demo;startlevel=11,\
+    org.apache.servicemix.bundles.junit;startlevel=21, \
+    org.apache.felix.configadmin;startlevel=6
+    
+-runtrace: true
+
+-runproperties: \
+    org.osgi.framework.startlevel.beginning=12
+

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/LauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/LauncherTest.java
@@ -1,5 +1,6 @@
 package biz.aQute.launcher;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +39,58 @@ public class LauncherTest {
 	public void after() {
 		System.getProperties()
 			.remove("launch.trace");
+	}
+
+	@Test
+	public void testRunOrder_1_basic() throws Exception {
+		File file = buildPackage("order-01.bndrun");
+
+		System.setProperty("test.cmd", "quit.no.exit");
+
+		String result = runFramework(file);
+
+		System.out.println(result);
+		assertThat(result).containsPattern("Startlevel\\s+21");
+		assertThat(result).containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle");
+		assertThat(result).containsPattern("21\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.log");
+		assertThat(result).containsPattern("10\\s+ACTIV\\s+<>\\s+jar/.?demo.jar");
+		assertThat(result).containsPattern("20\\s+ACTIV\\s+<>\\s+jar/.?org.apache.servicemix.bundles.junit");
+		assertThat(result).containsPattern("5\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.configadmin");
+	}
+
+	@Test
+	public void testRunOrder_2_decorations() throws Exception {
+		File file = buildPackage("order-02.bndrun");
+
+		System.setProperty("test.cmd", "quit.no.exit");
+
+		String result = runFramework(file);
+
+		System.out.println(result);
+		assertThat(result).containsPattern("Startlevel\\s+22");
+		assertThat(result).containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle");
+		assertThat(result).containsPattern("22\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.log");
+		assertThat(result).containsPattern("11\\s+ACTIV\\s+<>\\s+jar/.?demo.jar");
+		assertThat(result).containsPattern("21\\s+ACTIV\\s+<>\\s+jar/.?org.apache.servicemix.bundles.junit");
+		assertThat(result).containsPattern("6\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.configadmin");
+	}
+
+	@Test
+	public void testRunOrder_3_manual_beginning_level() throws Exception {
+		File file = buildPackage("order-03.bndrun");
+
+
+		System.setProperty("test.cmd", "quit.no.exit");
+
+		String result = runFramework(file);
+
+		System.out.println(result);
+		assertThat(result).containsPattern("Startlevel\\s+12");
+		assertThat(result).containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle");
+		assertThat(result).containsPattern("22\\s+RSLVD\\s+<>\\s+jar/.?org.apache.felix.log");
+		assertThat(result).containsPattern("11\\s+ACTIV\\s+<>\\s+jar/.?demo.jar");
+		assertThat(result).containsPattern("21\\s+RSLVD\\s+<>\\s+jar/.?org.apache.servicemix.bundles.junit");
+		assertThat(result).containsPattern("6\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.configadmin");
 	}
 
 	@Test
@@ -110,29 +163,6 @@ public class LauncherTest {
 	@Test
 	public void testEmbeddedLauncherTrace() throws Exception {
 		File file = buildPackage("keep_notrace.bndrun");
-
-		System.setProperty("test.cmd", "quit.no.exit");
-		File fwdir = IO.getFile(base, "generated/keepfw");
-		IO.delete(fwdir);
-
-		assertTrue(file.isFile());
-
-		System.setProperty("launch.trace", "true");
-
-		String result = runFrameworkWithRunMethod(file);
-		assertTrue(result.contains("installing jar/demo.jar"));
-
-		assertTrue(result.contains("[EmbeddedLauncher] looking for META-INF/MANIFEST.MF"));
-	}
-
-	/**
-	 * Tests the EmbeddedLauncher withstartlevels
-	 * 
-	 * @throws Exception
-	 */
-	@Test
-	public void testEmbeddedStartlevels() throws Exception {
-		File file = buildPackage("startlevels.bndrun");
 
 		System.setProperty("test.cmd", "quit.no.exit");
 		File fwdir = IO.getFile(base, "generated/keepfw");

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -4,8 +4,7 @@
 -maven-scope: provided
 
 -buildpath: \
-	osgi.core;version=@4,\
-	osgi.cmpn;version=@4,\
+	osgi.core;version=@6,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
     ${junit}

--- a/biz.aQute.junit/src/aQute/junit/runtime/OSGiTestCase.java
+++ b/biz.aQute.junit/src/aQute/junit/runtime/OSGiTestCase.java
@@ -53,7 +53,7 @@ public abstract class OSGiTestCase extends TestCase {
 	 */
 	protected void assertSvcAvail(String message, Class<?> service, String filter) {
 		BundleContext context = getBundleContext();
-		ServiceReference[] refs = null;
+		ServiceReference<?>[] refs = null;
 		try {
 			refs = context.getServiceReferences(service.getName(), filter);
 		} catch (InvalidSyntaxException e) {
@@ -141,18 +141,18 @@ public abstract class OSGiTestCase extends TestCase {
 		throws Exception {
 		BundleContext context = getBundleContext();
 
-		ServiceTracker tracker = null;
+		ServiceTracker<S, R> tracker = null;
 		if (filter != null) {
 			try {
 				Filter combined = FrameworkUtil
 					.createFilter("(" + Constants.OBJECTCLASS + "=" + service.getName() + ")");
-				tracker = new ServiceTracker(context, combined, null);
+				tracker = new ServiceTracker<>(context, combined, null);
 			} catch (InvalidSyntaxException e) {
 				fail("Invalid filter syntax.");
 				return null;
 			}
 		} else {
-			tracker = new ServiceTracker(context, service.getName(), null);
+			tracker = new ServiceTracker<>(context, service.getName(), null);
 		}
 		try {
 			tracker.open();

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -71,12 +71,13 @@ import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.FrameworkListener;
 import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceListener;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
-import org.osgi.service.packageadmin.PackageAdmin;
+import org.osgi.framework.startlevel.BundleStartLevel;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.FrameworkWiring;
 import org.osgi.service.permissionadmin.PermissionInfo;
-import org.osgi.service.startlevel.StartLevel;
 
 import aQute.launcher.agent.LauncherAgent;
 import aQute.launcher.constants.LauncherConstants;
@@ -92,31 +93,25 @@ import aQute.lib.strings.Strings;
  */
 public class Launcher implements ServiceListener {
 
-	private static final String				BND_LAUNCHER						= ".bnd.launcher";
-
-	// Use our own constant for this rather than depend on OSGi core 4.3
-	private static final String				FRAMEWORK_SYSTEM_CAPABILITIES_EXTRA	= "org.osgi.framework.system.capabilities.extra";
+	private static final String				BND_LAUNCHER		= ".bnd.launcher";
 
 	private PrintStream						out;
 	LauncherConstants						parms;
 	Framework								systemBundle;
-	volatile boolean						inrefresh;
+	FrameworkStartLevel						frameworkStartLevel;
+	FrameworkWiring							frameworkWiring;
 	private final Properties				properties;
 	private boolean							security;
 	private SimplePermissionPolicy			policy;
 	private Callable<Integer>				mainThread;
-	private final List<BundleActivator>		embedded							= new ArrayList<>();
-	private final Map<Bundle, Throwable>	errors								= new HashMap<>();
-	private final Map<File, Bundle>			installedBundles					= new LinkedHashMap<>();
-	private final Map<Bundle, Integer>		startLevels							= new LinkedHashMap<>();
-	private File							home								= new File(
-		System.getProperty("user.home"));
-	private File							bnd									= new File(home, "bnd");
-	private List<Bundle>					wantsToBeStarted					= new ArrayList<>();
-	AtomicBoolean							active								= new AtomicBoolean();
-	private AtomicReference<DatagramSocket>	commsSocket							= new AtomicReference<>();
-	private PackageAdmin					padmin;
-	private StartLevel						sadmin;
+	private final List<BundleActivator>		embedded			= new ArrayList<>();
+	private final Map<Bundle, Throwable>	errors				= new HashMap<>();
+	private final Map<File, Bundle>			installedBundles	= new LinkedHashMap<>();
+	private File							home				= new File(System.getProperty("user.home"));
+	private File							bnd					= new File(home, "bnd");
+	private List<Bundle>					wantsToBeStarted	= new ArrayList<>();
+	AtomicBoolean							active				= new AtomicBoolean();
+	private AtomicReference<DatagramSocket>	commsSocket			= new AtomicReference<>();
 	private int								maxStartLevel;
 
 	public static void main(String[] args) {
@@ -278,7 +273,6 @@ public class Launcher implements ServiceListener {
 							setParameters(properties);
 							List<Bundle> tobestarted = update(now);
 							startBundles(tobestarted);
-							setStartLevel();
 						} catch (Exception e) {
 							error("Error in updating the framework from the properties: %s", e);
 						}
@@ -372,7 +366,6 @@ public class Launcher implements ServiceListener {
 				trace("requested to register no services");
 			}
 
-
 			// Wait until a Runnable is registered with main.thread=true.
 			// not that this will never happen when we're running on the mini fw
 			// but the test case normally exits.
@@ -415,6 +408,10 @@ public class Launcher implements ServiceListener {
 		systemBundle = createFramework();
 		if (systemBundle == null)
 			return LauncherConstants.ERROR;
+
+		frameworkStartLevel = systemBundle.adapt(FrameworkStartLevel.class);
+		frameworkWiring = systemBundle.adapt(FrameworkWiring.class);
+
 		active.set(true);
 
 		doTimeoutHandler();
@@ -430,20 +427,7 @@ public class Launcher implements ServiceListener {
 		systemContext.addServiceListener(this, "(&(|(objectclass=" + Runnable.class.getName() + ")(objectclass="
 			+ Callable.class.getName() + "))(main.thread=true))");
 
-		// Initialize this framework so it becomes STARTING
 		systemBundle.start();
-
-		ServiceReference ref = systemContext.getServiceReference(PackageAdmin.class.getName());
-		if (ref != null) {
-			padmin = (PackageAdmin) systemContext.getService(ref);
-		} else
-			trace("could not get package admin");
-
-		ref = systemContext.getServiceReference(StartLevel.class.getName());
-		if (ref != null) {
-			sadmin = (StartLevel) systemContext.getService(ref);
-		} else
-			trace("could not get start level service");
 
 		trace("system bundle started ok");
 		// Start embedded activators
@@ -465,7 +449,6 @@ public class Launcher implements ServiceListener {
 			}
 		}
 
-		setStartLevel();
 		startBundles(tobestarted);
 
 		if (parms.trace) {
@@ -532,7 +515,7 @@ public class Launcher implements ServiceListener {
 			policy.setDefaultPermissions(null);
 
 		// Get the resolved status
-		if (padmin != null && padmin.resolveBundles(null) == false) {
+		if (frameworkWiring.resolveBundles(null) == false) {
 			List<String> failed = new ArrayList<>();
 
 			for (Bundle b : installedBundles.values()) {
@@ -578,18 +561,21 @@ public class Launcher implements ServiceListener {
 	}
 
 	private void refresh() throws InterruptedException {
-		if (padmin != null) {
-			inrefresh = true;
-			padmin.refreshPackages(null);
-			trace("Waiting for refresh to finish");
+		Semaphore semaphore = new Semaphore(0);
 
-			// Will be reset by the Framework listener we added
-			// when we created the framework.
-			while (inrefresh)
-				Thread.sleep(100);
+		frameworkWiring.refreshBundles(null, (e) -> {
+			if (e.getType() == FrameworkEvent.PACKAGES_REFRESHED)
+				semaphore.release();
+		});
 
-		} else
-			trace("cannot refresh the bundles because there is no Package Admin");
+		trace("Waiting for refresh to finish");
+
+		if (semaphore.tryAcquire(10, TimeUnit.MINUTES)) {
+			trace("Refresh is finished");
+			return;
+		}
+
+		trace("Could not refresh the framework in 5 minutes");
 	}
 
 	/**
@@ -628,19 +614,18 @@ public class Launcher implements ServiceListener {
 				Bundle bundle = installedBundles.get(f);
 				bundle.uninstall();
 				installedBundles.remove(f);
-				startLevels.remove(bundle);
 			} catch (Exception e) {
 				error("Failed to uninstall bundle %s, exception %s", f, e);
 			}
 
 		for (File f : tobeinstalled)
 			try {
+				int startLevel = desired.get(f);
 				trace("installing %s", f);
 				if (f.exists()) {
 					Bundle b = install(f);
 					installedBundles.put(f, b);
-					Integer startLevel = desired.get(f);
-					startLevels.put(b, startLevel);
+					setBundleStartLevel(b, startLevel);
 					tobestarted.add(b);
 				} else
 					error("should installing %s but file does not exist", f);
@@ -650,10 +635,10 @@ public class Launcher implements ServiceListener {
 
 		for (File f : tobeupdated)
 			try {
+				Integer startLevel = desired.get(f);
 				if (f.exists()) {
 					Bundle b = installedBundles.get(f);
-					Integer startLevel = desired.get(f);
-					startLevels.put(b, startLevel);
+					setBundleStartLevel(b, startLevel);
 
 					//
 					// Ensure we only update bundles that
@@ -817,7 +802,7 @@ public class Launcher implements ServiceListener {
 					tobestarted.add(bundle);
 				}
 			}
-			startLevels.put(bundle, getStartLevel(n));
+			setBundleStartLevel(bundle, getStartLevel(n));
 			n++;
 		}
 	}
@@ -935,6 +920,10 @@ public class Launcher implements ServiceListener {
 							System.exit(LauncherConstants.STOPPED);
 							break;
 
+						case FrameworkEvent.STARTLEVEL_CHANGED :
+							trace("start level changed");
+							break;
+
 						case FrameworkEvent.WAIT_TIMEDOUT :
 							trace("framework event timedout");
 							System.exit(LauncherConstants.TIMEDOUT);
@@ -981,11 +970,8 @@ public class Launcher implements ServiceListener {
 	}
 
 	private boolean isFragment(Bundle b) {
-		if (padmin != null)
-			return padmin.getBundleType(b) == PackageAdmin.BUNDLE_TYPE_FRAGMENT;
-
-		return b.getHeaders()
-			.get(Constants.FRAGMENT_HOST) != null;
+		return (b.adapt(BundleRevision.class)
+			.getTypes() & BundleRevision.TYPE_FRAGMENT) != 0;
 	}
 
 	public void deactivate() throws Exception {
@@ -1065,8 +1051,14 @@ public class Launcher implements ServiceListener {
 		}
 
 		if (parms.systemCapabilities != null) {
-			p.setProperty(FRAMEWORK_SYSTEM_CAPABILITIES_EXTRA, parms.systemCapabilities);
+			p.setProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES_EXTRA, parms.systemCapabilities);
 			trace("system capabilities used: %s", parms.systemCapabilities);
+		}
+
+		if (maxStartLevel > 0 && p.getProperty(Constants.FRAMEWORK_BEGINNING_STARTLEVEL) == null) {
+			int frameworkLevel = maxStartLevel + 1;
+			p.setProperty(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, frameworkLevel + "");
+			trace("setting beginning start level to %s", frameworkLevel);
 		}
 
 		Framework systemBundle;
@@ -1116,16 +1108,13 @@ public class Launcher implements ServiceListener {
 							case FrameworkEvent.WAIT_TIMEDOUT :
 								trace("Refresh will end due to error or timeout %s", event.toString());
 
-							case FrameworkEvent.PACKAGES_REFRESHED :
-								inrefresh = false;
-								trace("refresh ended");
-								break;
 						}
 					}
 				});
 		} catch (Exception e) {
 			trace("could not register a framework listener: %s", e);
 		}
+
 		trace("inited system bundle %s", systemBundle);
 		return systemBundle;
 	}
@@ -1183,7 +1172,7 @@ public class Launcher implements ServiceListener {
 			row(out, "Storage", parms.storageDir);
 			row(out, "Keep", parms.keep);
 			row(out, "Security", security);
-			row(out, "Startlevel", getStartLevel());
+			row(out, "Startlevel", frameworkStartLevel.getStartLevel());
 			list(out, fill("Run bundles", 40), parms.runbundles);
 			row(out, "Java Home", System.getProperty("java.home"));
 			list(out, fill("Classpath", 40), split(System.getProperty("java.class.path"), File.pathSeparator));
@@ -1559,84 +1548,28 @@ public class Launcher implements ServiceListener {
 	}
 
 	private int getBundleStartLevel(Bundle b) {
-		if (sadmin != null) {
-			return sadmin.getBundleStartLevel(b);
-		} else
-			return -1;
+		return b.adapt(BundleStartLevel.class)
+			.getStartLevel();
+	}
+
+	private void setBundleStartLevel(Bundle b, int level) {
+		if (level >= 1) {
+			b.adapt(BundleStartLevel.class)
+				.setStartLevel(level);
+			trace("startlevel %s %s", b, level);
+		}
 	}
 
 	private int getStartLevel(int n) {
-		return parms.startlevels != null && parms.startlevels.size() > n ? parms.startlevels.get(n) : maxStartLevel;
-	}
-
-	private void setStartLevel(Bundle bundle, Integer value) {
-		if (sadmin != null) {
-			if (bundle != null && value != null && value > 0) {
-				int bundleStartLevel = sadmin.getBundleStartLevel(bundle);
-				if (bundleStartLevel != value)
-					sadmin.setBundleStartLevel(bundle, value);
-				trace("bundle %s startlevels set to %s", bundle, value);
-			}
-		}
-	}
-
-	private void setStartLevel() {
-		if (sadmin != null && maxStartLevel >= 0) {
-
-			sadmin.setInitialBundleStartLevel(maxStartLevel);
-			startLevels.forEach(this::setStartLevel);
-
-			int sl = maxStartLevel + 1;
-			if (sadmin.getStartLevel() != sl) {
-				setFrameworkStartLevel(sl);
-			}
-
-			//
-			// Ensure that any new bundles (like testing)
-			// are getting a start level that is appropriate
-			//
-
-			trace("framework startlevel set to %s", sl);
-		} else {
-			trace("some startlevels set on bundles but no start level service so cannot set framework start level");
-		}
-	}
-
-	public void setFrameworkStartLevel(int sl) {
-		AtomicBoolean tickled = new AtomicBoolean(true);
-		Semaphore s = new Semaphore(0);
-		FrameworkListener listener = (e) -> {
-			tickled.set(true);
-			if (e.getType() == FrameworkEvent.STARTLEVEL_CHANGED) {
-				s.release();
-			}
-		};
-		systemBundle.getBundleContext()
-			.addFrameworkListener(listener);
-		try {
-			sadmin.setStartLevel(sl);
-			while (tickled.getAndSet(false)) {
-
-				trace("Will wait for reaching startlevel " + sl);
-				if (s.tryAcquire(1, TimeUnit.MINUTES))
-					break;
-			}
-		} catch (InterruptedException e) {
-			trace("Interrupted while waiting for startlevel");
-			Thread.currentThread()
-				.interrupt();
-		} finally {
-			trace("startlevel reached " + getStartLevel());
-			systemBundle.getBundleContext()
-				.removeFrameworkListener(listener);
-		}
-	}
-
-	private int getStartLevel() {
-		if (sadmin != null) {
-			return sadmin.getStartLevel();
-		} else
+		if (maxStartLevel < 1)
 			return -1;
+
+		int level = parms.startlevels != null && parms.startlevels.size() > n ? parms.startlevels.get(n) : -1;
+
+		if (level == -1)
+			return maxStartLevel + 1;
+
+		return level;
 	}
 
 }

--- a/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
+++ b/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
@@ -160,7 +160,7 @@ public class SimplePermissionPolicy implements SynchronousBundleListener {
 	}
 
 	private PermissionAdmin getPermissionAdmin() {
-		ServiceReference ref = context.getServiceReference(PermissionAdmin.class.getName());
+		ServiceReference<?> ref = context.getServiceReference(PermissionAdmin.class.getName());
 		if (ref == null)
 			return null;
 

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
@@ -28,7 +28,9 @@ import org.osgi.framework.BundleReference;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkListener;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.Version;
@@ -219,12 +221,12 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	}
 
 	@Override
-	public ServiceReference[] getRegisteredServices() {
+	public ServiceReference<?>[] getRegisteredServices() {
 		return null;
 	}
 
 	@Override
-	public ServiceReference[] getServicesInUse() {
+	public ServiceReference<?>[] getServicesInUse() {
 		return null;
 	}
 
@@ -319,7 +321,7 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	}
 
 	@Override
-	public ServiceReference[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		throw new UnsupportedOperationException();
 	}
 
@@ -349,12 +351,12 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	}
 
 	@Override
-	public ServiceReference getServiceReference(String clazz) {
+	public ServiceReference<?> getServiceReference(String clazz) {
 		return null;
 	}
 
 	@Override
-	public ServiceReference[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		return null;
 	}
 
@@ -393,35 +395,35 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	}
 
 	@Override
-	public ServiceRegistration registerService(String[] clazzes, Object service, Dictionary properties) {
+	public ServiceRegistration<?> registerService(String[] clazzes, Object service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
 	@Override
-	public ServiceRegistration registerService(String clazz, Object service, Dictionary properties) {
+	public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
-	public ServiceRegistration registerService(Class<?> clazz, Object service, Dictionary<String, ?> properties) {
+	public <T> ServiceRegistration<T> registerService(Class<T> clazz, T service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
-	public <S> ServiceReference getServiceReference(Class<S> clazz) {
+	public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
 		return null;
 	}
 
-	public <S> Collection<ServiceReference> getServiceReferences(Class<S> clazz, String filter)
+	public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
 		throws InvalidSyntaxException {
 		return null;
 	}
 
 	@Override
-	public Object getService(ServiceReference reference) {
+	public <S> S getService(ServiceReference<S> reference) {
 		return null;
 	}
 
 	@Override
-	public boolean ungetService(ServiceReference reference) {
+	public boolean ungetService(ServiceReference<?> reference) {
 		return false;
 	}
 
@@ -432,4 +434,17 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 	public <A> A adapt(Class<A> type) {
 		return null;
 	}
+
+
+	@Override
+	public <S> ServiceRegistration<S> registerService(Class<S> clazz, ServiceFactory<S> factory,
+		Dictionary<String, ?> properties) {
+		return null;
+	}
+
+	@Override
+	public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+		return null;
+	}
+
 }

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
@@ -24,7 +24,9 @@ import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.FrameworkListener;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.Version;
@@ -235,12 +237,12 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
-	public ServiceReference[] getRegisteredServices() {
+	public ServiceReference<?>[] getRegisteredServices() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public ServiceReference[] getServicesInUse() {
+	public ServiceReference<?>[] getServicesInUse() {
 		throw new UnsupportedOperationException();
 	}
 
@@ -290,17 +292,17 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
-	public ServiceReference[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public ServiceReference getServiceReference(String clazz) {
+	public ServiceReference<?> getServiceReference(String clazz) {
 		return null;
 	}
 
 	@Override
-	public ServiceReference[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+	public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
 		return null;
 	}
 
@@ -344,35 +346,35 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
-	public ServiceRegistration registerService(String[] clazzes, Object service, Dictionary properties) {
+	public ServiceRegistration<?> registerService(String[] clazzes, Object service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
 	@Override
-	public ServiceRegistration registerService(String clazz, Object service, Dictionary properties) {
+	public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
-	public <S> ServiceRegistration registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
+	public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
 		return null;
 	}
 
-	public <S> ServiceReference getServiceReference(Class<S> clazz) {
+	public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
 		return null;
 	}
 
-	public <S> Collection<ServiceReference> getServiceReferences(Class<S> clazz, String filter)
+	public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
 		throws InvalidSyntaxException {
 		return null;
 	}
 
 	@Override
-	public Object getService(ServiceReference reference) {
+	public <S> S getService(ServiceReference<S> reference) {
 		return null;
 	}
 
 	@Override
-	public boolean ungetService(ServiceReference reference) {
+	public boolean ungetService(ServiceReference<?> reference) {
 		return false;
 	}
 
@@ -382,5 +384,21 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 
 	public <A> A adapt(Class<A> type) {
 		return null;
+	}
+
+	@Override
+	public <S> ServiceRegistration<S> registerService(Class<S> clazz, ServiceFactory<S> factory,
+		Dictionary<String, ?> properties) {
+		return null;
+	}
+
+	@Override
+	public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+		return null;
+	}
+
+	@Override
+	public void init(FrameworkListener... listeners) throws BundleException {
+
 	}
 }

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -1,5 +1,4 @@
 org.osgi:osgi.annotation:7.0.0
-org.osgi:org.osgi.core:4.2.0
 org.osgi:osgi.core:6.0.0
 org.osgi:org.osgi.compendium:4.2.0
 org.osgi:org.osgi.namespace.contract:1.0.0


### PR DESCRIPTION
My customer does not need 4.2 anymore so moved the launcher 
to 5.0. Primarily driven by the ability to use the
new startlevel facilities. It was kind of inconvenient
to only be able to change start levels after the
framework was launched.



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>