### PR TITLE
[spi] allow @ServiceProvider to be placed on package and/or specify t…

### DIFF
--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/Constants.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/Constants.java
@@ -13,7 +13,7 @@ public final class Constants {
 	 */
 	public static final String	ATTRIBUTE_MACRO			= "${sjoin;\\;;${#attribute}}";
 
-	public static final String	REGISTER_MACRO			= "register:=${@class}";
+	public static final String	REGISTER_MACRO			= "register:=${#register}";
 
 	public static final String	VALUE_MACRO				= "${#value}";
 

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/ServiceProvider.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/ServiceProvider.java
@@ -8,6 +8,7 @@ import static aQute.bnd.annotation.spi.Constants.REGISTER_MACRO;
 import static aQute.bnd.annotation.spi.Constants.SERVICELOADER_REGISTRAR;
 import static aQute.bnd.annotation.spi.Constants.SERVICELOADER_VERSION;
 import static aQute.bnd.annotation.spi.Constants.VALUE_MACRO;
+import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 import static org.osgi.namespace.extender.ExtenderNamespace.EXTENDER_NAMESPACE;
@@ -35,7 +36,9 @@ import aQute.bnd.annotation.Resolution;
  *      Loader Mediator</a>
  */
 @Retention(CLASS)
-@Target(TYPE)
+@Target({
+	PACKAGE, TYPE
+})
 @Repeatable(ServiceProviders.class)
 @Capability(name = VALUE_MACRO, namespace = SERVICELOADER_NAMESPACE, attribute = {
 	REGISTER_MACRO, USES_MACRO, ATTRIBUTE_MACRO
@@ -101,5 +104,15 @@ public @interface ServiceProvider {
 	 * requirement clause.
 	 */
 	Resolution resolution() default Resolution.DEFAULT;
+
+	/**
+	 * The type to register as the provider.
+	 * <p>
+	 * If the annotation used on a package, then {@link #register()} must be
+	 * set. It is optional when used on a type using the type as the value.
+	 * <p>
+	 * The {@code register} directive is omitted from the requirement clause.
+	 */
+	Class<?> register() default Target.class;
 
 }

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/package-info.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/spi/package-info.java
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("1.1")
 package aQute.bnd.annotation.spi;

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/spi/providerF/Provider.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/spi/providerF/Provider.java
@@ -1,0 +1,5 @@
+package test.annotationheaders.spi.providerF;
+
+import test.annotationheaders.spi.SPIService;
+
+public class Provider implements SPIService {}

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/spi/providerF/package-info.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/spi/providerF/package-info.java
@@ -1,0 +1,7 @@
+@ServiceProvider(register = Provider.class, value = SPIService.class, attribute = {
+	"foo=bar"
+})
+package test.annotationheaders.spi.providerF;
+
+import aQute.bnd.annotation.spi.ServiceProvider;
+import test.annotationheaders.spi.SPIService;


### PR DESCRIPTION
…he type to register directly

This enables configuration of third party code, for example when using -[conditional|include]package

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>