### PR TITLE
[launcher] Location format

### DIFF
--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -226,6 +226,63 @@ public class AlsoLauncherTest {
 	}
 
 	@Test
+	public void testLocationFormat() throws Exception {
+		project.setProperty(Constants.RUNPROPERTIES, "test.cmd=exit");
+		project.setProperty(Constants.RUNTRACE, "true");
+		project.setProperty("-executable", "location='${@bsn}");
+		Entry<String, Resource> export = project.export("bnd.executablejar", null);
+		assertThat(project.check("Cannot find bsn in.*apiguardian-api")).isTrue();
+		assertThat(export).isNotNull();
+
+		try (Jar jar = new Jar(".", export.getValue()
+			.openInputStream())) {
+
+			assertThat(jar.getResources()
+				.keySet()).containsAll(Arrays.asList(//
+					"jar/biz.aQute.launcher.jar", // -runpath
+					"jar/org.apache.felix.framework-5.6.10.jar", // -runpath
+					"jar/apiguardian-api-1.1.0.jar", // not a bundle
+					"jar/demo", //
+					"jar/junit-jupiter-api", //
+					"jar/junit-jupiter-engine", //
+					"jar/junit-jupiter-params", //
+					"jar/junit-platform-commons", //
+					"jar/junit-platform-engine", //
+					"jar/junit-vintage-engine", //
+					"jar/org.apache.felix.configadmin", //
+					"jar/org.apache.felix.scr", //
+					"jar/org.apache.servicemix.bundles.junit", //
+					"jar/org.opentest4j" //
+			));
+
+			File tmp = File.createTempFile("foo", ".jar");
+			try {
+
+				jar.write(tmp);
+				Command cmd = new Command();
+				cmd.add(project.getJavaExecutable("java"));
+				cmd.add("-jar");
+				cmd.add(tmp.getAbsolutePath());
+
+				StringBuilder stdout = new StringBuilder();
+				StringBuilder stderr = new StringBuilder();
+				int execute = cmd.execute(stdout, stderr);
+				String output = stdout.append(stderr).toString();
+				System.out.println(output);
+
+				// These must be bsns ow
+				assertThat(output).contains("installing jar/org.apache.felix.scr");
+				assertThat(output).contains("installing jar/org.apache.felix.configadmin");
+
+				assertThat(execute).isEqualTo(42);
+
+			} finally {
+				tmp.delete();
+			}
+		}
+	}
+
+	@Test
 	public void testExecutableJarWithStripping() throws Exception {
 		long full = make(project, null);
 		long optStripped = make(project, "strip='OSGI-OPT/*'");

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/LauncherInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/LauncherInstructions.java
@@ -15,16 +15,39 @@ import aQute.bnd.osgi.Jar;
 @ProviderType
 public interface LauncherInstructions {
 
+	@ProviderType
 	interface Executable {
 		@SyntaxAnnotation(lead = "Re-jar the -runpath and -runbundles to the given compression. If "
-			+ "not set, bundles are not touched. This should not change the signatures", example = "STORE")
+			+ "not set, bundles are not touched. This should not change the signatures", example = "rejar=STORE")
 		Optional<Jar.Compression> rejar();
 
-		@SyntaxAnnotation(lead = "Strip OSGI-OPT from all jars. Default is to not strip", example = "true")
+		@SyntaxAnnotation(lead = "Strips files from embedded JARs. The syntax JARPATHMATCH ':' RESOURCEPATHMATCH, both globs.", example = "*:OSGI-OPT/*")
 		List<String> strip();
+
+		/**
+		 * By default, the name inside the executable JAR is based on the file
+		 * name in the repository. This name is also used as the location by by
+		 * the launcher. If the environment is not cleaned at startup, this can
+		 * cause problems since a change in this name install the same bundle
+		 * under two different locations. This will create a horrible conflict
+		 * during install that is hard to recover from.
+		 * <p>
+		 * This configuration allows you to calculate the location from the bsn
+		 * and version.
+		 *
+		 * @return a pattern or null
+		 */
+		@SyntaxAnnotation(lead = "A pattern to form the location for the bundle. This pattern "
+			+ "is processed by the macro processor. @bsn is the bsn, and @version is "
+			+ "the version, and @name is the file name. If no pattern is given, the file name is used to make a "
+			+ "unique name in the /jar directory. "
+			+ "If multiple bundles end up with the same name then the last one wins.The expansion may not contain file separators like /."
+			+ "If the storage area is not cleaned, use the example pattern", example = "location='${@bsn}-${version;=;${@version}}.jar'")
+		String location();
+
 	}
 
-	@SyntaxAnnotation(lead = "Options for the export of an executable", example = "rejar=STORE")
+	@SyntaxAnnotation(lead = "Options for the export of an executable", example = "rejar=STORE,strip=*:OSGI-OPT/*")
 	Executable executable();
 
 	enum RunOption {

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.2.0")
+@org.osgi.annotation.versioning.Version("1.3.0")
 package aQute.bnd.help.instructions;

--- a/docs/_instructions/executable.md
+++ b/docs/_instructions/executable.md
@@ -1,9 +1,24 @@
 ---
 layout: default
 class: Project
-title: -executable ( rejar= STORE | DEFLATE ) ( ','  strip= matcher ( ',' matcher )* )
-summary: Process an executable jar to strip optional directories of the contained bundles and/or change their compression
+title: -executable ( rejar= STORE | DEFLATE ) ( ','  strip= matcher ( ',' matcher )* ) ( ',' location= FORMAT )
+summary: Process an executable jar to strip optional directories of the contained bundles, and/or change their compression. The location string can also be calculated from bsn and version
 ---
+
+
+## Location
+
+Bundles are stored in a `jar` directory in the executable JAR. The name in this directory is by default the file name in the repository. This filename is, however, also used by the launcher as the location. This implies that if the file name contains the version, a new location is created when the version changes. This ends up with too many duplicates quickly. This is only a problem when you keep the storage area.
+
+The `location` option in the `-executable` instructions can provide a printf format to calculate a location based on the Bundle-SymbolicName and Bundle-Version.
+
+For example:
+
+    -executable: location='${@bsn}-${version;=;${@version}}'
+
+This format will create locations where a bundle will overwrite when the major part of the version is the same. I.e. `com.example.foo-1`. I.e., it will allow multiple bundles that are semantically incompatible but compatible bundles overwrite each other.
+
+## Compression
 
 When an executable JAR is created by the Project Launcher the compression is controlled with the [-compression](compression.html) 
 instruction. However, this über JAR contains bundles and JARs for the run path. Since executable JARs are sometimes used in 


### PR DESCRIPTION
The current launcher calculates a unique name for
each embedded JAR when creating an executable JAR.
This unique name is based on the name of the file
in the repo. Some of these files are just the bsn
but sometimes the full version is in there. 

Unfortunately, the launcher uses this path in the
executable JAR to create the location of the 
corresponding bundle. 

If the version is in that name, then this creates
a problem if the storage area is kept. If the version
of a bundle gets changed, it will create a new location
creating unwanted duplicates.

To generate a proper location, you need a strategy.
You could use a location that is unique for a
bsn, implying that all bundles are singletons. A sensible
strategy seems to include the major version in the 
location, allowing unique locations for incompatible
bundles.

Anyway, this patch allows the exporter to set a
strategy by specifying a format that uses macros. Available
are ${@version} and ${@bsn}.




Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>