### PR TITLE
fix scope handling at dependency resolution

### DIFF
--- a/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/DependencyResolver.java
+++ b/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/DependencyResolver.java
@@ -174,11 +174,6 @@ public class DependencyResolver {
 		List<RemoteRepository> remoteRepositories) throws MojoExecutionException {
 
 		for (DependencyNode node : nodes) {
-			if (!scopes.contains(node.getDependency()
-				.getScope())) {
-				continue;
-			}
-
 			List<RemoteRepository> combinedRepositories = new ArrayList<>(remoteRepositories);
 			combinedRepositories.addAll(node.getRepositories());
 
@@ -189,12 +184,17 @@ public class DependencyResolver {
 				logger.debug("Located file: {} for artifact {}", resolvedArtifact.getArtifact()
 					.getFile(), resolvedArtifact);
 
-				files.put(resolvedArtifact.getArtifact()
-					.getFile(), resolvedArtifact);
+				// Add artifact only if the scope of this artifact matches.
+				if (scopes.contains(node.getDependency()
+					.getScope())) {
+					files.put(resolvedArtifact.getArtifact()
+						.getFile(), resolvedArtifact);
+				}
 			} catch (ArtifactResolutionException e) {
 				throw new MojoExecutionException("Failed to resolve the dependency " + node.getArtifact()
 					.toString(), e);
 			}
+
 			if (includeTransitive) {
 				discoverArtifacts(files, node.getChildren(), node.getRequestContext(), combinedRepositories);
 			} else {


### PR DESCRIPTION
At dependency resolution the scope should be used to identify if an artifact should be added or not.
It must not be used to skip the whole part of a tree as the childs of a tree node could use a different scope then one of its predecessor.

Related to: https://github.com/bndtools/bnd/issues/3783