### PR TITLE
[startlevel] Start level for resolve ordering support

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/InstructionTest.java
+++ b/biz.aQute.bndlib.tests/test/test/InstructionTest.java
@@ -45,6 +45,35 @@ public class InstructionTest extends TestCase {
 			.containsEntry("n", "1");
 	}
 
+	public void testDecoratePriority() {
+		Instructions instrs = new Instructions("def;x=1, *;x=0");
+		Parameters params = new Parameters("abc, def, ghi");
+		instrs.decorate(params);
+		System.out.println(params);
+		assertThat(params.get("abc")).isNotNull()
+			.containsEntry("x", "0");
+
+		assertThat(params.get("def")).isNotNull()
+			.containsEntry("x", "1");
+
+		assertThat(params.get("ghi")).isNotNull()
+			.containsEntry("x", "0");
+	}
+
+	public void testNegate() {
+		Instructions instrs = new Instructions("!def, *;x=0");
+		Parameters params = new Parameters("abc, def, ghi");
+		instrs.decorate(params);
+		System.out.println(params);
+		assertThat(params.get("abc")).isNotNull()
+			.containsEntry("x", "0");
+
+		assertThat(params.get("def")).isNull();
+
+		assertThat(params.get("ghi")).isNotNull()
+			.containsEntry("x", "0");
+	}
+
 	public void testWildcard() {
 		assertTrue(new Instruction("a|b").matches("a"));
 		assertTrue(new Instruction("a|b").matches("b"));

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
@@ -1,7 +1,5 @@
 package aQute.bnd.help.instructions;
 
-import java.util.Optional;
-
 import aQute.bnd.help.SyntaxAnnotation;
 
 /**
@@ -34,18 +32,18 @@ public interface ResolutionInstructions {
 	 * Order the -runbundles sorted by name and merged with the existing value
 	 * if it exists. This is the default since it was the classic behavior.
 	 */
-	MERGESORTBYNAMEVERSION {
-		public boolean isMerge() {
-			return true;
-		}
-	};
-
-		public boolean isMerge() {
-			return false;
-		}
+	MERGESORTBYNAMEVERSION;
 	}
 
