### PR TITLE
Use 'this' as lock in prepare

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -270,7 +270,7 @@ public class Project extends Processor {
 			return;
 		}
 
-		synchronized (preparedPaths) {
+		synchronized (this) {
 			if (preparedPaths.get()) {
 				// ensure output folders exist
 				getSrcOutput0();


### PR DESCRIPTION
Using two different locks for the same file creates deadlocks.

Fixes #3453