### PR TITLE
Disable parallel gradle build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: java
 env:
   global:
     - LC_ALL=en_US.UTF-8
-    - GRADLE_OPTS=-Dorg.gradle.parallel=true
+    - GRADLE_OPTS=-Dorg.gradle.parallel=false
     - JAVA8_JDK=https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz
     - JAVA11_JDK=https://cdn.azul.com/zulu/bin/zulu11.33.15-ca-jdk11.0.4-linux_x64.tar.gz
     - JAVA12_JDK=https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-linux_x64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,19 +52,3 @@ before_script:
 
 script:
   - "./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy"
-
-before_cache:
-  - "git status"
-  - "rm -rf maven/target/m2/biz/aQute/bnd/"
-  - "rm -rf maven/target/m2/org/bndtools/"
-  - "rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock"
-  - "rm -rf $HOME/.gradle/caches/*/plugin-resolution/"
-
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-    - $HOME/.m2/wrapper/
-    - cnf/cache/stable/
-    - docs/bundler/
-    - maven/target/m2/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   LC_ALL: en_US.UTF-8
-  GRADLE_OPTS: -Dorg.gradle.parallel=true
+  GRADLE_OPTS: -Dorg.gradle.parallel=false
   JAVA8_JDK: https://cdn.azul.com/zulu/bin/zulu8.40.0.25-ca-jdk8.0.222-linux_x64.tar.gz
   JAVA11_JDK: https://cdn.azul.com/zulu/bin/zulu11.33.15-ca-jdk11.0.4-linux_x64.tar.gz
   JAVA12_JDK: https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-linux_x64.tar.gz


### PR DESCRIPTION
Gradle runs each test task in a separate java process. When a test case
uses the Bnd workspace as a workspace in a test, then the new java
process will register a remotews port. So we end up with one port from
the main gradle process for the build and another for each parallel test
process which accesses the Bnd workspace as a workspace in a test. Since
the remote client uses the most recent remotews file, one test process
can use the remote workspace port from another test process. When this
happens and the other test process exits, then the test process using
its remote port will fail as the remote port is unexpectedly closed.

So we disable parallel builds in the CI until we can find a better
solution.