### PR TITLE
docs: Clarify the default of -groupid is the workspace folder name

### DIFF
--- a/docs/_instructions/groupid.md
+++ b/docs/_instructions/groupid.md
@@ -7,6 +7,8 @@ summary:  Set the default Maven groupId
 
 The `-groupid` instruction defines the default Maven groupId to be used when generating POM resources and releasing to the [Maven Bnd Repository Plugin][1].
 
+If not specified, the value of `-groupid` defaults to the Bnd workspace folder name.
+
 Also see the [-pom][2] and [-maven-release][3] instructions.
 
 [1]: /plugins/maven


### PR DESCRIPTION
See https://github.com/bndtools/bnd/issues/3807

