### PR TITLE
reporter: Remove -maven-dependencies instruction

### DIFF
--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -2,18 +2,6 @@
 -include: ${workspace}/cnf/includes/jdt.bnd
 
 jtwig.version: 5.86.1.RELEASE
--maven-dependencies.jtwig:\
-	org.jtwig:jtwig-core:${jtwig.version};\
-	groupId=org.jtwig;\
-	artifactId=jtwig-core;\
-	version=${jtwig.version};\
-	scope=compile,\
-	\
-	org.jtwig:jtwig-reflection:${jtwig.version};\
-	groupId=org.jtwig;\
-	artifactId=jtwig-reflection;\
-	version=${jtwig.version};\
-	scope=compile
  
 -buildpath: \
 	osgi.annotation;version=latest;maven-scope=provided,\

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -10,7 +10,7 @@ javac.compliance:       1.8
 javac.debug:            on
 
 # This build requires newer Bnd features
--require-bnd: "(version>=4.3.0)"
+-require-bnd: "(version>=5.1.0)"
 
 #
 # Custom Settings


### PR DESCRIPTION
Recent enhancements to Bnd get maven metadata from the repository
plugin. So we don't need to specify the maven metadata for jtwig
anymore.

