### PR TITLE
gradle: Avoid multiple sets of org.gradle.libraryelements to jar

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -65,7 +65,15 @@ class BndUtils {
 
   public static void jarLibraryElements(Project project, String configurationName) {
     if (IS_GRADLE_COMPATIBLE_5_6) {
-      project.configurations[configurationName].attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.class, LibraryElements.JAR))
+      def attributes = project.configurations[configurationName].attributes
+      if (attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)?.name != LibraryElements.JAR) {
+        try {
+          attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.class, LibraryElements.JAR))
+          project.logger.info 'Set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)
+        } catch (IllegalArgumentException e) {
+          project.logger.info 'Unable to set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR, e
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
A project can have multiple Bundle tasks all using the same sourceSet.
So we avoid setting the org.gradle.libraryelements attribute to jar if
it is already set to jar. We also defend against attempting to set the
attribute after it have been made immutable.

Fixes https://github.com/bndtools/bnd/issues/3780

