### PR TITLE
[maven] eliminate Eclipse warning 'maven-invoker-plugin (goal "instal…

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -315,10 +315,13 @@
 										<versionRange>[1.0.0,)</versionRange>
 										<goals>
 											<goal>install</goal>
+											<goal>run</goal>
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore />
+										<ignore>
+											<message></message>
+										</ignore>
 									</action>
 								</pluginExecution>
 								<pluginExecution>


### PR DESCRIPTION
…l") is ignored by m2e.'

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>