### PR TITLE
Gradle 6 0 support

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -8,9 +8,8 @@ specified in the Bnd Workspace's `cnf/build.bnd` file and each project's
 `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins requires at least Gradle 4.0 for Java 8, at least
-Gradle 4.2.1 for Java 9, at least Gradle 4.7 for Java 10, and at
-least Gradle 5.0 for Java 11.
+These plugins requires at least Gradle 5.1 for Java 8 to Java 12, and at
+least Gradle 6.0 for Java 13.
 
 This README represents the capabilities and features of the Bnd Gradle Plugins in
 the branch containing this README. So for the `master` branch, this will be
@@ -433,7 +432,7 @@ plus _${project.configurations.archives.artifacts.files}_.
 
 The list of fully qualified names of test classes to run. If not set, or empty,
 Then all the test classes listed in the `Test-Classes` manifest header are
-run. In Gradle 4.6 and later, the `--tests` command line option can be used
+run. The `--tests` command line option can be used
 to set the fully qualified name of a test class to run. This can be repeated
 multiple times to specify multiple test classes to run.
 

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -7,8 +7,8 @@ repositories {
 dependencies {
     compileOnly localGroovy()
     compileOnly gradleApi()
-    testCompile gradleTestKit()
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4')  {
+    testImplementation gradleTestKit()
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4')  {
         exclude module: 'groovy-all'
     }
 }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
@@ -49,7 +49,6 @@
 package aQute.bnd.gradle
 
 import static aQute.bnd.gradle.BndUtils.builtBy
-import static aQute.bnd.gradle.BndUtils.toTask
 
 import aQute.bnd.differ.DiffPluginImpl
 import aQute.bnd.header.Parameters
@@ -68,6 +67,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
 
 public class Baseline extends DefaultTask {
   private ConfigurableFileCollection bundleCollection
@@ -214,7 +214,9 @@ public class Baseline extends DefaultTask {
 
   Task getBundleTask() {
     return bundleCollection.getBuiltBy().flatten().findResult { t ->
-      t = toTask(t)
+      if (t instanceof TaskProvider) {
+        t = t.get()
+      }
       t instanceof Task && t.convention.findPlugin(BundleTaskConvention.class) ? t : null
     }
   }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -19,9 +19,6 @@
 
 package aQute.bnd.gradle
 
-import static aQute.bnd.gradle.BndUtils.configureTask
-import static aQute.bnd.gradle.BndUtils.createTask
-
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -48,7 +45,7 @@ public class BndBuilderPlugin implements Plugin<Project> {
       }
       plugins.apply 'java'
 
-      def jar = configureTask(project, 'jar') { t ->
+      def jar = tasks.named('jar') { t ->
         t.description 'Assembles a bundle containing the main classes.'
         t.convention.plugins.bundle = new BundleTaskConvention(t)
         def defaultBndfile = project.file('bnd.bnd')
@@ -72,7 +69,7 @@ public class BndBuilderPlugin implements Plugin<Project> {
         }
       }
 
-      createTask(project, 'baseline', Baseline.class) { t ->
+      tasks.register('baseline', Baseline.class) { t ->
         t.description 'Baseline the project bundle.'
         t.group 'release'
         t.bundle jar

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -17,8 +17,6 @@ import org.gradle.api.logging.Logger
 import org.gradle.util.GradleVersion
 
 class BndUtils {
-  private static final boolean IS_GRADLE_MIN_50 = GradleVersion.current().compareTo(GradleVersion.version("5.0"))>=0
-
   private BndUtils() { }
 
   public static void logReport(def report, Logger logger) {
@@ -45,71 +43,10 @@ class BndUtils {
   }
 
   @CompileStatic
-  public static Object namedTask(Project project, String name) {
-    if (IS_GRADLE_MIN_50) {
-      return project.getTasks().named(name)
-    } else {
-      return project.getTasks().getByName(name)
-    }
-  }
-
-  @CompileStatic
-  public static <T extends Task> Object configureTask(Project project, String name, Action<? super T> configuration) {
-    if (IS_GRADLE_MIN_50) {
-      return project.getTasks().named(name, configuration)
-    } else {
-      return project.getTasks().getByName(name, configuration)
-    }
-  }
-
-  @CompileStatic
-  public static <T extends Task> Object createTask(Project project, String name, Action<? super T> configuration) {
-    if (IS_GRADLE_MIN_50) {
-      return project.getTasks().register(name, configuration)
-    } else {
-      return project.getTasks().create(name, configuration)
-    }
-  }
-
-  @CompileStatic
-  public static <T extends Task> Object createTask(Project project, String name, Class<T> type, Action<? super T> configuration) {
-    if (IS_GRADLE_MIN_50) {
-      return project.getTasks().register(name, type, configuration)
-    } else {
-      return project.getTasks().create(name, type, configuration)
-    }
-  }
-
-  @CompileStatic
-  public static <T extends Task> void configureEachTask(Project project, Class<T> type, Action<? super T> configuration) {
-    if (IS_GRADLE_MIN_50) {
-      project.getTasks().withType(type).configureEach(configuration)
-    } else {
-      project.getTasks().withType(type).all(configuration)
-    }
-  }
-
-  @CompileStatic
   public static ConfigurableFileCollection builtBy(ConfigurableFileCollection collection, Object... paths) {
-    if (IS_GRADLE_MIN_50) {
-      return collection.builtBy(paths.findAll { path ->
-        path instanceof Task || path instanceof TaskProvider || path instanceof Buildable
-      })
-    } else {
-      return collection.builtBy(paths.findAll { path ->
-        path instanceof Task || path instanceof Buildable
-      })
-    }
-  }
-
-  @CompileStatic
-  public static Object toTask(Object t) {
-    if (IS_GRADLE_MIN_50) {
-      if (t instanceof TaskProvider) {
-        return t.get()
-      }
-    }
-    return t
+    return collection.builtBy(paths.findAll { path ->
+      path instanceof Task || path instanceof TaskProvider || path instanceof Buildable
+    })
   }
 
   @CompileStatic

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -10,6 +10,8 @@ import org.gradle.api.Buildable
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.logging.Logger
 import org.gradle.util.GradleVersion
@@ -108,5 +110,16 @@ class BndUtils {
       }
     }
     return t
+  }
+
+  @CompileStatic
+  public static Object unwrap(Object value) {
+    if (value instanceof Provider) {
+      value = value.getOrNull()
+    } 
+    if (value instanceof FileSystemLocation) {
+      value = value.getAsFile()
+    } 
+    return value
   }
 }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -12,8 +12,6 @@
 
 package aQute.bnd.gradle
 
-import static aQute.bnd.gradle.BndUtils.createTask
-
 import aQute.bnd.build.Workspace
 import aQute.bnd.osgi.Constants
 
@@ -175,7 +173,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
       Project cnfProject = findProject(bnd_cnf)
       if (cnfProject != null) {
         ext.cnf = cnfProject
-        createTask(cnfProject, 'cleanCache', Delete.class) { t ->
+        cnfProject.tasks.register('cleanCache', Delete.class) { t ->
           t.description 'Clean the cache folder.'
           t.group 'build'
           t.delete 'cache'

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
@@ -5,6 +5,8 @@
 
 package aQute.bnd.gradle
 
+import static aQute.bnd.gradle.BndUtils.unwrap
+
 class PropertiesWrapper extends Properties {
   protected Properties defaults
 
@@ -23,6 +25,7 @@ class PropertiesWrapper extends Properties {
       Object value = props.drop(1).inject(get(props.first())) { obj, prop ->
         obj?."${prop}"
       }
+      value = unwrap(value)
       return (value != null) ? value.toString() : defaultValue(key)
     } catch (MissingPropertyException mpe) {
       return defaultValue(key)

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -24,15 +24,9 @@ class TestHelper {
   }
 
   private static String gradleVersion() {
-    if (JavaVersion.current().isJava11Compatible()) {
-      return '5.0'
+    if (JavaVersion.current().compareTo(JavaVersion.VERSION_12) > 0) {
+      return '6.0'
     }
-    if (JavaVersion.current().isJava10Compatible()) {
-      return '4.7'
-    }
-    if (JavaVersion.current().isJava9Compatible()) {
-      return '4.2.1'
-    }
-    return '4.0'
+    return '5.1'
   }
 }

--- a/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
@@ -19,15 +19,15 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-codec:commons-codec:1.5'
-    compile 'commons-lang:commons-lang:2.6'
-    testCompile 'junit:junit:4.9'
+    implementation 'commons-codec:commons-codec:1.5'
+    implementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'junit:junit:4.9'
 }
 
 jar {
     manifest {
-        attributes('Implementation-Title': baseName,
-                   'Implementation-Version': version,
+        attributes('Implementation-Title': project.archivesBaseName,
+                   'Implementation-Version': project.version,
                    '-includeresource': '{bar.txt}',
                    '-include': 'other.bnd',
                    'Override': 'This should be overridden by the bnd file'
@@ -54,7 +54,7 @@ task baselineSelf(type: Baseline) {
    description 'Baseline Self'
    group 'build'
    bundle jar
-   baseline jar.archivePath
+   baseline jar.archiveFile
    ignoreFailures = false
    baselineReportDirName = 'foo'
 }

--- a/biz.aQute.bnd.gradle/testresources/baselinetask4/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/baselinetask4/build.gradle
@@ -18,16 +18,16 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-codec:commons-codec:1.5'
-    compile 'commons-lang:commons-lang:2.6'
-    testCompile 'junit:junit:4.9'
+    implementation 'commons-codec:commons-codec:1.5'
+    implementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'junit:junit:4.9'
     baseline ':baselinetask1:1.0.0'
 }
 
 jar {
     manifest {
-        attributes('Implementation-Title': baseName,
-                   'Implementation-Version': version,
+        attributes('Implementation-Title': project.archivesBaseName,
+                   'Implementation-Version': project.version,
                    '-includeresource': '{bar.txt}',
                    '-include': 'other.bnd',
                    'Override': 'This should be overridden by the bnd file'

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -17,16 +17,16 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-codec:commons-codec:1.5'
-    compile 'commons-lang:commons-lang:2.6'
-    testCompile 'junit:junit:4.9'
+    implementation 'commons-codec:commons-codec:1.5'
+    implementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'junit:junit:4.9'
 }
 
 jar {
   ext.taskprop = 'prop.task'
   manifest {
-    attributes('Implementation-Title': baseName,
-               'Implementation-Version': version,
+    attributes('Implementation-Title': project.archivesBaseName,
+               'Implementation-Version': project.version,
                '-includeresource': '{${.}/bar.txt}',
                '-include': '${.}/other.bnd',
                'Override': 'This should be overridden by the bnd file'
@@ -39,13 +39,13 @@ task bundle(type: Bundle) {
    description 'Bundle'
    group 'build'
    from sourceSets.test.output
-   baseName = baseName+'_bundle'
+   archiveBaseName = "${project.archivesBaseName}_bundle"
    bnd = '''
 -exportcontents: doubler.impl
 -sources: true
 My-Header: my-value
 text: TEXT
-Bundle-Name: ${project.group}:${task.baseName}
+Bundle-Name: ${project.group}:${task.archiveBaseName}
 Project-Name: ${project.name}
 Project-Dir: ${project.dir}
 Project-Output: ${project.output}
@@ -61,6 +61,6 @@ Project-Buildpath: ${project.buildpath}
 }
 
 artifacts {
-  runtime bundle
+  runtimeOnly bundle
   archives bundle
 }

--- a/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
@@ -18,16 +18,16 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-codec:commons-codec:1.5'
-    compile 'commons-lang:commons-lang:2.6'
-    testCompile 'junit:junit:4.9'
+    implementation 'commons-codec:commons-codec:1.5'
+    implementation 'commons-lang:commons-lang:2.6'
+    testImplementation 'junit:junit:4.9'
 }
 
 jar {
   ext.taskprop = 'prop.task'
   manifest {
-    attributes('Implementation-Title': baseName,
-               'Implementation-Version': version,
+    attributes('Implementation-Title': project.archivesBaseName,
+               'Implementation-Version': project.version,
                '-includeresource': '{${.}/bar.txt}',
                '-include': '${.}/other.bnd',
                'Override': 'This should be overridden by the bnd file'
@@ -39,13 +39,13 @@ task bundle(type: Bundle) {
    description 'Bundle'
    group 'build'
    from sourceSets.test.output
-   baseName = baseName+'_bundle'
+   archiveBaseName = "${project.archivesBaseName}_bundle"
    bnd = '''
 -exportcontents: doubler.impl
 -sources: true
 My-Header: my-value
 text: TEXT
-Bundle-Name: ${project.group}:${task.baseName}
+Bundle-Name: ${project.group}:${task.archiveBaseName}
 Project-Name: ${project.name}
 Project-Dir: ${project.dir}
 Project-Output: ${project.output}
@@ -61,7 +61,7 @@ Project-Buildpath: ${project.buildpath}
 }
 
 artifacts {
-  runtime bundle
+  runtimeOnly bundle
   archives bundle
 }
 

--- a/biz.aQute.bnd.gradle/testresources/runtask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/runtask1/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.osgi:osgi.core:5.0.0'
-    runtime 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
+    runtimeOnly 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 
 task run(type: Bndrun) {

--- a/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
-    runtime 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
+    implementation "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
+    runtimeOnly 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 
 ext {

--- a/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
+    implementation "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     framework 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 

--- a/biz.aQute.bnd.gradle/testresources/testosgitask3/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask3/build.gradle
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
+    implementation "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     bundles "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
     bundles 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
@@ -30,7 +30,7 @@ task testosgi(type: TestOSGi) {
    group 'test'
    inputs.files jar
    bndrun "${name}.bndrun"
-   bundles = [configurations.bundles, jar.archivePath]
+   bundles = [configurations.bundles, jar.archiveFile]
 }
 
 check {

--- a/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    compile "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
-    runtime 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
+    implementation "biz.aQute.bnd:biz.aQute.junit:${bnd_version}"
+    runtimeOnly 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 
 task testosgiIgnoreFail(type: TestOSGi) {

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -164,7 +164,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.12.1</version>
+				<version>3.13.2</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -222,7 +222,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.1.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -32,8 +32,8 @@ def p2FeatureProperties = tasks.register('p2FeatureProperties', WriteProperties.
 
 def p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
   inputs.files p2FeatureProperties
-  destinationDir = file("${buildDir}/features")
-  archiveName    = 'bndtools.main.feature.jar'
+  destinationDirectory = file("${buildDir}/features")
+  archiveFileName = 'bndtools.main.feature.jar'
   from             'features/bndtools.main'
   include          'feature.xml'
   doFirst {
@@ -48,8 +48,8 @@ def p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
 
 def p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
   inputs.files p2FeatureProperties
-  destinationDir = file("${buildDir}/features")
-  archiveName    = 'bndtools.m2e.feature.jar'
+  destinationDirectory = file("${buildDir}/features")
+  archiveFileName    = 'bndtools.m2e.feature.jar'
   from             'features/bndtools.m2e'
   include          'feature.xml'
   doFirst {
@@ -64,8 +64,8 @@ def p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
 
 def p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
   inputs.files p2FeatureProperties
-  destinationDir = file("${buildDir}/features")
-  archiveName    = 'bndtools.pde.feature.jar'
+  destinationDirectory = file("${buildDir}/features")
+  archiveFileName    = 'bndtools.pde.feature.jar'
   from             'features/bndtools.pde'
   include          'feature.xml'
   doFirst {


### PR DESCRIPTION
Set Gradle 5.1 as the base version of Gradle supported.

Remove all conditional code for Gradle 4.0 and avoid using deprecated
fields in Gradle 6.0 to avoid runtime warnings.
