### PR TITLE
junit: Read Test-Cases header directly from bundle

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/BundleUtils.java
+++ b/biz.aQute.junit/src/aQute/junit/BundleUtils.java
@@ -1,0 +1,47 @@
+package aQute.junit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.osgi.framework.Bundle;
+
+public final class BundleUtils {
+	public static boolean hasTests(Bundle bundle) {
+		return testCases(bundle).anyMatch(s -> true);
+	}
+
+	public static boolean hasNoTests(Bundle bundle) {
+		return !hasTests(bundle);
+	}
+
+	private static final Attributes.Name TESTCASES = new Attributes.Name(aQute.bnd.osgi.Constants.TESTCASES);
+
+	public static Stream<String> testCases(Bundle bundle) {
+		URL url = bundle.getEntry("META-INF/MANIFEST.MF");
+		if (url == null) {
+			return Stream.empty();
+		}
+		try (InputStream in = url.openStream()) {
+			Manifest manifest = new Manifest(in);
+			return testCases(manifest.getMainAttributes()
+				.getValue(TESTCASES));
+		} catch (IOException e) {
+			return Stream.empty();
+		}
+	}
+
+	private final static Pattern SIMPLE_LIST_SPLITTER = Pattern.compile("\\s*,\\s*");
+
+	public static Stream<String> testCases(String testNames) {
+		if ((testNames == null) || (testNames = testNames.trim()).isEmpty()) {
+			return Stream.empty();
+		}
+		return SIMPLE_LIST_SPLITTER.splitAsStream(testNames)
+			.filter(testName -> !testName.isEmpty());
+	}
+}

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
@@ -14,6 +14,8 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
+import aQute.bnd.osgi.Constants;
+
 public class BundleDescriptor extends AbstractTestDescriptor {
 
 	final private Bundle							bundle;
@@ -22,8 +24,8 @@ public class BundleDescriptor extends AbstractTestDescriptor {
 
 	public static String displayNameOf(Bundle bundle) {
 		final Optional<String> bundleName = Optional.ofNullable(bundle.getHeaders()
-			.get(aQute.bnd.osgi.Constants.BUNDLE_NAME));
-		return "[" + bundle.getBundleId() + "] " + bundleName.orElse(bundle.getSymbolicName()) + ';'
+			.get(Constants.BUNDLE_NAME));
+		return "[" + bundle.getBundleId() + "] " + bundleName.orElseGet(bundle::getSymbolicName) + ';'
 			+ bundle.getVersion();
 	}
 


### PR DESCRIPTION
We avoid Bundle.getHeaders since it can merge a fragment's Test-Cases
header into the host's headers.

A nice effect of this change is that we now properly ignore empty Test-Cases headers.