### PR TITLE
memoize: Treat wrapped supplier returning null as a close

### DIFF
--- a/aQute.libg/src/aQute/lib/memoize/CloseableMemoize.java
+++ b/aQute.libg/src/aQute/lib/memoize/CloseableMemoize.java
@@ -26,7 +26,10 @@ public interface CloseableMemoize<S extends AutoCloseable> extends Memoize<S>, A
 	 *
 	 * @param <T> Type of the value returned by the supplier.
 	 * @param supplier The source supplier. Must not be {@code null}. The
-	 *            supplier must not return a {@code null} value.
+	 *            supplier should not return a {@code null} value. If the
+	 *            supplier does return a {@code null} value, the returned
+	 *            supplier will be marked closed and its {@code get()} method
+	 *            will throw an {@code IllegalStateException}.
 	 * @return A memoized supplier wrapping the specified supplier.
 	 */
 	static <T extends AutoCloseable> CloseableMemoize<T> closeableSupplier(Supplier<? extends T> supplier) {

--- a/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
+++ b/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
@@ -39,10 +39,13 @@ class CloseableMemoizingSupplier<T extends AutoCloseable> implements CloseableMe
 			final long stamp = lock.writeLock();
 			try {
 				if (initial) {
-					T result = requireNonNull(supplier.get());
+					T result = supplier.get();
 					memoized = result;
 					// write initial _after_ write memoized
 					initial = false;
+					if (result == null) {
+						throw new IllegalStateException("closed");
+					}
 					return result;
 				}
 			} finally {

--- a/aQute.libg/test/aQute/lib/memoize/MemoizeTest.java
+++ b/aQute.libg/test/aQute/lib/memoize/MemoizeTest.java
@@ -325,9 +325,10 @@ public class MemoizeTest {
 	public void closeable_null() {
 		assertThatNullPointerException()
 			.isThrownBy(() -> CloseableMemoize.closeableSupplier((Supplier<AutoCloseable>) null));
-		assertThatNullPointerException()
-			.isThrownBy(() -> CloseableMemoize.closeableSupplier((Supplier<AutoCloseable>) () -> null)
-				.get());
+		CloseableMemoize<AutoCloseable> memoized = CloseableMemoize.closeableSupplier((Supplier<AutoCloseable>) () -> null);
+		assertThatIllegalStateException().isThrownBy(memoized::get);
+		assertThat(memoized.isClosed()).isTrue();
+		assertThat(memoized.peek()).isNull();
 	}
 
 	@SuppressWarnings("resource")


### PR DESCRIPTION
If the wrapper supplier for a CloseableMemoize returns null, we treat
that as a close of the CloseableMemoize since we have no value to use.
