### PR TITLE
add parameterized commands for exporting and resolving bndrun files

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -1073,6 +1073,42 @@
          categoryId="bndtools.runEditor"/>
    </extension>
 
+   <extension point="org.eclipse.ui.commands">
+      <command
+         defaultHandler="bndtools.command.BndExportJarHandler"
+         id="bnd.command.export.jar"
+         name="bnd export jar"
+      >
+         <commandParameter
+            id="bnd.command.bndrunFile"
+            name="bndrun file"
+            optional="false"
+            values="bndtools.command.BndrunFilesParameterValues"/>
+      </command>
+      <command
+         defaultHandler="bndtools.command.BndExportRunbundlesHandler"
+         id="bnd.command.export.runbundles"
+         name="bnd export runbundles"
+      >
+         <commandParameter
+            id="bnd.command.bndrunFile"
+            name="bndrun file"
+            optional="false"
+            values="bndtools.command.BndrunFilesParameterValues"/>
+      </command>
+      <command
+         defaultHandler="bndtools.command.BndResolveHandler"
+         id="bnd.command.resolve"
+         name="bnd resolve"
+      >
+         <commandParameter
+            id="bnd.command.bndrunFile"
+            name="bndrun file"
+            optional="false"
+            values="bndtools.command.BndrunFilesParameterValues"/>
+      </command>
+   </extension>
+
    <extension point="org.eclipse.ui.bindings">
       <key
          sequence="M3+M2+X B"

--- a/bndtools.core/src/bndtools/command/BndExportJarHandler.java
+++ b/bndtools.core/src/bndtools/command/BndExportJarHandler.java
@@ -1,0 +1,76 @@
+package bndtools.command;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Map.Entry;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.exporter.executable.ExecutableJarExporter;
+import aQute.bnd.osgi.Resource;
+import aQute.lib.io.IO;
+import biz.aQute.resolve.Bndrun;
+import bndtools.Plugin;
+import bndtools.central.Central;
+
+public class BndExportJarHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		String bndrunFilePath = event.getParameter(BndrunFilesParameterValues.BNDRUN_FILE);
+		IFile bndrunFile = ResourcesPlugin.getWorkspace()
+			.getRoot()
+			.getFile(new Path(bndrunFilePath));
+		IProject project = bndrunFile.getProject();
+
+		WorkspaceJob job = new WorkspaceJob("bnd export jar: " + bndrunFilePath) {
+			@Override
+			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				IStatus status = Status.OK_STATUS;
+				try {
+					Bndrun bndrun = Bndrun.createBndrun(Central.getWorkspace(), new File(bndrunFile.getLocationURI()));
+					Project bndProject = Central.getProject(project);
+					bndrun.setBase(bndProject.getBase());
+
+					Entry<String, Resource> export = bndrun.export(ExecutableJarExporter.EXECUTABLE_JAR,
+						Collections.emptyMap());
+
+					if (export != null) {
+						try (Resource resource = export.getValue()) {
+							File exportDir = IO.getBasedFile(bndProject.getTargetDir(), "export");
+							exportDir.mkdirs();
+							File exported = IO.getBasedFile(exportDir, export.getKey());
+							try (OutputStream out = IO.outputStream(exported)) {
+								resource.write(out);
+							}
+							exported.setLastModified(resource.lastModified());
+							project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+						}
+					}
+				} catch (Exception e) {
+					status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, "Unable to export jar", e);
+				}
+				return status;
+			}
+		};
+		job.setRule(project);
+		job.schedule();
+
+		return null;
+	}
+
+}

