### PR TITLE
[reporter] Add more blocks to make manual editing of readme file easier

### DIFF
--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/templates/blocks.twig
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/templates/blocks.twig
@@ -5,6 +5,7 @@
 {%- set title = default(report.manifest.bundleName,report.commonInfo.name) -%}
 {%- set title = default(title,report.manifest.bundleSymbolicName.symbolicName) -%}
 {%- set title = default(title,report.fileName) -%}
+{%- block beforeTitle %}{% endblock -%}
 {{ printer.printTitle(title,1,iconUrl) }}
 {%- endmacro %}
 
@@ -14,7 +15,9 @@
 {% macro overviewBlock (printer, report) -%}
 {%- set description = default(report.manifest.bundleDescription,report.commonInfo.description) -%}
 {%- if not empty(description) -%}
-{{ '\n\n' }}{{ description }}
+{{ '\n\n' }}
+{%- block beforeOverview %}{% endblock -%}
+{{ description }}
 {%- endif -%}
 {%- endmacro %}
 
@@ -28,6 +31,7 @@
 {%- set download = default(report.manifest.bundleUpdateLocation,report.commonInfo.updateLocation) -%}
 {%- if not empty(docUrl) or not empty(codeBrowse) or not empty(codeDev) or not empty(download) -%}
 {{ '\n\n' }}{{ printer.printTitle('Links', 2, iconUrl) }}{{ '\n' }}
+{%- block beforeLinks %}{% endblock -%}
 {%- if not empty(docUrl) -%}
 {{ '\n' }}* [Documentation]({{ docUrl }})
 {%- endif -%}
@@ -50,6 +54,7 @@
 {% macro coordinatesBlock (printer, report, iconUrl) -%}
 {%- if not empty(report.mavenCoordinate) or not empty(report.manifest) -%}
 {{ '\n\n' }}{{ printer.printTitle('Coordinates',2, iconUrl) }}
+{%- block beforeCoordinates %}{% endblock -%}
 {%- if not empty(report.mavenCoordinate) -%}
 {{ '\n\n' }}{{ printer.printTitle('Maven',3) }}
 
@@ -71,6 +76,7 @@
 {%- if not empty(developers) -%}
 {{ '\n\n' }}{{ printer.printTitle('Developers',2, iconUrl) }}
 
+{% block beforeDevelopers %}{% endblock -%}
 {{ printer.printDevelopers(developers) }}
 {%- endif -%}
 {%- endmacro %}
@@ -83,6 +89,7 @@
 {%- if not empty(licenses) -%}
 {{ '\n\n' }}{{ printer.printTitle('Licenses',2, iconUrl) }}
 
+{% block beforeLicenses %}{% endblock -%}
 {{ printer.printLicenses(licenses) }}
 {%- endif -%}
 {%- endmacro %}
@@ -95,6 +102,7 @@
 {%- if not empty(copyright) -%}
 {{ '\n\n' }}{{ printer.printTitle('Copyright',2, iconUrl) }}
 
+{% block beforeCopyright %}{% endblock -%}
 {{ copyright }}
 {%- endif -%}
 {% endmacro %}
@@ -107,6 +115,7 @@
 {%- set address = default(report.manifest.bundleContactAddress,report.commonInfo.contactAddress) -%}
 {%- if not empty(vendor) or not empty(address) -%}
 {{ '\n\n' }}---
+{% block beforeVendor %}{% endblock -%}
 {{ printer.printVendor(vendor, address) }}
 {%- endif -%}
 {%- endmacro %}
@@ -118,6 +127,7 @@
 {% if not empty(report.projects) or length(report.bundles) > 1 -%}
 {{ '\n\n' }}{{ printer.printTitle('Built Artifacts',2, iconUrl) }}
 
+{% block beforeArtifacts %}{% endblock -%}
 {{ printer.printArtifacts(report) }}
 {%- endif -%}
 {%- endmacro %}
@@ -129,6 +139,7 @@
 {%- if not empty(report.codeSnippets) -%}
 {{ '\n\n' }}{{ printer.printTitle('Code Usage',2, iconUrl) }}
 
+{% block beforeCodeUsage %}{% endblock -%}
 {{ printer.printCodeSnippets(report.codeSnippets) }}
 {%- endif -%}
 {%- endmacro %}
@@ -140,6 +151,7 @@
 {%- if not empty(report.components) -%}
 {{ '\n\n' }}{{ printer.printTitle('Components',2, iconUrl) }}
 
