### PR TITLE
Properly handle version range idioms: @ prefix, @ suffix, = prefix

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/VersionPolicyTest.java
+++ b/biz.aQute.bndlib.tests/test/test/VersionPolicyTest.java
@@ -1,8 +1,16 @@
 package test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.Map;
 import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
 
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
@@ -12,108 +20,116 @@ import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.lib.io.IO;
-import junit.framework.TestCase;
 
-@SuppressWarnings("resource")
-public class VersionPolicyTest extends TestCase {
+public class VersionPolicyTest {
 
 	/**
 	 * Test disable default package versions.
 	 */
-	public static void testDisableDefaultPackageVersion() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("Bundle-Version", "1.2.3");
-		a.setProperty("Export-Package", "test.refer");
-		a.setProperty("-nodefaultversion", "true");
-		Jar jar = a.build();
+	@Test
+	public void testDisableDefaultPackageVersion() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("Bundle-Version", "1.2.3");
+			a.setProperty("Export-Package", "test.refer");
+			a.setProperty("-nodefaultversion", "true");
+			Jar jar = a.build();
 
-		Manifest m = jar.getManifest();
-		Parameters exports = Processor.parseHeader(m.getMainAttributes()
-			.getValue(Constants.EXPORT_PACKAGE), null);
-		Map<String, String> attrs = exports.get("test.refer");
-		assertNotNull(attrs);
-		assertNull(attrs.get("version"));
+			Manifest m = jar.getManifest();
+			Parameters exports = Processor.parseHeader(m.getMainAttributes()
+				.getValue(Constants.EXPORT_PACKAGE), null);
+			Map<String, String> attrs = exports.get("test.refer");
+			assertNotNull(attrs);
+			assertNull(attrs.get("version"));
+		}
 	}
 
 	/**
 	 * Test default package versions.
 	 */
-	public static void testDefaultPackageVersion() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("Bundle-Version", "1.2.3");
-		a.setProperty("Export-Package", "test.refer");
-		Jar jar = a.build();
+	@Test
+	public void testDefaultPackageVersion() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("Bundle-Version", "1.2.3");
+			a.setProperty("Export-Package", "test.refer");
+			Jar jar = a.build();
 
-		Manifest m = jar.getManifest();
-		Parameters exports = Processor.parseHeader(m.getMainAttributes()
-			.getValue(Constants.EXPORT_PACKAGE), null);
-		Map<String, String> attrs = exports.get("test.refer");
-		assertNotNull(attrs);
-		assertEquals("1.2.3", attrs.get("version"));
+			Manifest m = jar.getManifest();
+			Parameters exports = Processor.parseHeader(m.getMainAttributes()
+				.getValue(Constants.EXPORT_PACKAGE), null);
+			Map<String, String> attrs = exports.get("test.refer");
+			assertNotNull(attrs);
+			assertEquals("1.2.3", attrs.get("version"));
+		}
 	}
 
 	/**
 	 * Test import provide:.
 	 */
-	public static void testImportProvided() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(IO.getFile("jar/osgi.jar"));
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("Private-Package", "test.refer");
-		a.setProperty("Import-Package", "org.osgi.service.event;provide:=true,*");
-		Jar jar = a.build();
-		Map<String, String> event = a.getImports()
-			.getByFQN("org.osgi.service.event");
-		assertEquals("[1.0,1.1)", event.get("version"));
-		Map<String, String> http = a.getImports()
-			.getByFQN("org.osgi.service.http");
-		assertEquals("[1.2,2)", http.get("version"));
+	@Test
+	public void testImportProvided() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(IO.getFile("jar/osgi.jar"));
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("Private-Package", "test.refer");
+			a.setProperty("Import-Package", "org.osgi.service.event;provide:=true,*");
+			Jar jar = a.build();
+			Map<String, String> event = a.getImports()
+				.getByFQN("org.osgi.service.event");
+			assertEquals("[1.0,1.1)", event.get("version"));
+			Map<String, String> http = a.getImports()
+				.getByFQN("org.osgi.service.http");
+			assertEquals("[1.2,2)", http.get("version"));
 
-		Manifest m = jar.getManifest();
-		String imports = m.getMainAttributes()
-			.getValue(Constants.IMPORT_PACKAGE);
-		assertFalse(imports.contains(Constants.PROVIDE_DIRECTIVE));
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue(Constants.IMPORT_PACKAGE);
+			assertFalse(imports.contains(Constants.PROVIDE_DIRECTIVE));
+		}
 	}
 
 	/**
 	 * Test import provide:.
 	 */
