### PR TITLE
Adds org.osgi.dto Package to fixe ClassNotFoundException in gradle build when using P2Repository

### DIFF
--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -14,18 +14,10 @@ jtwig.version: 5.86.1.RELEASE
 	artifactId=jtwig-reflection;\
 	version=${jtwig.version};\
 	scope=compile
-
-dto.version: 1.0.0
--maven-dependencies.dto:\
-	dto;\
-	groupId=org.osgi;\
-	artifactId=org.osgi.dto;\
-	version=${dto.version};\
-	scope=compile
  
 -buildpath: \
 	osgi.annotation;version=latest;maven-scope=provided,\
-	org.osgi.dto;version=${dto.version},\
+	org.osgi.dto;version=latest,\
 	aQute.libg;version=project,\
 	biz.aQute.bndlib;version=latest,\
 	slf4j.api;version=latest,\

--- a/biz.aQute.bndlib/bnd.bnd
+++ b/biz.aQute.bndlib/bnd.bnd
@@ -5,7 +5,8 @@ Bundle-Description: bndlib: A Swiss Army Knife for OSGi
 
 -includepackage: \
 	aQute.bnd.*,\
-	aQute.lib.spring
+	aQute.lib.spring,\
+	org.osgi.dto
 
 Export-Package: \
     aQute.bnd.build;-noimport:=true,\
@@ -55,6 +56,7 @@ Export-Package: \
 Import-Package: \
 	org.osgi.service.repository,\
 	org.osgi.service.log,\
+	org.osgi.dto,\
 	${replacelist;${retainall;${packages;CONDITIONAL};${packages;NAMED;org.osgi.*}};$;\\;provide:=false},\
 	*
 


### PR DESCRIPTION
adds osgi.dto pckg to fix CNF Exception in gradle for p2 repo

* addionally counts the package version up, because baselineing
complained about it

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>