### PR TITLE
add "open project" command handler

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -560,7 +560,7 @@
          icon="icons/bundle.png"
       />
    </extension>
-   
+
    <extension point="org.eclipse.debug.core.sourceContainerTypes">
       <sourceContainerType
          id="org.bndtools.core.launch.sourceContainerTypes.bndrunDirective"
@@ -1106,6 +1106,17 @@
             name="bndrun file"
             optional="false"
             values="bndtools.command.BndrunFilesParameterValues"/>
+      </command>
+      <command
+         defaultHandler="bndtools.command.OpenProjectHandler"
+         id="bnd.command.open.project"
+         name="open project"
+      >
+         <commandParameter
+            id="bnd.command.projectName"
+            name="project name"
+            optional="false"
+            values="bndtools.command.ProjectNamesParameterValues"/>
       </command>
    </extension>
 

--- a/bndtools.core/src/bndtools/command/OpenProjectHandler.java
+++ b/bndtools.core/src/bndtools/command/OpenProjectHandler.java
@@ -1,0 +1,93 @@
+package bndtools.command;
+
+import static aQute.lib.exceptions.FunctionWithException.asFunction;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.expressions.IEvaluationContext;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.ISetSelectionTarget;
+
+import bndtools.Plugin;
+import bndtools.explorer.BndtoolsExplorer;
+
+public class OpenProjectHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		IProject project = ResourcesPlugin
+			.getWorkspace()
+			.getRoot()
+			.getProject(event.getParameter(ProjectNamesParameterValues.PROJECT_NAME));
+
+		if (!project.isOpen()) {
+			new WorkspaceJob("open project") {
+				@Override
+				public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+					project.open(monitor);
+					return Status.OK_STATUS;
+				}
+			}.schedule();
+		}
+
+		try {
+			selectProject(project);
+		} catch (Exception e) {
+			IEvaluationContext context = (IEvaluationContext) event.getApplicationContext();
+			ErrorDialog.openError((Shell) context.getVariable("activeShell"), "Open Project",
+				"Unable to select project",
+				new Status(IStatus.ERROR, Plugin.PLUGIN_ID, e.getMessage(), e));
+		}
+
+		return null;
+	}
+
+	private static void selectProject(IProject project) throws Exception {
+		IWorkbenchPage activePage = PlatformUI.getWorkbench()
+			.getActiveWorkbenchWindow()
+			.getActivePage();
+
+		Optional<String> viewPartId = restoreViewPartId(activePage, BndtoolsExplorer.VIEW_ID);
+
+		if (!viewPartId.isPresent()) {
+			viewPartId = restoreViewPartId(activePage, "org.eclipse.jdt.ui.PackageExplorer");
+		}
+
+		if (!viewPartId.isPresent()) {
+			viewPartId = Optional.of(activePage.showView(BndtoolsExplorer.VIEW_ID)
+				.getSite()
+				.getId());
+		}
+
+		viewPartId.map(asFunction(partId -> activePage.showView(
+			partId)))
+			.map(ISetSelectionTarget.class::cast)
+			.ifPresent(target -> target.selectReveal(new StructuredSelection(project)));
+	}
+
+	private static Optional<String> restoreViewPartId(IWorkbenchPage page, String viewId) {
+		return Arrays.stream(page.getViewReferences())
+			.filter(ref -> Objects.equals(ref.getId(),
+				viewId))
+			.map(ref -> ref.getPart(true))
+			.map(part -> part.getSite()
+				.getId())
+			.findFirst();
+	}
+}

--- a/bndtools.core/src/bndtools/command/ProjectNamesParameterValues.java
+++ b/bndtools.core/src/bndtools/command/ProjectNamesParameterValues.java
@@ -1,0 +1,25 @@
+package bndtools.command;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.eclipse.core.commands.IParameterValues;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+public class ProjectNamesParameterValues implements IParameterValues {
+
+	static final String PROJECT_NAME = "bnd.command.projectName";
+
+	@Override
+	public Map getParameterValues() {
+		return Arrays.stream(
+			ResourcesPlugin
+			.getWorkspace()
+			.getRoot()
+			.getProjects())
+			.collect(toMap(IProject::getName, IProject::getName));
+	}
+}

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -30,6 +30,8 @@ import aQute.libg.glob.Glob;
 import bndtools.Plugin;
 
 public class BndtoolsExplorer extends PackageExplorerPart {
+	public static final String		VIEW_ID		= "bndtools.PackageExplorer";
+
 	private final FilterPanelPart	filterPart	= new FilterPanelPart(Plugin.getDefault()
 		.getScheduler());
 	private PropertyChangeListener	listener;


### PR DESCRIPTION
Use the `Quick Access` `Cmd+3` and then type in a project name (or partial name) and you should see a new "open project" command available.

This will try to open the BndtoolsExplorer first and then falls back to PackageExplorer.  If neither are open, it will open the BndtoolsExplorer.

![openProject](https://user-images.githubusercontent.com/595221/81843543-59b25c80-9513-11ea-8a63-4748cf6fcebc.gif)
