### PR TITLE
resource: Add standard ordering to capabilities and requirements

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
@@ -8,7 +8,6 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -31,8 +30,8 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 
 	private volatile transient Map<URI, String>		locations;
 
-	void setCapabilities(Collection<Capability> capabilities) {
-		allCapabilities = unmodifiableList(new ArrayList<>(capabilities));
+	void setCapabilities(List<Capability> capabilities) {
+		allCapabilities = unmodifiableList(capabilities);
 		capabilityMap = capabilities.stream()
 			.collect(groupingBy(Capability::getNamespace, collectingAndThen(toList(), Collections::unmodifiableList)));
 
@@ -47,8 +46,8 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 		return (caps != null) ? caps : Collections.emptyList();
 	}
 
-	void setRequirements(Collection<Requirement> requirements) {
-		allRequirements = unmodifiableList(new ArrayList<>(requirements));
+	void setRequirements(List<Requirement> requirements) {
+		allRequirements = unmodifiableList(requirements);
 		requirementMap = requirements.stream()
 			.collect(groupingBy(Requirement::getNamespace, collectingAndThen(toList(), Collections::unmodifiableList)));
 	}

--- a/bndtools.m2e/src/bndtools/m2e/MavenBndrunContainer.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenBndrunContainer.java
@@ -70,7 +70,11 @@ public class MavenBndrunContainer implements MavenRunListenerHelper {
 					includeDependencyManagement = maven.getMojoParameterValue(mavenProject, mojoExecution,
 						"includeDependencyManagement", Boolean.class, monitor);
 
-					scopeValues = maven.getMojoParameterValue(mavenProject, mojoExecution, "scopes", Set.class, monitor);
+					@SuppressWarnings({
+						"rawtypes", "unchecked"
+					})
+					Class<Set<String>> asType = (Class) Set.class;
+					scopeValues = maven.getMojoParameterValue(mavenProject, mojoExecution, "scopes", asType, monitor);
 				}
 			} catch (Exception e) {
 				logger.logError("Failed to create Run for m2e project " + mavenProject.getName(), e);


### PR DESCRIPTION
addHashes had altered the encounter ordering for package capabilities
as they were copied to a HashSet and then possibly removed and replaced
in the capabilities if they were updated with hashes.

To keep a consistent ordering, we use a TreeMap to control the namespace
ordering and use "encounter" ordering on the sets. addHashes is fixed to
preserve the encounter ordering for the package capabilities.

Making an effort to have a defined ordering makes it easier when
regenerating indexes to compare with the prior revision of the index.