### PR TITLE
maven repo: Allow adding snapshots to index on release

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MacroTest.java
@@ -614,6 +614,16 @@ public class MacroTest {
 		assertEquals("false", processor.getReplacer()
 			.process("${apply;isnumber;1,2,3,a,4}"));
 
+		processor.setProperty("double", "${1}${1}");
+		assertEquals("A,B,C,D,E,F", processor.getReplacer()
+			.process("${map;toupper;a, b, c, d, e, f}"));
+		assertEquals("aa,bb,cc,dd,ee,ff", processor.getReplacer()
+			.process("${map;double;a, b, c, d, e, f}"));
+
+		processor.setProperty("sumbyindex", "${sum;${1},${2}}");
+		assertEquals("1,3,5,7,9,11,13,15,17,19", processor.getReplacer()
+			.process("${foreach;sumbyindex;1, 2, 3, 4, 5, 6, 7, 8, 9, 10}"));
+
 		assertEquals("6", processor.getReplacer()
 			.process("${size;a, b, c, d, e, f}"));
 		assertEquals("0", processor.getReplacer()
@@ -673,24 +683,6 @@ public class MacroTest {
 			.process("${min;2; 0; -13; 40; 55; -16; 700, -8, 9, 10}"));
 		assertEquals("9", processor.getReplacer()
 			.process("${max;2; 0, -13, 40, 55, -16, 700, -8, 9, 10}"));
-	}
-
-	/**
-	 * String functions
-	 */
-
-	@Test
-	@EnabledForJreRange(max = JRE.JAVA_14)
-	public void testJSMacroLists() throws Exception {
-		Processor processor = new Processor();
-		processor.setProperty("double", "${1}${1}");
-		processor.setProperty("mulbyindex", "${js;${1}*${2}}");
-		assertEquals("A,B,C,D,E,F", processor.getReplacer()
-			.process("${map;toupper;a, b, c, d, e, f}"));
-		assertEquals("aa,bb,cc,dd,ee,ff", processor.getReplacer()
-			.process("${map;double;a, b, c, d, e, f}"));
-		assertEquals("0,2,6,12,20,30,42,56,72,90", processor.getReplacer()
-			.process("${foreach;mulbyindex;1, 2, 3, 4, 5, 6, 7, 8, 9, 10}"));
 	}
 
 	/**
@@ -932,6 +924,9 @@ public class MacroTest {
 		assertEquals("5", processor.getReplacer()
 			.process("${js;domain.get('alpha')/5;}"));
 
+		processor.setProperty("mulbyindex", "${js;${1}*${2}}");
+		assertEquals("0,2,6,12,20,30,42,56,72,90", processor.getReplacer()
+			.process("${foreach;mulbyindex;1, 2, 3, 4, 5, 6, 7, 8, 9, 10}"));
 	}
 
 	/**

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -148,7 +148,7 @@ class IndexFile {
 		Set<Archive> toAdd = Collections.singleton(archive);
 		Promise<Boolean> serializer = serialize(
 			() -> update(toAdd).thenAccept(b -> save(toAdd, Collections.emptySet())));
-		serializer.getFailure(); // sync
+		sync(serializer);
 	}
 
 	/*
@@ -164,7 +164,7 @@ class IndexFile {
 			Set<Archive> toRemove = Collections.singleton(archive);
 			return update(null).thenAccept(b -> save(Collections.emptySet(), toRemove));
 		});
-		serializer.getFailure(); // sync
+		sync(serializer);
 	}
 
 	/*
@@ -191,7 +191,7 @@ class IndexFile {
 			}
 			return update(null).thenAccept(b -> save(Collections.emptySet(), toRemove));
 		});
-		serializer.getFailure(); // sync
+		sync(serializer);
 	}
 
 	/*
@@ -367,7 +367,7 @@ class IndexFile {
 		if (indexFile.lastModified() != lastModified && last + 10000 < System.currentTimeMillis()) {
 			last = System.currentTimeMillis();
 			Promise<Boolean> serializer = serialize(this::load).onResolve(refreshAction);
-			serializer.getFailure(); // sync
+			sync(serializer);
 			return true;
 		}
 		return false;
@@ -446,7 +446,7 @@ class IndexFile {
 	}
 
 	BridgeRepository getBridge() {
-		sync();
+		sync(updateSerializer);
 		return bridge.get();
 	}
 
@@ -462,7 +462,7 @@ class IndexFile {
 	}
 
 	Set<Archive> getArchives() {
-		sync();
+		sync(updateSerializer);
 		return archives.keySet();
 	}
 
@@ -563,9 +563,9 @@ class IndexFile {
 		return archive;
 	}
 
-	private void sync() {
+	private void sync(Promise<?> promise) {
 		try {
-			updateSerializer.getFailure();
+			promise.getFailure();
 		} catch (InterruptedException e) {
 			logger.info("Interrupted");
 			Thread.currentThread()

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -237,8 +237,9 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 						}
 					}
 				}
-				if (configuration.noupdateOnRelease() == false && !binaryArchive.isSnapshot())
+				if (configuration.noupdateOnRelease() == false) {
 					index.add(binaryArchive);
+				}
 			}
 			return result;
 		} catch (Exception e) {

--- a/biz.aQute.repository/src/aQute/maven/api/Program.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Program.java
@@ -2,7 +2,6 @@ package aQute.maven.api;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.regex.Pattern;
 
 import aQute.bnd.version.MavenVersion;
@@ -19,9 +18,6 @@ public class Program implements Comparable<Program> {
 	public final String							group;
 	public final String							artifact;
 	public final String							path;
-
-	final private static Map<String, Program>	programCache	= new WeakHashMap<>();
-	final private Map<String, Revision>			revisionCache	= new WeakHashMap<>();
 
 	Program(String group, String artifact) {
 		this.group = group;
@@ -47,15 +43,7 @@ public class Program implements Comparable<Program> {
 	 * @return the revision
 	 */
 	public Revision version(MavenVersion version) {
-		synchronized (revisionCache) {
-			String key = version.toString();
-			Revision r = revisionCache.get(key);
-			if (r == null) {
-				r = new Revision(this, version);
-				revisionCache.put(key, r);
-			}
-			return r;
-		}
+		return new Revision(this, version);
 	}
 
 	static String validate(String gav) {
@@ -130,16 +118,7 @@ public class Program implements Comparable<Program> {
 	 * @return the Program
 	 */
 	public static Program valueOf(String group, String artifact) {
-
-		synchronized (programCache) {
-			String key = group + ":" + artifact;
-			Program p = programCache.get(key);
-			if (p == null) {
-				p = new Program(group, artifact);
-				programCache.put(key, p);
-			}
-			return p;
-		}
+		return new Program(group, artifact);
 	}
 
 	/**

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -2,7 +2,6 @@ package aQute.bnd.repository.maven.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -636,7 +635,31 @@ public class MavenBndRepoTest {
 		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/maven-metadata-local.xml", 0);
 
 		String s = IO.collect(index);
-		assertFalse(s.contains("biz.aQute.bnd.maven"));
+		// snapshots added to index
+		assertThat(s).contains("biz.aQute.bnd.maven");
+	}
+
+	@Test
+	public void testPutDefaultLocalSnapshotNoUpdate() throws Exception {
+		Map<String, String> map = new HashMap<>();
+		map.put("releaseUrl", null);
+		map.put("snapshotUrl", null);
+		map.put("noupdateOnRelease", "true");
+		config(map);
+
+		File jar = IO.getFile("testresources/snapshot.jar");
+
+		PutResult put = repo.put(new FileInputStream(jar), null);
+
+		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.jar",
+			0);
+		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.pom",
+			0);
+		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/maven-metadata-local.xml", 0);
+
+		String s = IO.collect(index);
+		// snapshots not added to index
+		assertThat(s).doesNotContain("biz.aQute.bnd.maven");
 	}
 
 	@Test
@@ -656,8 +679,30 @@ public class MavenBndRepoTest {
 			0);
 
 		String s = IO.collect(index);
+		// snapshots added to index
+		assertThat(s).contains("biz.aQute.bnd.maven");
+	}
+
+	@Test
+	public void testPutDefaultLocalSnapshotFileRepoNoUpdate() throws Exception {
+		Map<String, String> map = new HashMap<>();
+		map.put("snapshotUrl", remote.toURI()
+			.toString());
+		map.put("noupdateOnRelease", "true");
+		config(map);
+
+		File jar = IO.getFile("testresources/snapshot.jar");
+
+		PutResult put = repo.put(new FileInputStream(jar), null);
+
+		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.jar",
+			0);
+		assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.pom",
+			0);
+
+		String s = IO.collect(index);
 		// snapshots not added to index
-		assertFalse(s.contains("biz.aQute.bnd.maven"));
+		assertThat(s).doesNotContain("biz.aQute.bnd.maven");
 	}
 
 	@Test


### PR DESCRIPTION
We now have `noupdateOnRelease=true` option to disable updating the
index on release. So the original decision to not update index on
release of snapshots can be relaxed.

And some other fixes.