### PR TITLE
memoize: Elide checkcast instructions

### DIFF
--- a/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
+++ b/aQute.libg/src/aQute/lib/memoize/CloseableMemoizingSupplier.java
@@ -58,7 +58,7 @@ class CloseableMemoizingSupplier<T extends AutoCloseable> implements CloseableMe
 		return value(memoized);
 	}
 
-	private static <T> T value(T value) {
+	private static <T extends AutoCloseable> T value(T value) {
 		if (value == null) {
 			throw new IllegalStateException("closed");
 		}


### PR DESCRIPTION
Since we know all the objects are instances of AutoCloseable, we make
the erasure of the method AutoCloseable to avoid checkcast
instructions at call sites.

