### PR TITLE
gradle: Build plugin markers for the Bnd Gradle plugins

### DIFF
--- a/biz.aQute.bnd.embedded-repo/bnd/embedded-repo.bnd
+++ b/biz.aQute.bnd.embedded-repo/bnd/embedded-repo.bnd
@@ -8,6 +8,4 @@ Timestamp: ${_@tstamp}
     biz.aQute.tester/biz.aQute.tester-${base.version}.jar=${repo;biz.aQute.tester;snapshot}, \
     biz.aQute.tester.junit-platform/biz.aQute.tester.junit-platform-${base.version}.jar=${repo;biz.aQute.tester.junit-platform;snapshot}
 
--digests: MD5, SHA1
-
 -pom: false

--- a/biz.aQute.bnd.gradle/biz.aQute.bnd.builder.gradle.plugin.bnd
+++ b/biz.aQute.bnd.gradle/biz.aQute.bnd.builder.gradle.plugin.bnd
@@ -1,0 +1,13 @@
+Bundle-SymbolicName: ${substring;${propertiesname};0;-${length;.bnd}}
+Bundle-Description: The Bnd Gradle ${substring;${bsn};0;-${length;.gradle.plugin}} plugin marker.
+
+-pom: groupid=${substring;${@bsn};0;-${length;.gradle.plugin}},\
+ artifactid=${@bsn},\
+ version=${versionmask;===s;${@version}}
+
+-maven-dependencies: plugin;\
+ groupId=${-groupid};\
+ artifactId=${p};\
+ version=${versionmask;===s;${base.version}${def;-snapshot;.SNAPSHOT}}
+
+-resourceonly: true

--- a/biz.aQute.bnd.gradle/biz.aQute.bnd.gradle.bnd
+++ b/biz.aQute.bnd.gradle/biz.aQute.bnd.gradle.bnd
@@ -1,0 +1,17 @@
+Bundle-SymbolicName: ${substring;${propertiesname};0;-${length;.bnd}}
+Bundle-Description: The Bnd Gradle plugins.
+
+-includepackage: \
+    aQute.bnd.gradle.*
+
+-conditionalpackage: \
+    aQute.lib.*, \
+    aQute.libg.*
+
+-includeresource: \
+    OSGI-OPT/src=src, \
+    resources
+#
+# The groovy compiler must be run from the gradle build
+#
+-fixupmessages.groovy: "Unused Private*aQute.bnd.gradle";replace:="The groovy classes must be compiled with the gradle build."

--- a/biz.aQute.bnd.gradle/biz.aQute.bnd.gradle.plugin.bnd
+++ b/biz.aQute.bnd.gradle/biz.aQute.bnd.gradle.plugin.bnd
@@ -1,0 +1,13 @@
+Bundle-SymbolicName: ${substring;${propertiesname};0;-${length;.bnd}}
+Bundle-Description: The Bnd Gradle ${substring;${bsn};0;-${length;.gradle.plugin}} plugin marker.
+
+-pom: groupid=${substring;${@bsn};0;-${length;.gradle.plugin}},\
+ artifactid=${@bsn},\
+ version=${versionmask;===s;${@version}}
+
+-maven-dependencies: plugin;\
+ groupId=${-groupid};\
+ artifactId=${p};\
+ version=${versionmask;===s;${base.version}${def;-snapshot;.SNAPSHOT}}
+
+-resourceonly: true

--- a/biz.aQute.bnd.gradle/biz.aQute.bnd.workspace.gradle.plugin.bnd
+++ b/biz.aQute.bnd.gradle/biz.aQute.bnd.workspace.gradle.plugin.bnd
@@ -1,0 +1,13 @@
+Bundle-SymbolicName: ${substring;${propertiesname};0;-${length;.bnd}}
+Bundle-Description: The Bnd Gradle ${substring;${bsn};0;-${length;.gradle.plugin}} plugin marker.
+
+-pom: groupid=${substring;${@bsn};0;-${length;.gradle.plugin}},\
+ artifactid=${@bsn},\
+ version=${versionmask;===s;${@version}}
+
+-maven-dependencies: plugin;\
+ groupId=${-groupid};\
+ artifactId=${p};\
+ version=${versionmask;===s;${base.version}${def;-snapshot;.SNAPSHOT}}
+
+-resourceonly: true

--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -3,16 +3,7 @@
 # for the bnd_version for the test cases.
 -include: ${workspace}/cnf/includes/jdt.bnd, ${workspace}/gradle.properties
 
--includepackage: \
-	aQute.bnd.gradle.*
-
--conditionalpackage: \
-    aQute.lib.*, \
-    aQute.libg.*
-
--digests: MD5, SHA1
-
-Bundle-Description: The Bnd Gradle plugin.
+-sub: *.bnd
 
 -buildpath: \
 	aQute.libg;version=project, \
@@ -26,16 +17,10 @@ Bundle-Description: The Bnd Gradle plugin.
 
 bnd_version: ${replace;${bnd_plugin};.*:(.*);$1}
 
--includeresource: \
-	OSGI-OPT/src=src, \
-	resources
-
 -builderignore: testresources
 
 # Use groovydoc task generated doc for -javadoc.jar
 -maven-release: pom;path=JAR,javadoc;path=${target}/docs/groovydoc
 
-#
-# The groovy compiler must be run from the gradle build
-#
--fixupmessages.groovy: "Unused Private*aQute.bnd.gradle";replace:="The groovy classes must be compiled with the gradle build."
+# Stop Eclipse whining about the bnd files using specific Bundle-SymbolicNames
+-fixupmessages.bndtools: "Eclipse: The Bundle Symbolic * name"

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -796,7 +796,6 @@ public class Macro {
 			.map(domain::getFile)
 			.filter(File::exists)
 			.map(File::getParentFile)
-			.filter(File::exists)
 			.map(IO::absolutePath)
 			.collect(Strings.joining());
 		return result;
@@ -809,8 +808,7 @@ public class Macro {
 		}
 		String result = Arrays.stream(args, 1, args.length)
 			.map(domain::getFile)
-			.filter(f -> f.exists() && f.getParentFile()
-				.exists())
+			.filter(File::exists)
 			.map(File::getName)
 			.collect(Strings.joining());
 		return result;


### PR DESCRIPTION
This will allow Gradle to find the Bnd Gradle plugin ids using the
`plugins {}` DSL block when using Maven Central or JCenter.

See https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers
