### PR TITLE
[junit-platform tester] Update tester workspace for Eclipse 2018-12

### DIFF
--- a/bndtools.test/tester/cnf/ext/central.mvn
+++ b/bndtools.test/tester/cnf/ext/central.mvn
@@ -31,6 +31,7 @@ org.osgi:org.osgi.util.promise:1.1.1
 
 org.apache.felix:org.apache.felix.configadmin:1.9.10
 org.apache.felix:org.apache.felix.log:1.2.0
+org.apache.felix:org.apache.felix.framework:4.2.1
 org.apache.felix:org.apache.felix.framework:5.6.10
 org.apache.felix:org.apache.felix.gogo.command:1.0.2
 org.apache.felix:org.apache.felix.gogo.runtime:1.1.0

--- a/bndtools.test/tester/cnf/ext/repositories.bnd
+++ b/bndtools.test/tester/cnf/ext/repositories.bnd
@@ -9,14 +9,18 @@ mavencentral:           https://repo.maven.apache.org/maven2
         readOnly=true,\
     aQute.bnd.deployer.repository.LocalIndexedRepo;\
         name="Local";\
-        local="${.}/../cache/local",\
-    aQute.bnd.deployer.repository.LocalIndexedRepo;\
-        name="Bnd 4.3.0 embedded repo cache";\
-        local="${.}/../cache/4.3.0/bnd-cache",\
+        local="${.}/../cache/local"
+        
+-plugin.1.Eclipse:\
     aQute.bnd.repository.osgi.OSGiRepository;\
-        name="Eclipse Oxygen 4.7.3a";\
-        locations="https://dl.bintray.com/bndtools/eclipse-repo/4.7.3a/index.xml.gz";\
+        name="Eclipse 2018-12";\
+        locations="https://dl.bintray.com/bndtools/eclipse-repo/4.10/index.xml.gz";\
         poll.time=-1;\
-        cache="${workspace}/cnf/cache/stable/EclipseOxygen",\
+        cache="${workspace}/cnf/cache/stable/Eclipse-2018-12",\
+    aQute.bnd.repository.maven.pom.provider.BndPomRepository;\
+        name="Eclipse m2e 1.10.0 Dependencies";\
+        revision="org.apache.maven:maven-core:3.5.3,org.apache.maven:maven-aether-provider:3.3.9,org.sonatype.plexus:plexus-build-api:0.0.7";\
+        releaseUrls="${mavencentral}";\
+        location="${workspace}/cnf/cache/stable/Eclipse-m2e-1.10.0/index.xml"
 
 -buildrepo: Local

--- a/bndtools.test/tester/main-with-runners/runtests-shared.bndrun
+++ b/bndtools.test/tester/main-with-runners/runtests-shared.bndrun
@@ -21,9 +21,13 @@
 	tester.trace=true
 
 runbundles.basetests: \
+	main-with-runners;version=snapshot,\
+	my.bundle.of.test3;version=snapshot,\
+	my.fragment.of.test4;version=snapshot,\
 	org.apache.felix.gogo.command,\
 	org.apache.felix.gogo.runtime,\
 	org.apache.felix.gogo.shell,\
+	org.apache.felix.log,\
 	org.apache.servicemix.bundles.junit,\
 	org.apiguardian,\
 	org.assertj.core,\
@@ -36,10 +40,7 @@ runbundles.basetests: \
 	org.junit.vintage.engine,\
 	org.opentest4j,\
 	test;version=snapshot,\
-	test-fragment;version=snapshot,\
-	main-with-runners;version=snapshot,\
-	my.bundle.of.test3;version=snapshot,\
-	my.fragment.of.test4;version=snapshot
-	
+	test-fragment;version=snapshot
+		
 runbundles.tester: \
 	biz.aQute.tester.junit-platform


### PR DESCRIPTION
Some fixes to bring the tester workspace up-to-date with Eclipse 2018-12 to make testing the tester easier.