### PR TITLE
workspacerepo: Remove use of .index.xml files

### DIFF
--- a/aQute.libg/src/aQute/lib/memoize/Memoize.java
+++ b/aQute.libg/src/aQute/lib/memoize/Memoize.java
@@ -2,29 +2,97 @@ package aQute.lib.memoize;
 
 import static java.util.Objects.requireNonNull;
 
+import java.lang.ref.Reference;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Memoization support.
+ */
 public class Memoize {
 
 	private Memoize() {}
 
-	public static <T> Supplier<T> supplier(Supplier<? extends T> delegate) {
-		if (delegate instanceof MemoizingSupplier) {
+	/**
+	 * Creates a supplier which memoizes the value returned by the specified
+	 * supplier.
+	 * <p>
+	 * When the returned supplier is called to get a value, it will call the
+	 * specified supplier at most once to obtain a value.
+	 *
+	 * @param <T> Type of the value returned by the supplier.
+	 * @param supplier The source supplier. Must not be {@code null}.
+	 * @return A memoized supplier wrapping the specified supplier.
+	 */
+	public static <T> Supplier<T> supplier(Supplier<? extends T> supplier) {
+		if (supplier instanceof MemoizingSupplier) {
 			@SuppressWarnings("unchecked")
-			Supplier<T> supplier = (Supplier<T>) delegate;
-			return supplier;
+			Supplier<T> memoized = (Supplier<T>) supplier;
+			return memoized;
 		}
-		return new MemoizingSupplier<>(delegate);
+		return new MemoizingSupplier<>(supplier);
 	}
 
-	public static <T> Supplier<T> supplier(Supplier<? extends T> delegate, long duration, TimeUnit unit) {
-		return new TimeboundMemoizingSupplier<>(delegate, duration, unit);
-	}
-
+	/**
+	 * Creates a supplier which memoizes the value returned by the specified
+	 * function applied to the specified argument.
+	 * <p>
+	 * When the returned supplier is called to get a value, it will call the
+	 * specified function applied to the specified argument at most once to
+	 * obtain a value.
+	 *
+	 * @param <T> Type of the value returned by the supplier.
+	 * @param function The source function. Must not be {@code null}.
+	 * @param argument The argument to the source function.
+	 * @return A memoized supplier wrapping the specified function and argument.
+	 */
 	public static <T, R> Supplier<R> supplier(Function<? super T, ? extends R> function, T argument) {
 		requireNonNull(function);
 		return supplier(() -> function.apply(argument));
+	}
+
+	/**
+	 * Creates a supplier which memoizes, for the specified time-to-live, the
+	 * value returned by the specified supplier.
+	 * <p>
+	 * When the returned supplier is called to get a value, it will call the
+	 * specified supplier to obtain a new value if any prior obtained value is
+	 * older than the specified time-to-live.
+	 *
+	 * @param <T> Type of the value returned by the supplier.
+	 * @param supplier The source supplier. Must not be {@code null}.
+	 * @param time_to_live The time-to-live for a value. Negative values are
+	 *            treated as zero.
+	 * @param unit The time unit of the time-to-live value. Must not be
+	 *            {@code null}.
+	 * @return A memoized supplier wrapping the specified supplier.
+	 */
+	public static <T> Supplier<T> refreshingSupplier(Supplier<? extends T> supplier, long time_to_live, TimeUnit unit) {
+		return new RefreshingMemoizingSupplier<>(supplier, time_to_live, unit);
+	}
+
+	/**
+	 * Creates a supplier which memoizes a reference object holding the value
+	 * returned by the specified supplier.
+	 * <p>
+	 * When the returned supplier is called to get a value, if the reference
+	 * object holding any prior obtained value is cleared, then the specified
+	 * supplier is called to obtain a new value and the specified reference
+	 * function is called to wrap the new value in a reference object.
+	 *
+	 * @param <T> Type of the value returned by the supplier.
+	 * @param supplier The source supplier. Must not be {@code null}. The
+	 *            supplier should not return a {@code null} value since a
+	 *            cleared reference also returns {@code null}.
+	 * @param reference A function which is called to wrap an object created by
+	 *            the specified supplier in a reference object. This allows the
+	 *            caller to control the reference type and whether a reference
+	 *            queue is used. The function must not return {@code null}.
+	 * @return A memoized supplier wrapping the specified supplier.
+	 */
+	public static <T> Supplier<T> referenceSupplier(Supplier<? extends T> supplier,
+		Function<? super T, ? extends Reference<? extends T>> reference) {
+		return new ReferenceMemoizingSupplier<>(supplier, reference);
 	}
 }

--- a/aQute.libg/src/aQute/lib/memoize/ReferenceMemoizingSupplier.java
+++ b/aQute.libg/src/aQute/lib/memoize/ReferenceMemoizingSupplier.java
@@ -1,0 +1,36 @@
+package aQute.lib.memoize;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+class ReferenceMemoizingSupplier<T> implements Supplier<T> {
+	private final Supplier<? extends T>									supplier;
+	private final Function<? super T, ? extends Reference<? extends T>>	reference;
+	private volatile Reference<? extends T>								memoized;
+
+	ReferenceMemoizingSupplier(Supplier<? extends T> supplier,
+		Function<? super T, ? extends Reference<? extends T>> reference) {
+		this.supplier = requireNonNull(supplier);
+		this.reference = requireNonNull(reference);
+		memoized = new WeakReference<>(null); // mark empty
+	}
+
+	@Override
+	public T get() {
+		T referent;
+		if ((referent = memoized.get()) == null) {
+			// critical section: only one at a time
+			synchronized (this) {
+				if ((referent = memoized.get()) == null) {
+					referent = supplier.get();
+					memoized = requireNonNull(reference.apply(referent));
+				}
+			}
+		}
+		return referent;
+	}
+}

--- a/aQute.libg/test/aQute/lib/memoize/MemoizeTest.java
+++ b/aQute.libg/test/aQute/lib/memoize/MemoizeTest.java
@@ -1,0 +1,126 @@
+package aQute.lib.memoize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class MemoizeTest {
+
+	@Test
+	public void supplier() {
+		AtomicInteger count = new AtomicInteger();
+		Supplier<String> source = () -> Integer.toString(count.incrementAndGet());
+		Supplier<String> memoized = Memoize.supplier(source);
+		assertThat(count).hasValue(0);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(100)).containsOnly("1");
+		assertThat(count).hasValue(1);
+	}
+
+	@Test
+	public void supplier_null() {
+		assertThatNullPointerException().isThrownBy(() -> Memoize.supplier(null));
+	}
+
+	@Test
+	public void supplier_function() {
+		Function<AtomicInteger, String> source = count -> Integer.toString(count.incrementAndGet());
+		AtomicInteger count = new AtomicInteger();
+		Supplier<String> memoized = Memoize.supplier(source, count);
+		assertThat(count).hasValue(0);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(100)).containsOnly("1");
+		assertThat(count).hasValue(1);
+	}
+
+	@Test
+	public void supplier_function_null() {
+		assertThatNullPointerException()
+			.isThrownBy(() -> Memoize.supplier((Function<Object, Object>) null, new Object()));
+	}
+
+	@Test
+	public void refreshing() throws Exception {
+		AtomicInteger count = new AtomicInteger();
+		Supplier<String> source = () -> Integer.toString(count.incrementAndGet());
+		Supplier<String> memoized = Memoize.refreshingSupplier(source, 100, TimeUnit.MILLISECONDS);
+		assertThat(count).hasValue(0);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(10)).containsOnly("1");
+		assertThat(count).hasValue(1);
+
+		sleep(200, TimeUnit.MILLISECONDS);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(10)).containsOnly("2");
+		assertThat(count).hasValue(2);
+
+		sleep(200, TimeUnit.MILLISECONDS);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(10)).containsOnly("3");
+		assertThat(count).hasValue(3);
+	}
+
+	void sleep(long duration, TimeUnit unit) throws InterruptedException {
+		for (long end = System.nanoTime() + unit.toNanos(duration), delay; (delay = end - System.nanoTime()) >= 0L;) {
+			Thread.sleep(TimeUnit.NANOSECONDS.toMillis(delay));
+		}
+	}
+
+	@Test
+	public void refreshing_null() {
+		assertThatNullPointerException()
+			.isThrownBy(() -> Memoize.refreshingSupplier((Supplier<Object>) null, 100, TimeUnit.MILLISECONDS));
+		assertThatNullPointerException().isThrownBy(() -> Memoize.refreshingSupplier(() -> "", 100, null));
+	}
+
+	@Test
+	public void reference() throws Exception {
+		AtomicInteger count = new AtomicInteger();
+		Supplier<String> source = () -> Integer.toString(count.incrementAndGet());
+		ReferenceQueue<String> queue = new ReferenceQueue<>();
+		Supplier<String> memoized = Memoize.referenceSupplier(source, t -> new WeakReference<>(t, queue));
+		assertThat(count).hasValue(0);
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(100)).containsOnly("1");
+		assertThat(count).hasValue(1);
+
+		System.gc();
+		assertThat(queue.remove(1000)).isNotNull();
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(100)).containsOnly("2");
+		assertThat(count).hasValue(2);
+
+		System.gc();
+		assertThat(queue.remove(1000)).isNotNull();
+
+		assertThat(Stream.generate(memoized::get)
+			.limit(100)).containsOnly("3");
+		assertThat(count).hasValue(3);
+	}
+
+	@Test
+	public void reference_null() {
+		assertThatNullPointerException()
+			.isThrownBy(() -> Memoize.referenceSupplier((Supplier<Object>) null, WeakReference::new));
+		assertThatNullPointerException().isThrownBy(() -> Memoize.referenceSupplier(() -> "", null));
+		assertThatNullPointerException().isThrownBy(() -> Memoize.referenceSupplier(() -> "", t -> null)
+			.get());
+	}
+
+}

