### PR TITLE
build: Update references to OSGi core artifact in bnd files

### DIFF
--- a/biz.aQute.bnd.runtime/bnd.bnd
+++ b/biz.aQute.bnd.runtime/bnd.bnd
@@ -4,7 +4,7 @@
 -buildpath: \
     osgi.annotation;version=latest;maven-scope=provided, \
     aQute.libg;version=project,\
-    osgi.core;version=@6;maven-scope=provided,\
+    osgi.core;version=latest;maven-scope=provided,\
     org.osgi.service.coordinator;maven-scope=provided,\
     org.osgi.service.cm, \
     org.osgi.service.component;version='[1.4,1.5)',\

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -4,7 +4,7 @@
 -maven-scope: provided
 
 -buildpath: \
-	osgi.core;version=@6,\
+	osgi.core;version=latest,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
     ${junit}

--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -4,7 +4,7 @@
 -dependson: demo
 
 -buildpath: \
-	osgi.core;version=4.2;maven-scope=provided,\
+	osgi.core;version=latest;maven-scope=provided,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
 	slf4j.api;version=latest

--- a/biz.aQute.launchpad.tests/bnd.bnd
+++ b/biz.aQute.launchpad.tests/bnd.bnd
@@ -1,9 +1,9 @@
 -buildpath: \
     org.osgi.service.component.annotations, \
-    osgi.annotation; version=6.0.1,\
-    osgi.core; version=6.0, \
+    osgi.annotation; version=latest,\
+    osgi.core; version=latest, \
     org.osgi.service.component
-    
+
 -testpath: \
     slf4j.api, \
     slf4j.simple, \

--- a/biz.aQute.tester/bnd.bnd
+++ b/biz.aQute.tester/bnd.bnd
@@ -33,7 +33,7 @@ Tester-Plugin: \
 -maven-scope: provided
 
 -buildpath: \
-	osgi.core;version=4.2,\
+	osgi.core;version=latest,\
 	biz.aQute.junit;version=latest;packages=aQute.junit.*,\
 	biz.aQute.bndlib;version=latest
 


### PR DESCRIPTION
We use latest to keep all projects in sync and control the OSGi core
version being used via repo curation in cnf/ext/central.mvn