-	public static void testExportProvided() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(IO.getFile("jar/osgi.jar"));
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("Private-Package", "test.refer");
-		a.setProperty("Export-Package", "org.osgi.service.http;provide:=true");
-		Jar jar = a.build();
-		Map<String, String> event = a.getImports()
-			.getByFQN("org.osgi.service.event");
-		assertEquals("[1.0,2)", event.get("version"));
-		Map<String, String> http = a.getImports()
-			.getByFQN("org.osgi.service.http");
-		assertEquals("[1.2,1.3)", http.get("version"));
+	@Test
+	public void testExportProvided() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(IO.getFile("jar/osgi.jar"));
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("Private-Package", "test.refer");
+			a.setProperty("Export-Package", "org.osgi.service.http;provide:=true");
+			Jar jar = a.build();
+			Map<String, String> event = a.getImports()
+				.getByFQN("org.osgi.service.event");
+			assertEquals("[1.0,2)", event.get("version"));
+			Map<String, String> http = a.getImports()
+				.getByFQN("org.osgi.service.http");
+			assertEquals("[1.2,1.3)", http.get("version"));
 
-		Manifest m = jar.getManifest();
-		String imports = m.getMainAttributes()
-			.getValue(Constants.IMPORT_PACKAGE);
-		assertFalse(imports.contains(Constants.PROVIDE_DIRECTIVE));
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue(Constants.IMPORT_PACKAGE);
+			assertFalse(imports.contains(Constants.PROVIDE_DIRECTIVE));
+		}
 	}
 
 	/**
 	 * Test export annotation.
 	 */
-	public static void testExportAnnotation() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("build", "xyz");
-		a.setProperty("Export-Package", "test.versionpolicy.api");
-		a.build();
-		Map<String, String> attrs = a.getExports()
-			.getByFQN("test.versionpolicy.api");
-		assertEquals("1.2.0.xyz", attrs.get("version"));
-		assertEquals("PrivateImpl", attrs.get("exclude:"));
-		assertEquals("a", attrs.get("mandatory:"));
+	@Test
+	public void testExportAnnotation() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("build", "xyz");
+			a.setProperty("Export-Package", "test.versionpolicy.api");
+			a.build();
+			Map<String, String> attrs = a.getExports()
+				.getByFQN("test.versionpolicy.api");
+			assertEquals("1.2.0.xyz", attrs.get("version"));
+			assertEquals("PrivateImpl", attrs.get("exclude:"));
+			assertEquals("a", attrs.get("mandatory:"));
+		}
 	}
 
 	/**
@@ -121,27 +137,30 @@ public class VersionPolicyTest extends TestCase {
 	 * ProviderType) causes the import of the api package to use the provider
 	 * version policy.
 	 */
-	public static void testProviderType() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setPrivatePackage("test.versionpolicy.implemented");
-		a.setExportPackage("test.versionpolicy.api");
-		a.setImportPackage("test.versionpolicy.api"); // what changed so this is
-														// not automatically
-														// added?
-		a.setProperty("build", "123");
-		a.setProperty("-fixupmessages",
-			"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
-		Jar jar = a.build();
-		assertTrue(a.check());
-		Manifest m = jar.getManifest();
-		m.write(System.err);
-		Domain d = Domain.domain(m);
+	@Test
+	public void testProviderType() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setPrivatePackage("test.versionpolicy.implemented");
+			a.setExportPackage("test.versionpolicy.api");
+			a.setImportPackage("test.versionpolicy.api"); // what changed so
+															// this is
+															// not automatically
+															// added?
+			a.setProperty("build", "123");
+			a.setProperty("-fixupmessages",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
+			Jar jar = a.build();
+			assertTrue(a.check());
+			Manifest m = jar.getManifest();
+			m.write(System.err);
+			Domain d = Domain.domain(m);
 
-		Parameters parameters = d.getImportPackage();
-		Attrs attrs = parameters.get("test.versionpolicy.api");
-		assertNotNull(attrs);
-		assertEquals("[1.2,1.3)", attrs.get("version"));
+			Parameters parameters = d.getImportPackage();
+			Attrs attrs = parameters.get("test.versionpolicy.api");
+			assertNotNull(attrs);
+			assertEquals("[1.2,1.3)", attrs.get("version"));
+		}
 
 	}
 
