### PR TITLE
build: Remove duplicate artifact provided by Eclipse index

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -89,7 +89,6 @@ org.littleshoot:littleproxy:1.1.2
 io.netty:netty-all:4.1.0.Final
 
 com.google.guava:guava:19.0
-com.google.guava:guava:21.0
 
 org.nanohttpd:nanohttpd:2.2.0
 


### PR DESCRIPTION
I cleaned up the index on bintray for Eclipse 2018-12 to reduce the
resource count from 5430 to 119. These resources are now also on bintray
to remove our dependency on Eclipse download site. This will speed up
building and refreshing repositories since the index file is much
smaller.

Since the Eclipse index provides the Guava 21 used by Eclipse, we remove
the artifact from maven central that was added some time back for
Eclipse Oxygen.
