### PR TITLE
[junit-platform tester] Resolve method selector parameters

### DIFF
--- a/biz.aQute.tester.test/src/aQute/tester/test/params/CustomParameter.java
+++ b/biz.aQute.tester.test/src/aQute/tester/test/params/CustomParameter.java
@@ -1,0 +1,5 @@
+package aQute.tester.test.params;
+
+public class CustomParameter {
+
+}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit5ParameterizedTest.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit5ParameterizedTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import aQute.tester.test.params.CustomParameter;
+
 // This test class is not supposed to be run directly; see readme.md for more info.
 public class JUnit5ParameterizedTest {
 
@@ -17,5 +19,16 @@ public class JUnit5ParameterizedTest {
 	public static Stream<Arguments> provideArgs() {
 		return Stream.of(Arguments.of("one", 1.0f), Arguments.of("two", 2.0f), Arguments.of("three", 3.0f),
 			Arguments.of("four", 4.0f), Arguments.of("five", 5.0f));
+	}
+
+	@ParameterizedTest
+	@MethodSource("customArgs")
+	public void customParameter(CustomParameter param) {
+		System.err.println(System.identityHashCode(param.getClass()));
+	}
+
+	public static Stream<Arguments> customArgs() {
+		return Stream.of(Arguments.of(new CustomParameter()), Arguments.of(new CustomParameter()),
+			Arguments.of(new CustomParameter()));
 	}
 }

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit5ParameterizedTest.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit5ParameterizedTest.java
@@ -1,0 +1,21 @@
+package aQute.tester.testclasses.bundle.engine;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+// This test class is not supposed to be run directly; see readme.md for more info.
+public class JUnit5ParameterizedTest {
+
+	@ParameterizedTest
+	@MethodSource("provideArgs")
+	public void parameterizedMethod(String param, float param2) {
+	}
+
+	public static Stream<Arguments> provideArgs() {
+		return Stream.of(Arguments.of("one", 1.0f), Arguments.of("two", 2.0f), Arguments.of("three", 3.0f),
+			Arguments.of("four", 4.0f), Arguments.of("five", 5.0f));
+	}
+}


### PR DESCRIPTION
This PR has two commits:

1. The first adds checks for unresolved methods - ie, reporting if you try to specify a method in `tester.names` that doesn't exist. Previously, it would only check for unresolved classes.
2. The second is the fix for #3589 - it sets the TCCL to the resolved test class before calling `ReflectionSupport.findMethod()`, so that the JUnit reflection code will use the correct class loader for attempting to resolve the parameters.