### PR TITLE
launcher: Fix handling of system properties and launcher parms on update

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -17,7 +17,6 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.instrument.Instrumentation;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
@@ -48,18 +47,17 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.StringTokenizer;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.Vector;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
@@ -97,6 +95,7 @@ public class Launcher implements ServiceListener {
 	private Framework						systemBundle;
 	private FrameworkWiring					frameworkWiring;
 	private final Properties				properties;
+	private final Properties				initialSystemProperties	= System.getProperties();
 	private boolean							security;
 	private SimplePermissionPolicy			policy;
 	private Callable<Integer>				mainThread;
@@ -199,19 +198,10 @@ public class Launcher implements ServiceListener {
 		out = System.err;
 	}
 
-	private static final Pattern QUOTED_P = Pattern.compile("^([\"'])(.*)\\1$");
-
-	private void loadPropertiesFromFileOrEmbedded() throws Throwable {
-
+	private void loadPropertiesFromFileOrEmbedded() throws Exception {
 		final InputStream in;
-
 		String path = getPropertiesPath();
 		if (path != null) {
-			Matcher matcher = QUOTED_P.matcher(path);
-			if (matcher.matches()) {
-				path = matcher.group(2);
-			}
-
 			File propertiesFile = new File(path).getAbsoluteFile();
 			if (!propertiesFile.isFile())
 				errorAndExit("Specified launch file `%s' was not found - absolutePath='%s'", path,
@@ -230,10 +220,20 @@ public class Launcher implements ServiceListener {
 	}
 
 	public String getPropertiesPath() {
-		return System.getProperty(LauncherConstants.LAUNCHER_PROPERTIES);
+		String path = System.getProperty(LauncherConstants.LAUNCHER_PROPERTIES);
+		if (path != null) {
+			int l = path.length() - 1;
+			if (l > 1) {
+				char q = path.charAt(0);
+				if (((q == '\'') || (q == '"')) && (q == path.charAt(l))) {
+					path = path.substring(1, l);
+				}
+			}
+		}
+		return path;
 	}
 
-	private void loadProperties(final InputStream in) throws UnsupportedEncodingException, IOException {
+	private void loadProperties(final InputStream in) throws IOException {
 		this.properties.clear();
 
 		try (Reader ir = IO.reader(in, UTF_8)) {
@@ -241,7 +241,7 @@ public class Launcher implements ServiceListener {
 		}
 
 		for (String key : LauncherConstants.LAUNCHER_PROPERTY_KEYS) {
-			String value = System.getProperty(key);
+			String value = initialSystemProperties.getProperty(key);
 			if (value == null)
 				continue;
 
@@ -250,43 +250,44 @@ public class Launcher implements ServiceListener {
 
 		for (Object key : properties.keySet()) {
 			String s = (String) key;
-			String v = System.getProperty(s);
+			String v = initialSystemProperties.getProperty(s);
 			if (v != null)
 				properties.put(key, v);
 		}
+	}
 
+	private void setSystemProperties() {
+		Properties sysProps = new LauncherSystemProperties(initialSystemProperties, properties);
+		System.setProperties(sysProps);
 	}
 
 	/*
 	 * If we have a properties file specified watch it and update
 	 */
 	private void watch() {
-		String propertiesPath = getPropertiesPath();
-		if (propertiesPath == null) {
+		String path = getPropertiesPath();
+		if (path == null) {
 			return;
 		}
-		File propertiesFile = new File(propertiesPath).getAbsoluteFile();
-
-		if (propertiesFile != null && parms.embedded == false) {
-			TimerTask watchdog = new TimerTask() {
-				long begin = propertiesFile.lastModified();
-
-				@Override
-				public void run() {
-					long now = propertiesFile.lastModified();
-					if (begin < now) {
-						try (InputStream in = IO.stream(propertiesFile)) {
-							loadProperties(in);
-							List<Bundle> tobestarted = update(now);
-							startBundles(tobestarted);
-						} catch (Exception e) {
-							error("Error in updating the framework from the properties: %s", e);
-						}
-						begin = now;
+		File propertiesFile = new File(path).getAbsoluteFile();
+		if (propertiesFile.isFile() && parms.embedded == false) {
+			ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+			AtomicLong lastModified = new AtomicLong(propertiesFile.lastModified());
+			scheduledExecutor.scheduleAtFixedRate(() -> {
+				long now = propertiesFile.lastModified();
+				if (lastModified.get() < now) {
+					try {
+						loadProperties(IO.stream(propertiesFile));
+						setSystemProperties();
+						parms = new LauncherConstants(properties);
+						List<Bundle> tobestarted = update(now);
+						startBundles(tobestarted);
+					} catch (Exception e) {
+						error("Error in updating the framework from the properties: %s", e);
 					}
+					lastModified.set(now);
 				}
-			};
-			new Timer(true).scheduleAtFixedRate(watchdog, 5000, 1000);
+			}, 5000, 1000, TimeUnit.MILLISECONDS);
 		}
 	}
 
@@ -319,10 +320,7 @@ public class Launcher implements ServiceListener {
 
 	private int launch(String args[]) throws Throwable {
 		try {
-
-			System.getProperties()
-				.putAll(this.properties);
-
+			setSystemProperties();
 			this.parms = new LauncherConstants(properties);
 			setupComms();
 
@@ -393,6 +391,7 @@ public class Launcher implements ServiceListener {
 		} finally {
 			deactivate();
 			trace("stopped system bundle due to leaving run body");
+			System.setProperties(initialSystemProperties);
 			// TODO should we wait here?
 		}
 	}

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -529,7 +529,7 @@ public class Launcher implements ServiceListener {
 
 			for (Bundle b : installedBundles.values()) {
 				try {
-					if (b.getState() == Bundle.INSTALLED) {
+					if ((b.getState() & Bundle.INSTALLED) != 0) {
 						start(b);
 					}
 				} catch (Exception e) {
@@ -667,7 +667,7 @@ public class Launcher implements ServiceListener {
 					if (f.lastModified() <= before) {
 						if (b.getLastModified() < f.lastModified()) {
 							trace("updating %s", f);
-							if (b.getState() == Bundle.ACTIVE || b.getState() == Bundle.STARTING) {
+							if ((b.getState() & (Bundle.ACTIVE | Bundle.STARTING)) != 0) {
 								tobestarted.add(b);
 								stop(b);
 							}

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -1437,10 +1437,7 @@ public class Launcher implements ServiceListener {
 					}
 				}
 
-				mainThread = () -> {
-					((Runnable) service).run();
-					return 0;
-				};
+				mainThread = Executors.callable((Runnable) service, 0);
 			} finally {
 				trace("selected main thread %s", event);
 				notifyAll();

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -36,6 +36,7 @@ import java.security.PermissionCollection;
 import java.security.Policy;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Formatter;
 import java.util.HashMap;
@@ -47,7 +48,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.StringTokenizer;
-import java.util.Vector;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -1351,7 +1351,7 @@ public class Launcher implements ServiceListener {
 		}
 	}
 
-	static PermissionCollection all = new AllPermissionCollection();
+	static final PermissionCollection all = new AllPermissionCollection();
 
 	class AllPolicy extends Policy {
 
@@ -1372,13 +1372,9 @@ public class Launcher implements ServiceListener {
 
 	static class AllPermissionCollection extends PermissionCollection {
 		private static final long			serialVersionUID	= 1L;
-		private static Vector<Permission>	list				= new Vector<>();
+		private static final List<Permission>	PERMISSIONS			= Collections.singletonList(new AllPermission());
 
-		static {
-			list.add(new AllPermission());
-		}
-
-		{
+		AllPermissionCollection() {
 			setReadOnly();
 		}
 
@@ -1387,7 +1383,7 @@ public class Launcher implements ServiceListener {
 
 		@Override
 		public Enumeration<Permission> elements() {
-			return list.elements();
+			return Collections.enumeration(PERMISSIONS);
 		}
 
 		@Override

--- a/biz.aQute.launcher/src/aQute/launcher/LauncherSystemProperties.java
+++ b/biz.aQute.launcher/src/aQute/launcher/LauncherSystemProperties.java
@@ -1,0 +1,54 @@
+package aQute.launcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+class LauncherSystemProperties extends Properties {
+	private static final long			serialVersionUID	= 1L;
+	private final Map<Object, Object>	userSet				= new HashMap<>();
+
+	LauncherSystemProperties(Properties... properties) {
+		for (Properties p : properties) {
+			for (Map.Entry<Object, Object> e : p.entrySet()) {
+				super.put(e.getKey(), e.getValue());
+			}
+		}
+		Properties sysProps = System.getProperties();
+		if (sysProps instanceof LauncherSystemProperties) {
+			synchronized (sysProps) {
+				for (Map.Entry<Object, Object> e : ((LauncherSystemProperties) sysProps).userSet.entrySet()) {
+					Object key = e.getKey();
+					Object value = e.getValue();
+					if (value != null) {
+						put(key, value);
+					} else {
+						remove(key);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public synchronized Object put(Object key, Object value) {
+		Object existing = super.put(key, value);
+		userSet.put(key, value);
+		return existing;
+	}
+
+	@Override
+	public synchronized Object remove(Object key) {
+		Object existing = super.remove(key);
+		if (existing != null) {
+			userSet.put(key, null);
+		}
+		return existing;
+	}
+
+	@Override
+	public synchronized void clear() {
+		super.clear();
+		userSet.clear();
+	}
+}


### PR DESCRIPTION
The watcher, now updated to use a scheduled executor, failed to properly
handle updating the system properties and the launcher parms when the
properties file was updated.

Also remove use of Vector and regex.