### PR TITLE
attr: Fix handling of plain List and avoid regex if no type specified

### DIFF
--- a/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/helpers/HeadersHelperTest.java
+++ b/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/helpers/HeadersHelperTest.java
@@ -668,9 +668,11 @@ public class HeadersHelperTest extends TestCase {
 		t.values.add("6.0.0");
 		c.typedAttributes.put("ttttt", t);
 		t = new TypedAttributeValueDTO();
+		t.multiValue = true;
 		t.type = "String";
-		t.values.add("dd,e");
-		c.typedAttributes.put("l:List", t);
+		t.values.add("dd");
+		t.values.add("e");
+		c.typedAttributes.put("l", t);
 		t = new TypedAttributeValueDTO();
 		t.multiValue = true;
 		t.type = "Double";
@@ -808,9 +810,11 @@ public class HeadersHelperTest extends TestCase {
 		t.values.add("6.0.0");
 		c.typedAttributes.put("ttttt", t);
 		t = new TypedAttributeValueDTO();
+		t.multiValue = true;
 		t.type = "String";
-		t.values.add("dd,e");
-		c.typedAttributes.put("l:List", t);
+		t.values.add("dd");
+		t.values.add("e");
+		c.typedAttributes.put("l", t);
 		t = new TypedAttributeValueDTO();
 		t.multiValue = true;
 		t.type = "Double";

--- a/biz.aQute.bndlib.tests/test/test/ParseHeaderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ParseHeaderTest.java
@@ -67,7 +67,7 @@ public class ParseHeaderTest extends TestCase {
 			// ,\"start,\,start,end\",end\," (not handling escape of comma)
 			Parameters pp = new Parameters(
 				"a;b:List=\"a\\\"quote,a\\\\backslash,a\\,comma, aSpace ,\\\"start,\\,start\\,end\"");
-			assertEquals("a;b:List=\"a\\\"quote,a\\\\backslash,a\\,comma, aSpace ,\\\"start,\\,start\\,end\"",
+			assertEquals("a;b:List<String>=\"a\\\"quote,a\\\\backslash,a\\,comma, aSpace ,\\\"start,\\,start\\,end\"",
 				pp.toString());
 		}
 


### PR DESCRIPTION
The previous code used a regex which would not match a plain List type.
So the key ended in `:List` and the value type was String. This fix
correctly handles plain List as the type `List<String>`.

Furthermore, we avoid regex matching when the key does not contain a `:`
which is the most common scenario. This can provide a small performance
boost.

Thanks to @seanbright for the test fixes in HeadersHelperTest!