### PR TITLE
Matcher append loop

### DIFF
--- a/aQute.libg/src/aQute/lib/io/IO.java
+++ b/aQute.libg/src/aQute/lib/io/IO.java
@@ -1332,18 +1332,15 @@ public class IO {
 			StringBuilder sb = new StringBuilder();
 			Matcher matcher = WINDOWS_MACROS.matcher(value);
 			int start = 0;
-			while (matcher.find(start)) {
+			for (; matcher.find(start); start = matcher.end()) {
 				String name = matcher.group(1);
 				String replacement = getSystemEnv(name, visited);
 				sb.append(value, start, matcher.start())
 					.append(replacement);
-				start = matcher.end();
 			}
-			if (start == 0) {
-				return value;
-			}
-			sb.append(value, start, value.length());
-			return sb.toString();
+			return (start == 0) ? value
+				: sb.append(value, start, value.length())
+					.toString();
 		}
 
 		String getenv(String key) {

--- a/aQute.libg/src/aQute/libg/remote/source/SourceFS.java
+++ b/aQute.libg/src/aQute/libg/remote/source/SourceFS.java
@@ -55,23 +55,18 @@ class SourceFS {
 	}
 
 	public String transform(String s) throws Exception {
-
 		Matcher m = LOCAL_P.matcher(s);
-		StringBuffer sb = new StringBuffer();
-		boolean found = false;
-
-		while (m.find()) {
+		StringBuilder sb = new StringBuilder();
+		int start = 0;
+		for (; m.find(start); start = m.end()) {
 			FileDescription fd = toRemote(m.group(0));
 			fd.touched = true;
-			m.appendReplacement(sb, fd.path);
-			found = true;
+			sb.append(s, start, m.start())
+				.append(fd.path);
 		}
-
-		if (!found)
-			return s;
-
-		m.appendTail(sb);
-		return sb.toString();
+		return (start == 0) ? s
+			: sb.append(s, start, s.length())
+				.toString();
 	}
 
 	private FileDescription toRemote(String localPath) throws Exception {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,8 @@
 variables:
   GRADLE_OPTS: -Dorg.gradle.parallel=true
+  Java8.JDK: https://cdn.azul.com/zulu/bin/zulu8.38.0.13-ca-jdk8.0.212-linux_x64.tar.gz
+  Java11.JDK: https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz
+  Java12.JDK: https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
 
 jobs:
 
@@ -10,7 +13,7 @@ jobs:
   - bash: |
       set -ev
       curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
-      source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu8.38.0.13-ca-jdk8.0.212-linux_x64.tar.gz
+      source install-jdk.sh --url $(Java8.JDK)
       ./gradlew --no-daemon --version
       ./mvnw --version
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
@@ -33,7 +36,7 @@ jobs:
   - bash: |
       set -ev
       curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
-      source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz
+      source install-jdk.sh --url $(Java11.JDK)
       ./gradlew --no-daemon --version
       ./mvnw --version
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
@@ -46,7 +49,7 @@ jobs:
   - bash: |
       set -ev
       curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
-      source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz
+      source install-jdk.sh --url $(Java12.JDK)
       ./gradlew --no-daemon --version
       ./mvnw --version
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
@@ -59,7 +62,7 @@ jobs:
   - bash: |
       set -ev
       curl -O -L --retry 3 https://github.com/sormuras/bach/raw/master/install-jdk.sh
-      source install-jdk.sh --url https://cdn.azul.com/zulu/bin/zulu8.38.0.13-ca-jdk8.0.212-linux_x64.tar.gz
+      source install-jdk.sh --url $(Java8.JDK)
       ./gradlew --no-daemon --version
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 :biz.aQute.bnd.gradle:build :biz.aQute.bnd.gradle:releaseNeeded
       ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles :buildscriptDependencies :build

--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -869,35 +869,37 @@ public class DSAnnotationReader extends ClassDataCollector {
 
 		private String identifierToPropertyName(String name) {
 			Matcher m = IDENTIFIERTOPROPERTY.matcher(name);
-			if (!m.find()) {
-				return name;
-			}
-			StringBuffer b = new StringBuffer();
-			do {
+			StringBuilder sb = new StringBuilder();
+			int start = 0;
+			for (; m.find(start); start = m.end()) {
+				String replacement;
 				switch (m.group()) {
 					case "__" : // __ to _
-						m.appendReplacement(b, "_");
+						replacement = "_";
 						break;
 					case "_" : // _ to .
-						m.appendReplacement(b, ".");
+						replacement = ".";
 						break;
 					case "$_$" : // $_$ to -
-						m.appendReplacement(b, "-");
+						replacement = "-";
 						break;
 					case "$$" : // $$ to $
-						m.appendReplacement(b, "\\$");
+						replacement = "$";
 						break;
 					case "$" : // $ removed
-						m.appendReplacement(b, "");
+						replacement = "";
 						break;
 					default : // unknown!
-						m.appendReplacement(b, m.group());
+						replacement = m.group();
 						analyzer.error("unknown mapping %s in property name %s", m.group(), name);
 						break;
 				}
-			} while (m.find());
-			m.appendTail(b);
-			return b.toString();
+				sb.append(name, start, m.start())
+					.append(replacement);
+			}
+			return (start == 0) ? name
+				: sb.append(name, start, name.length())
+				.toString();
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/metatype/ADDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/metatype/ADDef.java
@@ -70,14 +70,14 @@ public class ADDef extends ExtensionDef {
 		}
 
 		if (defaults != null) {
-			StringBuffer b = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			String sep = "";
 			for (String defaultValue : defaults) {
-				b.append(sep);
-				escape(defaultValue, b);
+				sb.append(sep);
+				escape(defaultValue, sb);
 				sep = ",";
 			}
-			ad.addAttribute("default", b.toString());
+			ad.addAttribute("default", sb.toString());
 		}
 
 		for (OptionDef option : options) {
@@ -91,16 +91,15 @@ public class ADDef extends ExtensionDef {
 
 	private static final Pattern escapes = Pattern.compile("[\\\\ ,]");
 
-	private void escape(String defaultValue, StringBuffer b) {
+	private void escape(String defaultValue, StringBuilder sb) {
 		Matcher m = escapes.matcher(defaultValue);
-		while (m.find()) {
-			String match = m.group();
-			if (match.equals("\\"))
-				m.appendReplacement(b, "\\\\\\\\");
-			else
-				m.appendReplacement(b, "\\\\" + match);
+		int start = 0;
+		for (; m.find(start); start = m.end()) {
+			sb.append(defaultValue, start, m.start())
+				.append('\\')
+				.append(m.group());
 		}
-		m.appendTail(b);
+		sb.append(defaultValue, start, defaultValue.length());
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -693,27 +693,26 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 
 	private void replaceParameters(Attrs attrs) throws IllegalArgumentException {
 		for (Entry<String, String> entry : attrs.entrySet()) {
-			boolean modified = false;
-			StringBuffer sb = new StringBuffer();
-
-			Matcher matcher = SIMPLE_PARAM_PATTERN.matcher(entry.getValue());
-			while (matcher.find()) {
-				modified = true;
+			StringBuilder sb = new StringBuilder();
+			String value = entry.getValue();
+			Matcher matcher = SIMPLE_PARAM_PATTERN.matcher(value);
+			int start = 0;
+			for (; matcher.find(start); start = matcher.end()) {
 				String key = matcher.group(1);
-				String substitution = attrs.get(key);
-				if (substitution == null) {
-					matcher.appendReplacement(sb, "");
-					sb.append(matcher.group(0));
-				} else if (SIMPLE_PARAM_PATTERN.matcher(substitution)
-					.find())
+				String replacement = attrs.get(key);
+				if (replacement == null) {
+					replacement = matcher.group(0);
+				} else if (SIMPLE_PARAM_PATTERN.matcher(replacement)
+					.find()) {
 					throw new IllegalArgumentException("nested substitutions not permitted");
-				else
-					matcher.appendReplacement(sb, substitution);
+				}
+				sb.append(value, start, matcher.start())
+					.append(replacement);
 			}
 
-			if (modified) {
-				matcher.appendTail(sb);
-				entry.setValue(sb.toString());
+			if (start != 0) {
+				entry.setValue(sb.append(value, start, value.length())
+					.toString());
 			}
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/TaggedData.java
@@ -70,7 +70,7 @@ public class TaggedData implements Closeable {
 			if (h.getResponseCode() / 100 < 4)
 				return null;
 
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 
 			try {
 				InputStream in = con.getInputStream();
@@ -103,19 +103,21 @@ public class TaggedData implements Closeable {
 			.replaceAll("");
 		sb = NEWLINES_P.matcher(sb)
 			.replaceAll("\n");
-		StringBuffer x = new StringBuffer();
+		StringBuilder x = new StringBuilder();
 		Matcher m = ENTITIES_P.matcher(sb);
-		while (m.find()) {
+		int start = 0;
+		for (; m.find(start); start = m.end()) {
+			x.append(sb, start, m.start());
 			if (m.group("nr") != null) {
 				char c = (char) Integer.parseInt(m.group("nr"));
-				m.appendReplacement(x, "");
 				x.append(c);
 			} else {
-				m.appendReplacement(x, entity(m.group("name")));
+				x.append(entity(m.group("name")));
 			}
 		}
-		m.appendTail(x);
-		return x.toString();
+		return (start == 0) ? sb.toString()
+			: x.append(sb, start, sb.length())
+				.toString();
 	}
 
 	private String entity(String name) {


### PR DESCRIPTION
Change append loop to avoid StringBuffer. We often don't need to use a replacement string with group numbers, so we can use a different loop to avoid StringBuffer and the expense of Matcher.appendReplacement which spends time looking at the replacement string for group numbers.