@@ -150,22 +169,24 @@ public class VersionPolicyTest extends TestCase {
 	 * annotated with OSGi R6 @ProviderType, causes import of the api package to
 	 * use the provider version policy
 	 */
-	public static void testProviderTypeR6() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(new File("bin_test"));
-		b.setPrivatePackage("test.versionpolicy.implemented.osgi");
-		b.setProperty("build", "123");
+	@Test
+	public void testProviderTypeR6() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(new File("bin_test"));
+			b.setPrivatePackage("test.versionpolicy.implemented.osgi");
+			b.setProperty("build", "123");
 
-		Jar jar = b.build();
-		assertTrue(b.check());
-		Manifest m = jar.getManifest();
-		m.write(System.err);
+			Jar jar = b.build();
+			assertTrue(b.check());
+			Manifest m = jar.getManifest();
+			m.write(System.err);
 
-		Domain d = Domain.domain(m);
-		Parameters params = d.getImportPackage();
-		Attrs attrs = params.get("test.version.annotations.osgi");
-		assertNotNull(attrs);
-		assertEquals("[1.2,1.3)", attrs.get("version"));
+			Domain d = Domain.domain(m);
+			Parameters params = d.getImportPackage();
+			Attrs attrs = params.get("test.version.annotations.osgi");
+			assertNotNull(attrs);
+			assertEquals("[1.2,1.3)", attrs.get("version"));
+		}
 	}
 
 	/**
@@ -173,24 +194,26 @@ public class VersionPolicyTest extends TestCase {
 	 * ConsumerType) causes the import of the api package to use the consumer
 	 * version policy.
 	 */
