### PR TITLE
tester: Flush more often to get progress messages to Eclipse

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -209,7 +209,6 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 	@Override
 	public void testPlanExecutionFinished(TestPlan testPlan) {
 		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
-		client.out.flush();
 		info("JUnitEclipseListener: testPlanExecutionFinished: Waiting .25 seconds");
 		try {
 			Thread.sleep(250L);
@@ -368,6 +367,7 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 
 		String message = key.concat(payload.toString());
 		client.out.println(message);
+		client.out.flush();
 		info("JUnitEclipseListener: %s", message);
 	}
 

--- a/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
@@ -103,7 +103,6 @@ public class JUnitEclipseReport implements TestReporter {
 	@Override
 	public void end() {
 		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
-		client.out.flush();
 		if (verbose) {
 			System.err.println("Test run ended; waiting .25 seconds");
 		}
@@ -157,6 +156,7 @@ public class JUnitEclipseReport implements TestReporter {
 
 		String message = key.concat(payload);
 		client.out.println(message);
+		client.out.flush();
 		if (verbose)
 			System.err.println(message);
 	}


### PR DESCRIPTION
The Eclipse JUnit view was slow to respond for test execution progress
for Bnd OSGi Test Launcher runs. More frequent flushing of the progress
messages to Eclipse seems to improve the UX.