### PR TITLE
A Processor's lastModified must consider the parent Processor

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/ant/BndTask.java
+++ b/biz.aQute.bnd/src/aQute/bnd/ant/BndTask.java
@@ -147,7 +147,7 @@ public class BndTask extends BaseTask {
 			else
 				project.action(command);
 
-			for (Project p : ws.getCurrentProjects())
+			for (Project p : ws.getAllProjects())
 				ws.getInfo(p, p + ":");
 
 			if (report(ws))

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2222,7 +2222,7 @@ public class Project extends Processor {
 		if (isCnf()) {
 			changed = workspace.refresh();
 		}
-		return super.refresh() || changed;
+		return super.refresh() | changed;
 	}
 
 	private void refreshData() {
@@ -2243,11 +2243,11 @@ public class Project extends Processor {
 
 	@Override
 	public void propertiesChanged() {
-		super.propertiesChanged();
 		setChanged();
 		makefile = null;
 		versionMap.clear();
 		refreshData();
+		super.propertiesChanged();
 	}
 
 	public String getName() {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -373,17 +373,13 @@ public class Workspace extends Processor {
 			.isPresent();
 	}
 
-	public Collection<Project> getCurrentProjects() {
-		return projects.getAllProjects();
-	}
-
 	@Override
 	public boolean refresh() {
 		refreshData();
 		gestalt = null;
 		if (super.refresh()) {
 
-			for (Project project : getCurrentProjects()) {
+			for (Project project : getAllProjects()) {
 				project.propertiesChanged();
 			}
 			return true;
@@ -442,6 +438,13 @@ public class Workspace extends Processor {
 
 	public Collection<Project> getAllProjects() {
 		return projects.getAllProjects();
+	}
+
+	/**
+	 * @see #getAllProjects() "Use getAllProjects() instead."
+	 */
+	public Collection<Project> getCurrentProjects() {
+		return getAllProjects();
 	}
 
 	/**
@@ -599,7 +602,7 @@ public class Workspace extends Processor {
 
 	public Collection<Project> getBuildOrder() throws Exception {
 		Set<Project> result = new LinkedHashSet<>();
-		for (Project project : projects.getAllProjects()) {
+		for (Project project : getAllProjects()) {
 			Collection<Project> dependsOn = project.getDependson();
 			getBuildOrder(dependsOn, result);
 			result.add(project);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -504,7 +504,7 @@ public class Jar implements Closeable {
 			IO.delete(file);
 			throw t;
 		}
-		file.setLastModified(lastModified);
+		file.setLastModified(lastModified());
 	}
 
 	public void write(String file) throws Exception {
@@ -660,7 +660,7 @@ public class Jar implements Closeable {
 		if (isReproducible()) {
 			ze.setTime(ZIP_ENTRY_CONSTANT_TIME);
 		} else {
-			ZipUtil.setModifiedTime(ze, lastModified);
+			ZipUtil.setModifiedTime(ze, lastModified());
 		}
 		Resource r = new WriteResource() {
 
@@ -927,7 +927,7 @@ public class Jar implements Closeable {
 			if (isReproducible()) {
 				ze.setTime(ZIP_ENTRY_CONSTANT_TIME);
 			} else {
-				ZipUtil.setModifiedTime(ze, lastModified);
+				ZipUtil.setModifiedTime(ze, lastModified());
 			}
 			if (compression == Compression.STORE) {
 				ze.setCrc(0L);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -217,7 +217,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	private long								lastModified;
 	private File								propertiesFile;
 	private boolean								fixup			= true;
-	long										modified;
 	Processor									parent;
 	private final CopyOnWriteArrayList<File>	included		= new CopyOnWriteArrayList<>();
 
@@ -1318,13 +1317,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		try {
 			if (propertiesFile.isFile()) {
 				// System.err.println("Loading properties " + propertiesFile);
-				long modified = propertiesFile.lastModified();
-				if (modified > System.currentTimeMillis() + 100) {
-					System.err.println("Huh? This is in the future " + propertiesFile);
-					this.modified = System.currentTimeMillis();
-				} else
-					this.modified = modified;
-
 				included.clear();
 				Properties p = loadProperties(propertiesFile);
 				setProperties(p);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -271,13 +271,15 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	public Processor(Processor parent, Properties props, boolean wrap) {
 		this(props, wrap);
 		this.parent = parent;
+		updateModified(parent.lastModified(), "parent");
 	}
 
-	public void setParent(Processor processor) {
-		this.parent = processor;
-		Properties updated = new UTF8Properties(processor.getProperties0());
+	public void setParent(Processor parent) {
+		this.parent = parent;
+		Properties updated = new UTF8Properties(parent.getProperties0());
 		updated.putAll(getProperties0());
 		properties = updated;
+		propertiesChanged();
 	}
 
 	public Processor getParent() {
@@ -1295,7 +1297,12 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		propertiesChanged();
 	}
 
-	public void propertiesChanged() {}
+	public void propertiesChanged() {
+		Processor p = getParent();
+		if (p != null) {
+			updateModified(p.lastModified(), "propertiesChanged");
+		}
+	}
 
 	/**
 	 * Set the properties by file. Setting the properties this way will also set
@@ -1639,7 +1646,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		return result;
 	}
 
-	public boolean updateModified(long time, @SuppressWarnings("unused") String reason) {
+	public boolean updateModified(long time, String reason) {
 		if (time > lastModified) {
 			lastModified = time;
 			return true;


### PR DESCRIPTION
A Project's parent is the Workspace. When the Workspace is updated
(such as by editing cnf/build.bnd), the lastModified of the Workspace
is updated and so the lastModified of its Projects must also be updated.
So when the Projects rebuild, their Jar files will get the updated
lastModified time and so will appear to be changed to observers such as
Eclipse.

Fixes #4017