### PR TITLE
jar: Replace incorrect use of computeIfAbsent in putResource

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -326,7 +326,11 @@ public class Jar implements Closeable {
 		} else if (path.equals(Constants.MODULE_INFO_CLASS)) {
 			moduleAttribute = null;
 		}
-		Map<String, Resource> s = directories.computeIfAbsent(getParent(path), dir -> {
+		String dir = getParent(path);
+		Map<String, Resource> s = directories.get(dir);
+		if (s == null) {
+			s = new TreeMap<>();
+			directories.put(dir, s);
 			// make ancestor directories
 			for (int n; (n = dir.lastIndexOf('/')) > 0;) {
 				dir = dir.substring(0, n);
@@ -334,8 +338,7 @@ public class Jar implements Closeable {
 					break;
 				directories.put(dir, null);
 			}
-			return new TreeMap<>();
-		});
+		}
 		boolean duplicate = s.containsKey(path);
 		if (!duplicate || overwrite) {
 			resources.put(path, resource);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -987,7 +987,8 @@ public class Jar implements Closeable {
 	public List<String> getPackages() {
 		check();
 		return MapStream.of(directories)
-			.filterValue(Objects::nonNull)
+			.filterValue(mdir -> Objects.nonNull(mdir) && !mdir
+				.isEmpty())
 			.keys()
 			.map(k -> k.replace('/', '.'))
 			.collect(toList());


### PR DESCRIPTION
We may need to make multiple modifications to the directories map when
adding a resource. computeIfAbsent does not allow the mapping function
to modify the map.

Fixes #3903