### PR TITLE
Fix performance issues in Jar viewer

### DIFF
--- a/aQute.libg/test/aQute/lib/hex/HexTest.java
+++ b/aQute.libg/test/aQute/lib/hex/HexTest.java
@@ -2,6 +2,7 @@ package aQute.lib.hex;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import aQute.lib.base64.Base64;
@@ -96,59 +97,88 @@ public class HexTest extends TestCase {
 	final static String EOL = String.format("%n");
 
 	public void testFormatEmpty() {
-		assertThat(Hex.format(new byte[] {})).isEqualTo("");
+		byte[] input = new byte[] {};
+		assertThat(Hex.format(input)).isEqualTo("")
+			.isEqualTo(Hex.format(ByteBuffer.allocate(0)));
 	}
 
 	public void testNull() {
-		assertThat(Hex.format(null)).isEmpty();
+		assertThat(Hex.format((byte[]) null)).isEmpty();
+		assertThat(Hex.format((ByteBuffer) null)).isEmpty();
 	}
 
 	public void testAscii() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			-1, 'A', 'a', '~', ' ', '\u007F'
-		})).isEqualTo("0x0000  FF 41 61 7E 20 7F                                 .Aa~ ." + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  FF 41 61 7E 20 7F                                 .Aa~ ." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
 	}
 
 	public void testFormatOne() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			-1
-		})).isEqualTo("0x0000  FF                                                ." + EOL);
+		};
+		assertThat(Hex.format(input)).isEqualTo("0x0000  FF                                                ." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
 	}
 
 	public void testFormatSeven() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06                              ......." + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06                              ......." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
 	}
 
 	public void testFormatEight() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6, 7
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06 07                           ........" + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06 07                           ........" + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
 	}
 
 	public void testFormatNine() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6, 7, 8
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06 07  08                       ........  ." + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06 07  08                       ........  ." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
 	}
 
 	public void testFormatFifteen() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E     ........  ......." + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E     ........  ......." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
+
 	}
 
 	public void testFormatSixteen() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........  ........" + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........  ........" + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
