### PR TITLE
Updates for JDK 14

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -56,8 +56,8 @@ jobs:
       shell: bash
       run: |
         ./.github/scripts/build.sh
-  OpenJDK13_Linux:
-    name: OpenJDK13 Linux
+  OpenJDK14_Linux:
+    name: OpenJDK14 Linux
     runs-on: ubuntu-latest
     steps:
     - name: Git Checkout
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@v1
       with:
-        java-version: 13
+        java-version: 14
     - name: Build
       shell: bash
       run: |

--- a/.gradle-wrapper/gradle-wrapper.properties
+++ b/.gradle-wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -8,8 +8,9 @@ specified in the Bnd Workspace's `cnf/build.bnd` file and each project's
 `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins requires at least Gradle 5.1 for Java 8 to Java 12, and at
-least Gradle 6.0 for Java 13.
+These plugins requires at least Gradle 5.1 for Java 8 to Java 12,
+at least Gradle 6.0 for Java 13,
+and at least Gradle 6.3 for Java 14.
 
 This README represents the capabilities and features of the Bnd Gradle Plugins in
 the branch containing this README. So for the `master` branch, this will be

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -24,7 +24,12 @@ class TestHelper {
   }
 
   private static String gradleVersion() {
-    if (JavaVersion.current().compareTo(JavaVersion.VERSION_12) > 0) {
+    JavaVersion current = JavaVersion.current()
+    JavaVersion[] versions = JavaVersion.values()
+    if ((versions.length > 14) && (current.compareTo(versions[14 - 1]) >= 0)) {
+      return '6.3'
+    }
+    if ((versions.length > 13) && (current.compareTo(versions[13 - 1]) >= 0)) {
       return '6.0'
     }
     return '5.1'


### PR DESCRIPTION
Now that JDK 14 is released and supported by Gradle 6.3, we update the build.