### PR TITLE
launcher: Fix MiniFramework operation

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -367,11 +367,11 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 		BundleWiring wiring = bundle.adapt(BundleWiring.class);
 		// Bundle isn't resolved.
 		if (wiring == null) {
-			System.err.println("unresolved bundle: " + bundle);
+			trace("unresolved bundle: %s", bundle);
 			return null;
 		}
 		List<BundleWire> wires = wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE);
-		System.err.println("required wires for " + bundle + " " + wires);
+		trace("required wires for %s %s", bundle, wires);
 
 		for (BundleWire wire : wires) {
 			hosts.add(wire.getProviderWiring()
@@ -469,20 +469,20 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 					"The test class %s extends %s and it uses JUnit 4 annotations. This means that the annotations will be ignored.",
 					clazz.getName(), TestCase.class.getName());
 			}
-			trace("using JUnit 3");
 			if (method != null) {
+				trace("using JUnit 3 for %s#%s", clazz.getName(), method);
 				suite.addTest(TestSuite.createTest(clazz, method));
 				return;
 			}
+			trace("using JUnit 3 for %s", clazz.getName());
 			suite.addTestSuite((Class<? extends TestCase>) clazz);
 			return;
 		}
 
-		trace("using JUnit 4");
 
 		JUnit4TestAdapter adapter = new JUnit4TestAdapter(clazz);
 		if (method != null) {
-			trace("method specified " + clazz + ":" + method);
+			trace("using JUnit 4 for %s#%s", clazz.getName(), method);
 			final Pattern glob = Pattern.compile(method.replaceAll("\\*", ".*")
 				.replaceAll("\\?", ".?"));
 
@@ -508,6 +508,8 @@ public class Activator implements BundleActivator, TesterConstants, Runnable {
 			} catch (NoTestsRemainException e) {
 				return;
 			}
+		} else {
+			trace("using JUnit 4 for %s", clazz.getName());
 		}
 		suite.addTest(adapter);
 	}

--- a/biz.aQute.junit/src/aQute/junit/plugin/ProjectTesterImpl.java
+++ b/biz.aQute.junit/src/aQute/junit/plugin/ProjectTesterImpl.java
@@ -50,7 +50,7 @@ public class ProjectTesterImpl extends ProjectTester implements EclipseJUnitTest
 				.put(TESTER_DIR, getReportDir().getAbsolutePath());
 			launcher.getRunProperties()
 				.put(TESTER_CONTINUOUS, "" + getContinuous());
