### PR TITLE
comm.tests: Use different port range for windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - GRADLE_OPTS=-Dorg.gradle.parallel=false
     - JAVA_JDK=https://cdn.azul.com/zulu/bin/zulu8.42.0.23-ca-jdk8.0.232-linux_x64.tar.gz
 
-matrix:
+jobs:
   include:
     - name: "OpenJDK8"
       env:

--- a/biz.aQute.bndlib.comm.tests/bnd.bnd
+++ b/biz.aQute.bndlib.comm.tests/bnd.bnd
@@ -7,6 +7,7 @@
 -testpath: \
 	org.osgi.util.function;version=latest,\
 	org.osgi.util.promise;version=latest,\
+	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest;packages=*,\
 	biz.aQute.http.testservers;version=latest,\
 	com.github.mike10004:fengyouchao-sockslib;version=latest,\

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientProxyTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientProxyTest.java
@@ -223,8 +223,9 @@ public class HttpClientProxyTest extends TestCase {
 	private AtomicBoolean				proxyCalled				= new AtomicBoolean();
 	private HttpTestServer				httpTestServer;
 	private SocksProxyServer			socks5Proxy;
-	private static final AtomicInteger	httpProxyPort			= new AtomicInteger(2080);
-	private static final AtomicInteger	socksProxyPort			= new AtomicInteger(3080);
+	private static final AtomicInteger	httpProxyPort			= new AtomicInteger(IO.isWindows() ? 52080 : 2080);
+	private static final AtomicInteger	socksProxyPort			= new AtomicInteger(IO.isWindows() ? 53080 : 3080);
+
 	private AtomicReference<Throwable>	exception				= new AtomicReference<>();
 	private AtomicInteger				created					= new AtomicInteger();
 


### PR DESCRIPTION
 We were having intermittent BindException because the chosen port was in
use.