-	public static void testConsumerType() throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setPrivatePackage("test.versionpolicy.uses");
-		a.setExportPackage("test.versionpolicy.api");
-		a.setProperty("build", "123");
-		a.setProperty("-fixupmessages",
-			"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
-		Jar jar = a.build();
-		assertTrue(a.check());
-		Manifest m = jar.getManifest();
-		m.write(System.err);
-		Domain d = Domain.domain(m);
+	@Test
+	public void testConsumerType() throws Exception {
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setPrivatePackage("test.versionpolicy.uses");
+			a.setExportPackage("test.versionpolicy.api");
+			a.setProperty("build", "123");
+			a.setProperty("-fixupmessages",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
+			Jar jar = a.build();
+			assertTrue(a.check());
+			Manifest m = jar.getManifest();
+			m.write(System.err);
+			Domain d = Domain.domain(m);
 
-		Parameters parameters = d.getImportPackage();
-		Attrs attrs = parameters.get("test.versionpolicy.api");
-		assertNotNull(attrs);
-		assertEquals("[1.2,2)", attrs.get("version"));
+			Parameters parameters = d.getImportPackage();
+			Attrs attrs = parameters.get("test.versionpolicy.api");
+			assertNotNull(attrs);
+			assertEquals("[1.2,2)", attrs.get("version"));
+		}
 
 	}
 
@@ -199,59 +222,63 @@ public class VersionPolicyTest extends TestCase {
 	 * test.versionpolicy.(uses|implemented)
 	 */
 	static void assertPolicy(String pack, String type) throws Exception {
-		Builder a = new Builder();
-		a.addClasspath(new File("bin_test"));
-		a.setProperty("Export-Package", "test.versionpolicy.api");
-		Jar jar = a.build();
+		try (Builder a = new Builder()) {
+			a.addClasspath(new File("bin_test"));
+			a.setProperty("Export-Package", "test.versionpolicy.api");
+			Jar jar = a.build();
 
-		Builder b = new Builder();
-		b.addClasspath(jar);
-		b.addClasspath(new File("bin_test"));
+			try (Builder b = new Builder()) {
+				b.addClasspath(jar);
+				b.addClasspath(new File("bin_test"));
 
-		b.setProperty("-versionpolicy-impl", "IMPL");
-		b.setProperty("-versionpolicy-uses", "USES");
-		b.setProperty("Private-Package", pack);
-		b.build();
-		Manifest m = b.getJar()
-			.getManifest();
-		m.write(System.err);
-		Map<String, String> map = b.getImports()
-			.getByFQN("test.versionpolicy.api");
-		assertNotNull(map);
-		// String s = map.get(Constants.IMPLEMENTED_DIRECTIVE);
-		// assertEquals("true", s);
-		Parameters mp = Processor.parseHeader(m.getMainAttributes()
-			.getValue("Import-Package"), null);
-		assertEquals(type, mp.get("test.versionpolicy.api")
-			.get("version"));
+				b.setProperty("-versionpolicy-impl", "IMPL");
+				b.setProperty("-versionpolicy-uses", "USES");
+				b.setProperty("Private-Package", pack);
+				b.build();
+				Manifest m = b.getJar()
+					.getManifest();
+				m.write(System.err);
+				Map<String, String> map = b.getImports()
+					.getByFQN("test.versionpolicy.api");
+				assertNotNull(map);
+				// String s = map.get(Constants.IMPLEMENTED_DIRECTIVE);
+				// assertEquals("true", s);
+				Parameters mp = Processor.parseHeader(m.getMainAttributes()
+					.getValue("Import-Package"), null);
+				assertEquals(type, mp.get("test.versionpolicy.api")
+					.get("version"));
+			}
+		}
 	}
 
 	/**
 	 * hardcoded imports
 	 */
-	public static void testHardcodedImports() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.setProperty("-versionpolicy", "${range;[==,+)}");
-		b.setProperty("Private-Package", "org.objectweb.asm");
-		b.setProperty("Import-Package", "org.osgi.framework,org.objectweb.asm,abc;version=2.0.0,*");
-		b.build();
-		Manifest m = b.getJar()
-			.getManifest();
-		m.write(System.err);
-		String s = b.getImports()
-			.getByFQN("org.objectweb.asm")
-			.get("version");
-		assertNull(s);
-		s = b.getImports()
-			.getByFQN("abc")
-			.get("version");
-		assertEquals("2.0.0", s);
+	@Test
+	public void testHardcodedImports() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("-versionpolicy", "${range;[==,+)}");
+			b.setProperty("Private-Package", "org.objectweb.asm");
+			b.setProperty("Import-Package", "org.osgi.framework,org.objectweb.asm,abc;version=2.0.0,*");
+			b.build();
+			Manifest m = b.getJar()
+				.getManifest();
+			m.write(System.err);
+			String s = b.getImports()
+				.getByFQN("org.objectweb.asm")
+				.get("version");
+			assertNull(s);
+			s = b.getImports()
+				.getByFQN("abc")
+				.get("version");
+			assertEquals("2.0.0", s);
 
-		s = b.getImports()
-			.getByFQN("org.osgi.framework")
-			.get("version");
-		assertEquals("[1.3,2)", s);
+			s = b.getImports()
+				.getByFQN("org.osgi.framework")
+				.get("version");
+			assertEquals("[1.3,2)", s);
+		}
 
 	}
 
@@ -259,17 +286,19 @@ public class VersionPolicyTest extends TestCase {
 	 * Specify the version on the export and verify that the policy is applied
 	 * on the matching import.
 	 */
-	public static void testExportsSpecifiesVersion() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.addClasspath(new File("bin_test"));
-		b.setProperty("Export-Package", "org.osgi.service.event");
-		b.setProperty("Private-Package", "test.refer");
-		b.build();
-		String s = b.getImports()
-			.getByFQN("org.osgi.service.event")
-			.get("version");
-		assertEquals("[1.0,2)", s);
+	@Test
+	public void testExportsSpecifiesVersion() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("Export-Package", "org.osgi.service.event");
+			b.setProperty("Private-Package", "test.refer");
+			b.build();
+			String s = b.getImports()
+				.getByFQN("org.osgi.service.event")
+				.get("version");
+			assertEquals("[1.0,2)", s);
+		}
 
 	}
 
@@ -277,70 +306,78 @@ public class VersionPolicyTest extends TestCase {
 	 * See if we a can override the version from the export statement and the
 	 * version from the source.
 	 */
-	public static void testImportOverridesDiscoveredVersion() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.addClasspath(new File("bin_test"));
-		b.setProperty("Export-Package", "org.osgi.service.event");
-		b.setProperty("Private-Package", "test.refer");
-		b.setProperty("Import-Package", "org.osgi.service.event;version=2.1.3.q");
-		b.build();
-		String s = b.getImports()
-			.getByFQN("org.osgi.service.event")
-			.get("version");
-		assertEquals("2.1.3.q", s);
+	@Test
+	public void testImportOverridesDiscoveredVersion() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("Export-Package", "org.osgi.service.event");
+			b.setProperty("Private-Package", "test.refer");
+			b.setProperty("Import-Package", "org.osgi.service.event;version=2.1.3.q");
+			b.build();
+			String s = b.getImports()
+				.getByFQN("org.osgi.service.event")
+				.get("version");
+			assertEquals("2.1.3.q", s);
+		}
 	}
 
 	/**
 	 * Test if we can get the version from the source and apply the default
 	 * policy.
 	 */
