### PR TITLE
launcher: Handle source enhanced files

### DIFF
--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -238,7 +238,7 @@ public class AlsoLauncherTest {
 			.openInputStream())) {
 
 			assertThat(jar.getResources()
-				.keySet()).containsAll(Arrays.asList(//
+				.keySet()).contains(//
 					"jar/biz.aQute.launcher.jar", // -runpath
 					"jar/org.apache.felix.framework-5.6.10.jar", // -runpath
 					"jar/apiguardian-api-1.1.0.jar", // not a bundle
@@ -253,7 +253,7 @@ public class AlsoLauncherTest {
 					"jar/org.apache.felix.scr", //
 					"jar/org.apache.servicemix.bundles.junit", //
 					"jar/org.opentest4j" //
-			));
+					);
 
 			File tmp = File.createTempFile("foo", ".jar");
 			try {
@@ -271,8 +271,8 @@ public class AlsoLauncherTest {
 				System.out.println(output);
 
 				// These must be bsns ow
-				assertThat(output).contains("installing jar/org.apache.felix.scr");
-				assertThat(output).contains("installing jar/org.apache.felix.configadmin");
+				assertThat(output).contains("installing jar/org.apache.felix.scr",
+					"installing jar/org.apache.felix.configadmin");
 
 				assertThat(execute).isEqualTo(42);
 

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -342,7 +342,7 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 
 		for (String path : runpath) {
 			logger.debug("embedding runpath {}", path);
-			File file = new File(path);
+			File file = getOriginalFile(path);
 			if (file.isFile()) {
 				String newPath = nonCollidingPath(file, jar, null);
 				jar.putResource(newPath, getJarFileResource(file, rejar, strip));
@@ -357,7 +357,7 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 
 		for (String path : runbundles) {
 			logger.debug("embedding run bundles {}", path);
-			File file = new File(path);
+			File file = getOriginalFile(path);
 			if (!file.isFile())
 				getProject().error("Invalid entry in -runbundles %s", file);
 			else {
@@ -486,6 +486,19 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		remove.forEach(jar::remove);
 		logger.debug("resources {}", Strings.join("\n", jar.getResources()
 			.keySet()));
+	}
+
+	File getOriginalFile(String path) {
+		File file = new File(path);
+		if (file.getName()
+			.startsWith("+") && file.exists()) { // file has source attached
+			File originalFile = new File(file.getParentFile(), file.getName()
+				.substring(1));
+			if (originalFile.exists()) {
+				return originalFile;
+			}
+		}
+		return file;
 	}
 
 	String nonCollidingPath(File file, Jar jar, String locationFormat) throws Exception {


### PR DESCRIPTION
Bndtools can attach source code to files for ease of debugging. These
source-enhanced-files have file names which start with '+'. When making
an executable, we should use the original files instead of the
source-enhanced-files.

I discovered this issue because a test case failed on my system because
I had had Bndtools add source to one of the files used by the test and
the extra '+' in the file name caused the test to fail.
