### PR TITLE
generics: Specify generics for Supplier method reference to new

### DIFF
--- a/aQute.libg/src/aQute/lib/collections/ExtList.java
+++ b/aQute.libg/src/aQute/lib/collections/ExtList.java
@@ -48,7 +48,7 @@ public class ExtList<T> extends ArrayList<T> {
 	}
 
 	private static Collector<String, ?, ExtList<String>> collector() {
-		return Collector.of(ExtList::new, List::add, (left, right) -> {
+		return Collector.of(ExtList<String>::new, List::add, (left, right) -> {
 			left.addAll(right);
 			return left;
 		});

--- a/aQute.libg/src/aQute/lib/promise/PromiseCollectors.java
+++ b/aQute.libg/src/aQute/lib/promise/PromiseCollectors.java
@@ -14,7 +14,7 @@ public class PromiseCollectors {
 
 	public static <V> Collector<Promise<V>, List<Promise<V>>, Promise<List<V>>> toPromise(
 		PromiseFactory promiseFactory) {
-		return Collector.of(ArrayList::new, List::add, PromiseCollectors::combiner, promiseFactory::all);
+		return Collector.of(ArrayList<Promise<V>>::new, List::add, PromiseCollectors::combiner, promiseFactory::all);
 	}
 
 	private static <E, C extends Collection<E>> C combiner(C t, C u) {

--- a/biz.aQute.bnd/src/aQute/bnd/main/XRefCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/XRefCommand.java
@@ -158,7 +158,7 @@ public class XRefCommand {
 		return packages.values()
 			.stream()
 			.flatMap(List::stream)
-			.collect(Collectors.toCollection(TreeSet::new));
+			.collect(Collectors.toCollection(TreeSet<T>::new));
 	}
 
 	private void printReferred(String referrredTo, String joined) throws FileNotFoundException {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2206,7 +2206,7 @@ public class Project extends Processor {
 		Map<String, Action> actions = MapStream.of(all)
 			.mapKey(key -> getReplacer().process(key))
 			.filterKey(Strings::nonNullOrTrimmedEmpty)
-			.collect(MapStream.toMap((u, v) -> v, LinkedHashMap::new));
+			.collect(MapStream.toMap((u, v) -> v, LinkedHashMap<String, Action>::new));
 		return actions;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/cdi/CDIAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/cdi/CDIAnnotations.java
@@ -102,7 +102,7 @@ public class CDIAnnotations implements AnalyzerPlugin {
 					Resource beansResource = currentJar.getResource(Processor.appendPath(path, "META-INF/beans.xml"));
 					return findDiscoveryMode(beansResource);
 				}
-			}), (u, v) -> u, HashMap::new));
+			}), (u, v) -> u, HashMap<String, Discover>::new));
 
 		Instructions instructions = new Instructions(header);
 		Packages contained = analyzer.getContained();

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/PomResource.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Supplier;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -345,7 +344,7 @@ public class PomResource extends WriteResource {
 			dependencies.stream()
 				.mapKey(Processor::removeDuplicateMarker)
 				.collect(MapStream.toMap((oldValue, value) -> value,
-					(Supplier<Map<String, Attrs>>) LinkedHashMap::new))
+					LinkedHashMap<String, Attrs>::new))
 				.values()
 				.forEach(attrs -> tdependencies.addContent(new Tag("dependency").addContent(attrs)));
 			if (!tdependencies.getContents()

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1214,7 +1214,8 @@ public class Analyzer extends Processor {
 			profiles = OSGiHeader.parseProperties(ee)
 				.stream()
 				.mapValue(v -> Strings.splitAsStream(v)
-					.collect(Collectors.collectingAndThen(toList(), SortedList::new)))
+					.collect(Collectors.collectingAndThen(toList(),
+						SortedList<String>::new)))
 				.collect(MapStream.toMap());
 		}
 		SortedSet<String> found = new TreeSet<>();
@@ -2087,7 +2088,7 @@ public class Analyzer extends Processor {
 			.distinct()
 			.filter(this::isProvider)
 			.map(TypeRef::getPackageRef)
-			.collect(toCollection(LinkedHashSet::new));
+			.collect(toCollection(LinkedHashSet<PackageRef>::new));
 		return providers;
 	}
 
@@ -3189,7 +3190,7 @@ public class Analyzer extends Processor {
 			.stream()
 			.filter(packageRef -> !packageRef.isMetaData())
 			.sorted()
-			.collect(toCollection(LinkedList::new));
+			.collect(toCollection(LinkedList<PackageRef>::new));
 
 		if (nomatch == null)
 			nomatch = Create.set();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1787,7 +1787,7 @@ public class Macro {
 
 		Deque<String> reversed = Arrays.stream(args, 1, args.length)
 			.flatMap(Strings::splitQuotedAsStream)
-			.collect(Collector.of(ArrayDeque::new, (deq, t) -> deq.addFirst(t), (d1, d2) -> {
+			.collect(Collector.of(ArrayDeque<String>::new, (deq, t) -> deq.addFirst(t), (d1, d2) -> {
 				d2.addAll(d1);
 				return d2;
 			}));
@@ -2146,7 +2146,7 @@ public class Macro {
 					} catch (Throwable e) {
 						throw Exceptions.duck(e);
 					}
-				}, (u, v) -> u, TreeMap::new));
+				}, (u, v) -> u, TreeMap<String, String>::new));
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
@@ -104,7 +104,7 @@ public class PermissionGenerator {
 			.map(attrs -> attrs.get(ServiceNamespace.CAPABILITY_OBJECTCLASS_ATTRIBUTE))
 			.filter(Objects::nonNull)
 			.flatMap(Strings::splitAsStream)
-			.collect(toCollection(TreeSet::new));
+			.collect(toCollection(TreeSet<String>::new));
 		return declaredServices;
 	}
 
