### PR TITLE
gradle: Use parseMavenString method to parse maven version strings

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -280,7 +280,7 @@ class BundleTaskConvention {
         // set bundle version from task's version if necessary
         String bundleVersion = builder.getProperty(Constants.BUNDLE_VERSION)
         if (isEmpty(bundleVersion)) {
-          builder.setProperty(Constants.BUNDLE_VERSION, MavenVersion.parseString(version?.toString()).getOSGiVersion().toString())
+          builder.setProperty(Constants.BUNDLE_VERSION, MavenVersion.parseMavenString(version?.toString()).getOSGiVersion().toString())
         }
 
         logger.debug 'builder properties: {}', builder.getProperties()

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -16,7 +16,7 @@ class TestHelper {
 
   public static GradleRunner getGradleRunner(String version) {
     String defaultversion = gradleVersion()
-    if (MavenVersion.parseString(defaultversion).compareTo(MavenVersion.parseString(version)) > 0) {
+    if (MavenVersion.parseMavenString(defaultversion).compareTo(MavenVersion.parseMavenString(version)) > 0) {
       version = defaultversion
     }
     return GradleRunner.create()


### PR DESCRIPTION
Forgot this change in https://github.com/bndtools/bnd/pull/3216

