### PR TITLE
workspacerepo: Move all indexing logic into EclipseWorkspaceRepository

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/indexer/BuiltBundleIndexer.java
+++ b/bndtools.builder/src/org/bndtools/builder/indexer/BuiltBundleIndexer.java
@@ -1,39 +1,24 @@
 package org.bndtools.builder.indexer;
 
-import static aQute.lib.exceptions.FunctionWithException.asFunction;
-import static java.util.stream.Collectors.toList;
-
 import java.io.File;
-import java.text.MessageFormat;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-import org.bndtools.api.ILogger;
-import org.bndtools.api.Logger;
 import org.bndtools.build.api.AbstractBuildListener;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
-import org.osgi.resource.Resource;
 
-import aQute.bnd.build.Project;
-import aQute.bnd.osgi.repository.XMLResourceGenerator;
-import aQute.bnd.osgi.resource.ResourceBuilder;
 import bndtools.central.Central;
 import bndtools.central.EclipseWorkspaceRepository;
 
 public class BuiltBundleIndexer extends AbstractBuildListener {
-	private final ILogger logger = Logger.getLogger(BuiltBundleIndexer.class);
-
 	@Override
 	public void builtBundles(final IProject project, IPath[] paths) {
 		IWorkspaceRoot wsroot = ResourcesPlugin.getWorkspace()
 			.getRoot();
-
 		Set<File> files = new HashSet<>();
 		for (IPath path : paths) {
 			try {
@@ -47,39 +32,7 @@ public class BuiltBundleIndexer extends AbstractBuildListener {
 			}
 		}
 
-		// Generate the index
-		try {
-			Project model = Central.getProject(project);
-			String name = model.getName();
-			List<Resource> resources = files.stream()
-				.map(asFunction(file -> {
-					ResourceBuilder rb = new ResourceBuilder();
-					rb.addFile(file, file.toURI());
-					// Add a capability specific to the workspace so that we can
-					// identify this fact later during resource processing.
-					rb.addWorkspaceNamespace(name);
-					return rb.build();
-				}))
-				.collect(toList());
-
-			EclipseWorkspaceRepository workspaceRepo = Central.getEclipseWorkspaceRepository();
-			workspaceRepo.update(project, resources);
-
-			File indexFile = new File(model.getTarget(), EclipseWorkspaceRepository.INDEX_FILENAME);
-			XMLResourceGenerator xmlResourceGenerator = new XMLResourceGenerator().name(name)
-				.base(project.getLocation()
-					.toFile()
-					.toURI())
-				.resources(resources);
-			xmlResourceGenerator.save(indexFile);
-			IFile indexPath = wsroot.getFile(Central.toPath(indexFile));
-			indexPath.refreshLocal(IResource.DEPTH_ZERO, null);
-			if (indexPath.exists())
-				indexPath.setDerived(true, null);
-		} catch (Exception e) {
-			logger.logError(
-				MessageFormat.format("Failed to generate index file for bundles in project {0}.", project.getName()),
-				e);
-		}
+		EclipseWorkspaceRepository workspaceRepo = Central.getEclipseWorkspaceRepository();
+		workspaceRepo.index(project, files);
 	}
 }

--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -1,15 +1,25 @@
 package bndtools.central;
 
+import static aQute.lib.exceptions.FunctionWithException.asFunction;
+import static java.util.stream.Collectors.toList;
+
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import org.bndtools.api.ILogger;
+import org.bndtools.api.Logger;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -17,17 +27,22 @@ import org.osgi.resource.Resource;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.osgi.repository.ResourcesRepository;
+import aQute.bnd.osgi.repository.XMLResourceGenerator;
 import aQute.bnd.osgi.repository.XMLResourceParser;
+import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.stream.MapStream;
 import aQute.lib.io.IO;
 import aQute.lib.memoize.Memoize;
 import biz.aQute.resolve.WorkspaceRepositoryMarker;
 
 public class EclipseWorkspaceRepository extends BaseRepository implements WorkspaceRepositoryMarker {
+	private final static ILogger						logger			= Logger
+		.getLogger(EclipseWorkspaceRepository.class);
 	private static final String							NAME			= "Workspace";
-	public static final String							INDEX_FILENAME	= ".index";
+	private static final String							INDEX_FILENAME	= ".index.xml";
 	private final Map<IProject, Collection<Resource>>	repositories;
 	private volatile Supplier<ResourcesRepository>		repository;
 
@@ -47,13 +62,27 @@ public class EclipseWorkspaceRepository extends BaseRepository implements Worksp
 		for (IProject project : projects) {
 			Project model = Central.getProject(project);
 			if (model != null) {
-				File indexFile = new File(getTarget(model), INDEX_FILENAME);
+				File target = getTarget(model);
+				File indexFile = new File(target, INDEX_FILENAME);
 				if (indexFile.isFile()) {
 					URI base = project.getLocation()
 						.toFile()
 						.toURI();
 					List<Resource> resources = XMLResourceParser.getResources(indexFile, base);
 					update(project, resources);
+					continue;
+				}
+				File buildfiles = new File(target, Constants.BUILDFILES);
+				if (buildfiles.isFile()) {
+					List<File> files;
+					try (BufferedReader rdr = IO.reader(buildfiles)) {
+						files = rdr.lines()
+							.map(line -> IO.getFile(target, line.trim()))
+							.filter(File::isFile)
+							.collect(toList());
+					}
+					index(project, files);
+					continue;
 				}
 			}
 		}
@@ -71,7 +100,42 @@ public class EclipseWorkspaceRepository extends BaseRepository implements Worksp
 		return target;
 	}
 
-	public void update(IProject project, Collection<Resource> resources) {
+	public void index(IProject project, Collection<File> files) {
+		try {
+			Project model = Central.getProject(project);
+			String name = model.getName();
+			List<Resource> resources = files.stream()
+				.map(asFunction(file -> {
+					ResourceBuilder rb = new ResourceBuilder();
+					rb.addFile(file, file.toURI());
+					// Add a capability specific to the workspace so that we can
+					// identify this fact later during resource processing.
+					rb.addWorkspaceNamespace(name);
+					return rb.build();
+				}))
+				.collect(toList());
+
+			update(project, resources);
+
+			File indexFile = new File(model.getTarget(), INDEX_FILENAME);
+			XMLResourceGenerator xmlResourceGenerator = new XMLResourceGenerator().name(name)
+				.base(project.getLocation()
+					.toFile()
+					.toURI())
+				.resources(resources);
+			xmlResourceGenerator.save(indexFile);
+			IWorkspaceRoot wsroot = ResourcesPlugin.getWorkspace()
+				.getRoot();
+			IFile indexPath = wsroot.getFile(Central.toPath(indexFile));
+			indexPath.refreshLocal(IResource.DEPTH_ZERO, null);
+			if (indexPath.exists())
+				indexPath.setDerived(true, null);
+		} catch (Exception e) {
+			logger.logError(MessageFormat.format("Failed to index bundles in project {0}.", project.getName()), e);
+		}
+	}
+
+	private void update(IProject project, Collection<Resource> resources) {
 		repositories.put(project, resources);
 		repository = Memoize.supplier(this::aggregate);
 	}


### PR DESCRIPTION
We now fall back to buildfiles if the index file is not present. We
also rename the index file to .index.xml to (1) force reindexing upon
update to this new support and (2) to be able to view the file using
the XML support in Eclipse.