--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -1,14 +1,15 @@
 package bndtools.central;
 
 import static aQute.lib.exceptions.FunctionWithException.asFunction;
+import static aQute.lib.exceptions.SupplierWithException.asSupplierOrElse;
 import static java.util.stream.Collectors.toList;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,10 +17,7 @@ import java.util.function.Supplier;
 
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -30,8 +28,6 @@ import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.osgi.repository.ResourcesRepository;
-import aQute.bnd.osgi.repository.XMLResourceGenerator;
-import aQute.bnd.osgi.repository.XMLResourceParser;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.stream.MapStream;
 import aQute.lib.io.IO;
@@ -39,18 +35,17 @@ import aQute.lib.memoize.Memoize;
 import biz.aQute.resolve.WorkspaceRepositoryMarker;
 
 public class EclipseWorkspaceRepository extends BaseRepository implements WorkspaceRepositoryMarker {
-	private final static ILogger						logger			= Logger
+	private final static ILogger											logger	= Logger
 		.getLogger(EclipseWorkspaceRepository.class);
-	private static final String							NAME			= "Workspace";
-	private static final String							INDEX_FILENAME	= ".index.xml";
-	private final Map<IProject, Collection<Resource>>	repositories;
-	private volatile Supplier<ResourcesRepository>		repository;
+	private static final String												NAME	= "Workspace";
+	private final Map<IProject, Supplier<? extends Collection<Resource>>>	resources;
+	private volatile Supplier<ResourcesRepository>							repository;
 
 	/**
 	 * Can only be instantiated within the package.
 	 */
 	EclipseWorkspaceRepository() {
-		repositories = new ConcurrentHashMap<>();
+		resources = new ConcurrentHashMap<>();
 		repository = Memoize.supplier(this::aggregate);
 		Central.onWorkspace(this::setupProjects);
 	}
@@ -63,25 +58,16 @@ public class EclipseWorkspaceRepository extends BaseRepository implements Worksp
 			Project model = Central.getProject(project);
 			if (model != null) {
 				File target = getTarget(model);
-				File indexFile = new File(target, INDEX_FILENAME);
-				if (indexFile.isFile()) {
-					URI base = project.getLocation()
-						.toFile()
-						.toURI();
-					List<Resource> resources = XMLResourceParser.getResources(indexFile, base);
-					update(project, resources);
-					continue;
-				}
 				File buildfiles = new File(target, Constants.BUILDFILES);
 				if (buildfiles.isFile()) {
-					List<File> files;
-					try (BufferedReader rdr = IO.reader(buildfiles)) {
-						files = rdr.lines()
-							.map(line -> IO.getFile(target, line.trim()))
-							.filter(File::isFile)
-							.collect(toList());
-					}
-					index(project, files);
+					index(project, asSupplierOrElse(() -> {
+						try (BufferedReader rdr = IO.reader(buildfiles)) {
+							return rdr.lines()
+								.map(line -> IO.getFile(target, line.trim()))
+								.filter(File::isFile)
+								.collect(toList());
+						}
+					}, Collections.emptyList()));
 					continue;
 				}
 			}
@@ -101,43 +87,38 @@ public class EclipseWorkspaceRepository extends BaseRepository implements Worksp
 	}
 
 	public void index(IProject project, Collection<File> files) {
+		index(project, () -> files);
+	}
+
+	public void index(IProject project, Supplier<? extends Collection<File>> files) {
 		try {
+			resources.keySet()
+				.removeIf(p -> !p.isOpen());
 			Project model = Central.getProject(project);
-			String name = model.getName();
-			List<Resource> resources = files.stream()
-				.map(asFunction(file -> {
-					ResourceBuilder rb = new ResourceBuilder();
-					rb.addFile(file, file.toURI());
-					// Add a capability specific to the workspace so that we can
-					// identify this fact later during resource processing.
-					rb.addWorkspaceNamespace(name);
-					return rb.build();
-				}))
-				.collect(toList());
-
-			update(project, resources);
-
-			File indexFile = new File(model.getTarget(), INDEX_FILENAME);
-			XMLResourceGenerator xmlResourceGenerator = new XMLResourceGenerator().name(name)
-				.base(project.getLocation()
-					.toFile()
-					.toURI())
-				.resources(resources);
-			xmlResourceGenerator.save(indexFile);
-			IWorkspaceRoot wsroot = ResourcesPlugin.getWorkspace()
-				.getRoot();
-			IFile indexPath = wsroot.getFile(Central.toPath(indexFile));
-			indexPath.refreshLocal(IResource.DEPTH_ZERO, null);
-			if (indexPath.exists())
-				indexPath.setDerived(true, null);
+			if (model != null) {
+				resources.put(project, Memoize.supplier(indexer(model.getName(), files)));
+			} else {
+				resources.remove(project);
+			}
+			repository = Memoize.supplier(this::aggregate);
 		} catch (Exception e) {
 			logger.logError(MessageFormat.format("Failed to index bundles in project {0}.", project.getName()), e);
 		}
 	}
 
