### PR TITLE
[junit-platform] Use Launcher builder framework

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
@@ -37,6 +37,7 @@ import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.LoggingListener;
@@ -117,18 +118,10 @@ public class Activator implements BundleActivator, Runnable {
 		// We can be started on our own thread or from the main code
 		thread = Thread.currentThread();
 
-		// Make sure that this is loaded
-		ClassLoader l = thread.getContextClassLoader();
-		try {
-			thread.setContextClassLoader(BundleEngine.class.getClassLoader());
-			// This will instantiate the BundleEngine class via ServiceLoader
-			launcher = LauncherFactory.create();
-		} catch (Throwable e) {
-			error("Couldn't load the BundleEngine: %s", e);
-			System.exit(254);
-		} finally {
-			thread.setContextClassLoader(l);
-		}
+		launcher = LauncherFactory.create(LauncherConfig.builder()
+				.enableTestEngineAutoRegistration(false)
+				.addTestEngines(new BundleEngine())
+				.build());
 
 		List<TestExecutionListener> listenerList = new ArrayList<>();
 


### PR DESCRIPTION
Now that we're on a more recent version of junit-platform-launcher, there is a builder API that can be used to construct launcher configs. This is a neater way of constructing a launcher that uses only the `BundleEngine` as a test engine, rather than using the ThreadContextClassLoader hack that we were forced to use in the earlier release.