### PR TITLE
junit-platform: Fix Sub-request to handle plain DiscoverySelector

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
@@ -520,16 +520,15 @@ public class BundleSelectorResolver {
 		@Override
 		public <T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
 			info(() -> "Getting selectors from sub-request for: " + selectorType);
-			if (selectorType.equals(ClassSelector.class) || selectorType.equals(MethodSelector.class)) {
-				return selectors.stream()
-					.filter(selectorType::isInstance)
-					.map(selectorType::cast)
-					.collect(toList());
-			}
-			if (selectorType.equals(BundleSelector.class)) {
-				return new ArrayList<>();
-			}
-			return request.getSelectorsByType(selectorType);
+			return Stream.concat( //
+				request.getSelectorsByType(selectorType)
+					.stream()
+					.filter(selector -> !(selector instanceof ClassSelector || selector instanceof MethodSelector
+						|| selector instanceof BundleSelector)),
+				selectors.stream()
+					.filter(selectorType::isInstance))
+				.map(selectorType::cast)
+				.collect(toList());
 		}
 
 		@Override

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
@@ -65,8 +65,8 @@ import aQute.tester.testclasses.junit.platform.Mixed35Test;
 import aQute.tester.testclasses.junit.platform.Mixed45Test;
 import aQute.tester.testclasses.junit.platform.ParameterizedTesterNamesTest;
 
-public class ActivatorTest extends AbstractActivatorTest {
-	public ActivatorTest() {
+public class ActivatorJUnitPlatformTest extends AbstractActivatorTest {
+	public ActivatorJUnitPlatformTest() {
 		super("aQute.tester.junit.platform.Activator", "biz.aQute.tester.junit-platform");
 	}
 


### PR DESCRIPTION
JUnit 5.5 changed to call getSelectorsByType with the base
DiscoverySelector type which caused us to fail to substitute the OSGi
ready selectors.

We change to call the original request and then filter out the selector
we will supply. We then add the selectors we will supply to the stream.

Fixes https://github.com/bndtools/bnd/issues/3745
