### PR TITLE
junit: Fix method name matching for JUnit 4

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -545,7 +545,7 @@ public class Activator implements BundleActivator, Runnable {
 					@Override
 					public boolean shouldRun(Description description) {
 						if (glob.matcher(description.getMethodName())
-							.lookingAt()) {
+							.matches()) {
 							trace("accepted " + description.getMethodName());
 							return true;
 						}


### PR DESCRIPTION
We want to match the complete method name and not a prefix of the
complete method name.

Fixes https://github.com/bndtools/bnd/issues/3562
