### PR TITLE
Issue 3443 - Incorrect behaviour for HttpsVerification.hostnameVerify

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/url/HttpsVerification.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/url/HttpsVerification.java
@@ -37,7 +37,6 @@ import aQute.service.reporter.Reporter;
 public class HttpsVerification extends DefaultURLConnectionHandler {
 	static Logger				logger	= LoggerFactory.getLogger(HttpsVerification.class);
 	private SSLSocketFactory	factory;
-	private HostnameVerifier	verifier;
 	private boolean				verify	= true;
 	private String				certificatesPath;
 	private X509Certificate[]	certificateChain;
@@ -61,7 +60,7 @@ public class HttpsVerification extends DefaultURLConnectionHandler {
 	}
 
 	/**
-	 * Initialize the SSL Context, factory and verifier.
+	 * Initialize the SSL Context and factory.
 	 *
 	 * @throws NoSuchAlgorithmException
 	 * @throws KeyManagementException
@@ -82,8 +81,6 @@ public class HttpsVerification extends DefaultURLConnectionHandler {
 			SSLContext context = SSLContext.getInstance("TLS");
 			context.init(null, trustManagers, new SecureRandom());
 			factory = context.getSocketFactory();
-
-			verifier = (string, session) -> verify;
 		}
 	}
 
@@ -97,7 +94,9 @@ public class HttpsVerification extends DefaultURLConnectionHandler {
 			HttpsURLConnection https = (HttpsURLConnection) connection;
 			init();
 			https.setSSLSocketFactory(factory);
-			https.setHostnameVerifier(verifier);
+			if (!verify) {
+				https.setHostnameVerifier((string, session) -> true);
+			}
 		}
 	}
 

--- a/biz.aQute.http.testservers/src/aQute/http/testservers/HttpTestServer.java
+++ b/biz.aQute.http.testservers/src/aQute/http/testservers/HttpTestServer.java
@@ -72,13 +72,17 @@ public class HttpTestServer implements AutoCloseable, Closeable {
 	}
 
 	public HttpTestServer(Config config) throws Exception {
+		this(config, "localhost");
+	}
+
+	public HttpTestServer(Config config, String cn) throws Exception {
 		this.config = config == null ? config = new Config() : config;
 
 		if (config.host == null)
 			config.host = InetAddress.getLoopbackAddress()
 				.getHostAddress();
 
-		server = new Server(config);
+		server = new Server(config, cn);
 
 	}
 

--- a/biz.aQute.http.testservers/src/aQute/http/testservers/Httpbin.java
+++ b/biz.aQute.http.testservers/src/aQute/http/testservers/Httpbin.java
@@ -31,6 +31,10 @@ public class Httpbin extends HttpTestServer {
 		super(config);
 	}
 
+	public Httpbin(Config config, String cn) throws Exception {
+		super(config, cn);
+	}
+
 	/**
 	 * Default page
 	 */

--- a/biz.aQute.http.testservers/src/aQute/http/testservers/Server.java
+++ b/biz.aQute.http.testservers/src/aQute/http/testservers/Server.java
@@ -46,13 +46,17 @@ class Server extends NanoHTTPD {
 	final Map<String, HttpContext>	contexts	= new HashMap<>();
 
 	public Server(HttpTestServer.Config config) throws Exception {
+		this(config, "localhost");
+	}
+
+	public Server(HttpTestServer.Config config, String cn) throws Exception {
 		super(config.host, config.port);
 
 		this.config = config;
 		if (config.https) {
 
 			KeyPair pair = createKey();
-			certificateChain = createSelfSignedCertifcate(pair);
+			certificateChain = createSelfSignedCertifcate(pair, cn);
 			KeyStore keystore = createKeystore(pair);
 			SSLContext ctx = createTLSContext(keystore);
 			makeSecure(ctx.getServerSocketFactory(), null);
@@ -180,9 +184,9 @@ class Server extends NanoHTTPD {
 		return ctx;
 	}
 
-	private X509Certificate[] createSelfSignedCertifcate(KeyPair keyPair) throws Exception {
+	private X509Certificate[] createSelfSignedCertifcate(KeyPair keyPair, String cn) throws Exception {
 		X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
-		nameBuilder.addRDN(BCStyle.CN, "localhost");
+		nameBuilder.addRDN(BCStyle.CN, cn);
 
 		Date notBefore = new Date();
 		Date notAfter = new Date(System.currentTimeMillis() + 24 * 3 * 60 * 60 * 1000);


### PR DESCRIPTION
The hostname verification logic in HttpsVerification is incorrect. If "verify" is true then it actually disables hostname verification. If "verify" is false, then it always fails hostname verification.

I added two tests using a cert with an incorrect CN for the hostname. Both tests fail with the old code and pass with the new.