### PR TITLE
xml: Centralize XML factory object creation for proper configuration

### DIFF
--- a/aQute.libg/src/aQute/lib/xml/XML.java
+++ b/aQute.libg/src/aQute/lib/xml/XML.java
@@ -1,0 +1,174 @@
+package aQute.lib.xml;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.TransformerFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+// https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
+
+public final class XML {
+	private static final Logger logger = LoggerFactory.getLogger(XML.class);
+
+	private XML() {}
+
+	/**
+	 * Create and return a DocumentBuilderFactory instance.
+	 * <p>
+	 * The returned DocumentBuilderFactory is configured to avoid XML External
+	 * Entity (XXE) attacks.
+	 *
+	 * @return A properly configured DocumentBuilderFactory instance.
+	 */
+	public static DocumentBuilderFactory newDocumentBuilderFactory() {
+		DocumentBuilderFactory instance = DocumentBuilderFactory.newInstance();
+		instance.setXIncludeAware(false);
+		instance.setExpandEntityReferences(false);
+		try {
+			instance.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		} catch (ParserConfigurationException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl", true);
+			} catch (ParserConfigurationException e2) {
+				logger.info(
+					"Unable to set feature to disallow DTD (doctypes): XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		try {
+			instance.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		} catch (ParserConfigurationException e) {
+			logger.info("Unable to set feature to disable load-external-dtd: XML External Entity (XXE) attack risk", e);
+		}
+		try {
+			instance.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		} catch (ParserConfigurationException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#external-general-entities",
+					false);
+			} catch (ParserConfigurationException e2) {
+				logger.info(
+					"Unable to set feature to disallow external-general-entities: XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		try {
+			instance.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		} catch (ParserConfigurationException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities",
+					false);
+			} catch (ParserConfigurationException e2) {
+				logger.info(
+					"Unable to set feature to disallow external-parameter-entities: XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		return instance;
+	}
+
+	/**
+	 * Create and return a SAXParserFactory instance.
+	 * <p>
+	 * The returned SAXParserFactory is configured to avoid XML External Entity
+	 * (XXE) attacks.
+	 *
+	 * @return A properly configured SAXParserFactory instance.
+	 */
+	public static SAXParserFactory newSAXParserFactory() {
+		SAXParserFactory instance = SAXParserFactory.newInstance();
+		instance.setXIncludeAware(false);
+		try {
+			instance.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl", true);
+			} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e2) {
+				logger.info("Unable to set feature to disallow DTD (doctypes): XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		try {
+			instance.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#external-general-entities",
+					false);
+			} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e2) {
+				logger.info(
+					"Unable to set feature to disallow external-general-entities: XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		try {
+			instance.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+			try { // Xerces 2 only fallback
+				instance.setFeature("http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities",
+					false);
+			} catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e2) {
+				logger.info(
+					"Unable to set feature to disallow external-parameter-entities: XML External Entity (XXE) attack risk",
+					e);
+			}
+		}
+		return instance;
+	}
+
+	/**
+	 * Create and return a XMLInputFactory instance.
+	 * <p>
+	 * The returned XMLInputFactory is configured to avoid XML External Entity
+	 * (XXE) attacks.
+	 *
+	 * @return A properly configured XMLInputFactory instance.
+	 */
+	public static XMLInputFactory newXMLInputFactory() {
+		XMLInputFactory instance = XMLInputFactory.newInstance();
+		try {
+			instance.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+		} catch (IllegalArgumentException e) {
+			logger.info("Unable to set property {} to false: XML External Entity (XXE) attack risk",
+				XMLInputFactory.SUPPORT_DTD, e);
+		}
+		try {
+			instance.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+		} catch (IllegalArgumentException e) {
+			logger.info("Unable to set property {} to false: XML External Entity (XXE) attack risk",
+				XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, e);
+		}
+		return instance;
+	}
+
+	/**
+	 * Create and return a TransformerFactory instance.
+	 * <p>
+	 * The returned TransformerFactory is configured to avoid XML External
+	 * Entity (XXE) attacks.
+	 *
+	 * @return A properly configured TransformerFactory instance.
+	 */
+	public static TransformerFactory newTransformerFactory() {
+		TransformerFactory instance = TransformerFactory.newInstance();
+		try {
+			instance.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		} catch (IllegalArgumentException e) {
+			logger.info("Unable to set attribute {} to \"\": XML External Entity (XXE) attack risk",
+				XMLConstants.ACCESS_EXTERNAL_DTD, e);
+		}
+		try {
+			instance.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		} catch (IllegalArgumentException e) {
+			logger.info("Unable to set attribute {} to \"\": XML External Entity (XXE) attack risk",
+				XMLConstants.ACCESS_EXTERNAL_STYLESHEET, e);
+		}
+		return instance;
+	}
+}

