### PR TITLE
[junit-platform tester] Add missing tests for method selectors

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
@@ -137,7 +137,7 @@ public class BundleSelectorResolver {
 		classSelectors.stream()
 			.map(ClassSelector::getClassName)
 			.forEach(unresolvedClasses::add);
-		methodSelectors.stream() // TODO: Test
+		methodSelectors.stream()
 			.map(MethodSelector::getClassName)
 			.forEach(unresolvedClasses::add);
 	}


### PR DESCRIPTION
There were no tests to check that method selectors with unresolved classes would be handled properly. There was a TODO in the code to add these, so it is now TODONE.

This was done partially in preparation for #3589 to make sure that we don't regress during that implementation.