-			if (getProject().is(Constants.RUNTRACE))
+			if (getProject().isRunTrace())
 				launcher.getRunProperties()
 					.put(TESTER_TRACE, "true");
 

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/BundleRevisionImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/BundleRevisionImpl.java
@@ -1,0 +1,68 @@
+package aQute.launcher.minifw;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleRequirement;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+
+class BundleRevisionImpl implements BundleRevision {
+	private final Bundle bundle;
+
+	BundleRevisionImpl(Bundle bundle) {
+		this.bundle = bundle;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return bundle;
+	}
+
+	@Override
+	public BundleWiring getWiring() {
+		return bundle.adapt(BundleWiring.class);
+	}
+
+	@Override
+	public Version getVersion() {
+		return bundle.getVersion();
+	}
+
+	@Override
+	public int getTypes() {
+		return (bundle.getHeaders()
+			.get(Constants.FRAGMENT_HOST) != null) ? BundleRevision.TYPE_FRAGMENT : 0;
+	}
+
+	@Override
+	public String getSymbolicName() {
+		return bundle.getSymbolicName();
+	}
+
+	@Override
+	public List<Requirement> getRequirements(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<BundleRequirement> getDeclaredRequirements(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<BundleCapability> getDeclaredCapabilities(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Capability> getCapabilities(String namespace) {
+		return Collections.emptyList();
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/BundleStartLevelImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/BundleStartLevelImpl.java
@@ -1,0 +1,40 @@
+package aQute.launcher.minifw;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.startlevel.BundleStartLevel;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+
+class BundleStartLevelImpl implements BundleStartLevel {
+	private final Bundle	bundle;
+	private volatile int	startLevel;
+
+	BundleStartLevelImpl(Bundle bundle, FrameworkStartLevel frameworkStartLevel) {
+		this.bundle = bundle;
+		this.startLevel = frameworkStartLevel.getInitialBundleStartLevel();
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return bundle;
+	}
+
+	@Override
+	public int getStartLevel() {
+		return startLevel;
+	}
+
+	@Override
+	public void setStartLevel(int startlevel) {
+		this.startLevel = startlevel;
+	}
+
+	@Override
+	public boolean isPersistentlyStarted() {
+		return false;
+	}
+
+	@Override
+	public boolean isActivationPolicyUsed() {
+		return false;
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/BundleWiringImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/BundleWiringImpl.java
@@ -1,0 +1,107 @@
+package aQute.launcher.minifw;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleRequirement;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Wire;
+
+class BundleWiringImpl implements BundleWiring {
+	private final Bundle		bundle;
+	private final ClassLoader		classLoader;
+
+	BundleWiringImpl(Bundle bundle, ClassLoader classLoader) {
+		this.bundle = bundle;
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return bundle;
+	}
+
+	@Override
+	public boolean isCurrent() {
+		return true;
+	}
+
+	@Override
+	public boolean isInUse() {
+		return true;
+	}
+
+	@Override
+	public List<BundleCapability> getCapabilities(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<BundleRequirement> getRequirements(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<BundleWire> getProvidedWires(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<BundleWire> getRequiredWires(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public BundleRevision getRevision() {
+		return bundle.adapt(BundleRevision.class);
+	}
+
+	@Override
+	public ClassLoader getClassLoader() {
+		return classLoader;
+	}
+
+	@Override
+	public List<URL> findEntries(String path, String filePattern, int options) {
+		return Collections
+			.list(bundle.findEntries(path, filePattern, (options & BundleWiring.FINDENTRIES_RECURSE) != 0));
+	}
+
+	@Override
+	public Collection<String> listResources(String path, String filePattern, int options) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Capability> getResourceCapabilities(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Requirement> getResourceRequirements(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Wire> getProvidedResourceWires(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Wire> getRequiredResourceWires(String namespace) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public BundleRevision getResource() {
+		return getRevision();
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/Context.java
@@ -34,6 +34,9 @@ import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.Version;
+import org.osgi.framework.startlevel.BundleStartLevel;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWiring;
 
 public class Context extends URLClassLoader implements Bundle, BundleContext, BundleReference {
 	long					id;
@@ -438,6 +441,15 @@ public class Context extends URLClassLoader implements Bundle, BundleContext, Bu
 
 	@Override
 	public <A> A adapt(Class<A> type) {
+		if (BundleRevision.class.equals(type)) {
+			return type.cast(new BundleRevisionImpl(this));
+		}
+		if (BundleWiring.class.equals(type)) {
+			return type.cast(new BundleWiringImpl(this, this));
+		}
+		if (BundleStartLevel.class.equals(type)) {
+			return type.cast(new BundleStartLevelImpl(this, fw.frameworkStartLevel));
+		}
 		return null;
 	}
 

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/FrameworkStartLevelImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/FrameworkStartLevelImpl.java
@@ -1,0 +1,50 @@
+package aQute.launcher.minifw;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+
+class FrameworkStartLevelImpl implements FrameworkStartLevel {
+	private final Framework	framework;
+	private volatile int	startLevel;
+	private volatile int	initialBundleStartLevel;
+
+	FrameworkStartLevelImpl(Framework framework) {
+		this.framework = framework;
+		this.startLevel = 0;
+		this.initialBundleStartLevel = 0;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return framework;
+	}
+
+	@Override
+	public int getStartLevel() {
+		return startLevel;
+	}
+
+	@Override
+	public void setStartLevel(int startlevel, FrameworkListener... listeners) {
+		this.startLevel = startlevel;
+		if (listeners != null) {
+			FrameworkEvent event = new FrameworkEvent(FrameworkEvent.STARTLEVEL_CHANGED, getBundle(), null);
+			for (FrameworkListener listener : listeners) {
+				listener.frameworkEvent(event);
+			}
+		}
+	}
+
+	@Override
+	public int getInitialBundleStartLevel() {
+		return initialBundleStartLevel;
+	}
+
+	@Override
+	public void setInitialBundleStartLevel(int startlevel) {
+		this.initialBundleStartLevel = startlevel;
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/FrameworkWiringImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/FrameworkWiringImpl.java
@@ -1,0 +1,56 @@
+package aQute.launcher.minifw;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.FrameworkWiring;
+import org.osgi.resource.Requirement;
+
+class FrameworkWiringImpl implements FrameworkWiring {
+	private final Framework framework;
+
+	FrameworkWiringImpl(Framework framework) {
+		this.framework = framework;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return framework;
+	}
+
+	@Override
+	public void refreshBundles(Collection<Bundle> bundles, FrameworkListener... listeners) {
+		if (listeners != null) {
+			FrameworkEvent event = new FrameworkEvent(FrameworkEvent.PACKAGES_REFRESHED, getBundle(), null);
+			for (FrameworkListener listener : listeners) {
+				listener.frameworkEvent(event);
+			}
+		}
+	}
+
+	@Override
+	public boolean resolveBundles(Collection<Bundle> bundles) {
+		return true;
+	}
+
+	@Override
+	public Collection<Bundle> getRemovalPendingBundles() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Collection<Bundle> getDependencyClosure(Collection<Bundle> bundles) {
+		return new ArrayList<>(bundles);
+	}
+
+	@Override
+	public Collection<BundleCapability> findProviders(Requirement requirement) {
+		return Collections.emptyList();
+	}
+}


### PR DESCRIPTION
The use of `-runframework: none` was broken by changes to the launcher
which expects the framework to be adaptable to certain start level and
wiring types.

Fixes #3489