@@ -174,7 +174,7 @@ public class PermissionGenerator {
 			.flatMap(filter -> new FilterParser().parse(filter)
 				.visit(new FindReferencedServices())
 				.stream())
-			.collect(toCollection(TreeSet::new));
+			.collect(toCollection(TreeSet<String>::new));
 
 		if (referencedServices.contains(MATCH_ALL)) {
 			return Collections.singleton(MATCH_ALL);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/ResourcesRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/ResourcesRepository.java
@@ -88,7 +88,7 @@ public class ResourcesRepository extends BaseRepository {
 	}
 
 	public static Collector<Capability, List<Capability>, List<Capability>> toCapabilities() {
-		return Collector.of(ArrayList::new, ResourcesRepository::accumulator, ResourcesRepository::merger);
+		return Collector.of(ArrayList<Capability>::new, ResourcesRepository::accumulator, ResourcesRepository::merger);
 	}
 
 	private static <E, C extends Collection<E>> void accumulator(C c, E e) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -488,7 +488,7 @@ public class ResourceUtils {
 			// ContentCapability::osgi_content values.
 			// .collect(toMap(ContentCapability::url,
 			// ContentCapability::osgi_content));
-			.collect(Collector.of(HashMap::new, (m, c) -> m.put(c.url(), c.osgi_content()), (m1, m2) -> {
+			.collect(Collector.of(HashMap<URI, String>::new, (m, c) -> m.put(c.url(), c.osgi_content()), (m1, m2) -> {
 				m1.putAll(m2);
 				return m1;
 			}));

--- a/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSModuleInfoPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSModuleInfoPlugin.java
@@ -210,7 +210,7 @@ public class JPMSModuleInfoPlugin implements VerifierPlugin {
 				Attrs containedAttrs = contained.get(packageRef);
 				if (containedAttrs != null && containedAttrs.containsKey(INTERNAL_EXPORT_TO_MODULES_DIRECTIVE)) {
 					targets = splitAsStream(containedAttrs.get(INTERNAL_EXPORT_TO_MODULES_DIRECTIVE))
-						.collect(toCollection(LinkedHashSet::new));
+						.collect(toCollection(LinkedHashSet<String>::new));
 				}
 
 				// TODO Do we want to handle access? I can't think of a reason.
@@ -251,7 +251,7 @@ public class JPMSModuleInfoPlugin implements VerifierPlugin {
 			.filterValue(attrs -> attrs.containsKey(INTERNAL_OPEN_TO_MODULES_DIRECTIVE))
 			.forEach((packageRef, attrs) -> {
 				Set<String> targets = splitAsStream(attrs.get(INTERNAL_OPEN_TO_MODULES_DIRECTIVE))
-					.collect(toCollection(LinkedHashSet::new));
+					.collect(toCollection(LinkedHashSet<String>::new));
 
 				// TODO Do we want to handle access? I can't think of a reason.
 				// Allowed: 0 | ACC_SYNTHETIC | ACC_MANDATED
@@ -397,7 +397,7 @@ public class JPMSModuleInfoPlugin implements VerifierPlugin {
 					.map(attrs -> attrs.get(SERVICELOADER_REGISTER_DIRECTIVE))
 					.map(impl -> analyzer.getTypeRefFromFQN(impl)
 						.getBinary())
-					.collect(toCollection(LinkedHashSet::new));
+					.collect(toCollection(LinkedHashSet<String>::new));
 				builder.provides(typeRef.getBinary(), impls);
 			});
 	}

--- a/biz.aQute.bndlib/test/aQute/bnd/stream/MapStreamTest.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/stream/MapStreamTest.java
@@ -499,7 +499,7 @@ public class MapStreamTest {
 		Supplier<MapStream<String, String>> supplier = () -> MapStream.concat(MapStream.of(testMap),
 			MapStream.of(testMap));
 		LinkedHashMap<String, String> result = supplier.get()
-			.collect(MapStream.toMap((v1, v2) -> v1.concat(v2), LinkedHashMap::new));
+			.collect(MapStream.toMap((v1, v2) -> v1.concat(v2), LinkedHashMap<String, String>::new));
 		assertThat(result).isInstanceOf(LinkedHashMap.class)
 			.containsOnly(entry("key1", "value1value1"), entry("key2", "value2value2"), entry("key3", "value3value3"),
 				entry("key4", "value4value4"), entry("key5", "value5value5"));

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/MiniBundle.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/MiniBundle.java
@@ -54,7 +54,7 @@ public class MiniBundle implements Bundle, BundleContext, Closeable {
 	private volatile int					state;
 	private final JarFile					jar;
 	private final Headers					headers;
-	private final TreeMap<String, JarEntry>	entries;
+	private final Map<String, JarEntry>	entries;
 	private final File						jarFile;
 	private final URLClassLoader			loader;
 
@@ -76,7 +76,7 @@ public class MiniBundle implements Bundle, BundleContext, Closeable {
 				// .peek(entry -> fw.trace("entry %s",entry.getName()))
 				.collect(toMap(JarEntry::getName, Function.identity(), (u, v) -> {
 					throw new IllegalStateException(String.format("Duplicate jar entry %s", u));
-				}, TreeMap::new));
+				}, TreeMap<String, JarEntry>::new));
 		} catch (IOException e) {
 			throw new BundleException("Failure to create MiniBundle", BundleException.READ_ERROR, e);
 		}


### PR DESCRIPTION
For generic types, we specify the generics when using the ::new method
reference. This helps the compiler and removes some cast to Supplier
to establish the generic types.

