### PR TITLE
indexing: Properly handle bundle-symbolic-name and bundle-version

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -583,6 +583,21 @@ public class Attrs implements Map<String, String> {
 		return ((last >= 0) && (key.charAt(last) == ':')) ? key.substring(0, last) : null;
 	}
 
+	/**
+	 * Predicate which returns true if the specified key is an attribute key.
+	 */
+	public static boolean isAttribute(String key) {
+		return !isDirective(key);
+	}
+
+	/**
+	 * Predicate which returns true if the specified key is a directive key.
+	 */
+	public static boolean isDirective(String key) {
+		int last = key.length() - 1;
+		return (last >= 0) && (key.charAt(last) == ':');
+	}
+
 	public static Attrs create(String key, String value) {
 		Attrs attrs = new Attrs();
 		attrs.put(key, value);

--- a/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.2.0")
+@Version("2.3.0")
 package aQute.bnd.header;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
We now decorate package capabilities with the bundle-symbolic-name
and bundle-version of the exporting bundle (when known).

We also properly generate the filter directive on wiring namespaces for
matching attributes.

Fixes #3748