### PR TITLE
[docs] Update/correct tester docs with latest version information

### DIFF
--- a/docs/_chapters/310-testing.md
+++ b/docs/_chapters/310-testing.md
@@ -72,7 +72,7 @@ You can find a bndtools project that shows this at [Github](https://github.com/b
 
 ## Testing With JUnit 5 - `biz.aQute.tester.junit-platform`
 
-As of 4.4, bnd includes a new tester bundle `biz.aQute.tester.junit-platform` that supports JUnit 5.
+As of Bnd 5.0, bnd includes a new tester bundle `biz.aQute.tester.junit-platform` that supports JUnit 5.
 
 As per the [JUnit 5 documentation](https://junit.org/junit5/docs/current/user-guide/#overview-what-is-junit-5), JUnit 5 is comprised of three modules:
 
@@ -130,14 +130,14 @@ Note that if you're only using JUnit 3/4, you can omit the `-runrequires` line f
 As noted above, `biz.aQute.tester.junit-platform` requires JUnit Platform (and its dependencies) on the classpath, and if it is to do much that is useful it will also require at least one `TestEngine`. Bundled versions of these are part of Eclipse since Oxygen. You can include them in your workspace from:
 
 * Eclipse's Orbit repository
-* Bnd project's Eclipse mirror: https://dl.bintray.com/bndtools/eclipse-repo/4.7.3a:
+* Bnd project's Eclipse mirror: https://dl.bintray.com/bndtools/eclipse-repo/4.10:
 ```
     -plugin.repository: \
         aQute.bnd.repository.osgi.OSGiRepository;\
-            name="Eclipse Oxygen 4.7.3a";\
-            locations="https://dl.bintray.com/bndtools/eclipse-repo/4.7.3a/index.xml.gz";\
+            name="Eclipse 2018-12";\
+            locations="https://dl.bintray.com/bndtools/eclipse-repo/4.10/index.xml.gz";\
             poll.time=-1;\
-            cache="${workspace}/cnf/cache/stable/EclipseOxygen"
+            cache="${workspace}/cnf/cache/stable/Eclipse-2018-12"
 ```
 * Your local Eclipse installation (using the P2Repository plugin):
 ```
@@ -147,7 +147,14 @@ As noted above, `biz.aQute.tester.junit-platform` requires JUnit Platform (and i
             url="file:///path/to/eclipse/";\
             location="${workspace}/cnf/cache/stable/EclipseLocal"
 ```
-Alternatively, it is not difficult to download the required (non-OSGi) modules from Maven Central and include them as-is on `-runpath`, or else (preferably) wrap them into bundles and include them in `-runrequires`/`-runbundles`.
+
+Alternatively, it is not difficult to download the required (non-OSGi) modules from Maven Central and include them as-is on `-runpath`, or else (preferably) wrap them into bundles and include them in `-runrequires`/`-runbundles`. 
+As of JUnit 5.6, the JUnit jars already have the OSGi metadata and so can be used as bundles 
+direct from Maven Central.
+
+Also note that unfortunately, due to a bug in `biz.aQute.tester.junit-platform`, Bndtools 5.0 
+*does not work with JUnit 5.5+*. A fix is already available in the latest development snapshot, and we expect the 
+fix to be included in a future Bndtools release (hopefully soon).
 
 ## Other Tester Frameworks
 The biz.aQute.tester is a normal bundle that gets started from the launcher framework. However, before bnd chooses the default tester, it scans the classpath for a tester (set with `-runpath`) for JARs that have the following header set:

--- a/docs/releases/5.0.0/chapters/310-testing.html
+++ b/docs/releases/5.0.0/chapters/310-testing.html
@@ -408,7 +408,7 @@ Private-Package: org.example.tests
 
 <h2 id="testing-with-junit-5---bizaqutetesterjunit-platform">Testing With JUnit 5 - <code class="highlighter-rouge">biz.aQute.tester.junit-platform</code></h2>
 
-<p>As of 4.4, bnd includes a new tester bundle <code class="highlighter-rouge">biz.aQute.tester.junit-platform</code> that supports JUnit 5.</p>
+<p>As of Bnd 5.0, bnd includes a new tester bundle <code class="highlighter-rouge">biz.aQute.tester.junit-platform</code> that supports JUnit 5.</p>
 
 <p>As per the <a href="https://junit.org/junit5/docs/current/user-guide/#overview-what-is-junit-5">JUnit 5 documentation</a>, JUnit 5 is comprised of three modules:</p>
 
@@ -481,13 +481,13 @@ Private-Package: org.example.tests
 
 <ul>
   <li>Eclipse’s Orbit repository</li>
-  <li>Bnd project’s Eclipse mirror: https://dl.bintray.com/bndtools/eclipse-repo/4.7.3a:
+  <li>Bnd project’s Eclipse mirror: https://dl.bintray.com/bndtools/eclipse-repo/4.10:
     <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>  -plugin.repository: \
       aQute.bnd.repository.osgi.OSGiRepository;\
-          name="Eclipse Oxygen 4.7.3a";\
-          locations="https://dl.bintray.com/bndtools/eclipse-repo/4.7.3a/index.xml.gz";\
+          name="Eclipse 2018-12";\
+          locations="https://dl.bintray.com/bndtools/eclipse-repo/4.10/index.xml.gz";\
           poll.time=-1;\
-          cache="${workspace}/cnf/cache/stable/EclipseOxygen"
+          cache="${workspace}/cnf/cache/stable/Eclipse-2018-12"
 </code></pre></div>    </div>
   </li>
   <li>Your local Eclipse installation (using the P2Repository plugin):
@@ -497,9 +497,11 @@ Private-Package: org.example.tests
           url="file:///path/to/eclipse/";\
           location="${workspace}/cnf/cache/stable/EclipseLocal"
 </code></pre></div>    </div>
-    <p>Alternatively, it is not difficult to download the required (non-OSGi) modules from Maven Central and include them as-is on <code class="highlighter-rouge">-runpath</code>, or else (preferably) wrap them into bundles and include them in <code class="highlighter-rouge">-runrequires</code>/<code class="highlighter-rouge">-runbundles</code>.</p>
   </li>
 </ul>
+<p>Alternatively, it is not difficult to download the required (non-OSGi) modules from Maven Central and include them as-is on <code class="highlighter-rouge">-runpath</code>, or else (preferably) wrap them into bundles and include them in <code class="highlighter-rouge">-runrequires</code>/<code class="highlighter-rouge">-runbundles</code>. As of JUnit 5.6, the JUnit jars already have the OSGi metadata and so can be used as bundles direct from Maven Central.</p>
+
+<p>Also note that unfortunately, due to a bug in <code class="highlighter-rouge">biz.aQute.tester.junit-platform</code>, Bndtools 5.0 <em>does not work with JUnit 5.5+</em>. A fix is already available in the latest development snapshot, and we expect the fix to be included in a future Bndtools release (hopefully soon).</p>
 
 <h2 id="other-tester-frameworks">Other Tester Frameworks</h2>
 <p>The biz.aQute.tester is a normal bundle that gets started from the launcher framework. However, before bnd chooses the default tester, it scans the classpath for a tester (set with <code class="highlighter-rouge">-runpath</code>) for JARs that have the following header set:</p>


### PR DESCRIPTION
* Old docs referred to 4.4 release which became the 5.0 release.
* Old docs referred to Eclipse Oxygen, which is now Eclipse 2018-12.
* Added note about 5.6 release of JUnit being bundled.
* Added note about incompatibility with JUnit 5.5.

Fix includes HEAD and 5.0.0 release notes.
