### PR TITLE
maven: Remove parallel option for maven build

### DIFF
--- a/maven/build.gradle
+++ b/maven/build.gradle
@@ -18,9 +18,6 @@ def deploy = tasks.register('deploy', Exec.class) {
     executable rootProject.file('mvnw')
   }
   args '--batch-mode'
-  if (project.gradle.startParameter.parallelProjectExecutionEnabled) {
-    args '-T1C'
-  }
   args '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
   if (logger.isDebugEnabled()) {
     args '--debug'


### PR DESCRIPTION
The maven build has been flaky. Removing this to see if it stabilizes.
