### PR TITLE
Updates for Java version support

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
@@ -2,72 +2,32 @@ package test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.Manifest;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Clazz.JAVA;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
+import aQute.lib.io.FileTree;
 
 public class ClassReferenceTest {
-	class Inner {
-
-	}
-
-	static {
-		System.err.println(Inner.class);
-	}
-
-	/**
-	 * We create a JAR with the test.classreferenc.ClassReference class. This
-	 * class contains a javax.swing.Box.class reference Prior to Java 1.5, this
-	 * was done in a silly way that is handled specially. After 1.5 it is a
-	 * normal reference.
-	 *
-	 * @throws Exception
-	 */
-
 	@ParameterizedTest(name = "Check code in compilerversions/src/{arguments}")
-	@ValueSource(strings = {
-		"sun_1_1", //
-		"sun_1_2", //
-		"sun_1_3", //
-		"sun_1_4", //
-		"sun_1_5", //
-		"sun_jsr14", //
-		"sun_1_6", //
-		"sun_1_7", //
-		"sun_1_8", //
-		"jdk_9_0", //
-		"jdk_10_0", //
-		"jdk_11_0", //
-		"jdk_12_0", //
-		"jdk_13_0", //
-		"jdk_14_0", //
-		"eclipse_1_1", //
-		"eclipse_1_2", //
-		"eclipse_1_3", //
-		"eclipse_1_4", //
-		"eclipse_1_5", //
-		"eclipse_1_6", //
-		"eclipse_1_7", //
-		"eclipse_1_8", //
-		"eclipse_9_0", //
-		"eclipse_10_0", //
-		"eclipse_11_0", //
-		"eclipse_12_0", //
-		"eclipse_13_0", //
-		"eclipse_14_0" //
-	})
+	@ArgumentsSource(CompilerVersionsArgumentsProvider.class)
 	@DisplayName("Class Reference Test")
-	public void doit(String pkg) throws Exception {
+	public void classReferences(String pkg) throws Exception {
 		Properties properties = new Properties();
 		properties.put("-classpath", "compilerversions/compilerversions.jar");
 		System.out.println("compiler version " + pkg);
@@ -93,6 +53,18 @@ public class ClassReferenceTest {
 				.contains("javax.swing")
 				.as("Package %s should not contain ClassRef", pkg)
 				.doesNotContain("ClassRef");
+		}
+	}
+
+	static class CompilerVersionsArgumentsProvider implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+			FileTree tree = new FileTree();
+			List<File> files = tree.getFiles(new File("compilerversions/src"), "*");
+			return files.stream()
+				.filter(File::isDirectory)
+				.map(File::getName)
+				.map(Arguments::of);
 		}
 	}
 }

--- a/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
@@ -3,6 +3,7 @@ package test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -17,7 +18,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import aQute.bnd.build.model.EE;
 import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Clazz;
 import aQute.bnd.osgi.Clazz.JAVA;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
@@ -64,6 +67,23 @@ public class ClassReferenceTest {
 			return files.stream()
 				.filter(File::isDirectory)
 				.map(File::getName)
+				.map(Arguments::of);
+		}
+	}
+
+	@ParameterizedTest(name = "Validate EE exists for {arguments}")
+	@ArgumentsSource(JAVAArgumentsProvider.class)
+	@DisplayName("Validate an EE exists for each JAVA")
+	public void checkEEFor(Clazz.JAVA java) throws Exception {
+		EE ee = EE.parse(java.getEE());
+		assertThat(ee).isNotNull();
+	}
+
+	static class JAVAArgumentsProvider implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+			Clazz.JAVA[] values = Clazz.JAVA.values();
+			return Arrays.stream(values, 0, values.length - 1)
 				.map(Arguments::of);
 		}
 	}

--- a/biz.aQute.bndlib.tests/test/test/model/EETest.java
+++ b/biz.aQute.bndlib.tests/test/test/model/EETest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import aQute.bnd.build.model.EE;
+import aQute.bnd.osgi.Clazz;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
 
@@ -67,6 +68,26 @@ public class EETest {
 	public void failsWithNullInput() throws Exception {
 		assertThatExceptionOfType(NullPointerException.class).isThrownBy( //
 			() -> EE.highestFromTargetVersion(null));
+	}
+
+	@ParameterizedTest(name = "Validate JAVA exists for {arguments}")
+	@ArgumentsSource(EEsArgumentsProvider.class)
+	@DisplayName("Validate a JAVA exists for each EE")
+	public void checkJAVAFor(EE ee) throws Exception {
+		assertThat(Clazz.JAVA.values()).anyMatch(j -> j
+			.getEE()
+			.equals(ee.getEEName()));
+	}
+
+	static class EEsArgumentsProvider implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+			EE[] values = EE.values();
+			return Arrays.stream(values, 0, values.length - 1)
+				.filter(ee -> ee.getCapabilityName()
+					.indexOf('/') < 0)
+				.map(Arguments::of);
+		}
 	}
 
 }

