### PR TITLE
Eclipse JUnit reporting fixes

### DIFF
--- a/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
@@ -161,7 +161,7 @@ public class JUnitEclipseReport implements TestReporter {
 			sb.append(tests.indexOf(test) + 1);
 		}
 		sb.append(',');
-		copyAndEscapeText(getTestName(test), sb);
+		appendEscaped(getTestName(test), sb);
 		String payload = sb.toString();
 		message(key, payload);
 	}
@@ -172,7 +172,7 @@ public class JUnitEclipseReport implements TestReporter {
 			StringBuilder sb = new StringBuilder();
 			sb.append(i + 1)
 				.append(',');
-			copyAndEscapeText(getTestName(test), sb);
+			appendEscaped(getTestName(test), sb);
 			sb.append(',')
 				.append(test instanceof TestSuite || test instanceof JUnit4TestAdapter)
 				.append(',');
@@ -195,7 +195,7 @@ public class JUnitEclipseReport implements TestReporter {
 		safeClose(client);
 	}
 
-	private static void copyAndEscapeText(String s, StringBuilder sb) {
+	private static void appendEscaped(String s, StringBuilder sb) {
 		if (s.isEmpty()) {
 			return;
 		}

--- a/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
@@ -104,6 +104,18 @@ public class JUnitEclipseReport implements TestReporter {
 	public void end() {
 		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
 		client.out.flush();
+		if (verbose) {
+			System.err.println("Test run ended; waiting .25 seconds");
+		}
+		try {
+			Thread.sleep(250L);
+		} catch (InterruptedException e) {
+			Thread.currentThread()
+				.interrupt();
+		}
+		if (verbose) {
+			System.err.println("Closing client connection");
+		}
 		safeClose(client);
 	}
 

--- a/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.junit/src/aQute/junit/JUnitEclipseReport.java
@@ -5,13 +5,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Reader;
-import java.net.ConnectException;
 import java.net.InetAddress;
-import java.net.Socket;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
 import java.util.List;
 
 import org.osgi.framework.Bundle;
@@ -25,24 +25,23 @@ public class JUnitEclipseReport implements TestReporter {
 	private long							startTime;
 	private List<Test>						tests;
 	private final boolean					verbose	= false;
-	private Connection<Reader, PrintWriter>	junit;
+	private Connection<Reader, PrintWriter>	client;
 
-	private static final class Connection<IN extends Closeable, OUT extends Closeable> implements Closeable {
-		final Socket	sock;
-		final IN		in;
-		final OUT		out;
+	private static final class Connection<IN, OUT> implements Closeable {
+		final SocketChannel	channel;
+		@SuppressWarnings("unused")
+		final IN			in;
+		final OUT			out;
 
-		Connection(Socket sock, IN in, OUT out) {
-			this.sock = sock;
+		Connection(SocketChannel channel, IN in, OUT out) {
+			this.channel = channel;
 			this.in = in;
 			this.out = out;
 		}
 
 		@Override
 		public void close() {
-			safeClose(out);
-			safeClose(in);
-			safeClose(sock);
+			safeClose(channel);
 		}
 	}
 
@@ -57,22 +56,28 @@ public class JUnitEclipseReport implements TestReporter {
 
 	public JUnitEclipseReport(int port) throws Exception {
 		try {
-			Socket socket = connectRetry(port);
-			junit = new Connection<>(socket, new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8)),
-				new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8), true));
-		} catch (ConnectException e) {
+			SocketChannel channel = connectRetry(port);
+			if (verbose) {
+				System.err.println("Opening streams for client connection " + channel);
+			}
+			client = new Connection<>(channel, new BufferedReader(Channels.newReader(channel, UTF_8.newDecoder(), -1)),
+				new PrintWriter(Channels.newWriter(channel, UTF_8.newEncoder(), -1)));
+		} catch (IOException e) {
 			System.err.println("Cannot open the JUnit Port: " + port + " " + e);
 			System.exit(254);
 			throw new AssertionError("unreachable");
 		}
 	}
 
-	private Socket connectRetry(int port) throws Exception {
-		ConnectException e = null;
+	private SocketChannel connectRetry(int port) throws Exception {
+		IOException e = null;
 		for (int i = 0; i < 30; i++) {
 			try {
-				return new Socket(InetAddress.getByName(null), port);
-			} catch (ConnectException ce) {
+				SocketAddress address = new InetSocketAddress(InetAddress.getByName(null), port);
+				SocketChannel channel = SocketChannel.open(address);
+				channel.finishConnect();
+				return channel;
+			} catch (IOException ce) {
 				e = ce;
 				Thread.sleep(i * 100);
 			}
@@ -98,8 +103,8 @@ public class JUnitEclipseReport implements TestReporter {
 	@Override
 	public void end() {
 		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
-		junit.out.flush();
-		safeClose(junit);
+		client.out.flush();
+		safeClose(client);
 	}
 
 	@Override
@@ -116,11 +121,11 @@ public class JUnitEclipseReport implements TestReporter {
 
 	void trace(Throwable t) {
 		message("%TRACES ", "");
-		t.printStackTrace(junit.out);
+		t.printStackTrace(client.out);
 		if (verbose) {
 			t.printStackTrace(System.err);
 		}
-		junit.out.println();
+		client.out.println();
 		message("%TRACEE ", "");
 	}
 
@@ -139,7 +144,7 @@ public class JUnitEclipseReport implements TestReporter {
 			throw new IllegalArgumentException(key + " is not 8 characters");
 
 		String message = key.concat(payload);
-		junit.out.println(message);
+		client.out.println(message);
 		if (verbose)
 			System.err.println(message);
 	}
@@ -187,7 +192,7 @@ public class JUnitEclipseReport implements TestReporter {
 	}
 
 	public void close() {
-		safeClose(junit);
+		safeClose(client);
 	}
 
 	private static void copyAndEscapeText(String s, StringBuilder sb) {

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -210,7 +210,15 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 	public void testPlanExecutionFinished(TestPlan testPlan) {
 		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
 		client.out.flush();
+		info("JUnitEclipseListener: testPlanExecutionFinished: Waiting .25 seconds");
+		try {
+			Thread.sleep(250L);
+		} catch (InterruptedException e) {
+			Thread.currentThread()
+				.interrupt();
+		}
 		if (control == null) {
+			info("JUnitEclipseListener: testPlanExecutionFinished: Closing client connection");
 			safeClose(client);
 			client = nullConnection();
 		}

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -420,12 +420,12 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 	// namePrefix is used as a special case to signal ignored and aborted tests.
 	private void message(String key, TestIdentifier testIdentifier, String namePrefix) {
 		StringBuilder sb = new StringBuilder(getTestId(testIdentifier)).append(',');
-		copyAndEscapeText(namePrefix, sb);
-		copyAndEscapeText(getTestName(testIdentifier), sb);
+		appendEscaped(namePrefix, sb);
+		appendEscaped(getTestName(testIdentifier), sb);
 		message(key, sb);
 	}
 
-	private static void copyAndEscapeText(String s, StringBuilder sb) {
+	private static void appendEscaped(String s, StringBuilder sb) {
 		if (s.isEmpty()) {
 			return;
 		}
@@ -464,7 +464,7 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 
 	private void visitEntry(TestIdentifier testIdentifier, boolean isDynamic) {
 		StringBuilder treeEntry = new StringBuilder(getTestId(testIdentifier)).append(',');
-		copyAndEscapeText(getTestName(testIdentifier), treeEntry);
+		appendEscaped(getTestName(testIdentifier), treeEntry);
 		treeEntry.append(',');
 		Set<TestIdentifier> children;
 		if (testIdentifier.isTest()) {
@@ -483,11 +483,11 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 			.append(',')
 			.append(getParentTestId(testIdentifier))
 			.append(',');
-		copyAndEscapeText(testIdentifier.getDisplayName(), treeEntry);
+		appendEscaped(testIdentifier.getDisplayName(), treeEntry);
 		treeEntry.append(',');
-		copyAndEscapeText(getTestParameterTypes(testIdentifier), treeEntry);
+		appendEscaped(getTestParameterTypes(testIdentifier), treeEntry);
 		treeEntry.append(',');
-		copyAndEscapeText(testIdentifier.getUniqueId(), treeEntry);
+		appendEscaped(testIdentifier.getUniqueId(), treeEntry);
 		message("%TSTTREE", treeEntry);
 		for (TestIdentifier child : children) {
 			visitEntry(child, isDynamic);

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -15,6 +15,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -464,36 +465,32 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 	private void visitEntry(TestIdentifier testIdentifier, boolean isDynamic) {
 		StringBuilder treeEntry = new StringBuilder(getTestId(testIdentifier)).append(',');
 		copyAndEscapeText(getTestName(testIdentifier), treeEntry);
+		treeEntry.append(',');
+		Set<TestIdentifier> children;
 		if (testIdentifier.isTest()) {
-			treeEntry.append(",false,1,")
-				.append(isDynamic)
+			children = Collections.emptySet();
+			treeEntry.append(false)
 				.append(',')
-				.append(getParentTestId(testIdentifier))
-				.append(',');
-			copyAndEscapeText(testIdentifier.getDisplayName(), treeEntry);
-			treeEntry.append(',');
-			copyAndEscapeText(getTestParameterTypes(testIdentifier), treeEntry);
-			treeEntry.append(',');
-			copyAndEscapeText(testIdentifier.getUniqueId(), treeEntry);
-			message("%TSTTREE", treeEntry);
+				.append('1');
 		} else {
-			final Set<TestIdentifier> children = testPlan.getChildren(testIdentifier);
-			treeEntry.append(",true,")
-				.append(children.size())
+			children = testPlan.getChildren(testIdentifier);
+			treeEntry.append(true)
 				.append(',')
-				.append(isDynamic)
-				.append(',')
-				.append(getParentTestId(testIdentifier))
-				.append(',');
-			copyAndEscapeText(testIdentifier.getDisplayName(), treeEntry);
-			treeEntry.append(',');
-			copyAndEscapeText(getTestParameterTypes(testIdentifier), treeEntry);
-			treeEntry.append(',');
-			copyAndEscapeText(testIdentifier.getUniqueId(), treeEntry);
-			message("%TSTTREE", treeEntry);
-			for (TestIdentifier child : children) {
-				visitEntry(child, isDynamic);
-			}
+				.append(children.size());
+		}
+		treeEntry.append(',')
+			.append(isDynamic)
+			.append(',')
+			.append(getParentTestId(testIdentifier))
+			.append(',');
+		copyAndEscapeText(testIdentifier.getDisplayName(), treeEntry);
+		treeEntry.append(',');
+		copyAndEscapeText(getTestParameterTypes(testIdentifier), treeEntry);
+		treeEntry.append(',');
+		copyAndEscapeText(testIdentifier.getUniqueId(), treeEntry);
+		message("%TSTTREE", treeEntry);
+		for (TestIdentifier child : children) {
+			visitEntry(child, isDynamic);
 		}
 	}
 

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -200,7 +200,7 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 		this.testPlan = testPlan;
 		for (TestIdentifier root : testPlan.getRoots()) {
 			for (TestIdentifier child : testPlan.getChildren(root)) {
-				visitEntry(child);
+				visitEntry(child, false);
 			}
 		}
 		startTime = System.currentTimeMillis();
@@ -456,10 +456,6 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 					break;
 			}
 		}
-	}
-
-	private void visitEntry(TestIdentifier testIdentifier) {
-		visitEntry(testIdentifier, false);
 	}
 
 	private void visitEntry(TestIdentifier testIdentifier, boolean isDynamic) {


### PR DESCRIPTION
The code now uses nio SocketChannel to communicate with the Eclipse client. The code now also waits for a brief delay after reporting the test run end to try to ensure the Eclipse client receives the message before the connection is closed and the test VM terminates. The 0.25 sec value chosen seems to reliably solve the issue on my system. We may need to tweak the value with some more experience.