### PR TITLE
[gavs pom] A menu action to copy GAVs

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/BridgeRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/BridgeRepository.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.resource.Capability;
@@ -75,6 +76,7 @@ public class BridgeRepository {
 		boolean			error;
 		String			tooltip;
 		private String	title;
+		private String	name;
 
 		public String getTooltip() {
 			init();
@@ -102,7 +104,7 @@ public class BridgeRepository {
 			String sha256 = cc == null ? "<>" : cc.osgi_content();
 
 			String error = null;
-			String name = null;
+			name = null;
 			String from = null;
 
 			if (info != null) {
@@ -159,6 +161,11 @@ public class BridgeRepository {
 
 		public InfoCapability getInfo() {
 			return BridgeRepository.getInfo(resource);
+		}
+
+		public String getName() {
+			init();
+			return name;
 		}
 
 		public String getTitle() {
@@ -390,5 +397,13 @@ public class BridgeRepository {
 				.negate())
 			.findAny()
 			.orElse(null);
+	}
+
+	public List<ResourceInfo> getResourceInfos() {
+		return index.values()
+			.stream()
+			.flatMap(map -> map.values()
+				.stream())
+			.collect(Collectors.toList());
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/Clipboard.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/Clipboard.java
@@ -1,0 +1,26 @@
+package aQute.bnd.service.clipboard;
+
+import java.util.Optional;
+
+/**
+ * Abstraction of the clip board since this can vary per driver
+ */
+public interface Clipboard {
+	/**
+	 * Copy the content and return true if successful.
+	 *
+	 * @param <T> the type of the content
+	 * @param content the content
+	 * @return true if succesfully copied to the clipboard
+	 */
+	<T> boolean copy(T content);
+
+	/**
+	 * Get the content from the clipboard
+	 *
+	 * @param <T>
+	 * @param type the type to fetch
+	 * @return a instance or empty if no such type was on the clipboard
+	 */
+	<T> Optional<T> paste(Class<T> type);
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.bundle.Export
+package aQute.bnd.service.clipboard;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -1,6 +1,7 @@
 package aQute.bnd.repository.maven.pom.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 import java.io.Closeable;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,6 +38,7 @@ import aQute.bnd.service.Registry;
 import aQute.bnd.service.RegistryPlugin;
 import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.service.clipboard.Clipboard;
 import aQute.bnd.util.repository.DownloadListenerPromise;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
@@ -293,7 +296,23 @@ public class BndPomRepository extends BaseRepository
 
 	@Override
 	public Map<String, Runnable> actions(Object... target) throws Exception {
-		return null;
+		init();
+		Clipboard cb = registry.getPlugin(Clipboard.class);
+		if (cb == null)
+			return null;
+
+		Map<String, Runnable> menu = new TreeMap<>();
+		menu.put("Copy GAVs", () -> {
+			String gavs = bridge.getResourceInfos()
+				.stream()
+				.map(ri -> {
+
+					return ri.getName();
+				})
+				.collect(joining("\n"));
+			cb.copy(gavs);
+		});
+		return menu;
 	}
 
 	@Override

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -244,6 +244,7 @@ public class Central implements IStartupParticipant {
 
 					ws.setOffline(new BndPreferences().isWorkspaceOffline());
 
+					ws.addBasicPlugin(new SWTClipboard());
 					ws.addBasicPlugin(new WorkspaceListener(ws));
 					ws.addBasicPlugin(getInstance().repoListenerTracker);
 					ws.addBasicPlugin(getWorkspaceR5Repository());

--- a/bndtools.core/src/bndtools/central/SWTClipboard.java
+++ b/bndtools.core/src/bndtools/central/SWTClipboard.java
@@ -1,0 +1,48 @@
+package bndtools.central;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.swt.dnd.TextTransfer;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.widgets.Display;
+
+import aQute.bnd.service.clipboard.Clipboard;
+
+public class SWTClipboard implements Clipboard {
+	private static final Transfer[] TEXT_TRANSFER = new Transfer[] {
+		TextTransfer.getInstance()
+	};
+
+	@Override
+	public <T> boolean copy(T content) {
+		Display d = Display.getCurrent() == null ? Display.getDefault() : Display.getCurrent();
+		AtomicBoolean ok = new AtomicBoolean();
+		d.syncExec(() -> {
+			final org.eclipse.swt.dnd.Clipboard cb = new org.eclipse.swt.dnd.Clipboard(d);
+			if (content instanceof String) {
+				cb.setContents(new Object[] {
+					content
+				}, TEXT_TRANSFER);
+				ok.set(true);
+			}
+		});
+		return ok.get();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> Optional<T> paste(Class<T> type) {
+		Display d = Display.getCurrent() == null ? Display.getDefault() : Display.getCurrent();
+		AtomicReference<Optional<T>> ok = new AtomicReference<>(Optional.empty());
+		d.syncExec(() -> {
+			final org.eclipse.swt.dnd.Clipboard cb = new org.eclipse.swt.dnd.Clipboard(null);
+			if (type == String.class) {
+				String data = (String) cb.getContents(TEXT_TRANSFER[0]);
+				ok.set((Optional<T>) Optional.ofNullable(data));
+			}
+		});
+		return ok.get();
+	}
+}


### PR DESCRIPTION
A menu action on the BndPomRepository to copy
the GAVs from the POM (or search, or etc.) to
the clipboard so they can be used for a MavenBndRepository



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>