### PR TITLE
[bndexplorer] Fix filters

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -1125,155 +1125,19 @@
       </filter>
       <filter
             targetId="bndtools.PackageExplorer"
-            name="%HideInnerClassFiles.label"
+            name="Hide Empty Packages"
             enabled="true"
-            description="%HideInnerClassFiles.description"
-            class="org.eclipse.jdt.internal.ui.filters.InnerClassFilesFilter"
-            id="org.eclipse.jdt.internal.ui.PackageExplorer.HideInnerClassFilesFilter">
+            description="Hide Empty Packages"
+            class="bndtools.explorer.EmptyPackageFilter"
+            id="bndtools.explorer.EmptyPackageFilter">
       </filter>
       <filter
             targetId="bndtools.PackageExplorer"
-            name="%HideEmptyPackages.label"
+            name="Only Bnd projects"
             enabled="false"
-            description="%HideEmptyPackages.description"
-            class="org.eclipse.jdt.internal.ui.filters.EmptyPackageFilter"
-            id="org.eclipse.jdt.internal.ui.PackageExplorer.EmptyPackageFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideEmptyInnerPackages.label"
-            enabled="true"
-            description="%HideEmptyInnerPackages.description"
-            class="org.eclipse.jdt.internal.ui.filters.EmptyInnerPackageFilter"
-            id="org.eclipse.jdt.internal.ui.PackageExplorer.EmptyInnerPackageFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideNonJavaElements.label"
-            enabled="false"
-            description="%HideNonJavaElements.description"
-            class="org.eclipse.jdt.internal.ui.filters.NonJavaElementFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.NonJavaElementFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideEmptyLibraryContainers.label"
-            enabled="true"
-            description="%HideEmptyLibraryContainers.description"
-            class="org.eclipse.jdt.internal.ui.filters.EmptyLibraryContainerFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.EmptyLibraryContainerFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideReferencedLibraries.label"
-            enabled="false"
-            description="%HideReferencedLibraries.description"
-            class="org.eclipse.jdt.internal.ui.filters.LibraryFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.LibraryFilter">
-      </filter>      
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideContainedLibraries.label"
-            enabled="false"
-            description="%HideContainedLibraries.description"
-            class="org.eclipse.jdt.internal.ui.filters.ContainedLibraryFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.ContainedLibraryFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideJavaFiles.label"
-            enabled="false"
-            description="%HideJavaFiles.description"
-            class="org.eclipse.jdt.internal.ui.filters.JavaFileFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.CuAndClassFileFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HidePackageDeclaration.label"
-            enabled="true"
-            description="%HidePackageDeclaration.description"
-            class="org.eclipse.jdt.internal.ui.filters.PackageDeclarationFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.PackageDeclarationFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideImportDeclaration.label"
-            enabled="true"
-            description="%HideImportDeclaration.description"
-            class="org.eclipse.jdt.internal.ui.filters.ImportDeclarationFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.ImportDeclarationFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideSyntheticMembers.label"
-            enabled="true"
-            description="%HideSyntheticMembers.description"
-            class="org.eclipse.jdt.internal.ui.filters.SyntheticMembersFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.SyntheticMembersFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideNonJavaProjects.label"
-            enabled="false"
-            description="%HideNonJavaProjects.description"
-            class="org.eclipse.jdt.internal.ui.filters.NonJavaProjectsFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.NonJavaProjectsFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideNonSharedProjects.label"
-            enabled="false"
-            description="%HideNonSharedProjects.description"
-            class="org.eclipse.jdt.internal.ui.filters.NonSharedProjectFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.NonSharedProjectsFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideClosedProjects.label"
-            enabled="false"
-            description="%HideClosedProjects.description"
-            class="org.eclipse.jdt.internal.ui.filters.ClosedProjectFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.ClosedProjectsFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideFields.label"
-            enabled="false"
-            description="%HideFields.description"
-            class="org.eclipse.jdt.internal.ui.filters.FieldsFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.FieldsFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideStatics.label"
-            enabled="false"
-            description="%HideStatics.description"
-            class="org.eclipse.jdt.internal.ui.filters.StaticsFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.StaticsFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideNonPublic.label"
-            enabled="false"
-            description="%HideNonPublic.description"
-            class="org.eclipse.jdt.internal.ui.filters.NonPublicFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.NonPublicFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideLocalTypes.label"
-            enabled="false"
-            description="%HideLocalTypes.description"
-            class="org.eclipse.jdt.internal.ui.filters.LocalTypesFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.LocalTypesFilter">
-      </filter>
-      <filter
-            targetId="bndtools.PackageExplorer"
-            name="%HideDeprecatedFieldsAndMethods.label"
-            enabled="false"
-            description="%HideDeprecatedFieldsAndMethods.description"
-            class="org.eclipse.jdt.internal.ui.filters.DeprecatedFieldsAndMethodsFilter"
-            id="org.eclipse.jdt.ui.PackageExplorer.DeprecatedMembersFilter">
+            description="Show only bnd projects"
+            class="bndtools.explorer.BndProjects"
+            id="bndtools.explorer.BndProjects">
       </filter>
    </extension>
  </plugin>

