### PR TITLE
bnd: Improvements to bnd nexus sign command

### DIFF
--- a/biz.aQute.repository/src/aQute/maven/nexus/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/maven/nexus/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.3.0")
+@Version("1.4.0")
 package aQute.maven.nexus.provider;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
We implement the --key option which was present but never implemented.
This allows the user to sign with a key other than the gpg default key.

We also add a --settings option to the nexus command to specify the
-connections-settings property to allow the user to specify connection
settings other than the default.

Documentation annotations are also added so that the bnd help command
can provide helpful output.