-	public static void testVersionPolicyImportedExportsDefaultPolicy() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.addClasspath(new File("bin_test"));
-		b.setProperty("Export-Package", "org.osgi.service.event");
-		b.setProperty("Private-Package", "test.refer");
-		b.build();
-		String s = b.getImports()
-			.getByFQN("org.osgi.service.event")
-			.get("version");
-		assertEquals("[1.0,2)", s);
+	@Test
+	public void testVersionPolicyImportedExportsDefaultPolicy() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("Export-Package", "org.osgi.service.event");
+			b.setProperty("Private-Package", "test.refer");
+			b.build();
+			String s = b.getImports()
+				.getByFQN("org.osgi.service.event")
+				.get("version");
+			assertEquals("[1.0,2)", s);
+		}
 	}
 
 	/**
 	 * The default policy is truncate micro. Check if this is applied to the
 	 * import.
 	 */
-	public static void testImportMicroTruncated() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.setProperty("Import-Package", "org.osgi.service.event");
-		b.build();
-		String s = b.getImports()
-			.getByFQN("org.osgi.service.event")
-			.get("version");
-		assertEquals("[1.0,2)", s);
+	@Test
+	public void testImportMicroTruncated() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("Import-Package", "org.osgi.service.event");
+			b.build();
+			String s = b.getImports()
+				.getByFQN("org.osgi.service.event")
+				.get("version");
+			assertEquals("[1.0,2)", s);
+		}
 	}
 
 	/**
 	 * Check if we can set a specific version on the import that does not use a
 	 * version policy.
 	 */
-	public static void testImportMicroNotTruncated() throws Exception {
-		Builder b = new Builder();
-		b.addClasspath(IO.getFile("jar/osgi.jar"));
-		b.setProperty("Import-Package",
-			"org.osgi.service.event;version=${@}, org.osgi.service.log;version=\"${range;[==,=+)}\"");
-		b.build();
-		String s = b.getImports()
-			.getByFQN("org.osgi.service.event")
-			.get("version");
-		String l = b.getImports()
-			.getByFQN("org.osgi.service.log")
-			.get("version");
-		assertEquals("1.0.1", s);
-		assertEquals("[1.3,1.4)", l);
+	@Test
+	public void testImportMicroNotTruncated() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("Import-Package",
+				"org.osgi.service.event;version=${@}, org.osgi.service.log;version=\"${range;[==,=+)}\"");
+			b.build();
+			String s = b.getImports()
+				.getByFQN("org.osgi.service.event")
+				.get("version");
+			String l = b.getImports()
+				.getByFQN("org.osgi.service.log")
+				.get("version");
+			assertEquals("1.0.1", s);
+			assertEquals("[1.3,1.4)", l);
+		}
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2665,6 +2665,19 @@ public class Analyzer extends Processor {
 			return prefix + cleanupVersion(first) + "," + cleanupVersion(last) + suffix;
 		}
 
