### PR TITLE
tests: Some tests depend upon jars in `-dependson` projects

### DIFF
--- a/biz.aQute.bndlib.tests/build.gradle
+++ b/biz.aQute.bndlib.tests/build.gradle
@@ -6,4 +6,6 @@ tasks.named('test') {
   // set heap size for the test JVM(s)
   minHeapSize = "1024m"
   maxHeapSize = "2048m"
+  // Some test's depend upon `-dependson` which are `jar` task dependencies.
+  inputs.files tasks.named('jar')
 }


### PR DESCRIPTION
So we configure gradle to make sure those project's `jar` tasks are
up-to-date before starting the `test` task.

Fixes https://github.com/bndtools/bnd/issues/3500