### PR TITLE
pom dependencies: Use classifier if present and non-empty

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -150,13 +150,18 @@ public class ProjectBuilder extends Builder {
 				attrs.put("artifactId", depArtifactId);
 				attrs.put("version", depVersion);
 				attrs.put("scope", scope);
-				String key = new StringBuilder().append(depGroupId)
+				StringBuilder key = new StringBuilder().append(depGroupId)
 					.append(':')
 					.append(depArtifactId)
 					.append(':')
-					.append(depVersion)
-					.toString();
-				dependencies.add(key, attrs);
+					.append(depVersion);
+				String depClassifier = containerAttributes.get("maven-classifier");
+				if ((depClassifier != null) && !depClassifier.isEmpty()) {
+					attrs.put("classifier", depClassifier);
+					key.append(":jar:")
+						.append(depClassifier);
+				}
+				dependencies.add(key.toString(), attrs);
 			} else {
 				// fall back to pom.properties in jar
 				jar.getResources(pomPropertiesFilter)


### PR DESCRIPTION
If we get a maven classifier attribute from a repo, we should use it in
the generated maven dependencies.