+		if (version.startsWith("@")) {
+			version = cleanupVersion(version.substring(1));
+			String right = Macro.version(Version.valueOf(version), "+0");
+			return "[" + version + "," + right + ")";
+		} else if (version.endsWith("@")) {
+			version = cleanupVersion(version.substring(0, version.length() - 1));
+			String right = Macro.version(Version.valueOf(version), "=+");
+			return "[" + version + "," + right + ")";
+		} else if (version.startsWith("=")) {
+			version = cleanupVersion(version.substring(1));
+			return "[" + version + "," + version + "]";
+		}
+
 		m = fuzzyVersion.matcher(version);
 		if (m.matches()) {
 			StringBuilder result = new StringBuilder();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -984,19 +984,13 @@ public class Macro {
 
 		String mask = args[1];
 
-		Version version = null;
+		Version version;
 		if (args.length >= 3) {
 			if (isLocalTarget(args[2]))
 				return LITERALVALUE;
 
 			version = Version.parseVersion(args[2]);
-		}
-
-		return version(version, mask);
-	}
-
-	String version(Version version, String mask) {
-		if (version == null) {
+		} else {
 			String v = domain.getProperty(Constants.CURRENT_VERSION);
 			if (v == null) {
 				return LITERALVALUE;
@@ -1004,6 +998,10 @@ public class Macro {
 			version = new Version(v);
 		}
 
+		return version(version, mask);
+	}
+
+	static String version(Version version, String mask) {
 		StringBuilder sb = new StringBuilder();
 		String del = "";
 
@@ -1073,7 +1071,7 @@ public class Macro {
 
 	public String _range(String[] args) {
 		verifyCommand(args, _rangeHelp, _rangePattern, 2, 3);
-		Version version = null;
+		Version version;
 		if (args.length >= 3) {
 			String string = args[2];
 			if (isLocalTarget(string))

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1005,49 +1005,87 @@ public class Macro {
 		StringBuilder sb = new StringBuilder();
 		String del = "";
 
-		for (int i = 0; i < mask.length(); i++) {
+		maskloop: for (int i = 0, len = mask.length(); i < len; i++) {
 			char c = mask.charAt(i);
-			String result = null;
-			if (c != '~') {
-				if (i == 3) {
-					result = version.getQualifier();
-					MavenVersion mv = new MavenVersion(version);
-					if (c == 'S') {
+			if (i == 3) {
+				switch (c) {
+					case '~' :
+						break;
+					case '0' :
+					case '1' :
+					case '2' :
+					case '3' :
+					case '4' :
+					case '5' :
+					case '6' :
+					case '7' :
+					case '8' :
+					case '9' :
+						sb.append(del)
+							.append(c);
+						break;
+					case 's' : {
+						MavenVersion mv = new MavenVersion(version);
 						// we have a request for a Maven snapshot
-						if (mv.isSnapshot())
-							return sb.append("-SNAPSHOT")
-								.toString();
-					} else if (c == 's') {
+						if (mv.isSnapshot()) {
+							sb.append("-SNAPSHOT");
+						}
+						break;
+					}
+					case 'S' : {
+						MavenVersion mv = new MavenVersion(version);
 						// we have a request for a Maven snapshot
-						if (mv.isSnapshot())
-							return sb.append("-SNAPSHOT")
-								.toString();
-						else
-							return sb.toString();
+						if (mv.isSnapshot()) {
+							sb.append("-SNAPSHOT");
+							break;
+						}
+						// FALL-THROUGH
 					}
-				} else if (Character.isDigit(c)) {
-					// Handle masks like +00, =+0
-					result = String.valueOf(c);
-				} else {
-					int x = version.get(i);
-					switch (c) {
-						case '+' :
-							x++;
-							break;
-						case '-' :
-							x--;
-							break;
-						case '=' :
-							break;
+					case '=' : {
+						String qualifier = version.getQualifier();
+						if (qualifier != null) {
+							sb.append(del)
+								.append(qualifier);
+						}
+						break;
 					}
-					result = Integer.toString(x);
+					default :
+						throw new IllegalArgumentException("Invalid mask character " + c + " at index " + i);
 				}
-				if (result != null) {
-					sb.append(del);
-					del = ".";
-					sb.append(result);
-				}
+				return sb.toString();
 			}
+			switch (c) {
+				case '~' :
+					continue maskloop; // don't modify del
+				case '0' :
+				case '1' :
+				case '2' :
+				case '3' :
+				case '4' :
+				case '5' :
+				case '6' :
+				case '7' :
+				case '8' :
+				case '9' :
+					sb.append(del)
+						.append(c);
+					break;
+				case '+' :
+					sb.append(del)
+						.append(version.get(i) + 1);
+					break;
+				case '-' :
+					sb.append(del)
+						.append(Math.max(0, version.get(i) - 1));
+					break;
+				case '=' :
+					sb.append(del)
+						.append(version.get(i));
+					break;
+				default :
+					throw new IllegalArgumentException("Invalid mask character " + c + " at index " + i);
+			}
+			del = ".";
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
https://bnd.bndtools.org/chapters/170-versioning.html describes several
idioms for describing version ranges: @ prefix, @ suffix, = prefix.

However these were not properly processed when used in Import-Package
statements as shown in the documentation. This fix updates the
cleanupVersion method to detect usage of these idioms and convert them
to the standard OSGi internal syntax.
