### PR TITLE
build: Clean up license notice to properly describe AL2 OR EPL2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 This program and the accompanying materials are made available under the
 terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
 
+SPDX-License-Identifier: (Apache-2.0 OR EPL-2.0)
+
 ==============
 
                                  Apache License

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -36,12 +36,10 @@ Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
 Automatic-Module-Name:  ${def;bsn}
 Bundle-Vendor:          Bndtools https://bndtools.org/
 Bundle-Copyright:       Copyright (c) aQute SARL (2000, ${tstamp;yyyy}) and others. All Rights Reserved.
-Bundle-License:         Apache-2.0;\
-                        description="Apache License, Version 2.0";\
-                        link="https://opensource.org/licenses/Apache-2.0",\
-                        EPL-2.0;\
-                        description="Eclipse Public License, Version 2.0";\
-                        link="https://opensource.org/licenses/EPL-2.0"
+SPDX-License-Identifier: (Apache-2.0 OR EPL-2.0)
+Bundle-License:         "${SPDX-License-Identifier}";\
+                        description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";\
+                        link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
 Bundle-DocURL:          https://bnd.bndtools.org/
 Bundle-SCM:             url=https://github.com/bndtools/bnd, \
                         connection=scm:git:https://github.com/bndtools/bnd.git, \

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -38,15 +38,9 @@
 	</organization>
 	<licenses>
 		<license>
-			<name>Apache-2.0</name>
-			<comments>Apache License, Version 2.0</comments>
-			<url>https://opensource.org/licenses/Apache-2.0</url>
-			<distribution>repo</distribution>
-		</license>
-		<license>
-			<name>EPL-2.0</name>
-			<comments>Eclipse Public License, Version 2.0</comments>
-			<url>https://opensource.org/licenses/EPL-2.0</url>
+			<name>(Apache-2.0 OR EPL-2.0)</name>
+			<comments>This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.</comments>
+			<url>https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -223,6 +217,16 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.2.0</version>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							</manifest>
+							<manifestEntries>
+								<SPDX-License-Identifier>${project.licenses[0].name}</SPDX-License-Identifier>
+							</manifestEntries>
+						</archive>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/org.bndtools.p2/features/bndtools.m2e/feature.xml
+++ b/org.bndtools.p2/features/bndtools.m2e/feature.xml
@@ -13,11 +13,10 @@
       Copyright Gregory Amerson others, 2016
    </copyright>
 
-   <license url="Apache-2.0 OR EPL-2.0">
-      Apache-2.0 OR EPL-2.0
+   <license url="(Apache-2.0 OR EPL-2.0)">
+      SPDX-License-Identifier: (Apache-2.0 OR EPL-2.0)
 
-This program and the accompanying materials are made available under the
-terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
 
 ==============
 

--- a/org.bndtools.p2/features/bndtools.main/feature.xml
+++ b/org.bndtools.p2/features/bndtools.main/feature.xml
@@ -16,11 +16,10 @@
 This software uses icons from the FamFamFam &quot;Silk&quot; icon set by Mark James (http://www.famfamfam.com/lab/icons/silk/)
    </copyright>
 
-   <license url="Apache-2.0 OR EPL-2.0">
-      Apache-2.0 OR EPL-2.0
+   <license url="(Apache-2.0 OR EPL-2.0)">
+      SPDX-License-Identifier: (Apache-2.0 OR EPL-2.0)
 
-This program and the accompanying materials are made available under the
-terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
 
 ==============
 

--- a/org.bndtools.p2/features/bndtools.pde/feature.xml
+++ b/org.bndtools.p2/features/bndtools.pde/feature.xml
@@ -13,11 +13,10 @@
       Copyright Elias N Vasylenko and others, 2017
    </copyright>
 
-   <license url="Apache-2.0 OR EPL-2.0">
-      Apache-2.0 OR EPL-2.0
+   <license url="(Apache-2.0 OR EPL-2.0)">
+      SPDX-License-Identifier: (Apache-2.0 OR EPL-2.0)
 
-This program and the accompanying materials are made available under the
-terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
+This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.
 
 ==============
 


### PR DESCRIPTION
We also add SPDX-License-Identifier.

https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b
