### PR TITLE
build: Add .editorconfig file to repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# Tab indentation size 4
+indent_style = tab
+indent_size = 4
+# Set default charset
+charset = utf-8


### PR DESCRIPTION
This will render the code in GitHub (and other editors/viewers which
support .editorconfig) to match the Eclipse settings we use.

https://editorconfig.org/