--- a/bndtools.core/src/bndtools/explorer/BndProjects.java
+++ b/bndtools.core/src/bndtools/explorer/BndProjects.java
@@ -1,0 +1,37 @@
+package bndtools.explorer;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectNature;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+
+import aQute.bnd.build.Project;
+import bndtools.Plugin;
+
+/**
+ * Only select bndtools projects
+ */
+public class BndProjects extends ViewerFilter {
+
+	/*
+	 * @see
+	 * org.eclipse.jface.viewers.ViewerFilter#select(org.eclipse.jface.viewers.
+	 * Viewer, java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	public boolean select(Viewer viewer, Object parent, Object element) {
+		if (element instanceof IProject) {
+
+			IProject p = (IProject) element;
+
+			try {
+				IProjectNature nature = p.getNature(Plugin.BNDTOOLS_NATURE);
+				return nature != null || p.getName() == Project.BNDCNF;
+			} catch (CoreException e) {}
+
+		}
+		return true;
+	}
+
+}

--- a/bndtools.core/src/bndtools/explorer/EmptyPackageFilter.java
+++ b/bndtools.core/src/bndtools/explorer/EmptyPackageFilter.java
@@ -1,0 +1,63 @@
+package bndtools.explorer;
+
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+
+
+/**
+ * Filters out all empty package fragments.
+ */
+public class EmptyPackageFilter extends ViewerFilter {
+
+	/*
+	 * @see org.eclipse.jface.viewers.ViewerFilter#select(org.eclipse.jface.viewers.Viewer, java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	public boolean select(Viewer viewer, Object parent, Object element) {
+		if (element instanceof IPackageFragment) {
+			IPackageFragment pkg= (IPackageFragment)element;
+			try {
+				return pkg.hasChildren() || hasUnfilteredResources(viewer, pkg);
+			} catch (JavaModelException e) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Tells whether the given package has unfiltered resources.
+	 *
+	 * @param viewer the viewer
+	 * @param pkg the package
+	 * @return <code>true</code> if the package has unfiltered resources
+	 * @throws JavaModelException if this element does not exist or if an exception occurs while
+	 *             accessing its corresponding resource
+	 * @since 3.4.1
+	 */
+	static boolean hasUnfilteredResources(Viewer viewer, IPackageFragment pkg) throws JavaModelException {
+		Object[] resources= pkg.getNonJavaResources();
+		int length= resources.length;
+		if (length == 0)
+			return false;
+
+		if (!(viewer instanceof StructuredViewer))
+			return true;
+
+		ViewerFilter[] filters= ((StructuredViewer)viewer).getFilters();
+		resourceLoop: for (int i= 0; i < length; i++) {
+			for (int j= 0; j < filters.length; j++) {
+				if (!filters[j].select(viewer, pkg, resources[i]))
+					continue resourceLoop;
+			}
+			return true;
+
+		}
+		return false;
+	}
+
+
+}


### PR DESCRIPTION
Filters from Package Explorer couldn't be used

- Added .* filter, empty packages
- Added filter for Bndtools projects

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>