### PR TITLE
Publish existing POM to Gradle Plugin Portal

### DIFF
--- a/biz.aQute.bnd.gradle/publish.gradle
+++ b/biz.aQute.bnd.gradle/publish.gradle
@@ -15,6 +15,8 @@ buildscript {
 
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'maven-publish'
 
 ext.groupId = 'biz.aQute.bnd'
 ext.artifactId = 'biz.aQute.bnd.gradle'
@@ -26,6 +28,7 @@ repositories {
 
 configurations {
   archives.artifacts.clear()
+  pom
   plugin
   plugin.dependencies.all { Dependency dep ->
     if (dep instanceof ExternalDependency) {
@@ -40,7 +43,7 @@ configurations {
 }
 
 dependencies {
-  plugin "${groupId}:${artifactId}:${artifactVersion}@pom"
+  pom "${groupId}:${artifactId}:${artifactVersion}@pom"
   plugin "${groupId}:${artifactId}:${artifactVersion}@jar"
   plugin "${groupId}:${artifactId}:${artifactVersion}:javadoc@jar"
   plugin "${groupId}:${artifactId}:${artifactVersion}:sources@jar"
@@ -62,6 +65,33 @@ tasks.create('displayArtifacts') {
     configurations.archives.artifacts.each { artifact ->
       println "${artifact} ${artifact.file}"
     }
+  }
+}
+
+def pomFile = file("$buildDir/pom.xml")
+
+task('copyPublishedPom') {
+  inputs.files(configurations.pom).withPathSensitivity(PathSensitivity.NONE)
+  outputs.file(pomFile)
+  doLast {
+    pomFile.text = configurations.pom.files.first().text
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      pluginMaven {
+        groupId = project.groupId
+        artifactId = project.artifactId
+        version = project.artifactVersion
+      }
+    }
+  }
+  tasks.generatePomFileForPluginMavenPublication {
+    destination = pomFile
+    enabled = false
+    finalizedBy('copyPublishedPom')
   }
 }
 
@@ -91,11 +121,5 @@ pluginBundle {
       description = "Gradle Plugin for developing OSGi bundles with Bnd. Bnd is the premiere tool for creating OSGi bundles. This gradle plugin is from the team that develops Bnd and is used by the Bnd team to build Bnd itself. See https://github.com/bndtools/bnd/blob/${project.artifactVersion}.REL/biz.aQute.bnd.gradle/README.md for information on using in a Bnd Workspace and a typical Gradle build."
       version = project.artifactVersion
     }
-  }
-
-  mavenCoordinates {
-    groupId = project.groupId
-    artifactId = project.artifactId
-    version = project.artifactVersion
   }
 }


### PR DESCRIPTION
This workaround makes use of the plugin-publish plugin's integration
with the java-gradle-plugin and maven-publish plugins. However, instead
of generating a POM based on the pluginMaven publication added by the
former, the task is disabled and the published POM is copied to its
destination. Thus, the publishPlugins task will pick it up and upload
it to the Gradle Plugin Portal.

---

Please note that I wasn't able to fully test this with the actual Plugin Portal.