### PR TITLE
launcher: Don't always set launch.activators to an empty string

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -619,7 +619,7 @@ public abstract class ProjectLauncher extends Processor {
 			properties.put(Constants.LAUNCH_ACTIVATION_EAGER, Boolean.toString(eager));
 
 		Collection<String> activators = getActivators();
-		if (activators.isEmpty())
+		if (!activators.isEmpty())
 			properties.put(Constants.LAUNCH_ACTIVATORS, join(activators, ","));
 
 		if (!keep)


### PR DESCRIPTION
The missing `!` caused Embedded-Activators to be ignored which breaks
biz.aQute.junit. I discovered this when trying to use 4.3.0 with the
OSGi build where some test project still use biz.aQute.junit as the
-tester.

Fixes https://github.com/bndtools/bnd/issues/3481