### PR TITLE
[junit-platform tester] Check for mixed JUnit 3 and 4 tests

### DIFF
--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit3And4Test.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit3And4Test.java
@@ -1,0 +1,17 @@
+package aQute.tester.testclasses.bundle.engine;
+
+import org.junit.Test;
+
+import junit.framework.TestCase;
+
+// This test class is not supposed to be run directly; see readme.md for more info.
+public class JUnit3And4Test extends TestCase {
+
+	public void testSomething() {}
+
+	@Test
+	public void aJUnit4Test() {}
+
+	@Test
+	public void bJUnit4Test() {}
+}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit3And5Test.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/bundle/engine/JUnit3And5Test.java
@@ -1,0 +1,17 @@
+package aQute.tester.testclasses.bundle.engine;
+
+import org.junit.jupiter.api.Test;
+
+import junit.framework.TestCase;
+
+// This test class is not supposed to be run directly; see readme.md for more info.
+public class JUnit3And5Test extends TestCase {
+
+	public void testSomething() {}
+
+	@Test
+	public void aJUnit4Test() {}
+
+	@Test
+	public void bJUnit4Test() {}
+}

--- a/biz.aQute.tester.test/src/org/junit/venus/Test.java
+++ b/biz.aQute.tester.test/src/org/junit/venus/Test.java
@@ -1,0 +1,13 @@
+package org.junit.venus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+	ElementType.METHOD
+})
+public @interface Test {
+}

--- a/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
@@ -64,6 +64,9 @@ import aQute.tester.test.params.CustomParameter;
 import aQute.tester.test.utils.ServiceLoaderMask;
 import aQute.tester.test.utils.TestBundler;
 import aQute.tester.testclasses.bundle.engine.AnotherTestClass;
+import aQute.tester.testclasses.bundle.engine.JUnit3And4Test;
+import aQute.tester.testclasses.bundle.engine.JUnit3And5Test;
+import aQute.tester.testclasses.bundle.engine.JUnit3AndVenusTest;
 import aQute.tester.testclasses.bundle.engine.JUnit4Test;
 import aQute.tester.testclasses.bundle.engine.JUnit5ParameterizedTest;
 import aQute.tester.testclasses.bundle.engine.JUnit5Test;
@@ -1124,5 +1127,67 @@ public class BundleEngineTest {
 			.haveExactly(0, event(uniqueIdSubstring("dynamic.bundle"), containerClass(TestClass.class)))
 			.haveExactly(1,
 				event(uniqueIdSubstring(test.getSymbolicName()), test("thisIsATest"), finishedSuccessfully()));
+	}
+
+	@Test
+	public void testClass_withBothJUnit3And4_raisesAnError() {
+		Bundle test = startTestBundle(JUnit3And4Test.class);
+
+		engineInFramework().execute()
+			.all()
+			.debug(debugStr)
+			.assertThatEvents()
+			.haveExactly(1,
+				event(uniqueIdSubstring(test.getSymbolicName()), testClass(JUnit3And4Test.class),
+					finishedWithFailure(instanceOf(JUnitException.class),
+						message(
+							x -> x.matches("^(?si).*TestCase.*JUnit 4 annotations.*annotations will be ignored.*$")))));
+
+	}
+
+	@Test
+	public void withClassSelector_testClass_withBothJUnit3And4_raisesAnError() {
+		Bundle test = startTestBundle(JUnit3And4Test.class);
+
+		engineInFramework().selectors(selectClass(JUnit3And4Test.class))
+			.execute()
+			.all()
+			.debug(debugStr)
+			.assertThatEvents()
+			.haveExactly(1,
+				event(uniqueIdSubstring(test.getSymbolicName()), testClass(JUnit3And4Test.class), finishedWithFailure(
+					instanceOf(JUnitException.class),
+					message(x -> x.matches("^(?si).*TestCase.*JUnit 4 annotations.*annotations will be ignored.*$")))));
+
+	}
+
+	@Test
+	public void withMethodSelector_testClass_withBothJUnit3And4_raisesAnError() {
+		Bundle test = startTestBundle(JUnit3And4Test.class);
+
+		engineInFramework().selectors(selectMethod(JUnit3And4Test.class, "testSomething"))
+			.execute()
+			.all()
+			.debug(debugStr)
+			.assertThatEvents()
+			.haveExactly(1,
+				event(uniqueIdSubstring(test.getSymbolicName()), testClass(JUnit3And4Test.class), finishedWithFailure(
+					instanceOf(JUnitException.class),
+					message(x -> x.matches("^(?si).*TestCase.*JUnit 4 annotations.*annotations will be ignored.*$")))));
+
+	}
+
+	@Test
+	public void testClass_withBothJUnit3AndOtherJUnit_doesntRaiseAnError() {
+		// "Venus" is a hypothetical not-yet-released JUnit implementation (the
+		// planet before Jupiter); need to make sure that our JUnit 4 testing
+		// is fairly future proof in the face of future JUnit releases.
+		Bundle test = startTestBundle(JUnit3And5Test.class, JUnit3AndVenusTest.class);
+
+		engineInFramework().execute()
+			.all()
+			.debug(debugStr)
+			.assertThatEvents()
+			.haveExactly(0, finishedWithFailure(instanceOf(JUnitException.class)));
 	}
 }

--- a/biz.aQute.tester.test/test/aQute/tester/testclasses/bundle/engine/JUnit3AndVenusTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testclasses/bundle/engine/JUnit3AndVenusTest.java
@@ -1,0 +1,13 @@
+package aQute.tester.testclasses.bundle.engine;
+
+import junit.framework.TestCase;
+
+public class JUnit3AndVenusTest extends TestCase {
+
+	@org.junit.venus.Test
+	public void someTest() {}
+
+	public void testSomethingElse() {
+
+	}
+}


### PR DESCRIPTION
Will check classes for mixed JUnit 3 and 4 tests and generate a test error for each one it finds under the bundle in which the class was found.

Fixes #3671.