### PR TITLE
memoize: Shorten code path for accept

### DIFF
--- a/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
+++ b/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
@@ -92,6 +92,9 @@ class CloseableMemoizingSupplier<T extends AutoCloseable> implements CloseableMe
 					return; // no value to close
 				}
 				closeable = memoized;
+				if (closeable == null) {
+					return; // already closed
+				}
 				memoized = null; // mark closed
 				// write initial _after_ write memoized
 				initial = false; // even though it is already false


### PR DESCRIPTION
If in initial state, we get write lock, then get value and downgrade
to read lock before calling consumer.

