### PR TITLE
[newproject] Removed the Java Page

### DIFF
--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -78,7 +78,7 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard {
 		addPage(templatePage);
 		addPage(pageOne);
 		addPage(paramsPage);
-		addPage(pageTwo);
+		// addPage(pageTwo);
 	}
 
 	@Override


### PR DESCRIPTION
The original design was to have no Java project setup. However, during one release the wizard crashed with an NPE if we skipped that page. That seems to be fixed.

We decided to remove this page to see how this goes?

Attempt for #3824

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>


