### PR TITLE
[view] Bndtools Explorer

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -1099,5 +1099,15 @@
             <description>Imports an existing Bnd workspace</description>
       </wizard>
    </extension>
+   <extension
+         point="org.eclipse.ui.views">
+      <view
+            name="Bndtools Explorer"
+            icon="/icons/bndtools-logo-16x16.png"
+            category="org.eclipse.jdt.ui.java"
+            class="bndtools.explorer.BndtoolsExplorer"
+            id="bndtools.PackageExplorer">
+      </view>
+   </extension>
 
  </plugin>

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -1,0 +1,71 @@
+package bndtools.explorer;
+
+import java.beans.PropertyChangeListener;
+
+import org.bndtools.utils.swt.FilterPanelPart;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import aQute.lib.strings.Strings;
+import aQute.libg.glob.Glob;
+import bndtools.Plugin;
+
+public class BndtoolsExplorer extends PackageExplorerPart {
+	private final FilterPanelPart	filterPart	= new FilterPanelPart(Plugin.getDefault()
+		.getScheduler());
+	private PropertyChangeListener	listener;
+
+	@Override
+	public void createPartControl(Composite parent) {
+		Composite c = new Composite(parent, SWT.NONE);
+		GridLayout sl = new GridLayout(1, true);
+		c.setLayout(sl);
+		filterPart.createControl(c);
+
+		super.createPartControl(c);
+		Control[] children = c.getChildren();
+		if (children.length > 1) {
+			children[1].setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		}
+		c.layout();
+
+		filterPart.setHint("Filter for projects (glob)");
+		listener = e -> {
+			String value = (String) e.getNewValue();
+
+			if (Strings.nonNullOrEmpty(value)) {
+				Glob glob = new Glob(value);
+				getTreeViewer().setFilters(new ViewerFilter() {
+
+					@Override
+					public boolean select(Viewer viewer, Object parentElement, Object element) {
+						if (element instanceof JavaProject) {
+							IJavaProject project = (JavaProject) element;
+							String name = project.getElementName();
+							return glob.finds(name) >= 0;
+
+						} else
+							return true;
+					}
+				});
+			} else {
+				getTreeViewer().setFilters();
+			}
+		};
+		filterPart.addPropertyChangeListener(listener);
+	}
+
+	@Override
+	public void dispose() {
+		filterPart.removePropertyChangeListener(listener);
+		super.dispose();
+	}
+}

--- a/bndtools.core/src/bndtools/perspective/BndPerspective.java
+++ b/bndtools.core/src/bndtools/perspective/BndPerspective.java
@@ -12,6 +12,8 @@ import bndtools.PartConstants;
 
 public class BndPerspective implements IPerspectiveFactory {
 
+	private static final String BNDTOOLS_PACKAGE_EXPLORER = "bndtools.PackageExplorer";
+
 	public static final String	ID_PROJECT_EXPLORER		= "org.eclipse.ui.navigator.ProjectExplorer";	//$NON-NLS-1$
 
 	public static final String	VIEW_ID_JUNIT_RESULTS	= "org.eclipse.jdt.junit.ResultView";
@@ -23,7 +25,8 @@ public class BndPerspective implements IPerspectiveFactory {
 		String editorArea = layout.getEditorArea();
 
 		IFolderLayout leftFolder = layout.createFolder("left", IPageLayout.LEFT, 0.25f, editorArea);
-		leftFolder.addView(JavaUI.ID_PACKAGES);
+		leftFolder.addView(BNDTOOLS_PACKAGE_EXPLORER);
+		// leftFolder.addView(JavaUI.ID_PACKAGES);
 		leftFolder.addView(JavaUI.ID_TYPE_HIERARCHY);
 
 		layout.addView(PartConstants.VIEW_ID_REPOSITORIES, IPageLayout.BOTTOM, 0.66f, "left");

--- a/bndtools.utils/src/org/bndtools/utils/swt/FilterPanelPart.java
+++ b/bndtools.utils/src/org/bndtools/utils/swt/FilterPanelPart.java
@@ -21,7 +21,7 @@ import org.eclipse.swt.widgets.Text;
 public class FilterPanelPart {
 
 	private static final String				PROP_FILTER				= "filter";
-	private static final long				SEARCH_DELAY			= 1000;
+	private static final long				SEARCH_DELAY			= 300;
 
 	private final ScheduledExecutorService	scheduler;
 
@@ -128,6 +128,10 @@ public class FilterPanelPart {
 
 	public void removePropertyChangeListener(PropertyChangeListener listener) {
 		propSupport.removePropertyChangeListener(PROP_FILTER, listener);
+	}
+
+	public void setHint(String string) {
+		getFilterControl().setMessage(string);
 	}
 
 }


### PR DESCRIPTION
A replacement for the package explorer in the
bndtools perspective. The bndtools explorer
has a filter field for projects. Filtering
is only done on project name (glob), all its
resources are then visible.



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>