### PR TITLE
junit-platform: Fix race condition in automatic()

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelector.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelector.java
@@ -1,5 +1,7 @@
 package aQute.tester.bundle.engine.discovery;
 
+import java.util.Objects;
+
 import org.junit.platform.engine.DiscoverySelector;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
@@ -37,5 +39,15 @@ public class BundleSelector implements DiscoverySelector {
 		return new BundleSelector(bundle.getSymbolicName(),
 			new VersionRange(VersionRange.LEFT_CLOSED, bundle.getVersion(), bundle.getVersion(),
 				VersionRange.RIGHT_CLOSED));
+	}
+
+	public boolean selects(Bundle bundle) {
+		return Objects.equals(getSymbolicName(), bundle.getSymbolicName())
+			&& getVersionRange().includes(bundle.getVersion());
+	}
+
+	@Override
+	public String toString() {
+		return "BundleSelector [symbolicName = '" + getSymbolicName() + "', versionRange = " + getVersionRange() + "]";
 	}
 }

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
@@ -189,26 +189,17 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 	// Try to build some resilience into this test to avoid
 	// race conditions when the new test starts.
 	private Thread getBndTestThread() throws InterruptedException {
-		int threadCount = Thread.activeCount();
-		Thread[] threads = new Thread[threadCount + 10];
-
-		final long endTime = System.currentTimeMillis() + 10000;
+		final long endTime = System.currentTimeMillis() + 30000;
 
 		while (System.currentTimeMillis() < endTime) {
-			threadCount = Thread.enumerate(threads);
-
-			if (threadCount == threads.length) {
-				threads = new Thread[threadCount + 10];
-				continue;
-			}
-
-			for (Thread thread : threads) {
+			for (Thread thread : Thread.getAllStackTraces()
+				.keySet()) {
 				if (thread.getName()
 					.equals(BND_TEST_THREAD)) {
 					return thread;
 				}
 			}
-			Thread.sleep(10);
+			Thread.sleep(1000);
 		}
 		return null;
 	}
@@ -219,8 +210,6 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 		createLP();
 		addTesterBundle();
 
-		final CountDownLatch latch = new CountDownLatch(1);
-
 		final Thread bndThread = getBndTestThread();
 
 		// Don't assert softly, since if we can't find this thread we can't do
@@ -230,12 +219,11 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 			.isNotNull()
 			.isNotSameAs(Thread.currentThread());
 
-		Runnable r = lp.getService(Runnable.class)
-			.orElse(null);
-		assertThat(r).as("runnable")
-			.isNull();
+		assertThat(lp.getService(Runnable.class)).as("runnable")
+			.isEmpty();
 
 		final AtomicReference<Throwable> exception = new AtomicReference<>();
+		final CountDownLatch latch = new CountDownLatch(1);
 		bndThread.setUncaughtExceptionHandler((thread, e) -> {
 			exception.set(e);
 			latch.countDown();
@@ -245,12 +233,8 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 		// is in place to ensure we're ready to catch System.exit().
 		addTestBundle(JUnit3Test.class);
 
-		final AtomicBoolean flag = new AtomicBoolean(false);
 		// Wait for the exception handler to catch the exit.
-		assertThatCode(() -> flag.set(latch.await(5000, TimeUnit.MILLISECONDS))).as("wait for exit")
-			.doesNotThrowAnyException();
-
-		assertThat(flag.get()).as("flag")
+		assertThat(latch.await(20000, TimeUnit.MILLISECONDS)).as("wait for exit")
 			.isTrue();
 
 		assertThat(exception.get()).as("exited")

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
@@ -418,7 +418,7 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 		int waitCount = 0;
 		try {
 			OUTER: while (true) {
-				Thread.sleep(10);
+				Thread.sleep(100);
 				final Thread.State state = runThread.getState();
 				switch (state) {
 					case TERMINATED :


### PR DESCRIPTION
This race condition caused random failures on JDK 11 on the CI builds.
A test bundle could have been installed between the initial request
creation and the opening of the BundleTracker. So tests would sometimes
see a test bundle fail to be processed.

We change to use the BundleTracker to create BundleSelectors for
all bundles and queue them for the main processing loop. In the main
processing loop, we process all available BundleSelectors together even
waiting briefly to see if the BundleTracker is still adding elements to
the queue.