### PR TITLE
bnd: Add test for the brew bnd formula expected output

### DIFF
--- a/biz.aQute.bnd/test/aQute/bnd/main/TestBndMain.java
+++ b/biz.aQute.bnd/test/aQute/bnd/main/TestBndMain.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import aQute.bnd.main.testrules.WatchedFolder.FileStatus;
 import aQute.bnd.osgi.Jar;
+import aQute.lib.io.IO;
 
 public class TestBndMain extends TestBndMainBase {
 
@@ -48,6 +49,20 @@ public class TestBndMain extends TestBndMainBase {
 			expectJarEntry(result, "jar/org.apache.felix.framework-5.6.10.jar");
 			expectJarEntry(result, "jar/printAndExit-1.0.0.jar");
 		}
+	}
+
+	@Test
+	public void testBrewFormulaExpectedOutput() throws Exception {
+		executeBndCmd(IO.getPath("testdata/brew"), "resolve", "resolve", "-b", "launch.bndrun");
+		/*
+		 * If the expected output changes for this test, we will need to modify
+		 * the brew formula for the bnd command to change the output asserts.
+		 * See
+		 * https://github.com/Homebrew/homebrew-core/blob/master/Formula/bnd.rb
+		 */
+		expectOutputContainsPattern(
+			"BUNDLES\\s+org.apache.felix.gogo.runtime;version='\\[1.0.0,1.0.1\\)'");
+		expectNoError();
 	}
 
 	@Test

--- a/biz.aQute.bnd/test/aQute/bnd/main/TestBndMainBase.java
+++ b/biz.aQute.bnd/test/aQute/bnd/main/TestBndMainBase.java
@@ -1,5 +1,6 @@
 package aQute.bnd.main;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -117,8 +118,18 @@ public class TestBndMainBase {
 		assertThat("missing output", capturedStdIO.getSystemOutContent(), containsString(expected));
 	}
 
+	protected void expectOutputContainsPattern(String regex) {
+		assertThat(capturedStdIO.getSystemOutContent()).as("output does not contain pattern")
+			.containsPattern(regex);
+	}
+
 	protected void expectErrorContains(String expected) {
 		assertThat("missing error", capturedStdIO.getSystemErrContent(), containsString(expected));
+	}
+
+	protected void expectErrorContainsPattern(String regex) {
+		assertThat(capturedStdIO.getSystemErrContent()).as("error does not contain pattern")
+			.containsPattern(regex);
 	}
 
 	protected void expectNoError(boolean ignoreWarnings, String... expects) {

--- a/biz.aQute.bnd/testdata/brew/index.xml
+++ b/biz.aQute.bnd/testdata/brew/index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<repository increment="0" name="Untitled" xmlns="http://www.osgi.org/xmlns/repository/v1.0.0">
+  <resource>
+    <capability namespace="osgi.identity">
+      <attribute name="osgi.identity" value="org.apache.felix.gogo.runtime"/>
+      <attribute name="type" value="osgi.bundle"/>
+      <attribute name="version" type="Version" value="1.0.0"/>
+    </capability>
+    <capability namespace="osgi.content">
+      <attribute name="osgi.content" value="baad835c6fa65afc1695cc92a9e1afe2967e546cae94d59fa9e49b557052b2b1"/>
+      <attribute name="url" value="org.apache.felix.gogo.runtime-1.0.0.jar"/>
+    </capability>
+  </resource>
+</repository>

--- a/biz.aQute.bnd/testdata/brew/launch.bndrun
+++ b/biz.aQute.bnd/testdata/brew/launch.bndrun
@@ -1,0 +1,2 @@
+-standalone: ${.}/index.xml
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.runtime)'


### PR DESCRIPTION
If the output of the resolve command changes such that this test method
needs to be changed, we must also modify the brew bnd formula
accordingly when we release.