+{% block beforeComponents %}{% endblock -%}
 {{ printer.printComponents(report.components, report.metatypes) }}
 {%- endif -%}
 {%- endmacro %}

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/templates/readme.twig
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/templates/readme.twig
@@ -14,68 +14,68 @@
 {%- do report.get('bundles').clear() -%}
 {%- endif -%}
 
-{%- block beforeTitle %}{% endblock -%}
-
 {%- block title -%}
 {{ blocks.titleBlock(printer, report, iconUrl) }}
 {%- endblock -%}
 
-{%- block beforeOverview %}{% endblock -%}
+{%- block afterTitle %}{% endblock -%}
 
 {%- block overview -%}
 {{ blocks.overviewBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeLinks %}{% endblock -%}
+{%- block afterOverview %}{% endblock -%}
 
 {%- block links -%}
 {{ blocks.linksBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeCoordinates %}{% endblock -%}
+{%- block afterLinks %}{% endblock -%}
 
 {%- block coordinates -%}
 {{ blocks.coordinatesBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeArtifacts %}{% endblock -%}
+{%- block afterCoordinates %}{% endblock -%}
 
 {%- block artifacts -%}
 {{ blocks.artifactsBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeCodeUsage %}{% endblock -%}
+{%- block afterArtifacts %}{% endblock -%}
 
 {%- block codeUsage -%}
 {{ blocks.codeUsageBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeComponents %}{% endblock -%}
+{%- block afterCodeUsage %}{% endblock -%}
 
 {%- block components -%}
 {{ blocks.componentsBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeDevelopers %}{% endblock -%}
+{%- block afterComponents %}{% endblock -%}
 
 {%- block developers -%}
 {{ blocks.developersBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeLicenses %}{% endblock -%}
+{%- block afterDevelopers %}{% endblock -%}
 
 {%- block licenses -%}
 {{ blocks.licensesBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeCopyright %}{% endblock -%}
+{%- block afterLicenses %}{% endblock -%}
 
 {%- block copyright -%}
 {{ blocks.copyrightBlock(printer, report) }}
 {%- endblock -%}
 
-{%- block beforeVendor %}{% endblock -%}
+{%- block afterCopyright %}{% endblock -%}
 
 {%- block vendor -%}
 {{ blocks.vendorBlock(printer, report) }}
 {%- endblock %}
+
+{%- block afterVendor %}{% endblock -%}

--- a/docs/_chapters/395-generating-documentation.md
+++ b/docs/_chapters/395-generating-documentation.md
@@ -66,7 +66,20 @@ Write your own markdown text here.
 Inside an `embed` tag one can only specify block tags which will override the parent template included. 
 Here, the parent template is the readme template file built-in into Bnd available at the `default:readme.twig` URL (see the file [here](https://raw.githubusercontent.com/bndtools/bnd/master/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/templates/readme.twig)). This file defines a set of blocks that you can override with your own text. 
 In the above snippet, we override the `beforeTitle` block. You can add multiple blocks depending on where you want to insert your text, here is a list of available blocks:
-`beforeTitle`, `beforeOverview`, `beforeLinks`, `beforeCoordinates`, `beforeArtifacts`, `beforeCodeUsage`, `beforeComponents`, `beforeDevelopers`, `beforeLicenses`, `beforeCopyright`, `beforeVendor`.
+
+* `beforeTitle`, `afterTitle`
+* `beforeOverview`, `afterOverview`
+* `beforeLinks`, `afterLinks`
+* `beforeCoordinates`, `afterCoordinates`
+* `beforeArtifacts`, `afterArtifacts`
+* `beforeCodeUsage`, `afterCodeUsage`
+* `beforeComponents`, `afterComponents`
+* `beforeDevelopers`, `afterDevelopers`
+* `beforeLicenses`, `afterLicenses`
+* `beforeCopyright`, `afterCopyright`
+* `beforeVendor`, `afterVendor`
+
+`before*` blocks are shown between the title of a section and the generated content. `after*` blocks are shown at the end of a section, after the generated content. 
 
 #### Parameters
 


### PR DESCRIPTION
Closes #3391 

This PR makes manual editing of readme file easier by adding more empty blocks.
The generated readme file is not affected by this modification, so no test to update. 
The documentation has been updated.

Signed-off-by: Clément Delgrange <cl.delgrange@protonmail.com>