### PR TITLE
[snapshot] Difference between Bndtools and other drivers in resolve o…

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -935,4 +935,22 @@ public class ResourceBuilder {
 
 	}
 
+	/**
+	 * A repository that implements the {@code WorkspaceRepositoryMarker} in the
+	 * resolver must add a WORKSPACE_NAMESPACE capability to make its clear the
+	 * resources are from the workspace. Ideally this would not be necessary but
+	 * we're having two workspace repositories. One for Bndtools where the
+	 * repository is interactive, the other is for resolving in Gradle, etc.
+	 *
+	 * @param name the project name
+	 */
+	public void addWorkspaceNamespace(String name) throws Exception {
+		// Add a capability specific to the workspace so that we can
+		// identify this fact later during resource processing.
+		Attrs attrs = new Attrs();
+		attrs.put(ResourceUtils.WORKSPACE_NAMESPACE, name);
+
+		addCapability(CapReqBuilder.createCapReqBuilder(ResourceUtils.WORKSPACE_NAMESPACE, attrs));
+
+	}
 }

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/R5RepoContentProvider.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/R5RepoContentProvider.java
@@ -149,6 +149,12 @@ public class R5RepoContentProvider implements IRepositoryContentProvider {
 	@Override
 	public void parseIndex(InputStream stream, URI baseUri, IRepositoryIndexProcessor listener, LogService log)
 		throws Exception {
+		this.parseIndex(baseUri + "", stream, baseUri, listener, log);
+	}
+
+	public void parseIndex(String projectName, InputStream stream, URI baseUri, IRepositoryIndexProcessor listener,
+		LogService log)
+		throws Exception {
 		XMLStreamReader reader = null;
 		try {
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
@@ -215,6 +221,7 @@ public class R5RepoContentProvider implements IRepositoryContentProvider {
 							capReqBuilder = null;
 						} else if (TAG_RESOURCE.equals(localName)) {
 							if (resourceBuilder != null) {
+								resourceBuilder.addWorkspaceNamespace(projectName);
 								Resource resource = resourceBuilder.build();
 								listener.processResource(resource);
 								resourceBuilder = null;

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/packageinfo
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/packageinfo
@@ -1,1 +1,1 @@
-version 2.0
+version 2.1

--- a/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceRepositoryMarker.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceRepositoryMarker.java
@@ -1,5 +1,31 @@
 package biz.aQute.resolve;
 
-public interface WorkspaceRepositoryMarker {
+import aQute.bnd.osgi.resource.ResourceUtils;
 
+/**
+ * This marker must be implemented by repositories that model the workspace. If
+ * things had gone well we would have had a single workspace repository.
+ * However, due to history, a rather special workspace was integrated with
+ * bndtools that did not make it into bnd itself. Worse, it depended on bndtools
+ * code, making it impossible to integrate it in the rest of the code base.
+ * <p>
+ * When bnd started to resolve things, a special resolver was needed and this
+ * was quickly hacked together. It was a static repository, it did not track the
+ * interactive changes like the bndtools repository did. However, it was
+ * confusing that sometimes bnd found a workspace repository (bndtools) and
+ * sometimes not (the other drivers).
+ * <p>
+ * The purpose of this WorkspaceRepositoryMarker interface is to make it clear
+ * to the resolver that a Workspace repository is present and should not be
+ * added.
+ * <p>
+ * As a little bonus, any repository implementing this interface *must* add a
+ * {@link ResourceUtils#WORKSPACE_NAMESPACE} capability to mark resources from
+ * the workspace.
+ * <p>
+ * Ideally, bnd should have a single workspace repository that tracks the files
+ * in the workspace but this is deemed too much work for now.
+ */
+public interface WorkspaceRepositoryMarker {
+	String WORKSPACE_NAMESPACE = ResourceUtils.WORKSPACE_NAMESPACE;
 }

--- a/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceR5Repository.java
@@ -24,7 +24,6 @@ import org.osgi.service.log.LogService;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.deployer.repository.CapabilityIndex;
-import aQute.bnd.deployer.repository.api.IRepositoryContentProvider;
 import aQute.bnd.deployer.repository.api.IRepositoryIndexProcessor;
 import aQute.bnd.deployer.repository.api.Referral;
 import aQute.bnd.deployer.repository.providers.R5RepoContentProvider;
@@ -37,7 +36,7 @@ public class WorkspaceR5Repository extends BaseRepository implements WorkspaceRe
 	private static final String						NAME			= "Workspace";
 
 	private final Map<IProject, CapabilityIndex>	projectMap		= new HashMap<>();
-	private final IRepositoryContentProvider		contentProvider	= new R5RepoContentProvider();
+	private final R5RepoContentProvider				contentProvider	= new R5RepoContentProvider();
 
 	private final ILogger							logger			= Logger.getLogger(WorkspaceR5Repository.class);
 	private final LogService						logAdapter		= new LogServiceAdapter(logger);
@@ -102,7 +101,7 @@ public class WorkspaceR5Repository extends BaseRepository implements WorkspaceRe
 						// ignore: we don't create any referrals
 					}
 				};
-				contentProvider.parseIndex(index, baseUri, processor, logAdapter);
+				contentProvider.parseIndex(project.getName(), index, baseUri, processor, logAdapter);
 			} catch (Exception e) {
 				logger.logError(
 					MessageFormat.format("Failed to process index file for bundles in project {0}.", project.getName()),


### PR DESCRIPTION
…utput

The output of a resolve operations is a list of -runbundles. This list
is calculated nowadays in one place (RunResolution) but unfortunately
there is a different workspace used in Bndtools and in other drivers. This
meant that Bndtools workspace resources were marked with the micro range
while these same workspaces in Gradle were marked with 'snapshot'.

A previous change added a WorkspaceRepositoryMarker to the repos that 
model the workspace projects. The new one used for Gradle added a 
WORKSPACE_NAMESPACE capability but the old one in Bndtools did not. 

This fix adds the same capability the old WorkspaceR5Repository so that
the versioning to identify the resource is now independent of the driver.

Long term solution should be to replace the WorkspaceR5Repository with
something more modern so that we have a single unified workspace 
resource repo.



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>