--- a/aQute.libg/src/aQute/lib/xml/package-info.java
+++ b/aQute.libg/src/aQute/lib/xml/package-info.java
@@ -1,0 +1,4 @@
+@Version("1.0.0")
+package aQute.lib.xml;
+
+import org.osgi.annotation.versioning.Version;

--- a/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
+++ b/aQute.libg/src/aQute/lib/xmldtoparser/DomDTOParser.java
@@ -25,13 +25,14 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
 import aQute.lib.converter.Converter;
+import aQute.lib.xml.XML;
 
 /**
  * Parse an XML file based on a DTO as schema
  */
 public class DomDTOParser {
 
-	final static DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory dbf = XML.newDocumentBuilderFactory();
 
 	/**
 	 * parse the given XML file based on the type as the schema. Attributes and

--- a/aQute.libg/src/aQute/lib/xpath/XPathParser.java
+++ b/aQute.libg/src/aQute/lib/xpath/XPathParser.java
@@ -21,9 +21,10 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import aQute.lib.converter.Converter;
+import aQute.lib.xml.XML;
 
 public class XPathParser {
-	final static DocumentBuilderFactory	dbf	= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	dbf	= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpf	= XPathFactory.newInstance();
 	final XPath							xp;
 	final Document						doc;

--- a/aQute.libg/src/aQute/libg/sax/SAXUtil.java
+++ b/aQute.libg/src/aQute/libg/sax/SAXUtil.java
@@ -1,18 +1,18 @@
 package aQute.libg.sax;
 
-import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Result;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.XMLReader;
 
+import aQute.lib.xml.XML;
+
 public class SAXUtil {
 
 	public static XMLReader buildPipeline(Result output, ContentFilter... filters) throws Exception {
-		SAXTransformerFactory factory = (SAXTransformerFactory) TransformerFactory.newInstance();
+		SAXTransformerFactory factory = (SAXTransformerFactory) XML.newTransformerFactory();
 		TransformerHandler handler = factory.newTransformerHandler();
 		handler.setResult(output);
 
@@ -22,7 +22,8 @@ public class SAXUtil {
 				filter.setParent(last);
 				last = filter;
 			}
-		XMLReader reader = SAXParserFactory.newInstance()
+		XMLReader reader = XML
+			.newSAXParserFactory()
 			.newSAXParser()
 			.getXMLReader();
 		reader.setContentHandler(last);

--- a/aQute.libg/src/aQute/libg/xslt/Transform.java
+++ b/aQute.libg/src/aQute/libg/xslt/Transform.java
@@ -15,8 +15,10 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import aQute.lib.xml.XML;
+
 public class Transform {
-	static TransformerFactory	transformerFactory	= TransformerFactory.newInstance();
+	static TransformerFactory	transformerFactory	= XML.newTransformerFactory();
 
 	static Map<URI, Templates>	cache				= new ConcurrentHashMap<>();
 

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/ComponentsPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/ComponentsPlugin.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.jar.Manifest;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -27,6 +26,7 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.reporter.ReportEntryPlugin;
+import aQute.lib.xml.XML;
 import aQute.service.reporter.Reporter;
 import biz.aQute.bnd.reporter.component.dto.ComponentDescriptionDTO;
 import biz.aQute.bnd.reporter.component.dto.ReferenceDTO;
@@ -86,7 +86,7 @@ public class ComponentsPlugin implements ReportEntryPlugin<Jar>, Plugin {
 		Objects.requireNonNull(locale, "locale");
 
 		final Set<String> componentPaths = new HashSet<>();
-		final DocumentBuilder db = DocumentBuilderFactory.newInstance()
+		final DocumentBuilder db = XML.newDocumentBuilderFactory()
 			.newDocumentBuilder();
 
 		try {

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/GogoPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/GogoPlugin.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -37,6 +36,7 @@ import aQute.bnd.osgi.ParameterAnnotation;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.reporter.ReportEntryPlugin;
+import aQute.lib.xml.XML;
 import aQute.service.reporter.Reporter;
 import biz.aQute.bnd.reporter.generator.EntryNamesReference;
 import biz.aQute.bnd.reporter.gogo.dto.GogoArgumentDTO;
@@ -84,7 +84,7 @@ public class GogoPlugin implements ReportEntryPlugin<Jar>, Plugin {
 		Objects.requireNonNull(locale, "locale");
 
 		final List<GogoScopeDTO> gogoCommands = new LinkedList<>();
-		final DocumentBuilder db = DocumentBuilderFactory.newInstance()
+		final DocumentBuilder db = XML.newDocumentBuilderFactory()
 			.newDocumentBuilder();
 
 		findComponentResources(jar).forEach((path, resource) -> {

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/MetatypesPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/entries/bundle/MetatypesPlugin.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -23,6 +22,7 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.reporter.ReportEntryPlugin;
+import aQute.lib.xml.XML;
 import aQute.service.reporter.Reporter;
 import biz.aQute.bnd.reporter.component.dto.AttributeDefinitionDTO;
 import biz.aQute.bnd.reporter.component.dto.IconDTO;
@@ -78,7 +78,7 @@ public class MetatypesPlugin implements ReportEntryPlugin<Jar>, Plugin {
 		Objects.requireNonNull(jar, "jar");
 		Objects.requireNonNull(locale, "locale");
 
-		final DocumentBuilder db = DocumentBuilderFactory.newInstance()
+		final DocumentBuilder db = XML.newDocumentBuilderFactory()
 			.newDocumentBuilder();
 
 		final List<ObjectClassDefinitionDTO> metas = new LinkedList<>();

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/resource/converter/XmlConverterPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/resource/converter/XmlConverterPlugin.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
+import aQute.lib.xml.XML;
 import biz.aQute.bnd.reporter.service.resource.converter.ResourceConverterPlugin;
 
 public class XmlConverterPlugin implements ResourceConverterPlugin {
@@ -31,7 +32,7 @@ public class XmlConverterPlugin implements ResourceConverterPlugin {
 
 	public XmlConverterPlugin() {
 		try {
-			final DocumentBuilderFactory b = DocumentBuilderFactory.newInstance();
+			final DocumentBuilderFactory b = XML.newDocumentBuilderFactory();
 			b.setNamespaceAware(true);
 			_db = b.newDocumentBuilder();
 		} catch (final ParserConfigurationException exception) {

--- a/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/XsltTransformerPlugin.java
+++ b/biz.aQute.bnd.reporter/src/biz/aQute/bnd/reporter/plugins/transformer/XsltTransformerPlugin.java
@@ -13,6 +13,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import aQute.bnd.service.reporter.ReportTransformerPlugin;
+import aQute.lib.xml.XML;
 
 public class XsltTransformerPlugin implements ReportTransformerPlugin {
 	static private final String[]		_extT				= {
@@ -22,7 +23,7 @@ public class XsltTransformerPlugin implements ReportTransformerPlugin {
 		"xml"
 	};
 
-	private final TransformerFactory	_transformerFactory	= TransformerFactory.newInstance();
+	private final TransformerFactory	_transformerFactory	= XML.newTransformerFactory();
 
 	@Override
 	public String[] getHandledTemplateExtensions() {

--- a/biz.aQute.bnd.test/src/aQute/bnd/test/XmlTester.java
+++ b/biz.aQute.bnd.test/src/aQute/bnd/test/XmlTester.java
@@ -17,8 +17,10 @@ import javax.xml.xpath.XPathFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import aQute.lib.xml.XML;
+
 public class XmlTester {
-	final static DocumentBuilderFactory	dbf		= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	dbf		= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpathf	= XPathFactory.newInstance();
 
 	static {

--- a/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
@@ -55,13 +55,14 @@ import aQute.lib.getopt.Description;
 import aQute.lib.getopt.Options;
 import aQute.lib.io.IO;
 import aQute.lib.tag.Tag;
+import aQute.lib.xml.XML;
 
 /**
  * Implements commands to maintain the Package versions db.
  */
 public class BaselineCommands {
 	private final static Logger	logger				= LoggerFactory.getLogger(BaselineCommands.class);
-	static TransformerFactory	transformerFactory	= TransformerFactory.newInstance();
+	static TransformerFactory	transformerFactory	= XML.newTransformerFactory();
 	final bnd					bnd;
 	final Baseline				baseline;
 	final DiffPluginImpl		differ				= new DiffPluginImpl();

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -131,6 +131,7 @@ import aQute.lib.settings.Settings;
 import aQute.lib.strings.Strings;
 import aQute.lib.tag.Tag;
 import aQute.lib.utf8properties.UTF8Properties;
+import aQute.lib.xml.XML;
 import aQute.libg.classdump.ClassDumper;
 import aQute.libg.cryptography.MD5;
 import aQute.libg.cryptography.SHA1;
@@ -2218,7 +2219,7 @@ public class bnd extends Processor {
 
 	private void doPerReport(Tag report, File file) throws Exception {
 		try {
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			DocumentBuilderFactory factory = XML.newDocumentBuilderFactory();
 			factory.setNamespaceAware(true); // never forget this!
 			DocumentBuilder builder = factory.newDocumentBuilder();
 			Document doc = builder.parse(file);
@@ -2250,7 +2251,7 @@ public class bnd extends Processor {
 		File html = new File(path);
 		logger.debug("Creating html report: {}", html);
 
-		TransformerFactory fact = TransformerFactory.newInstance();
+		TransformerFactory fact = XML.newTransformerFactory();
 
 		try (InputStream in = getClass().getResourceAsStream("testreport.xsl")) {
 			if (in == null) {

--- a/biz.aQute.bndlib.tests/test/test/MavenTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MavenTest.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
@@ -39,6 +38,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.Strategy;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 import junit.framework.TestCase;
 
 @SuppressWarnings("resource")
@@ -361,7 +361,8 @@ public class MavenTest extends TestCase {
 		assertTrue(b.check());
 		Resource r = jar.getResource(where);
 		IO.copy(r.openInputStream(), System.out);
-		Document d = DocumentBuilderFactory.newInstance()
+		Document d = XML
+			.newDocumentBuilderFactory()
 			.newDocumentBuilder()
 			.parse(r.openInputStream());
 		XPath xpath = XPathFactory.newInstance()

--- a/biz.aQute.bndlib.tests/test/test/component/ComponentTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/ComponentTest.java
@@ -31,6 +31,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.lib.io.IO;
 import aQute.lib.io.IOConstants;
+import aQute.lib.xml.XML;
 import junit.framework.TestCase;
 
 /**
@@ -42,7 +43,7 @@ import junit.framework.TestCase;
 public class ComponentTest extends TestCase {
 	static final int					BUFFER_SIZE	= IOConstants.PAGE_SIZE * 1;
 
-	static final DocumentBuilderFactory	dbf			= DocumentBuilderFactory.newInstance();
+	static final DocumentBuilderFactory	dbf			= XML.newDocumentBuilderFactory();
 	static final XPathFactory			xpathf		= XPathFactory.newInstance();
 	XPath								xpath;
 

--- a/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
@@ -93,6 +93,7 @@ public class PermissionGeneratorTest extends TestCase {
             "aQute.bnd.version",
             "aQute.lib.filter",
             "aQute.lib.io",
+            "aQute.lib.xml",
             "aQute.service.reporter",
             "javax.xml.namespace",
             "javax.xml.parsers",

--- a/biz.aQute.bndlib/src/aQute/bnd/cdi/CDIAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/cdi/CDIAnnotations.java
@@ -42,28 +42,18 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.AnalyzerPlugin;
 import aQute.bnd.version.Version;
-import aQute.lib.exceptions.Exceptions;
 import aQute.lib.exceptions.FunctionWithException;
 import aQute.lib.strings.Strings;
+import aQute.lib.xml.XML;
 import aQute.libg.glob.PathSet;
 
 /**
  * Analyze the class space for any classes that have an OSGi annotation for CCR.
  */
 public class CDIAnnotations implements AnalyzerPlugin {
-	static final DocumentBuilderFactory	dbf	= DocumentBuilderFactory.newInstance();
+	static final DocumentBuilderFactory		dbf					= XML.newDocumentBuilderFactory();
 	static final XPathFactory			xpf	= XPathFactory.newInstance();
 	private static final Predicate<String>	beansResourceFilter	= new PathSet("META-INF/beans.xml").matches();
-
-	static {
-		try {
-			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			dbf.setXIncludeAware(false);
-			dbf.setExpandEntityReferences(false);
-		} catch (Throwable t) {
-			throw Exceptions.duck(t);
-		}
-	}
 
 	@Override
 	public boolean analyzeJar(Analyzer analyzer) throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDependencyGraph.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDependencyGraph.java
@@ -18,8 +18,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import aQute.lib.xml.XML;
+
 public class MavenDependencyGraph {
-	final static DocumentBuilderFactory	docFactory		= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	docFactory		= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpathFactory	= XPathFactory.newInstance();
 	final List<Artifact>				dependencies	= new ArrayList<>();
 	final List<URL>						repositories	= new ArrayList<>();

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/PomParser.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/PomParser.java
@@ -22,6 +22,7 @@ import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Processor;
 import aQute.lib.io.IO;
 import aQute.lib.utf8properties.UTF8Properties;
+import aQute.lib.xml.XML;
 
 /**
  * Provides a way to parse a maven pom as properties. This provides most of the
@@ -31,7 +32,7 @@ import aQute.lib.utf8properties.UTF8Properties;
  * for this.
  */
 public class PomParser extends Processor {
-	static DocumentBuilderFactory	dbf			= DocumentBuilderFactory.newInstance();
+	static DocumentBuilderFactory	dbf			= XML.newDocumentBuilderFactory();
 	static XPathFactory				xpathf		= XPathFactory.newInstance();
 	static Set<String>				multiple	= new HashSet<>();
 	static Set<String>				skip		= new HashSet<>();

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/support/Pom.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/support/Pom.java
@@ -22,11 +22,12 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 import aQute.libg.reporter.ReporterAdapter;
 import aQute.service.reporter.Reporter;
 
 public abstract class Pom {
-	static DocumentBuilderFactory	dbf	= DocumentBuilderFactory.newInstance();
+	static DocumentBuilderFactory	dbf	= XML.newDocumentBuilderFactory();
 	static XPathFactory				xpf	= XPathFactory.newInstance();
 
 	static {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/eclipse/EclipseClasspath.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/eclipse/EclipseClasspath.java
@@ -22,6 +22,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import aQute.lib.xml.XML;
 import aQute.service.reporter.Reporter;
 
 /**
@@ -30,7 +31,7 @@ import aQute.service.reporter.Reporter;
  * problems. @version $Revision: 1.2 $
  */
 public class EclipseClasspath {
-	static final DocumentBuilderFactory	documentBuilderFactory	= DocumentBuilderFactory.newInstance();
+	static final DocumentBuilderFactory	documentBuilderFactory	= XML.newDocumentBuilderFactory();
 	File								project;
 	File								workspace;
 	Set<File>							sources					= new LinkedHashSet<>();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/XMLResourceParser.java
@@ -24,16 +24,16 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.lib.strings.Strings;
+import aQute.lib.xml.XML;
 import aQute.libg.gzip.GZipUtils;
 
 public class XMLResourceParser extends Processor {
 	private final static Logger		logger			= LoggerFactory.getLogger(XMLResourceParser.class);
-	final static XMLInputFactory	inputFactory	= XMLInputFactory.newInstance();
+	final static XMLInputFactory	inputFactory	= XML.newXMLInputFactory();
 
 	static {
 		inputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
 		inputFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
-		inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 	}
 
 	private static final String		NS_URI						= "http://www.osgi.org/xmlns/repository/v1.0.0";

--- a/biz.aQute.bndlib/src/aQute/lib/spring/SpringComponent.java
+++ b/biz.aQute.bndlib/src/aQute/lib/spring/SpringComponent.java
@@ -25,6 +25,7 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.service.AnalyzerPlugin;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 
 /**
  * This component is called when we find a resource in the META-INF/*.xml
@@ -43,7 +44,7 @@ public class SpringComponent implements AnalyzerPlugin {
 
 	public static Set<CharSequence> analyze(InputStream in) throws Exception {
 		if (transformer == null) {
-			TransformerFactory tf = TransformerFactory.newInstance();
+			TransformerFactory tf = XML.newTransformerFactory();
 			Source source = new StreamSource(SpringComponent.class.getResourceAsStream("extract.xsl"));
 			transformer = tf.newTransformer(source);
 		}

--- a/biz.aQute.bndlib/src/aQute/lib/spring/XMLType.java
+++ b/biz.aQute.bndlib/src/aQute/lib/spring/XMLType.java
@@ -22,6 +22,7 @@ import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 
 public class XMLType {
 
@@ -122,7 +123,7 @@ public class XMLType {
 	}
 
 	protected Transformer getTransformer(java.net.URL url) throws Exception {
-		TransformerFactory tf = TransformerFactory.newInstance();
+		TransformerFactory tf = XML.newTransformerFactory();
 		Source source = new StreamSource(url.openStream());
 		return tf.newTransformer(source);
 	}

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/R5RepoContentProvider.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/providers/R5RepoContentProvider.java
@@ -30,6 +30,7 @@ import aQute.bnd.osgi.repository.SimpleIndexer;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.service.Registry;
+import aQute.lib.xml.XML;
 
 public class R5RepoContentProvider implements IRepositoryContentProvider {
 
@@ -78,11 +79,10 @@ public class R5RepoContentProvider implements IRepositoryContentProvider {
 	public CheckResult checkStream(String name, InputStream stream) throws IOException {
 		XMLStreamReader reader = null;
 		try {
-			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+			XMLInputFactory inputFactory = XML.newXMLInputFactory();
 
 			inputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
 			inputFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
-			inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 
 			reader = inputFactory.createXMLStreamReader(stream);
 			ParserState state = ParserState.beforeRoot;
@@ -157,11 +157,10 @@ public class R5RepoContentProvider implements IRepositoryContentProvider {
 		throws Exception {
 		XMLStreamReader reader = null;
 		try {
-			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+			XMLInputFactory inputFactory = XML.newXMLInputFactory();
 
 			inputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
 			inputFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
-			inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 
 			reader = inputFactory.createXMLStreamReader(stream);
 

--- a/biz.aQute.repository/src/aQute/maven/provider/MetadataParser.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MetadataParser.java
@@ -16,6 +16,7 @@ import aQute.bnd.version.MavenVersion;
 import aQute.lib.date.Dates;
 import aQute.lib.io.IO;
 import aQute.lib.tag.Tag;
+import aQute.lib.xml.XML;
 
 /**
  * Utilities to parse the metadata XML files. Maven uses a single XSD (see
@@ -27,7 +28,7 @@ import aQute.lib.tag.Tag;
  * overlap. The parser is a best effort, no validation will take place.
  */
 public class MetadataParser {
-	final static XMLInputFactory	inputFactory		= XMLInputFactory.newInstance();
+	final static XMLInputFactory	inputFactory	= XML.newXMLInputFactory();
 	static final DateTimeFormatter	MAVEN_DATE_TIME	= DateTimeFormatter.ofPattern("yyyyMMddHHmmss", Locale.ROOT)
 		.withZone(Dates.UTC_ZONE_ID);
 

--- a/biz.aQute.repository/src/aQute/maven/provider/POM.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/POM.java
@@ -37,6 +37,7 @@ import aQute.lib.io.ByteBufferInputStream;
 import aQute.lib.io.ByteBufferOutputStream;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
+import aQute.lib.xml.XML;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IPom;
 import aQute.maven.api.MavenScope;
@@ -49,7 +50,7 @@ import aQute.maven.api.Revision;
 public class POM implements IPom {
 	static Logger						l						= LoggerFactory.getLogger(POM.class);
 
-	static DocumentBuilderFactory		dbf						= DocumentBuilderFactory.newInstance();
+	static DocumentBuilderFactory		dbf						= XML.newDocumentBuilderFactory();
 	static XPathFactory					xpf						= XPathFactory.newInstance();
 	private Revision					revision;
 	private String						packaging;

--- a/biz.aQute.repository/src/aQute/p2/provider/ArtifactRepository.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/ArtifactRepository.java
@@ -45,7 +45,7 @@ import aQute.p2.api.Classifier;
  * @formatter:on
  */
 
-class ArtifactRepository extends XML {
+class ArtifactRepository extends XMLBase {
 
 	static class Rule {
 		final Filter	filter;

--- a/biz.aQute.repository/src/aQute/p2/provider/CompositeArtifacts.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/CompositeArtifacts.java
@@ -30,7 +30,7 @@ import aQute.lib.strings.Strings;
  * </pre>
  */
 
-class CompositeArtifacts extends XML {
+class CompositeArtifacts extends XMLBase {
 	final List<URI>	uris	= new ArrayList<>();
 	final URI		base;
 

--- a/biz.aQute.repository/src/aQute/p2/provider/Feature.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/Feature.java
@@ -14,7 +14,7 @@ import org.w3c.dom.NodeList;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Resource;
 
-public class Feature extends XML {
+public class Feature extends XMLBase {
 
 	public static class Plugin {
 		public String	id;
@@ -42,7 +42,7 @@ public class Feature extends XML {
 			if (resource == null) {
 				throw new IllegalArgumentException("JAR does not contain proper 'feature.xml");
 			}
-			DocumentBuilder db = XML.dbf.newDocumentBuilder();
+			DocumentBuilder db = XMLBase.dbf.newDocumentBuilder();
 			Document doc = db.parse(resource.openInputStream());
 			return doc;
 		}

--- a/biz.aQute.repository/src/aQute/p2/provider/TargetImpl.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/TargetImpl.java
@@ -31,6 +31,7 @@ import aQute.bnd.service.url.TaggedData;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 import aQute.p2.api.Artifact;
 import aQute.p2.api.ArtifactProvider;
 import aQute.p2.api.Classifier;
@@ -41,7 +42,7 @@ public class TargetImpl implements ArtifactProvider {
 	private static final String			FEATURE_GROUP_SUFFIX	= ".feature.group";
 	private static final Version		ZERO					= new Version("0");
 	final static Logger					logger					= LoggerFactory.getLogger(TargetImpl.class);
-	final static DocumentBuilderFactory	dbf						= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	dbf						= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpf						= XPathFactory.newInstance();
 
 	final Unpack200						processor;

--- a/biz.aQute.repository/src/aQute/p2/provider/XMLBase.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/XMLBase.java
@@ -27,9 +27,10 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import aQute.lib.converter.Converter;
+import aQute.lib.xml.XML;
 
 class XMLBase {
-	final static DocumentBuilderFactory	dbf	= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	dbf	= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpf	= XPathFactory.newInstance();
 	final XPath							xp;
 	final Document						document;

--- a/biz.aQute.repository/src/aQute/p2/provider/XMLBase.java
+++ b/biz.aQute.repository/src/aQute/p2/provider/XMLBase.java
@@ -28,13 +28,13 @@ import org.xml.sax.SAXException;
 
 import aQute.lib.converter.Converter;
 
-public class XML {
+class XMLBase {
 	final static DocumentBuilderFactory	dbf	= DocumentBuilderFactory.newInstance();
 	final static XPathFactory			xpf	= XPathFactory.newInstance();
 	final XPath							xp;
 	final Document						document;
 
-	public XML(Document document) {
+	XMLBase(Document document) {
 		this.document = document;
 		xp = xpf.newXPath();
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -43,6 +43,7 @@ import aQute.bnd.service.progress.ProgressPlugin.Task;
 import aQute.bnd.version.Version;
 import aQute.http.testservers.HttpTestServer.Config;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IPom;
 import aQute.maven.api.MavenScope;
@@ -58,7 +59,7 @@ import junit.framework.TestCase;
  */
 public class MavenBndRepoTest extends TestCase {
 	private static final Version		DTO_VERSION	= Version.parseVersion("1.0.0.201505202023");
-	final static DocumentBuilderFactory	dbf			= DocumentBuilderFactory.newInstance();
+	final static DocumentBuilderFactory	dbf			= XML.newDocumentBuilderFactory();
 	final static XPathFactory			xpf			= XPathFactory.newInstance();
 	String								tmpName;
 	File								tmp;

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
@@ -37,6 +37,7 @@ import org.xmlunit.assertj.XmlAssert;
 
 import aQute.launchpad.LaunchpadBuilder;
 import aQute.lib.io.IO;
+import aQute.lib.xml.XML;
 import aQute.tester.test.assertions.CustomAssertionError;
 import aQute.tester.test.utils.ServiceLoaderMask;
 import aQute.tester.test.utils.TestEntry;
@@ -548,7 +549,7 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorTest {
 		AtomicReference<Document> docContainer = new AtomicReference<>();
 
 		Assertions.assertThatCode(() -> {
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilderFactory dbFactory = XML.newDocumentBuilderFactory();
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 			docContainer.set(dBuilder.parse(xmlFile));
 		})

--- a/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
@@ -16,6 +16,7 @@ import org.w3c.dom.Document;
 import org.xmlunit.assertj.XmlAssert;
 
 import aQute.junit.UnresolvedTester;
+import aQute.lib.xml.XML;
 import aQute.tester.test.assertions.CustomAssertionError;
 import aQute.tester.test.utils.TestRunData;
 import aQute.tester.testbase.AbstractActivatorTest;
@@ -134,7 +135,7 @@ public class ActivatorTest extends AbstractActivatorTest {
 		AtomicReference<Document> docContainer = new AtomicReference<>();
 
 		Assertions.assertThatCode(() -> {
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilderFactory dbFactory = XML.newDocumentBuilderFactory();
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 			docContainer.set(dBuilder.parse(xmlFile));
 		})

--- a/bndtools.pde/src/bndtools/pde/target/BndTargetLocation.java
+++ b/bndtools.pde/src/bndtools/pde/target/BndTargetLocation.java
@@ -4,10 +4,8 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -29,6 +27,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import aQute.lib.xml.XML;
 
 public abstract class BndTargetLocation extends AbstractBundleContainer
 	implements ITargetLocationUpdater, ITargetLocationEditor, ILabelProvider {
@@ -121,7 +121,8 @@ public abstract class BndTargetLocation extends AbstractBundleContainer
 	public String serialize() {
 		Document document;
 		try {
-			DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance()
+			DocumentBuilder docBuilder = XML
+				.newDocumentBuilderFactory()
 				.newDocumentBuilder();
 			document = docBuilder.newDocument();
 
@@ -132,7 +133,8 @@ public abstract class BndTargetLocation extends AbstractBundleContainer
 			serialize(document, locationElement);
 
 			StreamResult result = new StreamResult(new StringWriter());
-			Transformer transformer = TransformerFactory.newInstance()
+			Transformer transformer = XML
+				.newTransformerFactory()
 				.newTransformer();
 			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			transformer.transform(new DOMSource(document), result);

--- a/bndtools.pde/src/bndtools/pde/target/BndTargetLocationFactory.java
+++ b/bndtools.pde/src/bndtools/pde/target/BndTargetLocationFactory.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.bndtools.api.Logger;
 import org.eclipse.core.runtime.CoreException;
@@ -13,6 +12,8 @@ import org.eclipse.pde.core.target.ITargetLocationFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+
+import aQute.lib.xml.XML;
 
 public abstract class BndTargetLocationFactory implements ITargetLocationFactory {
 	private final String type;
@@ -26,7 +27,8 @@ public abstract class BndTargetLocationFactory implements ITargetLocationFactory
 		if (this.type.equals(type)) {
 			Element locationElement;
 			try {
-				DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance()
+				DocumentBuilder docBuilder = XML
+					.newDocumentBuilderFactory()
 					.newDocumentBuilder();
 				Document document = docBuilder.parse(new ByteArrayInputStream(serializedXML.getBytes("UTF-8")));
 				locationElement = document.getDocumentElement();


### PR DESCRIPTION
We need to properly configure XML factory objects to make sure they are
not vulnerable to certain security attacks such as XML External Entity
(XXE) attacks.

Fixes #3831