### PR TITLE
gradle: Use getOrNull to access archiveVersion property of Jar task

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ started.
 They are probably not perfect, please let us know if anything feels
 wrong or incomplete.
 
-## Acknowledgements
+## Acknowledgments
 YourKit supports open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of [YourKit Java Profiler](https://www.yourkit.com/java/profiler/index.jsp) and [YourKit .NET Profiler](https://www.yourkit.com/.net/profiler/index.jsp), innovative and intelligent tools for profiling Java and .NET applications.
 
 [![YourKit](https://www.yourkit.com/images/yklogo.png)](https://www.yourkit.com/)

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -233,7 +233,7 @@ class BundleTaskConvention {
         // Gradle 5.1 deprecates Jar task properties
         File archivePath = task.hasProperty('archiveFile') ? task.archiveFile.get().asFile : task.archivePath
         String archiveName = task.hasProperty('archiveFileName') ? task.archiveFileName.get() : task.archiveName
-        String version = task.hasProperty('archiveVersion') ? task.archiveVersion.get() : task.version
+        String version = task.hasProperty('archiveVersion') ? task.archiveVersion.getOrNull() : task.version
 
         // Include entire contents of Jar task generated jar (except the manifest)
         project.copy {


### PR DESCRIPTION
This will protect against an empty property/provider assigned to the
project.version property.