+
 	}
 
 	public void testFormatSeventeen() {
-		assertThat(Hex.format(new byte[] {
+		byte[] input = new byte[] {
 			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
-		})).isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........  ........" + EOL + //
-		/*         */ "0x0010  10                                                ." + EOL);
+		};
+		assertThat(Hex.format(input))
+			.isEqualTo("0x0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ........  ........" + EOL + //
+			/*         */ "0x0010  10                                                ." + EOL)
+			.isEqualTo(Hex.format(ByteBuffer.wrap(input)));
+
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -169,10 +169,10 @@ public class Jar implements Closeable {
 						if (entry.isDirectory()) {
 							continue;
 						}
-						if (filter.test(entry.getName())) {
-							int size = (int) entry.getSize();
-							try (ByteBufferOutputStream bbos = new ByteBufferOutputStream(
-								(size == -1) ? BUFFER_SIZE : size + 1)) {
+						String path = cleanPath(entry.getName());
+						if (filter.test(path)) {
+							int size = (entry.getSize() < 0) ? BUFFER_SIZE : (1 + (int) entry.getSize());
+							try (ByteBufferOutputStream bbos = new ByteBufferOutputStream(size)) {
 								bbos.write(jin);
 								Resource resource = new EmbeddedResource(bbos.toByteBuffer(),
 									ZipUtil.getModifiedTime(entry));
@@ -293,8 +293,8 @@ public class Jar implements Closeable {
 				if (entry.isDirectory()) {
 					continue;
 				}
-				int size = (int) entry.getSize();
-				try (ByteBufferOutputStream bbos = new ByteBufferOutputStream((size == -1) ? BUFFER_SIZE : size + 1)) {
+				int size = (entry.getSize() < 0) ? BUFFER_SIZE : (1 + (int) entry.getSize());
+				try (ByteBufferOutputStream bbos = new ByteBufferOutputStream(size)) {
 					bbos.write(jin);
 					putResource(entry.getName(),
 						new EmbeddedResource(bbos.toByteBuffer(), ZipUtil.getModifiedTime(entry)), true);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -317,7 +317,7 @@ public class Jar implements Closeable {
 		return putResource(path, resource, true);
 	}
 
-	private static String cleanPath(String path) {
+	public static String cleanPath(String path) {
 		if (path.isEmpty()) {
 			return "";
 		}

--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -29,7 +29,8 @@ Bundle-SymbolicName: bndtools.jareditor;singleton:=true
 	org.eclipse.jdt.core,\
 	org.eclipse.jdt.launching,\
 	org.eclipse.core.filesystem,\
-	org.eclipse.core.contenttype
+	org.eclipse.core.contenttype,\
+    bndtools.api;version=latest
 
 -includepackage: bndtools.jareditor.*,\
 	bndtools.test.plugin

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JAREditor.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JAREditor.java
@@ -2,6 +2,8 @@ package bndtools.jareditor.internal;
 
 import java.net.URI;
 
+import org.bndtools.api.ILogger;
+import org.bndtools.api.Logger;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -26,6 +28,7 @@ import aQute.lib.exceptions.FunctionWithException;
 import aQute.lib.strings.Strings;
 
 public class JAREditor extends FormEditor implements IResourceChangeListener {
+	private static final ILogger	logger		= Logger.getLogger(JAREditor.class);
 	private JARTreePage		treePage	= new JARTreePage(this, "treePage", "Tree");
 	private JARPrintPage	printPage	= new JARPrintPage(this, "printPage", "Print");
 	private URI				uri;
@@ -121,8 +124,8 @@ public class JAREditor extends FormEditor implements IResourceChangeListener {
 		printPage.setInput(uri);
 	}
 
-	static <T> void background(String message, FunctionWithException<IProgressMonitor, T> background,
-		ConsumerWithException<T> onDisplayThread) {
+	static <T> void background(String message, FunctionWithException<IProgressMonitor, ? extends T> background,
+		ConsumerWithException<? super T> onDisplayThread) {
 
 		Job job = new Job(message) {
 			@Override
@@ -137,7 +140,7 @@ public class JAREditor extends FormEditor implements IResourceChangeListener {
 							try {
 								onDisplayThread.accept(result);
 							} catch (Exception e) {
-								// ignore
+								logger.logError("JAREditor display thread exception! " + message, e);
 							}
 						});
 					return Status.OK_STATUS;

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryFile.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryFile.java
@@ -7,10 +7,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 
 import aQute.bnd.service.result.Result;
 import aQute.lib.strings.Strings;
@@ -20,12 +19,9 @@ import aQute.lib.strings.Strings;
  * clean up the temporary files as much as possible
  */
 public class TemporaryFile {
-	final static String			ID		= ".bndtools.jareditor.temp";
-	final static IWorkspaceRoot	root	= ResourcesPlugin.getWorkspace()
-		.getRoot();
-	final static AtomicLong		id		= new AtomicLong(10000000);
+	private final static AtomicLong			id			= new AtomicLong(10000000);
 
-	static TemporaryProject		tempProject	= new TemporaryProject();
+	private final static TemporaryProject	tempProject	= new TemporaryProject();
 
 	public static Result<IFolder, String> tempFolder(URI source, String path, IProgressMonitor monitor) {
 		try {
@@ -54,14 +50,16 @@ public class TemporaryFile {
 				return actualFolder;
 			});
 		} catch (Exception e) {
-			return Result.err(e.getMessage());
+			return Result.err("Error creating temp folder for JAREditor %s", e);
 		}
 	}
 
 	private static Result<IFolder, String> selectTempProject() throws CoreException, IOException {
-		IProject project = tempProject.getJavaProject()
-			.getProject();
-
+		IJavaProject javaProject = tempProject.getJavaProject();
+		if (javaProject == null) {
+			return Result.err("Unable to get temp project %s", TemporaryProject.PROJECT_NAME);
+		}
+		IProject project = javaProject.getProject();
 		return Result.ok(project.getFolder("temp"));
 	}
 

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryProject.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryProject.java
@@ -38,20 +38,18 @@ public class TemporaryProject {
 		proj.setDescription(description, new NullProgressMonitor());
 	}
 
-	private void checkForSupportProject() {
-		try {
-			IWorkspace workspace = ResourcesPlugin.getWorkspace();
-			IWorkspaceRoot root = workspace.getRoot();
-			IProject project = root.getProject(PROJECT_NAME);
+	private void checkForSupportProject() throws CoreException {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceRoot root = workspace.getRoot();
+		IProject project = root.getProject(PROJECT_NAME);
 
-			if (!project.exists() || !project.isOpen()) {
-				createProject();
-			}
+		if (!project.exists() || !project.isOpen()) {
+			createProject();
+		}
 
-			makeFolders(project.getFolder("temp"));
+		makeFolders(project.getFolder("temp"));
 
-			computeClasspath(JavaCore.create(project), new NullProgressMonitor());
-		} catch (CoreException ce) {}
+		computeClasspath(JavaCore.create(project), new NullProgressMonitor());
 	}
 
 	private void computeClasspath(IJavaProject project, IProgressMonitor monitor) {
@@ -94,18 +92,15 @@ public class TemporaryProject {
 		return project;
 	}
 
-	public IJavaProject getJavaProject() {
-		try {
-			checkForSupportProject();
-			IProject project = ResourcesPlugin.getWorkspace()
-				.getRoot()
-				.getProject(PROJECT_NAME);
+	public IJavaProject getJavaProject() throws CoreException {
+		checkForSupportProject();
+		IProject project = ResourcesPlugin.getWorkspace()
+			.getRoot()
+			.getProject(PROJECT_NAME);
 
-			if (project.exists() && project.isOpen() && project.hasNature(JavaCore.NATURE_ID)) {
-				return JavaCore.create(project);
-			}
-		} catch (CoreException ce) {}
-
+		if (project.exists() && project.isOpen() && project.hasNature(JavaCore.NATURE_ID)) {
+			return JavaCore.create(project);
+		}
 		return null;
 	}
 


### PR DESCRIPTION
We now avoid repetitively reading the entire jar into memory hundreds of times by properly caching the eclipse file system nodes and not reading entries into memory until they are needed for the view component.

Fixes https://github.com/bndtools/bnd/issues/3722