### PR TITLE
Use JUnit 5 for JUnit test cases

### DIFF
--- a/aQute.libg/bnd.bnd
+++ b/aQute.libg/bnd.bnd
@@ -10,7 +10,6 @@
 
 -testpath: \
 	${junit},\
-	osgi.core;version=latest,\
 	slf4j.simple;version=latest
 
 -exportcontents: *

--- a/aQute.libg/test/aQute/lib/io/IOTest.java
+++ b/aQute.libg/test/aQute/lib/io/IOTest.java
@@ -1,7 +1,13 @@
 package aQute.lib.io;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,11 +15,24 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
 import aQute.lib.io.IO.EnvironmentCalculator;
-import junit.framework.TestCase;
 
-public class IOTest extends TestCase {
+public class IOTest {
 
+	private String testName;
+
+	@BeforeEach
+	public void before(TestInfo info) {
+		testName = info.getTestMethod()
+			.map(Method::getName)
+			.get();
+	}
+
+	@Test
 	public void testEnvVarsForHome() throws Exception {
 		Map<String, String> map = new HashMap<>();
 
@@ -46,6 +65,7 @@ public class IOTest extends TestCase {
 		assertEquals("C:\\Documents and Settings\\foobar", ec2.getSystemEnv("HOME"));
 	}
 
+	@Test
 	public void testSafeFileName() {
 		if (IO.isWindows()) {
 			assertEquals("abc%def", IO.toSafeFileName("abc:def"));
@@ -58,6 +78,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testFilesetCopy() throws Exception {
 		File destDir = new File("generated/fileset-copy-test");
 
@@ -78,6 +99,7 @@ public class IOTest extends TestCase {
 		assertTrue(new File(destDir, "root").exists());
 	}
 
+	@Test
 	public void testCopyURLToByteArray() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -91,6 +113,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToExactHeapByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -105,6 +128,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToSmallerHeapByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -118,6 +142,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToLargerHeapByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -131,6 +156,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToExactDirectByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -145,6 +171,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToSmallerDirectByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -158,6 +185,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToLargerDirectByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -171,6 +199,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToHugeDirectByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -184,6 +213,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCopyToOffsetHeapByteBuffer() throws Exception {
 		File src = new File("testresources/unzipped.dat");
 		byte[] file = IO.read(src);
@@ -206,6 +236,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDestDirIsChildOfSource() throws Exception {
 		File parentDir = new File("generated/test/parentDir");
 
@@ -226,6 +257,7 @@ public class IOTest extends TestCase {
 		} catch (IllegalArgumentException e) {}
 	}
 
+	@Test
 	public void testIfCreateSymlinkOrCopyFileDependingOnOS() throws Exception {
 		File link = new File("generated/test/target.dat");
 
@@ -248,6 +280,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOnlyCopyIfReallyNeededOnWindows() throws Exception {
 		if (IO.isWindows()) {
 			File link = new File("generated/test/target.dat");
@@ -273,6 +306,7 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCreateSymlinkOrCopyWillDeleteOriginalLink() throws Exception {
 		File originalSource = new File("testresources/unzipped.dat");
 		File link = new File("generated/test/originalLink");
@@ -297,8 +331,9 @@ public class IOTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCreateDirectory_Symlink() throws Exception {
-		Path rootDirectory = Paths.get("generated/tmp/test/" + getName());
+		Path rootDirectory = Paths.get("generated/tmp/test/" + testName);
 		IO.delete(rootDirectory);
 		rootDirectory = Files.createDirectories(rootDirectory);
 
@@ -317,8 +352,9 @@ public class IOTest extends TestCase {
 			.exists());
 	}
 
+	@Test
 	public void testCreateDirectory_SymlinkMissingTarget() throws Exception {
-		Path rootDirectory = Paths.get("generated/tmp/test/" + getName());
+		Path rootDirectory = Paths.get("generated/tmp/test/" + testName);
 		IO.delete(rootDirectory);
 		rootDirectory = Files.createDirectories(rootDirectory);
 

--- a/aQute.libg/test/aQute/libg/uri/URIUtilsTest.java
+++ b/aQute.libg/test/aQute/libg/uri/URIUtilsTest.java
@@ -1,56 +1,62 @@
 package aQute.libg.uri;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
 import java.net.URI;
 
-import aQute.lib.io.IO;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
-public class URIUtilsTest extends TestCase {
+public class URIUtilsTest {
 
+	@Test
 	public void testResolveAbsolute() throws Exception {
 		// reference is absolute, so base is irrelevant
 		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml"), "http://example.org/bar.xml");
-		assertEquals("http://example.org/bar.xml", result.toString());
+		assertThat(result).hasToString("http://example.org/bar.xml");
 	}
 
+	@Test
 	public void testResolveRelativeHttp() throws Exception {
 		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml"), "bar.xml");
-		assertEquals("http://example.com/bar.xml", result.toString());
+		assertThat(result).hasToString("http://example.com/bar.xml");
 	}
 
+	@Test
 	public void testResolveBlank() throws Exception {
 		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml"), "");
-		assertEquals("http://example.com/foo.xml", result.toString());
+		assertThat(result).hasToString("http://example.com/foo.xml");
 	}
 
+	@Test
 	public void testResolveFragmentBlank() throws Exception {
 		URI result = URIUtil.resolve(URI.create("http://example.com/foo.xml#bar"), "");
-		assertEquals("http://example.com/foo.xml", result.toString());
+		assertThat(result).hasToString("http://example.com/foo.xml");
 	}
 
+	@Test
+	@EnabledOnOs(WINDOWS)
 	public void testResolveAbsoluteWindowsPath() throws Exception {
-		if (IO.isWindows()) {
-			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:\\Users\\sub dir\\foo.txt");
-			assertEquals("file:/C:/Users/sub%20dir/foo.txt", result.toString());
-			result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:/Users/sub dir/bar.txt");
-			assertEquals("file:/C:/Users/sub%20dir/bar.txt", result.toString());
-		}
+		URI result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:\\Users\\sub dir\\foo.txt");
+		assertThat(result).hasToString("file:/C:/Users/sub%20dir/foo.txt");
+		result = URIUtil.resolve(URI.create("file:/C:/Users/jimbob/base.txt"), "C:/Users/sub dir/bar.txt");
+		assertThat(result).hasToString("file:/C:/Users/sub%20dir/bar.txt");
 	}
 
+	@Test
+	@EnabledOnOs(WINDOWS)
 	public void testResolveRelativeWindowsPath() throws Exception {
-		if (IO.isWindows()) {
-			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "sub dir\\foo.txt");
-			assertEquals("file:/C:/Users/jim/sub%20dir/foo.txt", result.toString());
-		}
+		URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "sub dir\\foo.txt");
+		assertThat(result).hasToString("file:/C:/Users/jim/sub%20dir/foo.txt");
 	}
 
+	@Test
+	@EnabledOnOs(WINDOWS)
 	public void testResolveUNCWindowsPath() throws Exception {
-		if (IO.isWindows()) {
-			URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "\\\\server\\share\\foo.txt");
-			assertEquals("file:////server/share/foo.txt", result.toString());
-			result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "//server/share/foo.txt");
-			assertEquals("file:////server/share/foo.txt", result.toString());
-		}
+		URI result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "\\\\server\\share\\foo.txt");
+		assertThat(result).hasToString("file:////server/share/foo.txt");
+		result = URIUtil.resolve(URI.create("file:/C:/Users/jim/base.txt"), "//server/share/foo.txt");
+		assertThat(result).hasToString("file:////server/share/foo.txt");
 	}
-
 }

--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -22,6 +22,9 @@ Bundle-Description: The Bnd Gradle plugin.
 	biz.aQute.resolve;version=latest, \
 	biz.aQute.repository;version=latest
 
+-testpath: \
+	${junit}
+
 bnd_version: ${replace;${bnd_plugin};.*:(.*);$1}
 
 -includeresource: \

--- a/biz.aQute.junit/bnd.bnd
+++ b/biz.aQute.junit/bnd.bnd
@@ -7,7 +7,8 @@
 	osgi.core;version=latest,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
-    ${junit}
+    org.apache.servicemix.bundles.junit;version=latest,\
+    org.assertj.core;version=latest
 
 Tester-Plugin: aQute.junit.plugin.ProjectTesterImpl
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ subprojects {
       ]
     }
     tasks.named('test') {
+      useJUnitPlatform()
       testLogging {
         exceptionFormat 'full'
       }

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -57,6 +57,15 @@ org.apache.geronimo.specs:geronimo-jcdi_2.0_spec:1.1
 org.apache.ant:ant:1.7.1
 
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1
+org.junit.platform:junit-platform-commons:1.5.2
+org.junit.platform:junit-platform-engine:1.5.2
+org.junit.platform:junit-platform-launcher:1.5.2
+org.junit.jupiter:junit-jupiter-api:5.5.2
+org.junit.jupiter:junit-jupiter-engine:5.5.2
+org.junit.jupiter:junit-jupiter-params:5.5.2
+org.junit.vintage:junit-vintage-engine:5.5.2
+org.opentest4j:opentest4j:1.2.0
+org.apiguardian:apiguardian-api:1.1.0
 org.assertj:assertj-core:3.12.1
 
 org.eclipse.platform:org.eclipse.osgi:3.13.300

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -1,6 +1,15 @@
-junit: org.apache.servicemix.bundles.junit;version="[4.11,5)",\
- org.assertj.core;version="[3,4)"
+junit: org.junit.platform:junit-platform-commons;version=latest,\
+	org.junit.platform:junit-platform-engine;version=latest,\
+	org.assertj.core;version="[3,4)",\
+	org.opentest4j:opentest4j;version=latest,\
+	org.apiguardian:apiguardian-api;version=latest,\
+	org.junit.jupiter:junit-jupiter-api;version=latest,\
+	org.junit.jupiter:junit-jupiter-engine;version=latest,\
+	org.junit.jupiter:junit-jupiter-params;version=latest,\
+	org.apache.servicemix.bundles.junit;version="[4.11,5)",\
+	org.junit.vintage:junit-vintage-engine;version=latest
+
 mockito: org.mockito.mockito-core;version="[2,3)",\
-  net.bytebuddy.byte-buddy;version="[1,2)",\
-  org.objenesis;version="[2,3)"
+	net.bytebuddy.byte-buddy;version="[1,2)",\
+	org.objenesis;version="[2,3)"
 -runsystempackages.objenesis: sun.misc,sun.reflect


### PR DESCRIPTION
Example of how JUnit 5 support might be added to the Bnd build.

This PR does the following:

* Adds library packages for JUnit Platform, and the Jupiter and Vintage engines to ext/central.mvn
* Adds macros to group them logically to ext/junit.bnd
* Converts `aQute.libg` to use the JUnit Platform.
  * `build.gradle` modified to cause Gradle to use the JUnit Platform rather than the JUnit 4 runner.
  * Converted `aQute.lib.io.IOTest` and `aQute.libg.uri.URIUtils` to use the Jupiter engine.
  * All other test classes remain as they were (JUnit 3 or 4 tests) and are executed by JUnit Platform using the Vintage engine.
* All other projects continue to use the JUnit 4 runner. To migrate them:
   1. Replace the ${junit} dependency in `-testpath` with ${junit-platform}
   2. Add the engines that you need to `-testpath` too (eg, ${junit-vintage} to run the old JUnit 3/4 tests, and ${junit-jupiter} if you add any Jupiter tests).

As a bonus, using the `@DisabledOnOs` annotation, I have managed to get rid of the test failures for the symlink tests on my machine.

Suggested future enhancements:
1. Get the bnd-gradle-plugin to add the necessary configuration when it detects junit-platform on the class path, so that a `build.gradle` file is not necessary.
2. Similar customisation (if appropriate) for the bnd-maven-m2e integration.

Comments welcomed/appreciated.