### PR TITLE
-resolve instruction extended with beforelaunch

### DIFF
--- a/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
+++ b/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
@@ -198,6 +198,11 @@ public class StartLevelRuntimeHandler implements Closeable {
 							if (bundle.getBundleId() == 0)
 								return;
 
+							if (bundle.getSymbolicName() == null) {
+								logger.trace("Found bundle without a bsn %s, ignoring", bundle);
+								return;
+							}
+
 							BundleIdentity id = installed.computeIfAbsent(bundle, BundleIdentity::new);
 							if (event.getType() == BundleEvent.INSTALLED || event.getType() == BundleEvent.UPDATED) {
 								setStartlevel(bundle, id);


### PR DESCRIPTION
This PR extends the `-resolve` instruction from `manual` (default) and `auto` with `beforelaunch`. The `beforelaunch` option will  calculate the `-runbundles` on demand. It has a cache based on the project properties.
