### PR TITLE
actions: Update checkout to v2

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 ./gradlew --no-daemon --version
 ./mvnw --version
-./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy
+./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 --continue :build :maven:deploy "$@"

--- a/.github/scripts/docs.sh
+++ b/.github/scripts/docs.sh
@@ -4,4 +4,4 @@ gem --version
 gem install bundler -v '~> 2.0'
 bundle --version
 cd docs
-./build.sh
+./build.sh "$@"

--- a/.github/scripts/rebuild.sh
+++ b/.github/scripts/rebuild.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 ./gradlew --no-daemon --version
 ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 :biz.aQute.bnd.gradle:build :biz.aQute.bnd.gradle:releaseNeeded
-./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles :buildscriptDependencies :build
+./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles :buildscriptDependencies :build "$@"

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths-ignore:
     - 'docs/**'
+    - '.github/**/*docs*'
   pull_request:
     paths-ignore:
     - 'docs/**'
+    - '.github/**/*docs*'
 
 env:
   LC_ALL: en_US.UTF-8

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -20,7 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
+    - name: Git Unshallow
+      if: (github.repository == 'bndtools/bnd') && (github.event_name != 'pull_request')
+      shell: bash
+      run: |
+        git fetch --prune --unshallow
+        git describe --dirty --always --abbrev=9
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Set up Java
@@ -39,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Set up Java
@@ -55,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Set up Java
@@ -71,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Set up Java
@@ -87,7 +93,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Gradle Wrapper Validation
       uses: gradle/wrapper-validation-action@v1
     - name: Set up Java

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -98,19 +98,3 @@ jobs:
       shell: bash
       run: |
         ./.github/scripts/build.sh
-  OpenJDK8_macOS:
-    name: OpenJDK8 macOS
-    runs-on: macos-latest
-    steps:
-    - name: Git Checkout
-      uses: actions/checkout@v1
-    - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
-    - name: Set up Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Build
-      shell: bash
-      run: |
-        ./.github/scripts/build.sh

--- a/.github/workflows/docsbuild.yml
+++ b/.github/workflows/docsbuild.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/docsbuild.yml
+++ b/.github/workflows/docsbuild.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
     - 'docs/**'
+    - '.github/**/*docs*'
   pull_request:
     paths:
     - 'docs/**'
+    - '.github/**/*docs*'
 
 env:
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
v2 only does a shallow fetch so we must unshallow the fetch for building
push events on the main repo since we need to know the prior tag for
git describe.