### PR TITLE
baseline: Add BaselineIgnore annotation support

### DIFF
--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/baseline/BaselineIgnore.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/baseline/BaselineIgnore.java
@@ -1,0 +1,31 @@
+package aQute.bnd.annotation.baseline;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Baseline ignore annotation.
+ * <p>
+ * When this annotation is applied to a baselined element, the baseliner will
+ * ignore the annotated element when baselining against a baseline package whose
+ * version is less than the specified version. This means the annotated element
+ * will not produce a baselining mismatch. The correct baseline information
+ * about the element will be in the baseline report, but the element will not
+ * cause baselining to fail. When baselining against a baseline package whose
+ * version is greater than or equal to the specified version, this annotation is
+ * ignored and the annotated element will be included in the baselining.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+	ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR
+})
+public @interface BaselineIgnore {
+	/**
+	 * Baseline package version.
+	 * <p>
+	 * The version must be a valid OSGi version string.
+	 */
+	String value();
+}

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/baseline/package-info.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/baseline/package-info.java
@@ -1,0 +1,6 @@
+@Version("1.0.0")
+@Export
+package aQute.bnd.annotation.baseline;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib.tests/test/test/api/C.java
+++ b/biz.aQute.bndlib.tests/test/test/api/C.java
@@ -1,5 +1,8 @@
 package test.api;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
+
 public class C extends A {
+	@BaselineIgnore("1.1.0")
 	public int s;
 }

--- a/biz.aQute.bndlib.tests/test/test/api/Interf.java
+++ b/biz.aQute.bndlib.tests/test/test/api/Interf.java
@@ -3,6 +3,9 @@ package test.api;
 import java.util.Collection;
 import java.util.List;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
+
+@BaselineIgnore("1.1.0")
 public interface Interf {
 	/**
 	 * Test if a change in generic type is detected. The original has a String

--- a/biz.aQute.bndlib.tests/test/test/api/package-info.java
+++ b/biz.aQute.bndlib.tests/test/test/api/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package test.api;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
When this annotation is applied to a baselined element, the baseliner
will ignore the annotated element when baselining against a baseline
package whose version is less than the specified version.
This means the annotated element will not produce a baselining mismatch.
The correct baseline information about the element will be in the
baseline report, but the element will not cause baselining to fail.
When baselining against a baseline package whose version is greater
than or equal to the specified version, this annotation is ignored and the
annotated element will be included in the baselining.
