### PR TITLE
gradlew: Update to 6.1.1

### DIFF
--- a/.gradle-wrapper/gradle-wrapper.properties
+++ b/.gradle-wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This fixes the creation of the empty /gradle folder.