-	private void update(IProject project, Collection<Resource> resources) {
-		repositories.put(project, resources);
-		repository = Memoize.supplier(this::aggregate);
+	private Supplier<List<Resource>> indexer(String name, Supplier<? extends Collection<File>> files) {
+		return () -> files.get()
+			.stream()
+			.filter(File::isFile)
+			.map(asFunction(file -> {
+				ResourceBuilder rb = new ResourceBuilder();
+				rb.addFile(file, file.toURI());
+				// Add a capability specific to the workspace so that we can
+				// identify this fact later during resource processing.
+				rb.addWorkspaceNamespace(name);
+				return rb.build();
+			}))
+			.collect(toList());
 	}
 
 	@Override
@@ -148,9 +129,10 @@ public class EclipseWorkspaceRepository extends BaseRepository implements Worksp
 	}
 
 	private ResourcesRepository aggregate() {
-		ResourcesRepository aggregate = MapStream.of(repositories)
+		ResourcesRepository aggregate = MapStream.of(resources)
 			.filterKey(IProject::isOpen)
 			.values()
+			.map(Supplier::get)
 			.flatMap(Collection::stream)
 			.collect(ResourcesRepository.toResourcesRepository());
 		return aggregate;


### PR DESCRIPTION
We now always index through building Resources from the built bundles.
This avoids the need to cache and staleness of that cache.

We now defer, through the use of memoized suppliers, creating Resources
until they are actually necessary. So until you need to resolve, we can
defer this Resource creation. So this can significantly reduce Bndtools
startup time since we do not need to parse .index.xml files or bundles.
If you never use the resolver, we never need to index the workspace
bundles.