### PR TITLE
fixed error printout on launch without any error having appeared

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -558,7 +558,9 @@ public class Launcher implements ServiceListener {
 					failed.add(b.getSymbolicName() + "-" + b.getVersion() + " " + e + "\n");
 				}
 			}
-			error("could not resolve the bundles: %s", failed);
+			if (!failed.isEmpty()) {
+				error("could not resolve the bundles: %s", failed);
+			}
 			// return LauncherConstants.RESOLVE_ERROR;
 		}
 


### PR DESCRIPTION
If the launcher ran in this peace of code, it always communicated an error "could not resolve the bundles: []" which is apparently no error.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>