--- a/bndtools.core/src/bndtools/command/BndExportRunbundlesHandler.java
+++ b/bndtools.core/src/bndtools/command/BndExportRunbundlesHandler.java
@@ -1,0 +1,76 @@
+package bndtools.command;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map.Entry;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.exporter.runbundles.RunbundlesExporter;
+import aQute.bnd.osgi.JarResource;
+import aQute.bnd.osgi.Resource;
+import biz.aQute.resolve.Bndrun;
+import bndtools.Plugin;
+import bndtools.central.Central;
+
+public class BndExportRunbundlesHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		String bndrunFilePath = event.getParameter(BndrunFilesParameterValues.BNDRUN_FILE);
+		IFile bndrunFile = ResourcesPlugin.getWorkspace()
+			.getRoot()
+			.getFile(new Path(bndrunFilePath));
+		IProject project = bndrunFile.getProject();
+
+		WorkspaceJob job = new WorkspaceJob("bnd export runbundles: " + bndrunFilePath) {
+			@Override
+			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				IStatus status = Status.OK_STATUS;
+				try {
+					Bndrun bndrun = Bndrun.createBndrun(Central.getWorkspace(), new File(bndrunFile.getLocationURI()));
+					Project bndProject = Central.getProject(project);
+					bndrun.setBase(bndProject.getBase());
+
+					Entry<String, Resource> export = bndrun.export(RunbundlesExporter.RUNBUNDLES,
+						Collections.emptyMap());
+
+					if (export != null) {
+						try (JarResource jarResource = (JarResource) export.getValue()) {
+							File runbundlesDir = bndProject
+								.getTargetDir()
+								.toPath()
+								.resolve("export")
+								.resolve(bndrunFile.getName())
+								.toFile();
+							jarResource.getJar()
+								.writeFolder(runbundlesDir);
+							project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+						}
+					}
+				} catch (Exception e) {
+					status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, "Unable to export runbundles", e);
+				}
+				return status;
+			}
+		};
+		job.setRule(project);
+		job.schedule();
+
+		return null;
+	}
+
+}

--- a/bndtools.core/src/bndtools/command/BndResolveHandler.java
+++ b/bndtools.core/src/bndtools/command/BndResolveHandler.java
@@ -1,0 +1,60 @@
+package bndtools.command;
+
+import java.io.File;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+
+import aQute.bnd.build.Project;
+import biz.aQute.resolve.Bndrun;
+import bndtools.Plugin;
+import bndtools.central.Central;
+
+public class BndResolveHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		String bndrunFilePath = event.getParameter(BndrunFilesParameterValues.BNDRUN_FILE);
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace()
+			.getRoot();
+		IFile bndrunFile = root.getFile(new Path(bndrunFilePath));
+		IProject project = bndrunFile.getProject();
+
+		WorkspaceJob job = new WorkspaceJob("bnd resolve: " + bndrunFilePath) {
+			@Override
+			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				IStatus status = Status.OK_STATUS;
+				try {
+					Bndrun bndrun = Bndrun.createBndrun(Central.getWorkspace(), new File(bndrunFile.getLocationURI()));
+					Project bndProject = Central.getProject(project);
+					bndrun.setBase(bndProject.getBase());
+
+					bndrun.resolve(false, true);
+
+					bndrunFile.refreshLocal(IResource.DEPTH_ONE, monitor);
+				} catch (Exception e) {
+					status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, "Unable to resolve jar", e);
+				}
+
+				return status;
+			}
+		};
+		job.setRule(project);
+		job.schedule();
+
+		return null;
+	}
+
+}

