### PR TITLE
Mapstream update

### DIFF
--- a/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
+++ b/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
@@ -231,7 +231,7 @@ public class BndrunContainer {
 	/**
 	 * Creates a new repository in every invocation.
 	 *
-	 * @param the Maven project
+	 * @param project the Maven project
 	 * @return a new {@link ImplicitFileSetRepository}
 	 * @throws Exception
 	 */

--- a/biz.aQute.bndlib/src/aQute/bnd/stream/MapStream.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/stream/MapStream.java
@@ -1,7 +1,5 @@
 package aQute.bnd.stream;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,11 +51,6 @@ public interface MapStream<K, V> extends BaseStream<Entry<K, V>, MapStream<K, V>
 		return (stream != null) ? of(stream) : empty();
 	}
 
-	static <K, V> MapStream<K, V> ofKeys(Stream<? extends K> keys, Function<? super K, ? extends V> valueSupplier) {
-		requireNonNull(valueSupplier);
-		return of(keys.map(k -> entry(k, valueSupplier.apply(k))));
-	}
-
 	static <K, V> MapStream<K, V> concat(MapStream<? extends K, ? extends V> a, MapStream<? extends K, ? extends V> b) {
 		return of(Stream.concat(a.entries(), b.entries()));
 	}
@@ -85,6 +78,11 @@ public interface MapStream<K, V> extends BaseStream<Entry<K, V>, MapStream<K, V>
 	@SafeVarargs
 	static <K, V> MapStream<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
 		return of(Arrays.stream(entries));
+	}
+
+	static <O, K, V> MapStream<K, V> ofEntries(Stream<? extends O> stream,
+		Function<? super O, ? extends Entry<? extends K, ? extends V>> entryMapper) {
+		return of(stream.map(entryMapper));
 	}
 
 	static <K, V> Entry<K, V> entry(K key, V value) {

--- a/biz.aQute.bndlib/test/aQute/bnd/stream/MapStreamTest.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/stream/MapStreamTest.java
@@ -259,9 +259,9 @@ public class MapStreamTest {
 	}
 
 	@Test
-	public void ofKeys() {
-		Supplier<MapStream<String, String>> supplier = () -> MapStream.ofKeys(testMap.keySet()
-			.stream(), k -> k.concat("value"));
+	public void ofEntries_stream() {
+		Supplier<MapStream<String, String>> supplier = () -> MapStream.ofEntries(testMap.keySet()
+			.stream(), k -> entry(k.concat("key"), k.concat("value")));
 		assertThat(supplier.get()).isNotNull();
 		assertThat(supplier.get()
 			.count()).isEqualTo(testMap.size());
@@ -275,12 +275,12 @@ public class MapStreamTest {
 			.values()
 			.count()).isEqualTo(testMap.size());
 		assertThat(supplier.get()
-			.keys()).containsExactlyInAnyOrder("key1", "key2", "key3", "key4", "key5");
+			.keys()).containsExactlyInAnyOrder("key1key", "key2key", "key3key", "key4key", "key5key");
 		assertThat(supplier.get()
 			.values()).containsExactlyInAnyOrder("key1value", "key2value", "key3value", "key4value", "key5value");
 		assertThat(supplier.get()
-			.entries()).containsExactlyInAnyOrder(entry("key1", "key1value"), entry("key2", "key2value"),
-				entry("key3", "key3value"), entry("key4", "key4value"), entry("key5", "key5value"));
+			.entries()).containsExactlyInAnyOrder(entry("key1key", "key1value"), entry("key2key", "key2value"),
+				entry("key3key", "key3value"), entry("key4key", "key4value"), entry("key5key", "key5value"));
 	}
 
 	@Test
@@ -380,7 +380,7 @@ public class MapStreamTest {
 	}
 
 	@Test
-	public void ofEntries() {
+	public void ofEntries_array() {
 		Supplier<MapStream<String, String>> supplier = () -> MapStream.ofEntries(testEntries);
 		assertThat(supplier.get()).isNotNull();
 		assertThat(supplier.get()


### PR DESCRIPTION
Generalize ofKeys to ofEntries. This provides a more general method to create a MapStream from a Stream.