### PR TITLE
[repository] Workspace repositories

### DIFF
--- a/aQute.libg/src/aQute/libg/cryptography/Digester.java
+++ b/aQute.libg/src/aQute/libg/cryptography/Digester.java
@@ -11,6 +11,7 @@ import aQute.lib.io.IO;
 public abstract class Digester<T extends Digest> extends OutputStream {
 	protected MessageDigest	md;
 	OutputStream			out[];
+	int						length	= 0;
 
 	public Digester(MessageDigest instance, OutputStream... out) {
 		md = instance;
@@ -20,6 +21,7 @@ public abstract class Digester<T extends Digest> extends OutputStream {
 	@Override
 	public void write(byte[] buffer, int offset, int length) throws IOException {
 		md.update(buffer, offset, length);
+		this.length += length;
 		for (OutputStream o : out) {
 			o.write(buffer, offset, length);
 		}
@@ -28,6 +30,7 @@ public abstract class Digester<T extends Digest> extends OutputStream {
 	@Override
 	public void write(int b) throws IOException {
 		md.update((byte) b);
+		this.length++;
 		for (OutputStream o : out) {
 			o.write(b);
 		}
@@ -60,5 +63,9 @@ public abstract class Digester<T extends Digest> extends OutputStream {
 	public T from(byte[] f) throws Exception {
 		IO.copy(f, this);
 		return digest();
+	}
+
+	public int getLength() {
+		return length;
 	}
 }

--- a/aQute.libg/src/aQute/libg/cryptography/packageinfo
+++ b/aQute.libg/src/aQute/libg/cryptography/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/biz.aQute.bndall.tests/resources/ws-stalecheck/p2/bnd.bnd
+++ b/biz.aQute.bndall.tests/resources/ws-stalecheck/p2/bnd.bnd
@@ -1,2 +1,0 @@
--buildpath: \
-    biz.aQute.bndlib

--- a/biz.aQute.bndall.tests/test/biz/aQute/bnd/project/ProjectGenerateTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/bnd/project/ProjectGenerateTest.java
@@ -165,10 +165,14 @@ public class ProjectGenerateTest {
 	}
 
 	private void getRepo(Workspace ws) throws IOException, Exception {
+		System.out.println("current working dir " + IO.work);
 		FileTree tree = new FileTree();
 		List<File> files = tree.getFiles(IO.getFile("generated/"), "*.jar");
-		files.addAll(tree.getFiles(IO.getFile("../biz.aQute.bnd.javagen/generated/"), "*.jar"));
-
+		File file = IO.getFile("../biz.aQute.bnd.javagen/generated/")
+			.getCanonicalFile();
+		System.out.println("where " + file);
+		files.addAll(tree.getFiles(file, "*.jar"));
+		System.out.println("tmp repo " + files);
 		FileSetRepository repo = new FileSetRepository("test", files);
 		ws.addBasicPlugin(repo);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
@@ -1,0 +1,44 @@
+package aQute.bnd.build;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.repository.Repository;
+
+import aQute.bnd.osgi.repository.BaseRepository;
+import aQute.bnd.osgi.resource.ResourceUtils;
+import aQute.lib.collections.MultiMap;
+
+public class WorkspaceRepositoryDynamic extends BaseRepository implements Repository {
+
+	final Workspace workspace;
+
+	public WorkspaceRepositoryDynamic(Workspace workspace) {
+		this.workspace = workspace;
+	}
+
+	@SuppressWarnings({
+		"unchecked", "rawtypes"
+	})
+	@Override
+	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
+		MultiMap<Requirement, Capability> map = new MultiMap<>();
+
+		for (Project project : workspace.getAllProjects()) {
+			for (Resource resource : project.getResources()) {
+				for (Requirement requirement : requirements) {
+					for (Capability capability : resource.getCapabilities(requirement.getNamespace())) {
+						if (ResourceUtils.matches(requirement, capability)) {
+							map.add(requirement, capability);
+						}
+					}
+				}
+			}
+		}
+		return (Map) map;
+	}
+
+}


### PR DESCRIPTION
Proposed change to the workspace repositories
confusion.

Eclipse registers a workspace repository that
listens to builds. The Bndrun files register
some repository that scans the projects. 

The problem was that we did not mandate a driver to
register a Workspace repository. This introduced
the WorkspaceRepositoryMaker interface to allow
mostly the Bndrun to check if there was a workspace
repository present. Overall a mess, especially
because before BJ cleaned this up, we were using a 
very convoluted way to get to a repository because
the bndlib had no knowledge of repositories.

I ran into this because the ClassIndex & External
Plugins use a new Workspace.getResourceRepository() method
that tries to provide a single view on the Workspace
and its repositories. Since Gradle does _not_
register as workspace repo, the code did not work
in Gradle for local projects.

However, the recent cleanup did not go all the way.
It created a much better repo for Central but it 
did not solve the problem of Bndrun. 

First, we must unify that there is _always_ a workspace
repository. Second, we should use the most efficient 
way to calculate the resource, which is at build time.

This PR does the following:

- It provides yet another Workspace repository: WorkspaceRepositoryDynamic
  which should become the _only_ one in 5.2.0
- A Memoize is created by the ResourceBuilder class 
  to calculate the resource based on the Jar.
- The SHA256 & length are now calculated during save for efficiency


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>