### PR TITLE
pom: Make it possible to override computed dependency elements

### DIFF
--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -3,13 +3,13 @@
 
 jtwig.version: 5.86.1.RELEASE
 -maven-dependencies.jtwig:\
-	jtwig-core;\
+	org.jtwig:jtwig-core:${jtwig.version};\
 	groupId=org.jtwig;\
 	artifactId=jtwig-core;\
 	version=${jtwig.version};\
 	scope=compile,\
 	\
-	jtwig-reflection;\
+	org.jtwig:jtwig-reflection:${jtwig.version};\
 	groupId=org.jtwig;\
 	artifactId=jtwig-reflection;\
 	version=${jtwig.version};\

--- a/biz.aQute.bndlib.tests/test/test/MavenTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MavenTest.java
@@ -342,6 +342,12 @@ public class MavenTest extends TestCase {
 		b.setBundleSymbolicName(bsn);
 		b.setBundleVersion(version);
 		b.setProperty("-resourceonly", "true");
+		b.setProperty(
+			"-maven-dependencies",
+			"group1:artifact1:1.0.0-SNAPSHOT;groupId=group1;artifactId=artifact1;version=1.0.0-SNAPSHOT,group2:artifact2:2.0.0;groupId=group2;artifactId=artifact2;version=2.0.0");
+		b.setProperty(
+			"-maven-dependencies.fix",
+			"group1:artifact1:1.0.0-SNAPSHOT;groupId=group1;artifactId=artifact1;version=1.0.0");
 		if (developers != null)
 			b.setProperty(Constants.BUNDLE_DEVELOPERS, developers);
 
@@ -368,5 +374,13 @@ public class MavenTest extends TestCase {
 		assertEquals((scm == null) ? "0" : "1", xpath.evaluate("count(/project/scm)", d));
 		assertEquals(((license == null) || license.trim()
 			.equals("<<EXTERNAL>>")) ? "0" : "1", xpath.evaluate("count(/project/licenses)", d));
+
+		assertEquals("2", xpath.evaluate("count(/project/dependencies/dependency)", d));
+		assertEquals("group1", xpath.evaluate("/project/dependencies/dependency[1]/groupId", d));
+		assertEquals("artifact1", xpath.evaluate("/project/dependencies/dependency[1]/artifactId", d));
+		assertEquals("1.0.0", xpath.evaluate("/project/dependencies/dependency[1]/version", d));
+		assertEquals("group2", xpath.evaluate("/project/dependencies/dependency[2]/groupId", d));
+		assertEquals("artifact2", xpath.evaluate("/project/dependencies/dependency[2]/artifactId", d));
+		assertEquals("2.0.0", xpath.evaluate("/project/dependencies/dependency[2]/version", d));
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -29,7 +29,6 @@ import aQute.bnd.differ.Baseline.BundleInfo;
 import aQute.bnd.differ.Baseline.Info;
 import aQute.bnd.differ.DiffPluginImpl;
 import aQute.bnd.header.Attrs;
-import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
@@ -158,9 +157,13 @@ public class ProjectBuilder extends Builder {
 						attrs.put("version", depVersion);
 						attrs.put("scope", c.getAttributes()
 							.getOrDefault("maven-scope", getProperty(MAVEN_SCOPE, "compile")));
-						StringBuilder key = new StringBuilder();
-						OSGiHeader.quote(key, IO.absolutePath(file));
-						dependencies.put(key.toString(), attrs);
+						String key = new StringBuilder().append(depGroupId)
+							.append(':')
+							.append(depArtifactId)
+							.append(':')
+							.append(depVersion)
+							.toString();
+						dependencies.add(key, attrs);
 					}
 				});
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
@@ -5,9 +5,11 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Supplier;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,6 +21,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.WriteResource;
+import aQute.bnd.stream.MapStream;
 import aQute.lib.io.IO;
 import aQute.lib.tag.Tag;
 import aQute.libg.glob.Glob;
@@ -339,7 +342,11 @@ public class PomResource extends WriteResource {
 		Parameters dependencies = processor.getMergedParameters(Constants.MAVEN_DEPENDENCIES);
 		if (!dependencies.isEmpty()) {
 			Tag tdependencies = new Tag("dependencies");
-			dependencies.values()
+			dependencies.stream()
+				.mapKey(Processor::removeDuplicateMarker)
+				.collect(MapStream.toMap((oldValue, value) -> value,
+					(Supplier<Map<String, Attrs>>) LinkedHashMap::new))
+				.values()
 				.forEach(attrs -> tdependencies.addContent(new Tag("dependency").addContent(attrs)));
 			if (!tdependencies.getContents()
 				.isEmpty()) {


### PR DESCRIPTION
We now use the Maven G:A:V coordinates as the key for clauses in the
generated -maven-dependencies instruction. This will allow merged
-maven-dependencies instructions to override the computed dependency GAV
information by using the G:A:V key computed for the main
-maven-dependencies instruction.

Fixes https://github.com/bndtools/bnd/issues/3854
