### PR TITLE
[tester] OSGiJUnitLaunchDelegate to handle restarting tester bundle

### DIFF
--- a/bndtools.core/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
@@ -183,20 +183,17 @@ public class OSGiJUnitLaunchDelegate extends AbstractOSGiLaunchDelegate {
 		ILaunch					launch;
 		IJavaProject			project;
 		TestRunSessionAndPort	testRunSession;
-		int						port;
 		DataOutputStream		outStr;
 
-		public ControlThread(ILaunch launch, IJavaProject project, int port) {
+		public ControlThread(ILaunch launch, IJavaProject project, int port) throws IOException {
 			this.launch = launch;
 			this.project = project;
-			this.port = port;
+			listener = new ServerSocket(port);
 		}
 
 		@Override
 		public void run() {
 			try {
-				listener = new ServerSocket(port);
-
 				// Note that this loop will terminate when accept() throws a
 				// SocketException. This ordinarily happens when the
 				// ServerSocket is closed in ControlThread.close(), which is in

--- a/bndtools.core/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
@@ -178,12 +178,12 @@ public class OSGiJUnitLaunchDelegate extends AbstractOSGiLaunchDelegate {
 
 	private static class ControlThread implements Runnable, AutoCloseable {
 
-		ServerSocket			listener;
-		Socket					socket;
-		ILaunch					launch;
-		IJavaProject			project;
-		TestRunSessionAndPort	testRunSession;
-		DataOutputStream		outStr;
+		final ServerSocket				listener;
+		final ILaunch					launch;
+		final IJavaProject				project;
+		volatile Socket					socket;
+		volatile TestRunSessionAndPort	testRunSession;
+		volatile DataOutputStream		outStr;
 
 		public ControlThread(ILaunch launch, IJavaProject project, int port) throws IOException {
 			this.launch = launch;
@@ -223,9 +223,11 @@ public class OSGiJUnitLaunchDelegate extends AbstractOSGiLaunchDelegate {
 			IO.close(listener);
 			IO.close(outStr);
 			IO.close(socket);
-			if (testRunSession != null) {
-				testRunSession.stopTestRun();
-				testRunSession = null;
+			synchronized (this) {
+				if (testRunSession != null) {
+					testRunSession.stopTestRun();
+					testRunSession = null;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Loop around the call to `accept()` to accept reconnection attempts (such as what happens when the tester bundle is restarted).

Partial fix for #3528.