### PR TITLE
[launch] Launching on project or bnd.bnd failed

### DIFF
--- a/bndtools.core/src/bndtools/launch/api/AbstractLaunchShortcut.java
+++ b/bndtools.core/src/bndtools/launch/api/AbstractLaunchShortcut.java
@@ -141,7 +141,9 @@ public abstract class AbstractLaunchShortcut implements ILaunchShortcut2 {
 	}
 
 	protected void launchProject(IProject project, String mode) {
-		launch(null, project, mode);
+		IPath fullPath = project.getFullPath();
+		IPath bndfile = fullPath.append(Project.BNDFILE);
+		launch(bndfile, project, mode);
 	}
 
 	protected void launchBndRun(IFile bndRunFile, String mode) {

--- a/bndtools.test/workspace/.gitignore
+++ b/bndtools.test/workspace/.gitignore
@@ -1,3 +1,4 @@
-/.gradle/
-/.metadata
-/*
+.DS_Store
+.gradle/
+/generated/
+.metadata


### PR DESCRIPTION
There were changes made in the launching code. One of those changes called the launch method with a null path, this then created an NPE in:

		protected void launch(IPath targetPath, IProject targetProject, String mode) {


Because targetPath was null.

Changed to use the bnd.bnd file in the project directory as target path in:

		protected void launchProject(IProject project, String mode) {




Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>