--- a/bndtools.core/src/bndtools/command/BndrunFilesParameterValues.java
+++ b/bndtools.core/src/bndtools/command/BndrunFilesParameterValues.java
@@ -79,6 +79,8 @@ public class BndrunFilesParameterValues implements IParameterValues {
 	}
 
 	private static class InvalidateMapListener implements IResourceChangeListener {
+		private final int kind = IResourceDelta.ADDED | IResourceDelta.REMOVED;
+
 		@Override
 		public void resourceChanged(IResourceChangeEvent event) {
 			final AtomicBoolean bndrunChanged = new AtomicBoolean(false);
@@ -90,7 +92,7 @@ public class BndrunFilesParameterValues implements IParameterValues {
 					public boolean visit(IResourceDelta delta) throws CoreException {
 						String name = delta.getFullPath()
 							.lastSegment();
-						if (name != null && name.endsWith(".bndrun")) {
+						if (name != null && name.endsWith(".bndrun") && (delta.getKind() & kind) > 0) {
 							bndrunChanged.set(true);
 							return false;
 						}

--- a/bndtools.core/src/bndtools/command/BndrunFilesParameterValues.java
+++ b/bndtools.core/src/bndtools/command/BndrunFilesParameterValues.java
@@ -1,0 +1,106 @@
+package bndtools.command;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.commands.IParameterValues;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IResourceDelta;
+import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+
+import aQute.bnd.build.Workspace;
+import bndtools.central.Central;
+
+public class BndrunFilesParameterValues implements IParameterValues {
+
+	static final String BNDRUN_FILE = "bnd.command.bndrunFile";
+
+	private static Map<String, String> bndrunFilesMap;
+	private static IResourceChangeListener	listener	= new InvalidateMapListener();
+
+	@Override
+	public Map getParameterValues() {
+		Workspace ws = Central.getWorkspaceIfPresent();
+
+		if (ws == null)
+			return Collections.EMPTY_MAP;
+
+		synchronized (ws) {
+			if (bndrunFilesMap == null) {
+				bndrunFilesMap = ws
+					.getAllProjects()
+					.stream()
+					.map(Central::getProject)
+					.filter(Optional::isPresent)
+					.map(Optional::get)
+					.map(
+						this::findBndrunFiles)
+					.flatMap(Collection::stream)
+					.map(IResource::getFullPath)
+					.collect(Collectors.toMap(IPath::toPortableString,
+						IPath::toPortableString));
+
+				ResourcesPlugin.getWorkspace()
+					.addResourceChangeListener(listener);
+			}
+		}
+
+		return bndrunFilesMap;
+	}
+
+	private List<IFile> findBndrunFiles(IProject project) {
+		List<IFile> bndrunFiles = new ArrayList<>();
+
+		try {
+			project.accept(proxy -> {
+				String name = proxy.getName();
+				if (proxy.getType() == IResource.FILE && name.endsWith(".bndrun")) {
+					bndrunFiles.add((IFile) proxy.requestResource());
+					return false;
+				}
+				return true;
+			}, IResource.DEPTH_INFINITE);
+		} catch (CoreException e) {}
+
+		return bndrunFiles;
+	}
+
+	private static class InvalidateMapListener implements IResourceChangeListener {
+		@Override
+		public void resourceChanged(IResourceChangeEvent event) {
+			final AtomicBoolean bndrunChanged = new AtomicBoolean(false);
+
+			try {
+				IResourceDelta delta = event.getDelta();
+				delta.accept(new IResourceDeltaVisitor() {
+					@Override
+					public boolean visit(IResourceDelta delta) throws CoreException {
+						String name = delta.getFullPath()
+							.lastSegment();
+						if (name != null && name.endsWith(".bndrun")) {
+							bndrunChanged.set(true);
+							return false;
+						}
+						return true;
+					}
+				});
+			} catch (CoreException e) {}
+
+			if (bndrunChanged.get())
+				bndrunFilesMap = null;
+		}
+	}
+}


### PR DESCRIPTION
Recently I've been exporting jars using the gradle tasks because its just faster for me to type into a terminal what I need instead of fishing around the Eclipse UI for the correct bndrun file and then clicking through the "Export Run descriptor" wizard.  

However, when I run `gradlew export` tasks from the CLI, I often will run into the problem of both the gradle export task and Eclipse builder running at the same time (because I have auto-refresh set to true for my Eclipse workspace).  So as you can expect having two builders (eclipse and gradle) running at the same time blows up often when they try to read/write the files

So I decided to add a new feature to Bndtools that will make it just as fast (minimal keystrokes) for me to execute this `export` operation.  I did this as Eclipse Parameterized commands.  

This works by dynamically creating an eclipse command for exporting and resolving bndrun files.  Then developers can access these commands through the most underrated feature of Eclipse, the  `Quick access` search feature.  So with this if I want to "export" or "resolve" a bndrun file, I can just type this from anywhere in Eclipse UI

1. Cmd + 3
2. type: `bnd export jar`
3. select from list of bndrun files and click enter

This `command` will execute on the workspace and lock the "project" so it will keep the Eclipse builder from executing any builds if files change.

Then if I "export again" the `quick access` dialog has a `previous entries` that will be sorted to the top, so on subsequent commands  you can just do it with 2 keystrokes

1. Cmd + 3
2. enter (to select the most recently selected 'command')

### TLDR;
Here is a video
![bnd_commands](https://user-images.githubusercontent.com/595221/81750887-fc1b0300-9473-11ea-85f0-816aab845c31.gif)

If you want to just type the file name of the bndrun, the 3 available commands for that filename will show up:

![bndrunfile](https://user-images.githubusercontent.com/595221/81751912-0807c480-9476-11ea-8d4a-f1428aadd1a8.gif)

So far I've added the following quick commands

1. bnd export jar (bndrun file)
2. bnd export runbundles (bndrun file)
3. bnd resolve (bndrun file)

I asked for some advice from @rotty3000  on what these bare bones commands should execute and he suggested we start with something similar to what the maven mojos are doing.  But I would like to get some feedback as to what others would expect here.