### PR TITLE
[templating] Added a template function

### DIFF
--- a/aQute.libg/src/aQute/lib/date/DateUtil.java
+++ b/aQute.libg/src/aQute/lib/date/DateUtil.java
@@ -1,0 +1,105 @@
+package aQute.lib.date;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+
+import aQute.lib.strings.Strings;
+
+public class DateUtil {
+	private static final Map<Pattern, SimpleDateFormat>	DATE_FORMAT_REGEXPS	= new HashMap<Pattern, SimpleDateFormat>();
+	public static final TimeZone						UTC_TIME_ZONE		= TimeZone.getTimeZone("UTC");
+	public static Pattern								IS_NUMMERIC_P		= Pattern.compile("[+-]?\\d+");
+
+	static {
+		put("\\d{6}", "yyMMdd");
+		put("\\d{8}", "yyyyMMdd");
+		put("\\d{12}", "yyyyMMddHHmm");
+		put("\\d{12}\\.\\d{3}Z?", "yyyyMMddHHmmss.SSSZ");
+		put("\\d{14}", "yyyyMMddHHmmss");
+		put("\\d{8}\\s\\d{4}", "yyyyMMdd HHmm");
+		put("\\d{1,2}-\\d{1,2}-\\d{4}", "dd-MM-yyyy");
+		put("\\d{4}-\\d{1,2}-\\d{1,2}", "yyyy-MM-dd");
+		put("\\d{1,2}/\\d{1,2}/\\d{4}", "MM/dd/yyyy");
+		put("\\d{4}/\\d{1,2}/\\d{1,2}", "yyyy/MM/dd");
+		put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}", "dd MMM yyyy");
+		put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}", "dd MMMM yyyy");
+		put("\\d{1,2}-\\d{1,2}-\\d{4}\\s\\d{1,2}:\\d{2}", "dd-MM-yyyy HH:mm");
+		put("\\d{4}-\\d{1,2}-\\d{1,2}\\s\\d{1,2}:\\d{2}", "yyyy-MM-dd HH:mm");
+		put("\\d{1,2}/\\d{1,2}/\\d{4}\\s\\d{1,2}:\\d{2}", "MM/dd/yyyy HH:mm");
+		put("\\d{4}/\\d{1,2}/\\d{1,2}\\s\\d{1,2}:\\d{2}", "yyyy/MM/dd HH:mm");
+		put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}\\s\\d{1,2}:\\d{2}", "dd MMM yyyy HH:mm");
+		put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}\\s\\d{1,2}:\\d{2}", "dd MMMM yyyy HH:mm");
+		put("\\d{8}\\s\\d{6}", "yyyyMMdd HHmmss");
+		put("\\d{1,2}-\\d{1,2}-\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd-MM-yyyy HH:mm:ss");
+		put("\\d{4}-\\d{1,2}-\\d{1,2}\\s\\d{1,2}:\\d{2}:\\d{2}", "yyyy-MM-dd HH:mm:ss");
+		put("\\d{1,2}/\\d{1,2}/\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "MM/dd/yyyy HH:mm:ss");
+		put("\\d{4}/\\d{1,2}/\\d{1,2}\\s\\d{1,2}:\\d{2}:\\d{2}", "yyyy/MM/dd HH:mm:ss");
+		put("\\d{1,2}\\s[a-z]{3}\\s\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd MMM yyyy HH:mm:ss");
+		put("\\d{1,2}\\s[a-z]{4,}\\s\\d{4}\\s\\d{1,2}:\\d{2}:\\d{2}", "dd MMMM yyyy HH:mm:ss");
+	}
+
+	private static void put(String regex, String simpleDateFormat) {
+		DATE_FORMAT_REGEXPS.put(Pattern.compile(regex), new SimpleDateFormat(simpleDateFormat));
+	}
+
+	/**
+	 * Determine SimpleDateFormat pattern matching with the given date string.
+	 * Returns null if format is unknown. You can simply extend DateUtil with
+	 * more formats if needed.
+	 *
+	 * @param dateString The date string to determine the SimpleDateFormat
+	 *            pattern for.
+	 * @return The matching SimpleDateFormat pattern, or null if format is
+	 *         unknown.
+	 * @see SimpleDateFormat
+	 */
+	public static Optional<SimpleDateFormat> determineDateFormat(String dateString) {
+		if (dateString == null)
+			return Optional.empty();
+
+		String s = Strings.trim(dateString);
+
+		return DATE_FORMAT_REGEXPS.entrySet()
+			.stream()
+			.filter(e -> e.getKey()
+				.matcher(s)
+				.matches())
+			.map(Map.Entry::getValue)
+			.findAny();
+	}
+
+	public static Date parse(String dateString) {
+		Date date = determineDateFormat(dateString).map(df -> {
+			try {
+				synchronized (df) {
+					df.setTimeZone(UTC_TIME_ZONE);
+					return df.parse(dateString);
+				}
+			} catch (ParseException e) {
+				return null;
+			}
+		})
+			.orElse(null);
+
+		if (date != null)
+			return date;
+
+		if (IS_NUMMERIC_P.matcher(dateString)
+			.matches()) {
+			try {
+				long ldate = Long.parseLong(dateString);
+				return new Date(ldate);
+			} catch (NumberFormatException nfe) {
+				// ok, we've no clue what it is
+			}
+		}
+		return null;
+	}
+
+}

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/LauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/LauncherTest.java
@@ -63,7 +63,6 @@ public class LauncherTest {
 
 		String result = runFramework(file);
 
-		System.out.println(result);
 		assertThat(result).containsPattern("startlevel: not handled")
 			.containsPattern("Startlevel\\s+1")
 			.containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle")
@@ -81,7 +80,6 @@ public class LauncherTest {
 
 		String result = runFramework(file);
 
-		System.out.println(result);
 		assertThat(result).containsPattern("handled \\[-1, 10, 20, -1, 5\\]")
 			.containsPattern("Startlevel\\s+22")
 			.containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle")
@@ -102,13 +100,11 @@ public class LauncherTest {
 
 		String result = runFramework(file);
 
-		System.out.println(result);
 		assertThat(result).containsPattern("Startlevel\\s+23")
 			.containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle")
 			.containsPattern("22\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.log")
 			.containsPattern("11\\s+ACTIV\\s+<>\\s+jar/.?demo.jar")
 			.containsPattern("21\\s+ACTIV\\s+<>\\s+jar/.?org.apache.servicemix.bundles.junit")
-			.containsPattern("6\\s+ACTIV\\s+<>\\s+jar/.?org.apache.felix.configadmin")
 			.containsPattern("startlevel: default=22, beginning=23, now moving to 1")
 			.containsPattern("startlevel: beginning level 23")
 			.containsPattern("startlevel: notified reached final level 23");
@@ -124,7 +120,6 @@ public class LauncherTest {
 
 		String result = runFramework(file);
 
-		System.out.println(result);
 		assertThat(result).containsPattern("Startlevel\\s+12")
 			.containsPattern("0\\s+ACTIV\\s+<>\\s+System Bundle")
 			.containsPattern("22\\s+RSLVD\\s+<>\\s+jar/.?org.apache.felix.log")

--- a/biz.aQute.bndlib.tests/test/test/InstructionTest.java
+++ b/biz.aQute.bndlib.tests/test/test/InstructionTest.java
@@ -23,7 +23,7 @@ public class InstructionTest extends TestCase {
 	public void testDecorate() {
 		Instructions instrs = new Instructions("a;x=1,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
 		Parameters params = new Parameters("foo.com.example.bar;version=1, a;v=0, bbb;v=1");
-		instrs.decorate(params);
+		instrs.decorate(params, true);
 		System.out.println(params);
 		assertThat(params.get("a")).isNotNull()
 			.containsEntry("v", "0")

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
@@ -328,11 +328,23 @@ public class Instructions implements Map<Instruction, Attrs> {
 	/**
 	 * Match the instruction against the parameters and merge the attributes if
 	 * matches. Remove any negated instructions. Literal unmatched instructions
-	 * are added
+	 * are not added
 	 *
-	 * @param parameters
+	 * @param parameters the parameters to decorate
 	 */
 	public void decorate(Parameters parameters) {
+		decorate(parameters, false);
+	}
+
+	/**
+	 * Match the instruction against the parameters and merge the attributes if
+	 * matches. Remove any negated instructions. Literal unmatched instructions
+	 * are added if the addLiterals is true
+	 *
+	 * @param parameters the parameters to decorate
+	 * @param addLiterals add literals to the output
+	 */
+	public void decorate(Parameters parameters, boolean addLiterals) {
 		Iterator<Map.Entry<String, Attrs>> it = parameters.entrySet()
 			.iterator();
 		Set<Instruction> used = new HashSet<>(keySet());
@@ -351,13 +363,16 @@ public class Instructions implements Map<Instruction, Attrs> {
 				}
 			}
 		}
-		//
-		// Add the literals
-		used.stream()
-			.filter(Instruction::isLiteral)
-			.forEach(i -> {
-				parameters.put(i.getLiteral(), new Attrs(get(i)));
-			});
+
+		if (addLiterals) {
+			//
+			// Add the literals
+			used.stream()
+				.filter(Instruction::isLiteral)
+				.forEach(i -> {
+					parameters.put(i.getLiteral(), new Attrs(get(i)));
+				});
+		}
 	}
 
 }


### PR DESCRIPTION
In a lot of cases you need to expand a Parameters via a template. I've added  a
macro:

	${template;-runbundles;@=@startlevel;,}

This will get the property `-runbundles` (in merged and decorated form) and will iterate over its entries. It will expand the template
for each entry. While expanding, it will set
@ to the key and all attributes with a '@' prefixed.

I've changed the macros slightly. Normally macros set override built in functions. However, this was not the case with macros that too parameters. Now the name of the macro
is used to do the lookup.

Also added some more test to get more coverage

[decorate] Made the default to not expand literals for the decorator

The decorator added literals to the output even if they did not exist in the output. Made this optional and the default to not include them.


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>