### PR TITLE
fixed support for current java Versions in templates

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/EE.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/EE.java
@@ -15,46 +15,46 @@ import aQute.lib.utf8properties.UTF8Properties;
 
 public enum EE {
 
-	OSGI_Minimum_1_0("OSGi/Minimum-1.0", "OSGi/Minimum", new Version("1.0")),
+	OSGI_Minimum_1_0("OSGi/Minimum-1.0", "OSGi/Minimum", "1.0"),
 
-	OSGI_Minimum_1_1("OSGi/Minimum-1.1", "OSGi/Minimum", new Version("1.1"), OSGI_Minimum_1_0),
+	OSGI_Minimum_1_1("OSGi/Minimum-1.1", "OSGi/Minimum", "1.1", OSGI_Minimum_1_0),
 
-	OSGI_Minimum_1_2("OSGi/Minimum-1.2", "OSGi/Minimum", new Version("1.2"), OSGI_Minimum_1_1),
+	OSGI_Minimum_1_2("OSGi/Minimum-1.2", "OSGi/Minimum", "1.2", OSGI_Minimum_1_1),
 
-	JRE_1_1("JRE-1.1", "JRE", new Version("1.1")),
+	JRE_1_1("JRE-1.1", "JRE", "1.1"),
 
-	J2SE_1_2("J2SE-1.2", "JavaSE", new Version("1.2"), JRE_1_1),
+	J2SE_1_2("J2SE-1.2", "JavaSE", "1.2", JRE_1_1),
 
-	J2SE_1_3("J2SE-1.3", "JavaSE", new Version("1.3"), J2SE_1_2, OSGI_Minimum_1_1),
+	J2SE_1_3("J2SE-1.3", "JavaSE", "1.3", J2SE_1_2, OSGI_Minimum_1_1),
 
-	J2SE_1_4("J2SE-1.4", "JavaSE", new Version("1.4"), J2SE_1_3, OSGI_Minimum_1_2),
+	J2SE_1_4("J2SE-1.4", "JavaSE", "1.4", J2SE_1_3, OSGI_Minimum_1_2),
 
-	J2SE_1_5("J2SE-1.5", "JavaSE", new Version("1.5"), J2SE_1_4),
+	J2SE_1_5("J2SE-1.5", "JavaSE", "1.5", J2SE_1_4),
 
-	JavaSE_1_6("JavaSE-1.6", "JavaSE", new Version("1.6"), J2SE_1_5),
+	JavaSE_1_6("JavaSE-1.6", "JavaSE", "1.6", J2SE_1_5),
 
-	JavaSE_1_7("JavaSE-1.7", "JavaSE", new Version("1.7"), JavaSE_1_6),
+	JavaSE_1_7("JavaSE-1.7", "JavaSE", "1.7", JavaSE_1_6),
 
-	JavaSE_compact1_1_8("JavaSE/compact1-1.8", "JavaSE/compact1", new Version("1.8"), OSGI_Minimum_1_2),
+	JavaSE_compact1_1_8("JavaSE/compact1-1.8", "JavaSE/compact1", "1.8", OSGI_Minimum_1_2),
 
-	JavaSE_compact2_1_8("JavaSE/compact2-1.8", "JavaSE/compact2", new Version("1.8"), JavaSE_compact1_1_8),
+	JavaSE_compact2_1_8("JavaSE/compact2-1.8", "JavaSE/compact2", "1.8", JavaSE_compact1_1_8),
 
-	JavaSE_compact3_1_8("JavaSE/compact3-1.8", "JavaSE/compact3", new Version("1.8"), JavaSE_compact2_1_8),
+	JavaSE_compact3_1_8("JavaSE/compact3-1.8", "JavaSE/compact3", "1.8", JavaSE_compact2_1_8),
 
-	JavaSE_1_8("JavaSE-1.8", "JavaSE", new Version("1.8"), JavaSE_1_7, JavaSE_compact3_1_8),
+	JavaSE_1_8("JavaSE-1.8", "JavaSE", "1.8", JavaSE_1_7, JavaSE_compact3_1_8),
 
-	JavaSE_9_0("JavaSE-9", "JavaSE", new Version("9"), JavaSE_1_8),
+	JavaSE_9_0("JavaSE-9", "JavaSE", "9", JavaSE_1_8),
 
-	JavaSE_10_0("JavaSE-10", "JavaSE", new Version("10"), JavaSE_9_0),
+	JavaSE_10_0("JavaSE-10", "JavaSE", "10", JavaSE_9_0),
 
-	JavaSE_11_0("JavaSE-11", "JavaSE", new Version("11"), JavaSE_10_0),
+	JavaSE_11_0("JavaSE-11", "JavaSE", "11", JavaSE_10_0),
 
-	JavaSE_12_0("JavaSE-12", "JavaSE", new Version("12"), JavaSE_11_0),
+	JavaSE_12_0("JavaSE-12", "JavaSE", "12", JavaSE_11_0),
 
-	JavaSE_13_0("JavaSE-13", "JavaSE", new Version("13"), JavaSE_12_0),
-	JavaSE_14_0("JavaSE-14", "JavaSE", new Version("14"), JavaSE_13_0),
+	JavaSE_13_0("JavaSE-13", "JavaSE", "13", JavaSE_12_0),
+	JavaSE_14_0("JavaSE-14", "JavaSE", "14", JavaSE_13_0),
 
-	UNKNOWN("Unknown", "unknown", new Version(0));
+	UNKNOWN("Unknown", "unknown", "0");
 
 	private final String			eeName;
 	private final String			capabilityName;
@@ -63,11 +63,13 @@ public enum EE {
 	private transient EnumSet<EE>	compatibleSet;
 	private transient Parameters	packages	= null;
 	private transient Parameters	modules		= null;
+	private String					versionLabel;
 
-	EE(String name, String capabilityName, Version capabilityVersion, EE... compatible) {
+	EE(String name, String capabilityName, String versionLabel, EE... compatible) {
 		this.eeName = name;
 		this.capabilityName = capabilityName;
-		this.capabilityVersion = capabilityVersion;
+		this.versionLabel = versionLabel;
+		this.capabilityVersion = new Version(versionLabel);
 		this.compatible = compatible;
 	}
 
@@ -100,6 +102,10 @@ public enum EE {
 
 	public String getCapabilityName() {
 		return capabilityName;
+	}
+
+	public String getVersionLabel() {
+		return versionLabel;
 	}
 
 	public Version getCapabilityVersion() {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
@@ -1,4 +1,4 @@
-@Version("3.5.0")
+@Version("3.6.0")
 package aQute.bnd.build.model;
 
 import org.osgi.annotation.versioning.Version;

--- a/bndtools.utils/src/org/bndtools/utils/javaproject/JavaProjectUtils.java
+++ b/bndtools.utils/src/org/bndtools/utils/javaproject/JavaProjectUtils.java
@@ -8,6 +8,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 
+import aQute.bnd.build.model.EE;
+
 public class JavaProjectUtils {
 
 	/**
@@ -65,37 +67,6 @@ public class JavaProjectUtils {
 	public static final String	PATH_JRE_CONTAINER		= "org.eclipse.jdt.launching.JRE_CONTAINER";
 	public static final String	PATH_JRE_STANDARD_VM	= "org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType";
 
-	private enum JavaLevel {
-		J2SE_1_2("J2SE-1.2", "1.2"),
-		J2SE_1_3("J2SE-1.3", "1.3"),
-		J2SE_1_4("J2SE-1.4", "1.4"),
-		J2SE_1_5("J2SE-1.5", "1.5"),
-		JAVASE_1_6("JavaSE-1.6", "1.6"),
-		JAVASE_1_7("JavaSE-1.7", "1.7"),
-		JAVASE_1_8("JavaSE-1.8", "1.8"),
-		JAVASE_9("JavaSE-9", "9");
-
-		private final String	label;
-		private final String	level;
-
-		JavaLevel(String label, String level) {
-			this.label = label;
-			this.level = level;
-		}
-
-		String getLevel() {
-			return level;
-		}
-
-		static JavaLevel fromLabel(String label) {
-			for (JavaLevel level : JavaLevel.values()) {
-				if (level.label.equals(label))
-					return level;
-			}
-			throw new IllegalArgumentException("Unrecognized Java compliance level: " + label);
-		}
-	}
-
 	public static String getJavaLevel(IJavaProject project) throws Exception {
 		IClasspathEntry[] classpathEntries = project.getRawClasspath();
 
@@ -106,8 +77,11 @@ public class JavaProjectUtils {
 					continue;
 				if (PATH_JRE_CONTAINER.equals(path.segment(0)) && PATH_JRE_STANDARD_VM.equals(path.segment(1))) {
 					String jreName = path.segment(2);
-					return JavaLevel.fromLabel(jreName)
-						.getLevel();
+					EE ee = EE.parse(jreName);
+					if (ee == null) {
+						throw new IllegalArgumentException("Unrecognized Java compliance level: " + jreName);
+					}
+					return ee.getVersionLabel();
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #3798 by replacing the bndtools specic JavaLevel Enum with the
usage of the EE enum

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>