### PR TITLE
Fix MiniFramework to work with recent changes to testing

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/Activator.java
+++ b/biz.aQute.junit/src/aQute/junit/Activator.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -433,7 +434,10 @@ public class Activator implements BundleActivator, Runnable {
 	}
 
 	private TestSuite createSuite(Bundle tfw, Stream<String> testNames, TestResult result) {
-		TestSuite suite = new TestSuite();
+		String name = Optional.ofNullable(tfw)
+			.map(Bundle::getSymbolicName)
+			.orElse("test.run");
+		TestSuite suite = new TestSuite(name);
 		testNames.forEachOrdered(fqn -> addTest(tfw, suite, fqn, result));
 		return suite;
 	}

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -1125,7 +1125,7 @@ public class Launcher implements ServiceListener {
 		} else {
 			trace("using embedded mini framework because we were told not to use META-INF/services");
 			// we have to use our own dummy framework
-			systemBundle = new MiniFramework(p);
+			systemBundle = new MiniFramework(p).setTracing(this::trace);
 		}
 		systemBundle.init();
 

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/BundleClassLoader.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/BundleClassLoader.java
@@ -1,0 +1,26 @@
+package aQute.launcher.minifw;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleReference;
+
+class BundleClassLoader extends URLClassLoader implements BundleReference {
+	private final Bundle bundle;
+
+	BundleClassLoader(File file, ClassLoader parent, Bundle bundle) throws IOException {
+		super(new URL[] {
+			file.toURI()
+				.toURL()
+		}, parent);
+		this.bundle = bundle;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return bundle;
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/Headers.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/Headers.java
@@ -1,0 +1,63 @@
+package aQute.launcher.minifw;
+
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+
+class Headers extends Dictionary<String, String> {
+	private final Manifest manifest;
+
+	Headers(Manifest manifest) {
+		this.manifest = manifest;
+	}
+
+	@Override
+	public Enumeration<String> elements() {
+		@SuppressWarnings({
+			"unchecked", "rawtypes"
+		})
+		Collection<String> elements = (Collection) manifest.getMainAttributes()
+			.values();
+		return new IteratorEnumeration<>(elements);
+	}
+
+	@Override
+	public String get(Object key) {
+		String o = manifest.getMainAttributes()
+			.getValue((String) key);
+		return o;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return manifest.getMainAttributes()
+			.isEmpty();
+	}
+
+	@Override
+	public Enumeration<String> keys() {
+		Stream<String> keys = manifest.getMainAttributes()
+			.keySet()
+			.stream()
+			.map(Object::toString);
+		return new IteratorEnumeration<>(keys);
+	}
+
+	@Override
+	public String put(String key, String value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String remove(Object key) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int size() {
+		return manifest.getMainAttributes()
+			.size();
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/IteratorEnumeration.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/IteratorEnumeration.java
@@ -1,0 +1,27 @@
+package aQute.launcher.minifw;
+
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+class IteratorEnumeration<E> implements Enumeration<E> {
+	private final Iterator<E> iterator;
+
+	IteratorEnumeration(Stream<E> stream) {
+		iterator = stream.iterator();
+	}
+
+	IteratorEnumeration(Iterable<E> iterable) {
+		iterator = iterable.iterator();
+	}
+
+	@Override
+	public boolean hasMoreElements() {
+		return iterator.hasNext();
+	}
+
+	@Override
+	public E nextElement() {
+		return iterator.next();
+	}
+}

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
@@ -45,6 +45,7 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	int					state	= Bundle.INSTALLED;
 	ClassLoader			last;
 	final FrameworkStartLevelImpl	frameworkStartLevel;
+	private Tracing					tracing	= Tracing.noop;
 	public MiniFramework(Map<Object, Object> properties) {
 		this.properties = new Properties(System.getProperties());
 		this.properties.putAll(properties);
@@ -52,6 +53,14 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		bundles.put(Long.valueOf(0), this);
 		last = loader = getClass().getClassLoader();
 		frameworkStartLevel = new FrameworkStartLevelImpl(this);
+
+	public MiniFramework setTracing(Tracing tracing) {
+		this.tracing = tracing;
+		return this;
+	}
+
+	void trace(String msg, Object... objects) {
+		tracing.trace(msg, objects);
 	}
 
 	@Override

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/MiniFramework.java
@@ -10,15 +10,17 @@ import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.Manifest;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.BundleListener;
+import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.FrameworkListener;
@@ -38,21 +40,33 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.framework.wiring.FrameworkWiring;
 
 public class MiniFramework implements Framework, Bundle, BundleContext {
-	ClassLoader			loader;
-	Properties			properties;
-	Map<Long, Bundle>	bundles	= new HashMap<>();
-	int					ID		= 0;
-	int					state	= Bundle.INSTALLED;
-	ClassLoader			last;
+	final ClassLoader				loader;
+	private final Properties		properties;
+	private Map<Long, Bundle>		bundles	= new HashMap<>();
+	private final AtomicInteger		ID		= new AtomicInteger(0);
+	int								state	= Bundle.RESOLVED;
+	ClassLoader						last;
 	final FrameworkStartLevelImpl	frameworkStartLevel;
 	private Tracing					tracing	= Tracing.noop;
+	private final Manifest			manifest;
+	private long					lastModified;
+
 	public MiniFramework(Map<Object, Object> properties) {
 		this.properties = new Properties(System.getProperties());
 		this.properties.putAll(properties);
 
-		bundles.put(Long.valueOf(0), this);
+		bundles.put(Long.valueOf(0), getBundle());
 		last = loader = getClass().getClassLoader();
 		frameworkStartLevel = new FrameworkStartLevelImpl(this);
+		manifest = new Manifest();
+		manifest.getMainAttributes()
+			.putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
+		manifest.getMainAttributes()
+			.putValue(Constants.BUNDLE_SYMBOLICNAME, "Mini framework");
+		manifest.getMainAttributes()
+			.putValue(Constants.BUNDLE_VERSION, "1.8.0");
+		lastModified = System.currentTimeMillis();
+	}
 
 	public MiniFramework setTracing(Tracing tracing) {
 		this.tracing = tracing;
@@ -69,6 +83,11 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
+	public void init(FrameworkListener... listeners) throws BundleException {
+		init();
+	}
+
+	@Override
 	public FrameworkEvent waitForStop(long timeout) throws InterruptedException {
 		long deadline = System.currentTimeMillis() + timeout;
 
@@ -76,11 +95,11 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 			if (timeout != 0) {
 				long wait = deadline - System.currentTimeMillis();
 				if (wait <= 0)
-					return new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, this, null);
+					return new FrameworkEvent(FrameworkEvent.WAIT_TIMEDOUT, getBundle(), null);
 			}
 			Thread.sleep(100);
 		}
-		return new FrameworkEvent(FrameworkEvent.STOPPED, this, null);
+		return new FrameworkEvent(FrameworkEvent.STOPPED, getBundle(), null);
 	}
 
 	@Override
@@ -95,29 +114,30 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 
 	@Override
 	public URL getEntry(String path) {
-		if (path.startsWith("/"))
+		if (path.startsWith("/")) {
 			path = path.substring(1);
+		}
 		return loader.getResource(path);
 	}
 
 	@Override
 	public Enumeration<String> getEntryPaths(String path) {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public Dictionary<String, String> getHeaders() {
-		return new Hashtable<>();
+		return new Headers(manifest);
 	}
 
 	@Override
 	public Dictionary<String, String> getHeaders(String locale) {
-		throw new UnsupportedOperationException();
+		return new Headers(manifest);
 	}
 
 	@Override
 	public long getLastModified() {
-		return 0;
+		return lastModified;
 	}
 
 	@Override
@@ -162,22 +182,24 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 
 	@Override
 	public void start() {
-		state = Bundle.ACTIVE;
+		start(0);
 	}
 
 	@Override
 	public void start(int options) {
-		start();
+		state = Bundle.ACTIVE;
 	}
 
 	@Override
-	public synchronized void stop() {
-		state = Bundle.UNINSTALLED;
+	public void stop() {
+		stop(0);
+	}
+
+	@Override
+	public synchronized void stop(int options) {
+		state = Bundle.RESOLVED;
 		notifyAll();
 	}
-
-	@Override
-	public void stop(int options) throws BundleException {}
 
 	@Override
 	public Bundle getBundle() {
@@ -208,19 +230,36 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
-	public Bundle installBundle(String location) throws BundleException {
+	public Bundle installBundle(String location, InputStream in) throws BundleException {
 		try {
-			if (location.startsWith("reference:"))
-				location = new File(new URL(location.substring("reference:".length())).toURI()).getPath();
-			else if (location.startsWith("file:"))
-				location = new File(location.substring("file:".length())).getPath();
+			if (in != null) {
+				in.close();
+			}
+			if (location.startsWith("reference:")) {
+				location = location.substring("reference:".length());
+			}
+			if (location.startsWith("file:")) {
+				location = new File(new URL(location).toURI()).getAbsolutePath();
+			} else {
+				try {
+					@SuppressWarnings("unused")
+					URL url = new URL(location);
+				} catch (MalformedURLException e) {
+					throw new BundleException(
+						"For the mini framework, the location must be a proper URL even though this is not required by the specification "
+							+ location,
+						e);
+				}
+			}
 
-			while (location.startsWith("//"))
+			while (location.startsWith("//")) {
 				location = location.substring(1);
+			}
 
-			Context c = new Context(this, last, ++ID, location);
-			bundles.put(Long.valueOf(c.id), c);
-			last = c;
+			MiniBundle c = new MiniBundle(this, last, ID.incrementAndGet(), location);
+			bundles.put(Long.valueOf(c.getBundleId()), c);
+			last = c.getClassLoader();
+			lastModified = c.getLastModified();
 			return c;
 		} catch (Exception e) {
 			throw new BundleException("Failed to install", e);
@@ -228,61 +267,43 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	}
 
 	@Override
-	public Bundle installBundle(String location, InputStream in) throws BundleException {
-		Context c;
-		try {
-			in.close();
-			try {
-				@SuppressWarnings("unused")
-				URL url = new URL(location);
-			} catch (MalformedURLException e) {
-				throw new BundleException(
-					"For the mini framework, the location must be a proper URL even though this is not required by the specification "
-						+ location,
-					e);
-			}
-			c = new Context(this, last, ++ID, location);
-			bundles.put(Long.valueOf(c.id), c);
-			last = c;
-			return c;
-		} catch (Exception e) {
-			throw new BundleException("Can't install " + location, e);
-		}
+	public Bundle installBundle(String location) throws BundleException {
+		return installBundle(location, null);
 	}
 
 	@Override
 	public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public ServiceReference<?>[] getRegisteredServices() {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public ServiceReference<?>[] getServicesInUse() {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
 	public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int signersType) {
-		throw new UnsupportedOperationException();
+		return new HashMap<>();
 	}
 
 	@Override
 	public void uninstall() throws BundleException {
-		throw new UnsupportedOperationException();
+		throw new BundleException("Cannot uninstall framework", BundleException.UNSUPPORTED_OPERATION);
 	}
 
 	@Override
 	public void update() throws BundleException {
-		throw new UnsupportedOperationException();
+		throw new BundleException("Cannot update mini framework", BundleException.UNSUPPORTED_OPERATION);
 	}
 
 	@Override
 	public void update(InputStream in) throws BundleException {
-		throw new UnsupportedOperationException();
+		throw new BundleException("Cannot update mini framework", BundleException.UNSUPPORTED_OPERATION);
 	}
 
 	@Override
@@ -312,7 +333,7 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 
 	@Override
 	public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	@Override
@@ -342,27 +363,12 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 
 	@Override
 	public String toString() {
-		return "Mini framework";
-	}
-
-	class Loader extends ClassLoader {
-		@Override
-		public Class<?> findClass(String name) throws ClassNotFoundException {
-			for (Bundle b : bundles.values()) {
-				try {
-					return b.loadClass(name);
-				} catch (ClassNotFoundException e) {
-					// Ignore, try next
-				}
-			}
-			throw new ClassNotFoundException(name);
-		}
+		return "0 Mini framework";
 	}
 
 	@Override
-	public int compareTo(Bundle var0) {
-		// TODO Auto-generated method stub
-		return 0;
+	public int compareTo(Bundle other) {
+		return Long.signum(getBundleId() - other.getBundleId());
 	}
 
 	@Override
@@ -409,13 +415,13 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 	@Override
 	public <A> A adapt(Class<A> type) {
 		if (BundleRevision.class.equals(type)) {
-			return type.cast(new BundleRevisionImpl(this));
+			return type.cast(new BundleRevisionImpl(getBundle()));
 		}
 		if (BundleWiring.class.equals(type)) {
-			return type.cast(new BundleWiringImpl(this, loader));
+			return type.cast(new BundleWiringImpl(getBundle(), loader));
 		}
 		if (BundleStartLevel.class.equals(type)) {
-			return type.cast(new BundleStartLevelImpl(this, frameworkStartLevel));
+			return type.cast(new BundleStartLevelImpl(getBundle(), frameworkStartLevel));
 		}
 		if (FrameworkStartLevel.class.equals(type)) {
 			return type.cast(frameworkStartLevel);
@@ -423,6 +429,7 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		if (FrameworkWiring.class.equals(type)) {
 			return type.cast(new FrameworkWiringImpl(this));
 		}
+		trace("### No adaptation for adapt(%s) %s", type, this);
 		return null;
 	}
 
@@ -437,8 +444,4 @@ public class MiniFramework implements Framework, Bundle, BundleContext {
 		return null;
 	}
 
-	@Override
-	public void init(FrameworkListener... listeners) throws BundleException {
-		init();
-	}
 }

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/Tracing.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/Tracing.java
@@ -1,0 +1,8 @@
+package aQute.launcher.minifw;
+
+@FunctionalInterface
+public interface Tracing {
+	Tracing noop = (String msg, Object... objects) -> {};
+
+	void trace(String msg, Object... objects);
+}


### PR DESCRIPTION
Testing changed to use Bundle.getEntry to read the bundle manifest. The MiniFramework implementation of Bundle.getEntry did not return the correct manifest.