### PR TITLE
gradle: Add --noparallel instruction support to Bnd Gradle workspace

### DIFF
--- a/biz.aQute.bndall.tests/bnd.bnd
+++ b/biz.aQute.bndall.tests/bnd.bnd
@@ -25,5 +25,8 @@
 -buildpath:  \
     aQute.libg;version=project, \
     biz.aQute.bndlib;version=5.1.0
-    
+
 -sub: *.bnd
+
+-buildrepo:
+-releaserepo:

--- a/bndtools.utils/src/org/bndtools/utils/jdt/ASTUtil.java
+++ b/bndtools.utils/src/org/bndtools/utils/jdt/ASTUtil.java
@@ -56,6 +56,7 @@ public class ASTUtil {
 
 		l++;
 
+		@SuppressWarnings("unchecked")
 		List<SingleVariableDeclaration> params = methodDecl.parameters();
 		if (params.isEmpty()) {
 			return methodName.charAt(l) == ')';


### PR DESCRIPTION
`-noparallel: launchpad;task="test"` in a project's bnd.bnd file
will claim the category "launchpad" for the `test` task. Any other task,
including tasks from other projects, which claims the same category
will not run in parallel when using Gradle's `--parallel` mode.

Multiple categories and multiple task names per category can be
specified.