### PR TITLE
[junit-platform tester] Always use BSN for bundle display name

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
@@ -2,7 +2,6 @@ package aQute.tester.bundle.engine;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineExecutionListener;
@@ -14,8 +13,6 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
-import aQute.bnd.osgi.Constants;
-
 public class BundleDescriptor extends AbstractTestDescriptor {
 
 	final private Bundle							bundle;
@@ -23,9 +20,7 @@ public class BundleDescriptor extends AbstractTestDescriptor {
 	final private Map<TestDescriptor, TestEngine>	engineMap	= new HashMap<>();
 
 	public static String displayNameOf(Bundle bundle) {
-		final Optional<String> bundleName = Optional.ofNullable(bundle.getHeaders()
-			.get(Constants.BUNDLE_NAME));
-		return "[" + bundle.getBundleId() + "] " + bundleName.orElseGet(bundle::getSymbolicName) + ';'
+		return "[" + bundle.getBundleId() + "] " + bundle.getSymbolicName() + ';'
 			+ bundle.getVersion();
 	}
 

--- a/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
@@ -1048,18 +1048,6 @@ public class BundleEngineTest {
 	}
 
 	@Test
-	public void usesBundleDisplayName() throws Exception {
-		Bundle tb1 = buildTestBundle(JUnit4Test.class).header("Bundle-Name", "This is my name")
-			.start();
-
-		engineInFramework().execute()
-			.all()
-			.debug(debugStr)
-			.assertThatEvents()
-			.haveExactly(1, event(bundle(tb1), displayNameContaining("This is my name"), finishedSuccessfully()));
-	}
-
-	@Test
 	public void testClass_inFragment_withClassSelector_runsOnlyInFragment() throws Exception {
 		Bundle testFragmentHostWithoutItsOwnTests = testBundler.bundleWithEE()
 			.bundleSymbolicName("host.bundle")


### PR DESCRIPTION
Original implementation mimicked Gogo's "lb" command - it would use `Bundle-Name` if available, then BSN. The core team felt that always using BSN would be better in a dev context.

This is easily revertable, or possibly in the future configurable if there is a demand.