### PR TITLE
[3558] Intermittent CI failures in biz.aQute.launcher.AlsoLauncherTes…

### DIFF
--- a/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
+++ b/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
@@ -198,6 +198,11 @@ public class StartLevelRuntimeHandler implements Closeable {
 							if (bundle.getBundleId() == 0)
 								return;
 
+							if (bundle.getSymbolicName() == null) {
+								logger.trace("Found bundle without a bsn %s, ignoring", bundle);
+								return;
+							}
+
 							BundleIdentity id = installed.computeIfAbsent(bundle, BundleIdentity::new);
 							if (event.getType() == BundleEvent.INSTALLED || event.getType() == BundleEvent.UPDATED) {
 								setStartlevel(bundle, id);


### PR DESCRIPTION
…t > testReporting_notUsingReferences #3558

It seems a number of JUnit bundles are installed that do not have a
BSN set (they are not bundles). The startlevel code assumed that all
code were bundles since they have no purpose (this JUnit code cannot
be available to anybody else as far as I can see?).

However, getBundleSymbolicName() can return null so I ignore bundles
in the startlevel code that have a null bsn.

Fixes #3558

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>