### PR TITLE
gradle: Use dependency's jars for compilation

### DIFF
--- a/biz.aQute.bnd.gradle/publish.gradle
+++ b/biz.aQute.bnd.gradle/publish.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 ext.groupId = 'biz.aQute.bnd'
 ext.artifactId = 'biz.aQute.bnd.gradle'
-ext.artifactVersion = '4.3.0'
+ext.artifactVersion = '4.3.1'
 
 repositories {
   jcenter()
@@ -29,7 +29,9 @@ configurations {
   plugin
   plugin.dependencies.all { Dependency dep ->
     if (dep instanceof ExternalDependency) {
-      dep.force = true
+      dep.version {
+        strictly dep.getVersion()
+      }
     }
     if (dep instanceof ModuleDependency) {
       dep.transitive = false

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -62,7 +62,9 @@ public class BndBuilderPlugin implements Plugin<Project> {
         baseline
         baseline.dependencies.all { Dependency dep ->
           if (dep instanceof ExternalDependency) {
-            dep.force = true
+            dep.version {
+              strictly dep.getVersion()
+            }
           }
           if (dep instanceof ModuleDependency) {
             dep.transitive = false
@@ -81,9 +83,11 @@ public class BndBuilderPlugin implements Plugin<Project> {
         Task baselineTask = tasks.getByName('baseline')
         Task bundleTask = baselineTask.getBundleTask()
         if (bundleTask) {
-          logger.debug 'Searching for default baseline {}:{}:(,{}[', group, bundleTask.baseName, bundleTask.version
-          Dependency baselineDep = dependencies.create('group': group, 'name': bundleTask.baseName, 'version': "(,${bundleTask.version}[") {
-            force = true
+          logger.debug 'Searching for default baseline {}:{}:(0,{}[', group, bundleTask.baseName, bundleTask.version
+          Dependency baselineDep = dependencies.create('group': group, 'name': bundleTask.baseName) {
+            version {
+              strictly "(0,${bundleTask.version}["
+            }
             transitive = false
           }
           try {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -16,6 +16,7 @@ package aQute.bnd.gradle
 
 import static aQute.bnd.exporter.executable.ExecutableJarExporter.EXECUTABLE_JAR
 import static aQute.bnd.exporter.runbundles.RunbundlesExporter.RUNBUNDLES
+import static aQute.bnd.gradle.BndUtils.jarLibraryElements
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.osgi.Processor.isTrue
 
@@ -108,6 +109,7 @@ public class BndPlugin implements Plugin<Project> {
             t.destinationDir = destinationDir
           }
           output.dir(destinationDir, builtBy: compileJavaTaskName)
+          jarLibraryElements(project, compileClasspathConfigurationName)
         }
         test {
           FileCollection srcDirs = files(bndProject.getTestSrc())
@@ -120,6 +122,7 @@ public class BndPlugin implements Plugin<Project> {
             t.destinationDir = destinationDir
           }
           output.dir(destinationDir, builtBy: compileJavaTaskName)
+          jarLibraryElements(project, compileClasspathConfigurationName)
         }
       }
       /* Configure srcDirs for any additional languages */

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -9,6 +9,7 @@ import org.gradle.api.Action
 import org.gradle.api.Buildable
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
@@ -18,6 +19,8 @@ import org.gradle.util.GradleVersion
 
 class BndUtils {
   private BndUtils() { }
+
+  private static final boolean IS_GRADLE_COMPATIBLE_5_6 = GradleVersion.current().compareTo(GradleVersion.version('5.6')) >= 0
 
   public static void logReport(def report, Logger logger) {
     if (logger.isWarnEnabled()) {
@@ -58,5 +61,11 @@ class BndUtils {
       value = value.getAsFile()
     } 
     return value
+  }
+
+  public static void jarLibraryElements(Project project, String configurationName) {
+    if (IS_GRADLE_COMPATIBLE_5_6) {
+      project.configurations[configurationName].attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.class, LibraryElements.JAR))
+    }
   }
 }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -24,6 +24,7 @@
 package aQute.bnd.gradle
 
 import static aQute.bnd.gradle.BndUtils.builtBy
+import static aQute.bnd.gradle.BndUtils.jarLibraryElements
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.gradle.BndUtils.unwrap
 
@@ -193,6 +194,7 @@ class BundleTaskConvention {
    */
   public void setSourceSet(SourceSet sourceSet) {
     this.sourceSet = sourceSet
+    jarLibraryElements(project, sourceSet.compileClasspathConfigurationName)
     if (!classpathModified) {
       setClasspath(sourceSet.compileClasspath)
       classpathModified = false


### PR DESCRIPTION
If the `java-library` plugin is applied, Gradle will compile against
the dependency's classes dir instead of building the jar and compiling
against the jar. This is not good for bundles since Bnd can pull in code
from other places and also set the package metadata.

So we configure the sourceSet's compileClasspath configuration to use
jars for compilation.

This support requires Gradle 5.6 or later.

See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_classes_usage
