### PR TITLE
libg: Add convenience unchecked methods to Exceptions

### DIFF
--- a/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
+++ b/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
@@ -5,9 +5,26 @@ import static java.util.Objects.requireNonNull;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.StringJoiner;
+import java.util.concurrent.Callable;
 
 public class Exceptions {
 	private Exceptions() {}
+
+	public static <V> V unchecked(Callable<? extends V> callable) {
+		try {
+			return callable.call();
+		} catch (Exception t) {
+			throw duck(t);
+		}
+	}
+
+	public static void unchecked(RunnableWithException runnable) {
+		try {
+			runnable.run();
+		} catch (Exception t) {
+			throw duck(t);
+		}
+	}
 
 	public static RuntimeException duck(Throwable t) {
 		Exceptions.throwsUnchecked(t);

--- a/aQute.libg/src/aQute/lib/exceptions/packageinfo
+++ b/aQute.libg/src/aQute/lib/exceptions/packageinfo
@@ -1,1 +1,1 @@
-version 2.2
+version 2.3


### PR DESCRIPTION
These methods make it easy to call Callables and RunnableWithExceptions
and duck the thrown exception. It is expected these methods would be
used mostly with lambda expression and the compiler will select the
proper unchecked method depending upon whether the lambda provides a
return value.
