### PR TITLE
Refactor WorkspaceRepositoryDynamic to reuse filter

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
@@ -102,4 +102,10 @@ class ProjectTracker implements AutoCloseable {
 			.map(models::remove)
 			.forEach(IO::close);
 	}
+
+	@Override
+	public String toString() {
+		return models.keySet()
+			.toString();
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -71,6 +71,7 @@ import aQute.bnd.osgi.Resource;
 import aQute.bnd.osgi.Verifier;
 import aQute.bnd.osgi.repository.AggregateRepository;
 import aQute.bnd.osgi.repository.AugmentRepository;
+import aQute.bnd.osgi.repository.WorkspaceRepositoryMarker;
 import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.remoteworkspace.server.RemoteWorkspaceServer;
@@ -1466,24 +1467,14 @@ public class Workspace extends Processor {
 	 * <p>
 	 * TODO make this public in 5.2.0 & use everywhere
 	 * <p>
-	 * 
+	 *
 	 * @return an aggregate repository
 	 * @throws Exception
 	 */
 	Repository getResourceRepository() throws Exception {
 		List<Repository> plugins = getPlugins(Repository.class);
-		Repository found = null;
-		outer: for ( Repository r : plugins) {
-			for ( Class<?> c : r.getClass().getInterfaces()) {
-				if ( c.getName().endsWith("WorkspaceRepositoryMarker")) {
-					found = r;
-					break outer;
-				}
-			}
-		}
-		if (found != null) {
-			plugins.remove(found);
-		}
+		// replace any WorkspaceRepositoryMarker plugin
+		plugins.removeIf(WorkspaceRepositoryMarker.class::isInstance);
 		plugins.add(new WorkspaceRepositoryDynamic(this));
 
 		AggregateRepository repository = new AggregateRepository(plugins);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/WorkspaceRepositoryMarker.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/WorkspaceRepositoryMarker.java
@@ -1,0 +1,31 @@
+package aQute.bnd.osgi.repository;
+
+import aQute.bnd.osgi.resource.ResourceUtils;
+
+/**
+ * This marker must be implemented by repositories that model the workspace. If
+ * things had gone well we would have had a single workspace repository.
+ * However, due to history, a rather special workspace was integrated with
+ * bndtools that did not make it into bnd itself. Worse, it depended on bndtools
+ * code, making it impossible to integrate it in the rest of the code base.
+ * <p>
+ * When bnd started to resolve things, a special resolver was needed and this
+ * was quickly hacked together. It was a static repository, it did not track the
+ * interactive changes like the bndtools repository did. However, it was
+ * confusing that sometimes bnd found a workspace repository (bndtools) and
+ * sometimes not (the other drivers).
+ * <p>
+ * The purpose of this WorkspaceRepositoryMarker interface is to make it clear
+ * to the resolver that a Workspace repository is present and should not be
+ * added.
+ * <p>
+ * As a little bonus, any repository implementing this interface *must* add a
+ * {@link ResourceUtils#WORKSPACE_NAMESPACE} capability to mark resources from
+ * the workspace.
+ * <p>
+ * Ideally, bnd should have a single workspace repository that tracks the files
+ * in the workspace but this is deemed too much work for now.
+ */
+public interface WorkspaceRepositoryMarker {
+	String	NAME				= "Workspace";
+}

--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -40,6 +40,7 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.repository.AggregateRepository;
 import aQute.bnd.osgi.repository.AugmentRepository;
+import aQute.bnd.osgi.repository.WorkspaceRepositoryMarker;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
@@ -51,7 +52,6 @@ import aQute.bnd.service.resolve.hook.ResolverHook;
 import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
 import aQute.lib.utf8properties.UTF8Properties;
-
 /**
  * This class does the resolving for bundles. It loads the details from a
  * BndEditModel & Project

--- a/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceRepositoryMarker.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceRepositoryMarker.java
@@ -1,31 +1,8 @@
 package biz.aQute.resolve;
 
-import aQute.bnd.osgi.resource.ResourceUtils;
-
 /**
- * This marker must be implemented by repositories that model the workspace. If
- * things had gone well we would have had a single workspace repository.
- * However, due to history, a rather special workspace was integrated with
- * bndtools that did not make it into bnd itself. Worse, it depended on bndtools
- * code, making it impossible to integrate it in the rest of the code base.
- * <p>
- * When bnd started to resolve things, a special resolver was needed and this
- * was quickly hacked together. It was a static repository, it did not track the
- * interactive changes like the bndtools repository did. However, it was
- * confusing that sometimes bnd found a workspace repository (bndtools) and
- * sometimes not (the other drivers).
- * <p>
- * The purpose of this WorkspaceRepositoryMarker interface is to make it clear
- * to the resolver that a Workspace repository is present and should not be
- * added.
- * <p>
- * As a little bonus, any repository implementing this interface *must* add a
- * {@link ResourceUtils#WORKSPACE_NAMESPACE} capability to mark resources from
- * the workspace.
- * <p>
- * Ideally, bnd should have a single workspace repository that tracks the files
- * in the workspace but this is deemed too much work for now.
+ * @deprecated Replaced by aQute.bnd.osgi.repository.WorkspaceRepositoryMarker
  */
-public interface WorkspaceRepositoryMarker {
-	String	NAME				= "Workspace";
+@Deprecated
+public interface WorkspaceRepositoryMarker extends aQute.bnd.osgi.repository.WorkspaceRepositoryMarker {
 }

--- a/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceResourcesRepository.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceResourcesRepository.java
@@ -12,6 +12,7 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.AbstractIndexingRepository;
+import aQute.bnd.osgi.repository.WorkspaceRepositoryMarker;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.lib.io.IO;
 

--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -17,9 +17,9 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.AbstractIndexingRepository;
+import aQute.bnd.osgi.repository.WorkspaceRepositoryMarker;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.lib.io.IO;
-import biz.aQute.resolve.WorkspaceRepositoryMarker;
 
 public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProject> implements WorkspaceRepositoryMarker {
 	EclipseWorkspaceRepository() {


### PR DESCRIPTION
We refactor to use ResourceUtils.matcher as a stream filter. This will
only create the filter once for the requirement rather than once for
each capability tested against a requirement.

When matching across multiple capabilities, as we do here, one should
prefer ResourceUtils.matcher over ResourceUtils.matches. The latter
always creates a new filter object which wastes time in reparsing the
requirement into a filter. Using matcher also allows any optimizations
that can be achieved from reusing the filter object for matches over
the multiple capabilities.

We also make WorkspaceRepositoryDynamic a WorkspaceRepositoryMarker so
others may recognize it if encountered. We also reduce to package
private to avoid making API at this point. We will likely improve this
area after this release.