-	@SyntaxAnnotation(lead = "Specify the runorder of the resolved bundles", example = "'-runorder leastdependentfirst")
-	Optional<Runorder> runorder();
+	@interface RunStartLevel {
+		Runorder order() default Runorder.MERGESORTBYNAMEVERSION;
+
+		int begin() default 100;
+
+		int step() default 10;
+	}
+
+	@SyntaxAnnotation(lead = "Specify the runorder and startlevel behavior of the resolved bundles", example = "'-runstartlevel order=leastdependenciesfirst, begin=1, step=1")
+	RunStartLevel runstartlevel(RunStartLevel deflt);
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -211,7 +211,12 @@ public interface Constants {
 
 	String								RUNBUNDLES									= "-runbundles";
 	String								RUNBUNDLES_STARTLEVEL_ATTRIBUTE				= "startlevel";
-	String								RUNORDER									= "-runorder";
+
+	String								RUNSTARTLEVEL								= "-runstartlevel";
+	String								RUNSTARTLEVEL_ORDER							= "order";
+	String								RUNSTARTLEVEL_BEGIN							= "begin";
+	String								RUNSTARTLEVEL_STEP							= "step";
+
 	String								AUGMENT										= "-augment";
 	String								AUGMENT_RANGE_ATTRIBUTE						= "version:";
 	String								AUGMENT_CAPABILITY_DIRECTIVE				= "capability:";
@@ -287,7 +292,7 @@ public interface Constants {
 		JAVA_DEBUG, EXPORTTYPE, RUNREMOTE, TESTER, AUGMENT, REQUIRE_BND, GROUPID, STANDALONE, IGNORE_STANDALONE,
 		RUNREPOS, INIT, MAVEN_RELEASE, BUILDREPO, CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE,
 		REPRODUCIBLE, INCLUDEPACKAGE, CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK,
-		MAVEN_SCOPE, RUNORDER
+		MAVEN_SCOPE, RUNSTARTLEVEL
 
 	};
 

--- a/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
@@ -3,11 +3,14 @@ package biz.aQute.resolve;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.osgi.Constants;
 import aQute.lib.io.IO;
 
 public class RunResolutionTest {
@@ -40,6 +43,87 @@ public class RunResolutionTest {
 		bndrun.getModel()
 			.setRunBundles(Collections.emptyList());
 		assertThat(resolution.updateBundles(bndrun.getModel())).isTrue();
+	}
+
+	@Test
+	public void testStartLevelsLeastDependenciesFirst() throws Exception {
+		Bndrun bndrun = Bndrun.createBndrun(workspace,
+			IO.getFile("testdata/pre-buildworkspace/test.simple/resolve.bndrun"));
+
+		bndrun.setProperty("-runstartlevel", "order=leastdependenciesfirst,begin=100,step=10");
+
+		RunResolution resolution = bndrun.resolve();
+		assertThat(bndrun.check()).isTrue();
+
+		List<VersionedClause> runBundles = resolution.getRunBundles();
+		assertThat(runBundles).hasSize(2);
+		assertThat(runBundles.get(0)
+			.getName()).isEqualTo("osgi.enroute.junit.wrapper");
+		assertThat(runBundles.get(0)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "100");
+		assertThat(runBundles.get(1)
+			.getName()).isEqualTo("test.simple");
+		assertThat(runBundles.get(1)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "110");
+
+	}
+
+	@Test
+	public void testStartLevelsLeastDependenciesLast() throws Exception {
+		Bndrun bndrun = Bndrun.createBndrun(workspace,
+			IO.getFile("testdata/pre-buildworkspace/test.simple/resolve.bndrun"));
+
+		bndrun.setProperty("-runstartlevel", "order=leastdependencieslast,begin=100,step=10");
+
+		RunResolution resolution = bndrun.resolve();
+		assertThat(bndrun.check()).isTrue();
+
+		List<VersionedClause> runBundles = resolution.getRunBundles();
+		assertThat(runBundles).hasSize(2);
+		assertThat(runBundles.get(0)
+			.getName()).isEqualTo("test.simple");
+		assertThat(runBundles.get(0)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "100");
+		assertThat(runBundles.get(1)
+			.getName()).isEqualTo("osgi.enroute.junit.wrapper");
+		assertThat(runBundles.get(1)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "110");
+
+	}
+
+	@Test
+	public void testStartLevelsStep() throws Exception {
+		Bndrun bndrun = Bndrun.createBndrun(workspace,
+			IO.getFile("testdata/pre-buildworkspace/test.simple/resolve.bndrun"));
+		bndrun.setProperty("-runstartlevel", "order=random,begin=10,step=1");
+
+		RunResolution resolution = bndrun.resolve();
+		assertThat(bndrun.check()).isTrue();
+
+		List<VersionedClause> runBundles = resolution.getRunBundles();
+		assertThat(runBundles).hasSize(2);
+		assertThat(runBundles.get(0)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "10");
+		assertThat(runBundles.get(1)
+			.getAttribs()).containsEntry(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE, "11");
+
+	}
+
+	@Test
+	public void testNoStartLevels() throws Exception {
+		Bndrun bndrun = Bndrun.createBndrun(workspace,
+			IO.getFile("testdata/pre-buildworkspace/test.simple/resolve.bndrun"));
+
+		RunResolution resolution = bndrun.resolve();
+		assertThat(bndrun.check()).isTrue();
+
+		List<VersionedClause> runBundles = resolution.getRunBundles();
+		assertThat(runBundles).hasSize(2);
+		assertThat(runBundles.get(0)
+			.getAttribs()).doesNotContainKey(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE);
+		assertThat(runBundles.get(1)
+			.getAttribs()).doesNotContainKey(Constants.RUNBUNDLES_STARTLEVEL_ATTRIBUTE);
+
 	}
 
 	@Test

--- a/docs/_chapters/300-launching.md
+++ b/docs/_chapters/300-launching.md
@@ -98,6 +98,56 @@ The launcher supports _embedded activators_. These are like normal Bundle Actvia
 
     Embedded-Activator: com.example.MyActivator
 
+
+## Startlevels
+
+The `-runbundles` instruction supports an `startlevel` attribute. If one or more of the bundles listed in the `-runbundles` instruction
+uses the `startlevel` attribute then the launcher will assign a startlevel to each bundle. This is currently supported for the
+normal launcher and not for Launchpad nor the remote launcher.
+
+If a bundle has a `startlevel` attribute then this must be an integer > 0, otherwise it is ignored. Bundles that have no
+`startlevel` attribute will be assign the maximum assigned startlevel attribute + 1. For example, given the following 
+bundles:
+
+	-runbundles: \
+		org.apache.felix.configadmin;version='[1.8.8,1.8.9)',\
+		org.apache.felix.http.jetty;version='[3.2.0,3.2.1)';startlevel=10,\
+		org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+		...
+		osgi.enroute.twitter.bootstrap.webresource;version='[3.3.5,3.3.6)';startlevel=12,\
+		osgi.enroute.web.simple.provider;version='[2.1.0,2.1.1)'
+
+The `org.apache.felix.configadmin`,  `org.apache.felix.http.servlet-api`, and `osgi.enroute.web.simple.provider` do not specify 
+a `startlevel` attribute and will therefore be assigned to start level 13. This value is picked because max(10,12)= 12 + 1 = 13.
+
+Startlevels are assigned before the framework is started, they are updated on the fly if during a debug session the setup changes.
+
+Normally in OSGi the begining start level is selected with the system property `org.osgi.framework.startlevel.beginning`. If
+this `-runproperty` is not set then the launcher will set this property before starting the framework to the maximum of
+specified levels + 2. If a start level management agent is present then this property should be set, the launcher will
+then not interfere.
+
+For example, a management agent that manages start levels is placed in start level 1 and all other bundles are placed
+at start level 100.
+
+	-runbundles: \
+		org.apache.felix.configadmin;version='[1.8.8,1.8.9)',\
+		org.apache.felix.http.jetty;version='[3.2.0,3.2.1)';startlevel=100,\
+		org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+		org.example.management.agent;startlevel=1
+		osgi.enroute.twitter.bootstrap.webresource;version='[3.3.5,3.3.6)';startlevel=100,\
+		osgi.enroute.web.simple.provider;version='[2.1.0,2.1.1)'
+
+
+The `-runproperties` specify a begining of 1:
+
+    -runproperties: \
+           org.osgi.framework.startlevel.beginning=1
+
+The launcher will install all bundles and assign them their start level. The framework is then started and moves
+to level 1. This starts the management agent. This management agent will then move the start level higher to finally
+level 100.
+
 ### Packaging
 
 Any bndrun file can be packaged by the launcher plugin. This creates an executable JAR that will contain all its dependencies.

--- a/docs/_chapters/305-startlevels.md
+++ b/docs/_chapters/305-startlevels.md
@@ -1,0 +1,83 @@
+---
+order: 305
+title: Startlevels
+layout: default
+---
+
+One of the primary authors of bnd has always objected to startlevels. His motivation was twofold:
+
+* A dynamic OSGi system should be ablet to startup in any order. Startlevels are often abused to hide bundles
+  that do not handle their dynamic dependencies correctly. Hiding these bugs by controlling the start ordering
+  is dangerous since it removes the symptom but the cause can still bite at a later inconvenient time.
+* Start levels are global data about a set of bundles. OSGi is quite elegant that it stores virtually all
+  meta data inside the bundle, not requiring global information. However, for start levels you need 
+  data outside the bundles. This often becomes wrong over time.
+
+With this disclaimer out of the way, there are actually cases where startlevels are quite important to 
+improve the non-functional aspects.
+
+* Jojo – Declarative services provides an elegant model to build components. However, they usually depend on
+  configuration. If the component is started before configuration admin is started then it will start only to
+  be immediately brought down when it receives its configuration. Using the [OSGi Configurator][1], the component
+  can be brought down a second time. This _jojo_ effect is highly undesirable at startup. (Although the good part is
+  that it exposes a lot of bugs.)
+* Logging – A number of bundles, where the most prevalent is the logger, are more useful when they are running
+  right from the beginning.
+
+## Startlevel Support in bnd
+
+Run configurations in bnd are described in _bndrun_ files. The list of bundles to run are listed in the  [-runbundles]
+instruction. The `runbundles` instruction has a `startlevel` attribute that specifies the startlevel of each bundle.
+
+Since the `-runbundles` instruction is frequently calculated by the resolver support in bnd it is not possible to manually
+assign the `startlevel` attributes to specific bundles. For this reason there is a _decorator_ support in bnd for some selected 
+instructions. A decorator is a header with the same name but ending with a plus sign (`+`). This instruction acts like a selector
+and can be used to assign `startlevel` attributes on the `-runbundles`.
+
+### Launching
+
+The [launcher] is responsible for installing the bundles after starting or communicating with a framework. The
+default bnd launcher will assign each bundle a startlevel, where bundles that do not have a specified `startlevel` are
+assigned one level higher than the maximum specified levels.
+
+The default launcher will then move the framework startlevel to 2 higher than the highest specified start level.
+
+### Resolving
+
+The resolve support in bnd can automatically assign `startlevel` attributes to the `-runbundles` based on different ordering
+strategies. There are two strategies that use the dependency graph. This graph can be sorted in _topological_ order.
+This means that a resource is always listed ahead of any of its dependencies when there are no cycles.
+
+The [-runstartlevel] instruction controls the ordering and assigned start levels. 
+
+## Strategies
+
+At the time of this writing it is not yet clear what the best strategy is, and it may depend.
+
+Ordering by the topological sort (a resource is followed by its dependencies) will start something like the log service
+last and any applications bundles first. Although at first sight this feels wrong (the log service should be started first
+to capture the events at startup) it does solve the jojo problem because one of the last bundles started will be the
+Service Component Runtime that will activate all components. At that time all initialization should have taken place.
+
+Reversing the topplogical sort will start the something like SCR and log first because they have few or no dependencies.
+Application bundles are then started latest. 
+
+## Numbering
+
+Traditionally start levels are managed by an application bundle. Shell commands can increase and decrease start levels.
+For this reason, start levels often use _nice_ numbers.
+
+Using the resolver the need for _nice_ numbers is diminished since bnd is now taking care. The basic default model
+is to assign bundles sequentially in selected order from an initial level stepping with 10. The [-runstartlevel] instruction
+can provide the initial level and the step if desired.
+
+The launcher will by default move the framework then to a start level that includes any used start levels. This
+default behavior can be blocked by specifyig the `org.osgi.framework.startlevel.beginning` property. If this
+property is set bnd will assume that there is an agent that will handle the runtime start levels.
+
+
+
+[1]: https://osgi.org/specification/osgi.cmpn/7.0.0/service.configurator.html 
+[-runbundles]: /instructions/runbundles.html
+[-runstartlevel]: /instructions/runstartlevel.html
+[launcher]: /chapters/launching.html

--- a/docs/_instructions/runbundles.md
+++ b/docs/_instructions/runbundles.md
@@ -7,7 +7,7 @@ summary:  Add additional bundles, specified with their bsn and version like in -
 
 The runbundles instruction is used to specify which bundles should be installed when a framework is started. This is the primary mechanism to run applications directly from bnd/bndtools. A bundle listed in -runbundles can be either a workspace bundle (a bundle created by one of the workspace's projects) or a bundle from one of the configured repositories. Note that all required bundles to run the application should be listed, transitive dependencies are not handles automatically so that there is full control over the runtime.
 
-This list can be maintained manually it is normally calculated by the resolver. That is, when a resolve is run then it will, without warning, override this list.
+This list can be maintained manually it is normally calculated by the [resolver][1]. That is, when a resolve is run then it will, without warning, override this list.
 
 For example:
 
@@ -19,3 +19,33 @@ For example:
 		osgi.enroute.twitter.bootstrap.webresource;version='[3.3.5,3.3.6)',\
 		osgi.enroute.web.simple.provider;version='[2.1.0,2.1.1)'
 
+## Start Levels
+
+Some launchers support startlevels and the `-runbundles` instruction therefore has a `startlevel` attribute. This attribute
+must be a positive integer larger than 0.
+
+    -runbundles: \
+		org.apache.felix.configadmin;version='[1.8.8,1.8.9)'; startlevel=100,\
+		org.apache.felix.http.jetty;version='[3.2.0,3.2.1)'; startlevel=110,\
+        ...
+
+Since the common workflow is to use the [resolver][1] to calculate the set of run bundles, any start level settings
+would be overridden after the next resolve. There are the following solutions.
+
+Use the [-runstartlevel][2] instruction to let the resolver calculate the start level ordering. In that case the
+resolver will add the `startlevel` attribute.
+
+Use the _decoration_ facility. With the decoration facility you can augment the `-runbundles` instruction by
+specifying the `-runbundles+` property. The keys are _glob_ expressions and any attributes or directives
+will be set (or overridden) on the merged `-runbundles` instruction.
+
+	-runbundles: \
+		org.apache.felix.configadmin;version='[1.8.8,1.8.9)',\
+		org.apache.felix.http.jetty;version='[3.2.0,3.2.1)',\
+		org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+
+    -runbundles+: \
+        org.apache.felix.servlet-api;startlevel=100, \
+        *;startlevel=110
+
+[1]: /chapters/250-resolving.html

--- a/docs/_instructions/runstartlevel.md
+++ b/docs/_instructions/runstartlevel.md
@@ -1,0 +1,77 @@
+---
+layout: default
+class: Project
+title: -runstartlevel ( order | begin | step )*
+summary:  Assign a start level to each run-bundle after resolving 
+---
+
+After a [resolve][1] the resolver calculates a number of resources that are mapped to bundles. This mapping can
+include ordering and assigned startlevels. The basic instruction that parameterizes this is `-runstartlevel`. 
+
+## Default behavior when not set
+
+If `-runstartlevel` is not set the set of -runbundles will be sorted by name and version after which it is merged with the existing
+`-runbundles`. Setting the `-runstartlevel` makes it possible to let bnd assign startlevels based on different
+ordering strategies.
+
+## Syntax
+
+This instruction has the following syntax:
+
+    -runstartlevel      ::= runstartlevel ( ',' runstartlevel )
+    runstartlevel       ::  order | begin | step
+    order               ::= 'order=' ORDER
+    ORDER               ::= 
+            'leastdependenciesfirst' 
+        |   'leastdependencieslast'
+        |   'random'
+        |   'sortedbyname'
+        |   'mergedsortedbyname'
+    begin               ::= 'begin=' NUMBER
+    step                ::= 'step=' NUMBER
+
+The final `-runstartlevel` flattens the properties so that the last of each of `order`, `begin`, or `step` will be used.
+
+### Order Types
+
+The value of `order` can take on the following values:
+
+* `mergedsortedbyname` – Ordering by name (and version) and then merging was the original behavior. This is therefore the default.
+* `sortedbyname` – For completeness, this option orders the bundles by name and version and then assigns a startlevel.
+* `random` – Use a random ordering. The ordering uses an algorithm that is based on the random number generator and should therefore 
+  be different on each run.
+* `leastdependenciesfirst` – Sort the resources _topologically_ and place the resources with the least dependencies first.
+* `leastdependencieslast` – Sort the resources _topologically_ and place the resources with the least dependencies last.
+
+The topological sorting algorithm is based on [Tarjan][2]. It can handle cyclic dependencies well. However, cyclic dependencies
+make the ordering not perfect.
+
+## Startlevels
+
+After the resources have been resolved they are sorted according to the `order`. If the `begin` attribute is set and
+higher than 0, the resources will be assigned a startlevel that starts at the given value. By default, the step for each
+bundle is 10. (A lesson taught to us by BASIC) The step can be overridden by setting the `step` value.
+
+If the `begin` value is not set, or it is set to a value < 1, then no startlevel attribute is added. However, the
+order of the `-runbundles` will be in the specified `order`. In most cases, this is then some kind of _natural_ ordering
+since launchers start these 
+
+## Example
+
+    -runstartlevel: \
+        order = leastdependenciesfirst, \
+        begin = 1000, \
+        step  =    1
+
+After resolving, this can generate:
+
+	-runbundles: \
+		org.apache.felix.configadmin;version='[1.8.8,1.8.9)';startlevel=1000,\
+		org.apache.felix.http.jetty;version='[3.2.0,3.2.1);startlevel=1001',\
+		org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3);startlevel=1002',\
+		...
+		osgi.enroute.twitter.bootstrap.webresource;version='[3.3.5,3.3.6);startlevel=1019',\
+		osgi.enroute.web.simple.provider;version='[2.1.0,2.1.1);startlevel=1020'
+
+[1]: /chapters/250-resolving.html
+[2]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm


### PR DESCRIPTION
- Changed the instruction from -runorder to -runstartlevel
- Order bundles now also with a start level attribute
- Support a begin and step for the auto numbering in resolve
- Added tests
- Provide documentation


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>