### PR TITLE
Better computation of maven dependencies

### DIFF
--- a/aQute.libg/src/aQute/lib/strings/Strings.java
+++ b/aQute.libg/src/aQute/lib/strings/Strings.java
@@ -154,15 +154,23 @@ public class Strings {
 	private final static Pattern SIMPLE_LIST_SPLITTER = Pattern.compile("\\s*,\\s*");
 
 	public static Stream<String> splitAsStream(String s) {
+		return splitAsStream(s, SIMPLE_LIST_SPLITTER);
+	}
+
+	public static Stream<String> splitAsStream(String s, Pattern splitter) {
 		if ((s == null) || (s = s.trim()).isEmpty()) {
 			return Stream.empty();
 		}
-		return SIMPLE_LIST_SPLITTER.splitAsStream(s)
+		return splitter.splitAsStream(s)
 			.filter(Strings::notEmpty);
 	}
 
 	public static List<String> split(String s) {
 		return splitAsStream(s).collect(toList());
+	}
+
+	public static List<String> split(String s, Pattern splitter) {
+		return splitAsStream(s, splitter).collect(toList());
 	}
 
 	public static Stream<String> splitQuotedAsStream(String s) {
@@ -209,10 +217,7 @@ public class Strings {
 	public static List<String> split(String regex, String s) {
 		if ((s == null) || (s = s.trim()).isEmpty())
 			return new ArrayList<>();
-		return Pattern.compile(regex)
-			.splitAsStream(s)
-			.filter(Strings::notEmpty)
-			.collect(toList());
+		return split(s, Pattern.compile(regex));
 	}
 
 	public static boolean in(String[] skip, String key) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
@@ -96,6 +96,10 @@ public class Container {
 		DownloadBlocker blocker = db;
 		if (blocker != null) {
 			File f = blocker.getFile();
+			Map<String, String> dbAttrs = blocker.getAttributes();
+			if (!dbAttrs.isEmpty()) {
+				dbAttrs.forEach(getWritableAttributes()::putIfAbsent);
+			}
 			if (blocker.getStage() == Stage.FAILURE) {
 				String r = blocker.getReason();
 				if (error == null) {
@@ -201,12 +205,16 @@ public class Container {
 		return attributes;
 	}
 
-	public synchronized void putAttribute(String name, String value) {
-		if (attributes == Collections.<String, String> emptyMap())
-			attributes = new HashMap<>(1);
-		attributes.put(name, value);
+	public void putAttribute(String name, String value) {
+		getWritableAttributes().put(name, value);
 	}
 
+	private synchronized Map<String, String> getWritableAttributes() {
+		if (attributes == Collections.<String, String> emptyMap()) {
+			return attributes = new HashMap<>();
+		}
+		return attributes;
+	}
 	/**
 	 * Return the this if this is anything else but a library. If it is a
 	 * library, return the members. This could work recursively, e.g., libraries

--- a/biz.aQute.bndlib/src/aQute/bnd/service/RepositoryPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/RepositoryPlugin.java
@@ -129,6 +129,19 @@ public interface RepositoryPlugin {
 		void success(File file) throws Exception;
 
 		/**
+		 * Called when the file is successfully downloaded from a remote
+		 * repository.
+		 *
+		 * @param file The file that was downloaded
+		 * @param attrs Additional attributes about the file. This may include
+		 *            maven coordinates.
+		 * @throws Exception , are logged and ignored
+		 */
+		default void success(File file, Map<String, String> attrs) throws Exception {
+			success(file);
+		}
+
+		/**
 		 * Called when the file could not be downloaded from a remote
 		 * repository.
 		 *

--- a/biz.aQute.bndlib/src/aQute/bnd/util/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/util/repository/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.util.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -293,7 +293,8 @@ public class BndPomRepository extends BaseRepository
 		if (listeners.length == 0)
 			return p.getValue();
 
-		new DownloadListenerPromise(reporter, name + ": get " + bsn + ";" + version, p, listeners);
+		Map<String, String> attrs = archive.attributes();
+		new DownloadListenerPromise(reporter, name + ": get " + bsn + ";" + version, p, attrs, listeners);
 		return repoImpl.getMavenRepository()
 			.toLocalFile(archive);
 	}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -498,9 +498,10 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 			return f;
 		}
 
+		Map<String, String> attrs = archive.attributes();
 		for (DownloadListener dl : listeners) {
 			try {
-				dl.success(f);
+				dl.success(f, attrs);
 			} catch (Exception e) {
 				logger.warn("updating listener has error", e);
 			}
@@ -929,8 +930,9 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 		Promise<File> promise = storage.get(sourcesArchive);
 		if (listeners.length != 0) {
+			Map<String, String> attrs = sourcesArchive.attributes();
 			new DownloadListenerPromise(reporter, "Get sources " + sourceBsn + "-" + version + " for " + getName(),
-				promise, listeners);
+				promise, attrs, listeners);
 			return storage.toLocalFile(sourcesArchive);
 		} else
 			return promise.getValue();

--- a/biz.aQute.repository/src/aQute/maven/api/Archive.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Archive.java
@@ -1,5 +1,6 @@
 package aQute.maven.api;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -242,5 +243,12 @@ public class Archive implements Comparable<Archive> {
 
 	public Archive update(MavenVersion version) {
 		return new Archive(new Revision(revision.program, version), version, extension, classifier);
+	}
+
+	public Map<String, String> attributes() {
+		Map<String, String> attrs = revision.attributes();
+		attrs.put("maven-classifier", classifier);
+		attrs.put("maven-extension", extension);
+		return attrs;
 	}
 }

--- a/biz.aQute.repository/src/aQute/maven/api/Program.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Program.java
@@ -1,5 +1,6 @@
 package aQute.maven.api;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.regex.Pattern;
@@ -170,5 +171,12 @@ public class Program implements Comparable<Program> {
 			return n;
 
 		return artifact.compareTo(o.artifact);
+	}
+
+	public Map<String, String> attributes() {
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put("maven-groupId", group);
+		attrs.put("maven-artifactId", artifact);
+		return attrs;
 	}
 }

--- a/biz.aQute.repository/src/aQute/maven/api/Program.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Program.java
@@ -2,6 +2,7 @@ package aQute.maven.api;
 
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.regex.Pattern;
 
 import aQute.bnd.version.MavenVersion;
 import aQute.lib.strings.Strings;
@@ -33,7 +34,7 @@ public class Program implements Comparable<Program> {
 	 * @param version the version
 	 * @return the revision
 	 */
-	public synchronized Revision version(String version) {
+	public Revision version(String version) {
 		MavenVersion v = new MavenVersion(version);
 		return version(v);
 	}
@@ -54,12 +55,12 @@ public class Program implements Comparable<Program> {
 	}
 
 	static String validate(String gav) {
-		String parts[] = gav.split(":");
+		String parts[] = GAV_SPLITTER.split(gav);
 		return validate(parts);
 	}
 
 	static String validate(String parts[]) {
-		if (parts.length != 1)
+		if (parts.length != 3)
 			return "A GAV must consists of at least of <g>:<a>:<v>";
 
 		if (!isValidName(parts[0]))
@@ -152,9 +153,10 @@ public class Program implements Comparable<Program> {
 		return path + "/maven-metadata-" + id + ".xml";
 	}
 
+	static final Pattern GAV_SPLITTER = Pattern.compile(":");
+
 	public static Program valueOf(String bsn) {
-		String parts[] = Strings.trim(bsn)
-			.split(":");
+		String parts[] = GAV_SPLITTER.split(Strings.trim(bsn));
 		if (parts.length != 2)
 			return null;
 

--- a/biz.aQute.repository/src/aQute/maven/api/Revision.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Revision.java
@@ -3,6 +3,7 @@ package aQute.maven.api;
 import static aQute.maven.api.Program.GAV_SPLITTER;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 import aQute.bnd.version.MavenVersion;
 
@@ -127,4 +128,9 @@ public class Revision implements Comparable<Revision> {
 
 	}
 
+	public Map<String, String> attributes() {
+		Map<String, String> attrs = program.attributes();
+		attrs.put("maven-version", version.toString());
+		return attrs;
+	}
 }

--- a/biz.aQute.repository/src/aQute/maven/api/Revision.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Revision.java
@@ -1,5 +1,7 @@
 package aQute.maven.api;
 
+import static aQute.maven.api.Program.GAV_SPLITTER;
+
 import java.nio.file.Path;
 
 import aQute.bnd.version.MavenVersion;
@@ -116,7 +118,7 @@ public class Revision implements Comparable<Revision> {
 		if (s == null)
 			return null;
 
-		String[] parts = s.split(":");
+		String[] parts = GAV_SPLITTER.split(s);
 		if (parts.length != 3)
 			return null;
 

--- a/biz.aQute.repository/src/aQute/maven/api/package-info.java
+++ b/biz.aQute.repository/src/aQute/maven/api/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.5.0")
+@Version("1.6.0")
 package aQute.maven.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -27,6 +27,7 @@ import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.w3c.dom.Document;
 
+import aQute.bnd.build.DownloadBlocker;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.http.HttpClient;
@@ -420,6 +421,19 @@ public class MavenBndRepoTest extends TestCase {
 		File file = repo.get("commons-cli:commons-cli", new Version("1.0.0"), null);
 		assertNotNull(file);
 		assertTrue(file.isFile());
+	}
+
+	public void testGetAttributes() throws Exception {
+		config(null);
+		DownloadBlocker db = new DownloadBlocker(null);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0.0"), null, db);
+		assertThat(file).isFile();
+		assertThat(db.getFile()).isEqualTo(file);
+		assertThat(db.getAttributes()).containsEntry("maven-groupId", "commons-cli")
+			.containsEntry("maven-artifactId", "commons-cli")
+			.containsEntry("maven-version", "1.0")
+			.containsEntry("maven-classifier", "")
+			.containsEntry("maven-extension", "jar");
 	}
 
 	public void testGetWithSource() throws Exception {


### PR DESCRIPTION
We provide a means for maven repo types to supply maven attributes about artifacts through DownloadListeners into Containers which can then be examined by the maven dependency computation logic. pom.properties processing is the fall back for when artifacts come from non-maven repos such as the workspace repo.

This is done with limited API changes.