--- a/biz.aQute.bndlib.tests/test/test/model/EETest.java
+++ b/biz.aQute.bndlib.tests/test/test/model/EETest.java
@@ -3,39 +3,57 @@ package test.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import aQute.bnd.build.model.EE;
+import aQute.bnd.version.MavenVersion;
+import aQute.bnd.version.Version;
 
 public class EETest {
 
+	@ParameterizedTest(name = "Check ee {1} label {0}")
+	@ArgumentsSource(EEVersionsArgumentsProvider.class)
+	@DisplayName("Test EE.highestFromTargetVersion")
+	public void highestFromTargetVersion(String label, EE ee) throws Exception {
+		assertThat(EE.highestFromTargetVersion(label)).contains(ee);
+	}
+
+	static class EEVersionsArgumentsProvider implements ArgumentsProvider {
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+			EE[] values = EE.values();
+			return Arrays.stream(values, 0, values.length - 1)
+				.filter(ee -> ee.getCapabilityName()
+					.indexOf('/') < 0)
+				.map(ee -> Arguments.of(ee.getVersionLabel(), ee));
+		}
+	}
+
 	@Test
-	public void highestFromTargetVersion() throws Exception {
+	public void highestFromTargetVersionOther() throws Exception {
 		assertThat(EE.highestFromTargetVersion("1.0")).contains(EE.OSGI_Minimum_1_0);
-		assertThat(EE.highestFromTargetVersion("1.1")).contains(EE.JRE_1_1);
-		assertThat(EE.highestFromTargetVersion("1.2")).contains(EE.J2SE_1_2);
-		assertThat(EE.highestFromTargetVersion("1.3")).contains(EE.J2SE_1_3);
-		assertThat(EE.highestFromTargetVersion("1.4")).contains(EE.J2SE_1_4);
-		assertThat(EE.highestFromTargetVersion("1.5")).contains(EE.J2SE_1_5);
-		assertThat(EE.highestFromTargetVersion("1.6")).contains(EE.JavaSE_1_6);
-		assertThat(EE.highestFromTargetVersion("1.7")).contains(EE.JavaSE_1_7);
-		assertThat(EE.highestFromTargetVersion("1.8")).contains(EE.JavaSE_1_8);
 		assertThat(EE.highestFromTargetVersion("1.9")).isEmpty();
-		assertThat(EE.highestFromTargetVersion("9")).contains(EE.JavaSE_9_0);
-		assertThat(EE.highestFromTargetVersion("10")).contains(EE.JavaSE_10_0);
-		assertThat(EE.highestFromTargetVersion("11")).contains(EE.JavaSE_11_0);
 		assertThat(EE.highestFromTargetVersion("1.11")).isEmpty();
-		assertThat(EE.highestFromTargetVersion("12")).contains(EE.JavaSE_12_0);
-		assertThat(EE.highestFromTargetVersion("13")).contains(EE.JavaSE_13_0);
-		assertThat(EE.highestFromTargetVersion("14")).contains(EE.JavaSE_14_0);
-		assertThat(EE.highestFromTargetVersion("15")).contains(EE.JavaSE_15_0);
 	}
 
 	@Test
 	public void getEEFromJvm() throws Exception {
-		assertThat(EE.highestFromTargetVersion(System.getProperty("java.version"))).hasValueSatisfying( //
-			new Condition<>(ee -> ee.compareTo(EE.JavaSE_1_8) >= 0, "At least JavaSE-1.8"));
+		String java_version = System.getProperty("java.version");
+		Version version = MavenVersion.parseMavenString(java_version)
+			.getOSGiVersion();
+		assertThat(EE.highestFromTargetVersion(java_version)).hasValueSatisfying( //
+			new Condition<>(ee -> ee.getCapabilityVersion()
+				.getMajor() == version.getMajor(), "EE capability version same version as JDK"));
 	}
 
 	@Test

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/EE.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/EE.java
@@ -53,21 +53,23 @@ public enum EE {
 
 	JavaSE_13_0("JavaSE-13", "JavaSE", "13", JavaSE_12_0),
 	JavaSE_14_0("JavaSE-14", "JavaSE", "14", JavaSE_13_0),
-	JavaSE_15_0("JavaSE-15", "JavaSE", "15", JavaSE_14_0),
+	JavaSE_15("JavaSE-15", "JavaSE", "15", JavaSE_14_0),
+	JavaSE_16("JavaSE-16", "JavaSE", "16", JavaSE_15),
+	JavaSE_17("JavaSE-17", "JavaSE", "17", JavaSE_16),
 
-	UNKNOWN("Unknown", "unknown", "0");
+	UNKNOWN("<UNKNOWN>", "UNKNOWN", "0");
 
 	private final String			eeName;
 	private final String			capabilityName;
+	private final String			versionLabel;
 	private final Version			capabilityVersion;
 	private final EE[]				compatible;
 	private transient EnumSet<EE>	compatibleSet;
 	private transient Parameters	packages	= null;
 	private transient Parameters	modules		= null;
-	private String					versionLabel;
 
-	EE(String name, String capabilityName, String versionLabel, EE... compatible) {
-		this.eeName = name;
+	EE(String eeName, String capabilityName, String versionLabel, EE... compatible) {
+		this.eeName = eeName;
 		this.capabilityName = capabilityName;
 		this.versionLabel = versionLabel;
 		this.capabilityVersion = new Version(versionLabel);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -166,6 +166,8 @@ public class Clazz {
 		OpenJDK13(57, "JavaSE-13", "(&(osgi.ee=JavaSE)(version=13))"), //
 		OpenJDK14(58, "JavaSE-14", "(&(osgi.ee=JavaSE)(version=14))"), //
 		OpenJDK15(59, "JavaSE-15", "(&(osgi.ee=JavaSE)(version=15))"), //
+		OpenJDK16(60, "JavaSE-16", "(&(osgi.ee=JavaSE)(version=16))"), //
+		OpenJDK17(61, "JavaSE-17", "(&(osgi.ee=JavaSE)(version=17))"), //
 		UNKNOWN(Integer.MAX_VALUE, "<UNKNOWN>", "(osgi.ee=UNKNOWN)");
 
 		final int		major;
@@ -201,12 +203,8 @@ public class Clazz {
 			return major >= J2SE5.major;
 		}
 
-		public static JAVA getJava(int major, @SuppressWarnings("unused") int minor) {
-			for (JAVA j : JAVA.values()) {
-				if (j.major == major)
-					return j;
-			}
-			return UNKNOWN;
+		public static JAVA getJava(int major, int minor) {
+			return format(major);
 		}
 
 		public String getEE() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -18,6 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import aQute.bnd.build.model.EE;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
@@ -62,14 +63,11 @@ public class Verifier extends Processor {
 			+ "|CDC-1\\.1/PersonalJava-1\\.1");
 	public final static String	EES[];
 	static {
-		Clazz.JAVA[] ees = Clazz.JAVA.values();
+		EE[] ees = EE.values();
 		EES = Stream.concat(Arrays.stream(ees, 0, ees.length - 1)
-			.map(Clazz.JAVA::getEE),
+			.map(EE::getEEName),
 			Stream.of("CDC-1.0/Foundation-1.0", //
 				"CDC-1.1/Foundation-1.1", //
-				"OSGi/Minimum-1.0", //
-				"OSGi/Minimum-1.1", //
-				"OSGi/Minimum-1.2", //
 				"PersonalJava-1.1", //
 				"PersonalJava-1.2", //
 				"CDC-1.0/PersonalBasis-1.0", //

--- a/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSModuleInfoPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSModuleInfoPlugin.java
@@ -266,7 +266,9 @@ public class JPMSModuleInfoPlugin implements VerifierPlugin {
 		String eeAttribute = instruction.getValue()
 			.get(Constants.EE_ATTRIBUTE);
 
-		EE moduleEE = (eeAttribute != null) ? EE.valueOf(eeAttribute) : DEFAULT_MODULE_EE;
+		EE moduleEE = (eeAttribute != null) ? Optional.of(eeAttribute)
+			.map(EE::parse)
+			.orElseThrow(() -> new IllegalArgumentException("unrecognize ee name: " + eeAttribute)) : DEFAULT_MODULE_EE;
 
 		Packages exports = analyzer.getExports();
 		Packages imports = analyzer.getImports();

--- a/docs/_chapters/330-jpms.md
+++ b/docs/_chapters/330-jpms.md
@@ -52,7 +52,7 @@ When calculating the module **requires** the following is considered:
    e.g. `-jpms-module-info: foo.module;modules='java.desktop,java.logging'`, the modules `java.desktop`, and `java.logging` are added to module requires
 
 2. In addition, if the `-jpms-module-info` instruction contains a key having a `ee` attribute, the `ee` attribute indicates the Java module name mapping table to use for Java SE packages using bnd's `aQute.bnd.build.model.EE` definitions which define a set of Java module name mapping tables keyed by `EE`.
-   e.g. `-jpms-module-info: foo.module;ee=JavaSE_10_0`, bnd will use the Java module name mapping table for Java SE 10 when determining module name for a given Java SE package
+   e.g. `-jpms-module-info: foo.module;ee=JavaSE-10`, bnd will use the Java module name mapping table for Java SE 10 when determining module name for a given Java SE package
 
    If no `ee` attribute is specified, bnd will use the Java module name mapping table for Java SE 11 when determining module name for a given Java SE package
 


### PR DESCRIPTION
More of the test parameters are automatically generated based upon code or test resources.

Also, constants are added fro Java 16 and 17 to get a little ahead of the game.

Unfortunately we have 2 enums, EE and JAVA, which are in the public API that must be changed for each new version of Java. Tests were added to ensure they are updated together.