### PR TITLE
[export] bndrun configurations cannot be exported #3339

### DIFF
--- a/aQute.libg/src/aQute/lib/collections/MultiMap.java
+++ b/aQute.libg/src/aQute/lib/collections/MultiMap.java
@@ -3,13 +3,12 @@ package aQute.lib.collections;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MultiMap<K, V> extends HashMap<K, List<V>> implements Map<K, List<V>> {
+public class MultiMap<K, V> extends LinkedHashMap<K, List<V>> implements Map<K, List<V>> {
 	private static final long	serialVersionUID	= 1L;
 	private final boolean		noduplicates;
 	private final Class<?>		keyClass;

--- a/aQute.libg/src/aQute/lib/collections/packageinfo
+++ b/aQute.libg/src/aQute/lib/collections/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/biz.aQute.bnd/src/aQute/bnd/ant/PackageTask.java
+++ b/biz.aQute.bnd/src/aQute/bnd/ant/PackageTask.java
@@ -11,6 +11,7 @@ public class PackageTask extends BaseTask {
 	File	output		= null;
 	boolean	keep		= false;
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void execute() throws BuildException {
 		if (output == null)

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2217,6 +2217,11 @@ public class Project extends Processor {
 		return null;
 	}
 
+	/**
+	 * The keep flag is really awkward since it overrides the -runkeep flag in
+	 * the file. Use doExport instead
+	 */
+	@Deprecated
 	public void export(String runFilePath, boolean keep, File output) throws Exception {
 		Map<String, String> options = Collections.singletonMap("keep", Boolean.toString(keep));
 		Entry<String, Resource> export;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -42,6 +42,7 @@ import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
 import java.util.jar.Manifest;
@@ -1872,6 +1873,7 @@ public class Project extends Processor {
 			if (underTest)
 				builder.setProperty(Constants.UNDERTEST, "true");
 			Jar jars[] = builder.builds();
+
 			getInfo(builder);
 
 			if (isPedantic() && !unreferencedClasspathEntries.isEmpty()) {
@@ -1882,27 +1884,75 @@ public class Project extends Processor {
 				return null;
 			}
 
-			Set<File> builtFiles = Create.set();
+			//
+			// Save the JARs
+			//
+
+			Set<File> buildFilesSet = Create.set();
 			long lastModified = 0L;
 			for (Jar jar : jars) {
 				File file = saveBuild(jar);
 				if (file == null) {
-					getInfo(builder);
 					error("Could not save %s", jar.getName());
-					return null;
+				} else {
+					buildFilesSet.add(file);
+					if (lastModified < jar.lastModified()) {
+						lastModified = jar.lastModified();
+					}
 				}
-				builtFiles.add(file);
-				if (lastModified < jar.lastModified()) {
-					lastModified = jar.lastModified();
-				}
+			}
+
+			if (!isOk())
+				return null;
+
+			//
+			// Handle the exports
+			//
+
+			Instructions runspec = new Instructions(getProperty(EXPORT));
+			Set<Instruction> missing = new LinkedHashSet<>();
+
+			Map<File, List<Attrs>> selectedRunFiles = runspec.select(getBase(), Function.identity(), missing);
+
+			if (!missing.isEmpty()) {
+				// this is a new error :-( so make it a warning
+				warning("-export entries %s could not be found", missing);
+			}
+			if (selectedRunFiles.containsKey(getPropertiesFile())) {
+				error("Cannot export the same file that contains the -export instruction %s", getPropertiesFile());
+				return null;
+			}
+
+			Map<File, Resource> exports = builder.doExports(selectedRunFiles);
+			getInfo(builder);
+
+			if (!isOk())
+				return null;
+
+			for (Map.Entry<File, Resource> ee : exports.entrySet()) {
+				File outputFile = ee.getKey();
+					File actual = write(f -> {
+						IO.copy(ee.getValue()
+							.openInputStream(), f);
+					}, outputFile);
+
+					if (actual != null) {
+						buildFilesSet.add(actual);
+					} else {
+						error("Could not save %s", ee.getKey());
+					}
+			}
+
+			if (!isOk()) {
+				return null;
 			}
 
 			boolean bfsWrite = !bfs.exists() || (lastModified > bfs.lastModified());
 			if (buildfiles != null) {
 				Set<File> removed = Create.set(buildfiles);
-				if (!removed.equals(builtFiles)) {
+				if (!removed.equals(buildFilesSet)) {
 					bfsWrite = true;
-					removed.removeAll(builtFiles);
+					removed.removeAll(buildFilesSet);
 					for (File remove : removed) {
 						IO.delete(remove);
 						getWorkspace().changedFile(remove);
@@ -1913,7 +1963,7 @@ public class Project extends Processor {
 			// so we can get them later even in another process
 			if (bfsWrite) {
 				try (PrintWriter fw = IO.writer(bfs)) {
-					for (File f : builtFiles) {
+					for (File f : buildFilesSet) {
 						fw.write(IO.absolutePath(f));
 						fw.write('\n');
 					}
@@ -1921,7 +1971,8 @@ public class Project extends Processor {
 				getWorkspace().changedFile(bfs);
 			}
 			bfs = null; // avoid delete in finally block
-			return files = builtFiles.toArray(new File[0]);
+
+			return files = buildFilesSet.toArray(new File[0]);
 		} finally {
 			if (tstamp)
 				unsetProperty(TSTAMP);
@@ -1942,93 +1993,12 @@ public class Project extends Processor {
 	public File saveBuild(Jar jar) throws Exception {
 		try {
 			File outputFile = getOutputFile(jar.getName(), jar.getVersion());
-			File logicalFile = outputFile;
 
 			reportNewer(outputFile.lastModified(), jar);
+			File logicalFile = write(jar::write, outputFile);
 
-			File fp = outputFile.getParentFile();
-			if (!fp.isDirectory()) {
-				IO.mkdirs(fp);
-			}
-
-			// On windows we sometimes cannot delete a file because
-			// someone holds a lock in our or another process. So if
-			// we set the -overwritestrategy flag we use an avoiding
-			// strategy.
-			// We will always write to a temp file name. Basically the
-			// calculated name + a variable suffix. We then create
-			// a link with the constant name to this variable name.
-			// This allows us to pick a different suffix when we cannot
-			// delete the file. Yuck, but better than the alternative.
-
-			String overwritestrategy = getProperty("-x-overwritestrategy", "classic");
-			swtch: switch (overwritestrategy) {
-				case "delay" :
-					for (int i = 0; i < 10; i++) {
-						try {
-							IO.deleteWithException(outputFile);
-							jar.write(outputFile);
-							break swtch;
-						} catch (Exception e) {
-							Thread.sleep(500);
-						}
-					}
-
-					// Execute normal case to get classic behavior
-					// FALL THROUGH
-
-				case "classic" :
-					IO.deleteWithException(outputFile);
-					jar.write(outputFile);
-					break swtch;
-
-				case "gc" :
-					try {
-						IO.deleteWithException(outputFile);
-					} catch (Exception e) {
-						System.gc();
-						System.runFinalization();
-						IO.deleteWithException(outputFile);
-					}
-					jar.write(outputFile);
-					break swtch;
-
-				case "windows-only-disposable-names" :
-					if (!IO.isWindows()) {
-						IO.deleteWithException(outputFile);
-						jar.write(outputFile);
-						break swtch;
-					}
-					// Fall through
-
-				case "disposable-names" :
-					int suffix = 0;
-					while (true) {
-						outputFile = new File(outputFile.getParentFile(), outputFile.getName() + "-" + suffix);
-						IO.delete(outputFile);
-						if (!outputFile.isFile()) {
-							// Succeeded to delete the file
-							jar.write(outputFile);
-							Files.createSymbolicLink(logicalFile.toPath(), outputFile.toPath());
-							break;
-						} else {
-							warning("Could not delete build file {} ", overwritestrategy);
-							logger.warn("Cannot delete file {} but that should be ok", outputFile);
-						}
-						suffix++;
-					}
-					break swtch;
-
-				default :
-					error(
-						"Invalid value for -x-overwritestrategy: %s, expected classic, delay, gc, windows-only-disposable-names, disposable-names",
-						overwritestrategy);
-					IO.deleteWithException(outputFile);
-					jar.write(outputFile);
-					break swtch;
-
-			}
-
+			logger.debug("{} ({}) {}", jar.getName(), outputFile.getName(), jar.getResources()
+				.size());
 			//
 			// For maven we've got the shitty situation that the
 			// files in the generated directories have an ever changing
@@ -2053,16 +2023,103 @@ public class Project extends Processor {
 				}
 				getWorkspace().changedFile(canonical);
 			}
-
-			getWorkspace().changedFile(outputFile);
-			if (!outputFile.equals(logicalFile))
-				getWorkspace().changedFile(logicalFile);
-			logger.debug("{} ({}) {}", jar.getName(), outputFile.getName(), jar.getResources()
-				.size());
 			return logicalFile;
 		} finally {
 			jar.close();
 		}
+	}
+
+	private File write(ConsumerWithException<File> jar, File outputFile)
+		throws IOException, InterruptedException, Exception {
+		File logicalFile = outputFile;
+
+		File fp = outputFile.getParentFile();
+		if (!fp.isDirectory()) {
+			IO.mkdirs(fp);
+		}
+
+		// On windows we sometimes cannot delete a file because
+		// someone holds a lock in our or another process. So if
+		// we set the -overwritestrategy flag we use an avoiding
+		// strategy.
+		// We will always write to a temp file name. Basically the
+		// calculated name + a variable suffix. We then create
+		// a link with the constant name to this variable name.
+		// This allows us to pick a different suffix when we cannot
+		// delete the file. Yuck, but better than the alternative.
+
+		String overwritestrategy = getProperty("-x-overwritestrategy", "classic");
+		swtch: switch (overwritestrategy) {
+			case "delay" :
+				for (int i = 0; i < 10; i++) {
+					try {
+						IO.deleteWithException(outputFile);
+						jar.accept(outputFile);
+						break swtch;
+					} catch (Exception e) {
+						Thread.sleep(500);
+					}
+				}
+
+				// Execute normal case to get classic behavior
+				// FALL THROUGH
+
+			case "classic" :
+				IO.deleteWithException(outputFile);
+				jar.accept(outputFile);
+				break swtch;
+
+			case "gc" :
+				try {
+					IO.deleteWithException(outputFile);
+				} catch (Exception e) {
+					System.gc();
+					System.runFinalization();
+					IO.deleteWithException(outputFile);
+				}
+				jar.accept(outputFile);
+				break swtch;
+
+			case "windows-only-disposable-names" :
+				if (!IO.isWindows()) {
+					IO.deleteWithException(outputFile);
+					jar.accept(outputFile);
+					break swtch;
+				}
+				// Fall through
+
+			case "disposable-names" :
+				int suffix = 0;
+				while (true) {
+					outputFile = new File(outputFile.getParentFile(), outputFile.getName() + "-" + suffix);
+					IO.delete(outputFile);
+					if (!outputFile.isFile()) {
+						// Succeeded to delete the file
+						jar.accept(outputFile);
+						Files.createSymbolicLink(logicalFile.toPath(), outputFile.toPath());
+						break;
+					} else {
+						warning("Could not delete build file {} ", overwritestrategy);
+						logger.warn("Cannot delete file {} but that should be ok", outputFile);
+					}
+					suffix++;
+				}
+				break swtch;
+
+			default :
+				error(
+					"Invalid value for -x-overwritestrategy: %s, expected classic, delay, gc, windows-only-disposable-names, disposable-names",
+					overwritestrategy);
+				IO.deleteWithException(outputFile);
+				jar.accept(outputFile);
+				break swtch;
+
+		}
+
+		getWorkspace().changedFile(outputFile);
+		if (!outputFile.equals(logicalFile))
+			getWorkspace().changedFile(logicalFile);
+		return logicalFile;
 	}
 
 	/**
@@ -2186,15 +2243,27 @@ public class Project extends Processor {
 		release(false);
 	}
 
+	/**
+	 * Export this project via the exporters. The return is the calculated name
+	 * (can be overridden with the option `name`, which must be the basename
+	 * since the extension is defined by the exporter)
+	 *
+	 * @param type an exporter type like `bnd.executablejar` or null as default
+	 *            `bnd.pack`, the original export function
+	 * @param options parameters to the exporters
+	 * @return and entry with the name and resource for the export
+	 * @throws Exception
+	 */
 	public Map.Entry<String, Resource> export(String type, Map<String, String> options) throws Exception {
-		Exporter exporter = getExporter(type);
-		if (exporter == null) {
-			error("No exporter for %s", type);
-			return null;
-		}
+
 		if (options == null) {
 			options = Collections.emptyMap();
 		}
+
+		if (type == null) {
+			type = options.getOrDefault(Constants.EXPORT_TYPE, "bnd.executablejar.pack");
+		}
+
 		Parameters exportTypes = parseHeader(getProperty(Constants.EXPORTTYPE));
 		Map<String, String> attrs = exportTypes.get(type);
 		if (attrs != null) {
@@ -2202,7 +2271,19 @@ public class Project extends Processor {
 			options = attrs;
 		}
 
-		return exporter.export(type, this, options);
+		Exporter exporter = getExporter(type);
+		if (exporter == null) {
+			error("No exporter for %s", type);
+			return null;
+		}
+
+		Entry<String, Resource> entry = exporter.export(type, this, options);
+		if (entry == null) {
+			error("Export failed %s for type %s", this, type);
+			return null;
+		}
+
+		return entry;
 	}
 
 	private Exporter getExporter(String type) {
@@ -2909,18 +2990,14 @@ public class Project extends Processor {
 
 	/**
 	 * Pack the project (could be a bndrun file) and save it on disk. Report
-	 * errors if they happen.
-	 */
-	static List<String> ignore = new ExtList<>(BUNDLE_SPECIFIC_HEADERS);
-
-	/**
-	 * Caller must close this JAR
+	 * errors if they happen. Caller must close this JAR
 	 *
 	 * @param profile
 	 * @return a jar with the executable code
 	 * @throws Exception
 	 */
 	public Jar pack(String profile) throws Exception {
+		List<String> ignore = new ExtList<>(BUNDLE_SPECIFIC_HEADERS);
 		try (ProjectBuilder pb = getBuilder(null)) {
 			List<Builder> subBuilders = pb.getSubBuilders();
 
@@ -2930,55 +3007,56 @@ public class Project extends Processor {
 				return null;
 			}
 
-			Builder b = subBuilders.iterator()
-				.next();
+			try (Builder b = subBuilders.iterator()
+				.next()) {
 
-			ignore.remove(BUNDLE_SYMBOLICNAME);
-			ignore.remove(BUNDLE_VERSION);
-			ignore.add(SERVICE_COMPONENT);
+				ignore.remove(BUNDLE_SYMBOLICNAME);
+				ignore.remove(BUNDLE_VERSION);
+				ignore.add(SERVICE_COMPONENT);
 
-			try (ProjectLauncher launcher = getProjectLauncher()) {
-				launcher.getRunProperties()
-					.put("profile", profile); // TODO
-												// remove
-				launcher.getRunProperties()
-					.put(PROFILE, profile);
-				Jar jar = launcher.executable();
-				Manifest m = jar.getManifest();
-				Attributes main = m.getMainAttributes();
-				for (String key : this) {
-					if (Character.isUpperCase(key.charAt(0)) && !ignore.contains(key)) {
-						String value = getProperty(key);
-						if (value == null)
-							continue;
-						Name name = new Name(key);
-						String trimmed = value.trim();
-						if (trimmed.isEmpty())
-							main.remove(name);
-						else if (EMPTY_HEADER.equals(trimmed))
-							main.put(name, "");
-						else
-							main.put(name, value);
+				try (ProjectLauncher launcher = getProjectLauncher()) {
+					launcher.getRunProperties()
+						.put("profile", profile); // TODO
+													// remove
+					launcher.getRunProperties()
+						.put(PROFILE, profile);
+					Jar jar = launcher.executable();
+					Manifest m = jar.getManifest();
+					Attributes main = m.getMainAttributes();
+					for (String key : this) {
+						if (Character.isUpperCase(key.charAt(0)) && !ignore.contains(key)) {
+							String value = getProperty(key);
+							if (value == null)
+								continue;
+							Name name = new Name(key);
+							String trimmed = value.trim();
+							if (trimmed.isEmpty())
+								main.remove(name);
+							else if (EMPTY_HEADER.equals(trimmed))
+								main.put(name, "");
+							else
+								main.put(name, value);
+						}
 					}
+
+					if (main.getValue(BUNDLE_SYMBOLICNAME) == null)
+						main.putValue(BUNDLE_SYMBOLICNAME, b.getBsn());
+
+					if (main.getValue(BUNDLE_SYMBOLICNAME) == null)
+						main.putValue(BUNDLE_SYMBOLICNAME, getName());
+
+					if (main.getValue(BUNDLE_VERSION) == null) {
+						main.putValue(BUNDLE_VERSION, Version.LOWEST.toString());
+						warning("No version set, uses 0.0.0");
+					}
+
+					jar.setManifest(m);
+					jar.calcChecksums(new String[] {
+						"SHA1", "MD5"
+					});
+					launcher.removeClose(jar);
+					return jar;
 				}
-
-				if (main.getValue(BUNDLE_SYMBOLICNAME) == null)
-					main.putValue(BUNDLE_SYMBOLICNAME, b.getBsn());
-
-				if (main.getValue(BUNDLE_SYMBOLICNAME) == null)
-					main.putValue(BUNDLE_SYMBOLICNAME, getName());
-
-				if (main.getValue(BUNDLE_VERSION) == null) {
-					main.putValue(BUNDLE_VERSION, Version.LOWEST.toString());
-					warning("No version set, uses 0.0.0");
-				}
-
-				jar.setManifest(m);
-				jar.calcChecksums(new String[] {
-					"SHA1", "MD5"
-				});
-				launcher.removeClose(jar);
-				return jar;
 			}
 		}
 	}
@@ -3529,4 +3607,9 @@ public class Project extends Processor {
 	public boolean isStandalone() {
 		return getWorkspace().getLayout() == WorkspaceLayout.STANDALONE;
 	}
+
+	public boolean isRun() {
+		return false;
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -103,6 +103,7 @@ public abstract class ProjectLauncher extends Processor {
 
 	public ProjectLauncher(Project project) throws Exception {
 		this.project = project;
+		this.setBase(project.getBase());
 		builderInstrs = project.getInstructions(BuilderInstructions.class);
 		launcherInstrs = project.getInstructions(LauncherInstructions.class);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Run.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Run.java
@@ -50,4 +50,8 @@ public class Run extends Project {
 		return getPropertiesFile().getName();
 	}
 
+	@Override
+	public boolean isRun() {
+		return true;
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Run.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Run.java
@@ -49,9 +49,4 @@ public class Run extends Project {
 	public String getName() {
 		return getPropertiesFile().getName();
 	}
-
-	@Override
-	public boolean isRun() {
-		return true;
-	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/exporter/executable/ExecutableJarExporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/exporter/executable/ExecutableJarExporter.java
@@ -10,14 +10,27 @@ import aQute.bnd.build.ProjectLauncher;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.JarResource;
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.export.Exporter;
 import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
 
+/**
+ * Exports a project or run file to an executable JAR.
+ * <p>
+ * This exporter supports 2 types for backward compatibility. This exporter used
+ * the project launcher's execute function. However, there also was an -export
+ * instruction that used the {@link Project#pack(String)} method. This method
+ * was a bit more powerful. Since both exports were used, the
+ * {@link #EXECUTABLE_JAR} was used from Gradle and bndtools while the
+ * {@link #EXECUTABLE_PACK} was used from bnd build, we needed to handle them
+ * slightly differently since it is difficult to ensure backward compatibility.
+ */
 @BndPlugin(name = "exporter.executablejar")
 public class ExecutableJarExporter implements Exporter {
-	public static final String EXECUTABLE_JAR = "bnd.executablejar";
+	public static final String	EXECUTABLE_JAR	= "bnd.executablejar";
+	public static final String	EXECUTABLE_PACK	= "bnd.executablejar.pack";
 
 	interface Configuration {
 		boolean keep();
@@ -28,26 +41,48 @@ public class ExecutableJarExporter implements Exporter {
 	@Override
 	public String[] getTypes() {
 		return new String[] {
-			EXECUTABLE_JAR
+			EXECUTABLE_JAR, EXECUTABLE_PACK
 		};
 	}
 
 	@Override
 	public Entry<String, Resource> export(String type, Project project, Map<String, String> options) throws Exception {
-		Configuration configuration = Converter.cnv(Configuration.class, options);
 		project.prepare();
-		try (ProjectLauncher launcher = project.getProjectLauncher()) {
-			launcher.setKeep(configuration.keep());
-			Jar jar = launcher.executable();
-			project.getInfo(launcher);
+		Jar jar;
+		if (EXECUTABLE_JAR.equals(type)) {
+			try (ProjectLauncher launcher = project.getProjectLauncher()) {
+				//
+				// Ensure that we do not override the -runkeep property
+				// if keep is not explicitly set. We therefore take the `or`
+				// of the keep option and the -runkeep
+				//
 
-			String name = jar.getName();
-			String[] baseext = Strings.extension(name);
-			if (baseext != null && ("bnd".equals(baseext[1]) || "bndrun".equals(baseext[1]))) {
-				name = baseext[0];
+				Configuration configuration = Converter.cnv(Configuration.class, options);
+				if (configuration.keep() || Processor.isTrue(project.getProperty(Constants.RUNKEEP)))
+					launcher.setKeep(true);
+
+				jar = launcher.executable();
+				launcher.removeClose(jar);
+				project.getInfo(launcher);
 			}
-			name = name + Constants.DEFAULT_JAR_EXTENSION;
-			return new SimpleEntry<>(name, new JarResource(jar, true));
+		} else if (EXECUTABLE_PACK.equals(type)) {
+
+			String profile = options.getOrDefault(Constants.PROFILE, project.getProperty(Constants.PROFILE));
+			jar = project.pack(profile);
+			if (jar == null)
+				return null;
+
+		} else {
+			project.error("Unknown type %s", type);
+			return null;
 		}
+
+		String name = jar.getName();
+		String[] baseext = Strings.extension(name);
+		if (baseext != null && ("bnd".equals(baseext[1]) || "bndrun".equals(baseext[1]))) {
+			name = baseext[0];
+		}
+		name = name + Constants.DEFAULT_JAR_EXTENSION;
+		return new SimpleEntry<>(name, new JarResource(jar, true));
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -135,6 +135,12 @@ public interface Constants {
 	String				EEPROFILE									= "-eeprofile";
 	String				EXECUTABLE									= "-executable";
 	String				EXPORT										= "-export";
+	String				EXPORT_TYPE									= "type";
+	String				EXPORT_BSN									= "bsn";
+	String				EXPORT_NAME									= "name";
+	String				EXPORT_VERSION								= "version";
+
+
 	String				EXPORTTYPE									= "-exporttype";
 	String				EXPORT_APIGUARDIAN							= "-export-apiguardian";
 	String				FAIL_OK										= "-failok";
@@ -573,5 +579,7 @@ public interface Constants {
 	String				DEBUG										= "-debug";
 	@Deprecated
 	String				EXPERIMENTS									= "-experiments";
+
+
 
 }

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -314,6 +314,7 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		Parameters ir = getProject().getIncludeResource();
 		if (!ir.isEmpty()) {
 			try (Builder b = new Builder()) {
+				b.setBase(getProject().getBase());
 				b.setIncludeResource(ir.toString());
 				b.setProperty(Constants.RESOURCEONLY, "true");
 				b.build();

--- a/demo/export-options.bndrun
+++ b/demo/export-options.bndrun
@@ -1,0 +1,25 @@
+Bundle-Version: 1.0.0
+
+-runfw: org.apache.felix.framework
+-runee: JavaSE-1.8
+-runsystemcapabilities: ${native_capability}
+-resolve.effective: active
+
+-runbundles:\
+	org.apache.felix.gogo.runtime,\
+	org.apache.felix.gogo.shell,\
+	org.apache.felix.gogo.command
+
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)',\
+	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
+
+-runproperties.testlauncher2: in.bndrun=bndrun
+
+-exporttype: bnd.executablejar;foo=x, bnd.runbundles;bar=x
+
+-executable: rejar=STORE, strip=OSGI-OPT/*
+
+[debug]port = DEBUG
+[prod]port= PROD
+
+Bar = ${port} 

--- a/docs/_instructions/export.md
+++ b/docs/_instructions/export.md
@@ -29,7 +29,7 @@ The `-exporttype` can be used to set some default attributes for a specific type
 The Exporters use a plugin mechanism and therefore the list is not closed. The following exporters are supported by bnd out of the box:
 
 * `bnd.executablejar.pack` – Exports a JAR file using the launcher from the `-runpath` or the default if no launcher is specified.
-* `bnd.executablejar` – Similar to the previous but does not support profiles
+* `bnd.executablejar` – Similar to the previous but does not support profiles, has no automatic bsn assigned, and entries are not signed. The reason there are two types for the more or less the same format with subtle differences is for backward compatibility.
 * `bnd.runbundles` – A JAR with the runbundles
 * `osgi.subsystem.application` – Export into an application subsystem
 * `osgi.subsystem.feature` – Export into a feature subsystem 

--- a/docs/_instructions/export.md
+++ b/docs/_instructions/export.md
@@ -1,6 +1,51 @@
 ---
 layout: default
-class: Run
-title: -export FILE ( ';' PARAMETER )* ( ',' FILE ( ';' PARAMETER )* )*
+class: Project
+title: -export PATH ( ';' PARAMETER )* ( ',' PATH ( ';' PARAMETER )* )*
 summary: Turns a bndrun file into its deployable format 
 ---
+
+The `-export` instruction can be used to export a `bndrun` or `bnd` file to an executable JAR during the build process. In contrast to the export functions, this `-export` instruction is supported in all drivers, including Eclipse. It can be used to continously build executable JARs or other supported exporters. It can only be used in the top level bnd.bnd file.
+
+The format of the `-export` instruction is:
+
+    -export     ::= filespec ( ',' filespec )*
+    filespec    ::= path (';' PARAMATER )*
+
+The `path` is either a relative path in the project directory or it is a wildcard specification using globs. All files in the project directory are selected. In general, these should be bnd or bndrun files.
+
+The following attributes are architected:
+
+* `type` – The type specifies the exporter type. The default type is `bnd.executablejar.pack`.
+* `name` – Overrides the default name of the output file. It should contain the extension. The file should not have path segments, it will be placed in the target directory. Without a name, the exporter defines the file name since the extensions can differ depending on the exporter.
+* `bsn` – Set the bundle symbolic name of the resulting JAR file if possible
+* `version` – Set the version of the resulting JAR file if possible
+* other – Any remaining properties are added to the properties of the run file. For example, `-profile` can be used to select a specific property profile.
+
+The `-exporttype` can be used to set some default attributes for a specific type.
+
+## Exporters
+
+The Exporters use a plugin mechanism and therefore the list is not closed. The following exporters are supported by bnd out of the box:
+
+* `bnd.executablejar.pack` – Exports a JAR file using the launcher from the `-runpath` or the default if no launcher is specified.
+* `bnd.executablejar` – Similar to the previous but does not support profiles
+* `bnd.runbundles` – A JAR with the runbundles
+* `osgi.subsystem.application` – Export into an application subsystem
+* `osgi.subsystem.feature` – Export into a feature subsystem 
+* `osgi.subsystem.composite` – Export into a composite subsystem
+
+## Example
+
+For example:
+
+    -export: \
+        foo.bndrun; \
+            -profile=debug; \
+            -runkeep=true; \
+            name = "foo.jar, \
+        bar.bndrun
+
+## Backward Compatibility
+
+If the  `filespec` clause does not set the `type` nor the `name` then it is assumed the backward compatible mode is required. This will set the output name to the file name with a `.jar` extension and it will set the bundle symbolic name.


### PR DESCRIPTION
The -export instruction can export bndrun files. However,
these exports were done in the Project Builder. At that
time any bundles are build but not yet present on the file
system. If the bndrun file included the bundles (Jars) 
then it got an error on a clean build or a previous
version.

This patch moves the -export execution into Project
and executes it after the bundles/jars are stored
on the file system.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>