### PR TITLE
[docs] Fixed misleading doc for -runvm

### DIFF
--- a/docs/_instructions/runvm.md
+++ b/docs/_instructions/runvm.md
@@ -2,7 +2,7 @@
 layout: default
 class: Project
 title: -runvm KEYS 
-summary:  Additional arguments for the VM invocation. Keys that start with a - are added as options, otherwise they are treated as -D properties for the VM.
+summary:  Additional arguments for the VM invocation. Arguments are added as-is.
 ---
 
 


### PR DESCRIPTION
Doc incorrectly stated that -D would be inferred if no leading - was found on the property. This is not the case - arguments are added as-is.

Fixes #3652.