### PR TITLE
jareditor: Plugin must be started for the Bundle-Activator to be called

### DIFF
--- a/bndtools.jareditor/bnd.bnd
+++ b/bndtools.jareditor/bnd.bnd
@@ -44,3 +44,4 @@ Import-Package: \
 	aQute.lib.*
 
 Bundle-Activator: bndtools.jareditor.internal.Plugin
+Bundle-ActivationPolicy: lazy

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryFile.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/TemporaryFile.java
@@ -12,6 +12,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 
 import aQute.bnd.service.result.Result;
+import aQute.lib.exceptions.Exceptions;
 import aQute.lib.strings.Strings;
 
 /**
@@ -50,7 +51,7 @@ public class TemporaryFile {
 				return actualFolder;
 			});
 		} catch (Exception e) {
-			return Result.err("Error creating temp folder for JAREditor %s", e);
+			return Result.err("Error creating temp folder for JAREditor %s", Exceptions.toString(e));
 		}
 	}
 


### PR DESCRIPTION
The code NPE'd trying to get the state location because no one started
the bundle. So we mark it lazy activation to get Eclipse to start it.