### PR TITLE
resolve: Move resolve debug output report out of synchronized init

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/clipboard/package-info.java
@@ -1,3 +1,2 @@
 @org.osgi.annotation.versioning.Version("1.0.0")
-@org.osgi.annotation.bundle.Export
 package aQute.bnd.service.clipboard;

--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -122,9 +122,8 @@ public class BndrunResolveContext extends AbstractResolveContext {
 		if (initialized)
 			return;
 
-		initialized = true;
-
 		try {
+			initialized = true;
 
 			if (getLevel() <= 0) {
 				Integer level = Converter.cnv(Integer.class, properties.getProperty("-resolvedebug", "0"));

--- a/biz.aQute.resolve/src/biz/aQute/resolve/GenericResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/GenericResolveContext.java
@@ -16,7 +16,7 @@ public class GenericResolveContext extends AbstractResolveContext {
 	protected static final String	IDENTITY_INITIAL_RESOURCE	= "<<INITIAL>>";
 	protected static final String	IDENTITY_SYSTEM_RESOURCE	= "<<SYSTEM>>";
 
-	private boolean					initialised					= false;
+	private boolean					initialized					= false;
 	private ResourceBuilder			system						= new ResourceBuilder();
 	private ResourceBuilder			input						= new ResourceBuilder();
 
@@ -26,20 +26,18 @@ public class GenericResolveContext extends AbstractResolveContext {
 
 	@Override
 	public synchronized void init() {
-		if (initialised)
+		if (initialized)
 			return;
 
 		try {
-
-			initialised = true;
+			initialized = true;
 
 			setInputResource(input.build());
 			setSystemResource(system.build());
-
-			super.init();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+		super.init();
 	}
 
 	public ResourceBuilder getInput() {


### PR DESCRIPTION
The debug report resulted in calling the resolver which called back
into the resolve context on another thread. Since the resolve context
was still initializing and held the init lock, the resolver could
deadlock.

So we move the debug report operation to after the
init operation completes and releases the init lock.

Fixes #3900