### PR TITLE
workspace: Ensure workspace plugins are fully initialized before use

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -113,6 +113,10 @@ public class BndWorkspacePlugin implements Plugin<Object> {
         gradle.bndWorkspaceConfigure(workspace)
       }
 
+      /* Make sure all workspace plugins are loaded before preparing
+       * projects.
+       */
+      workspace.getPlugins()
       /* Prepare each project in the workspace to establish complete 
        * dependencies and dependents information.
        */

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ if (JavaVersion.current().isJava9Compatible()) {
     '--illegal-access=warn',
     '--add-opens=java.base/java.lang=ALL-UNNAMED',
     '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+    '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
     '--add-opens=java.base/java.io=ALL-UNNAMED',
     '--add-opens=java.base/java.net=ALL-UNNAMED',
     '--add-opens=java.base/java.nio=ALL-UNNAMED',


### PR DESCRIPTION
Project plugins include workspace plugins, so we want to make sure
workspace plugins are complete before adding to projects plugins.

Fixes https://github.com/bndtools/bnd/issues/3499
