### PR TITLE
[baseline] Lost baseline error

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
+++ b/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
@@ -126,34 +126,36 @@ class MarkerSupport {
 			BuildErrorDetailsHandler handler = BuildErrorDetailsHandlers.INSTANCE.findHandler(type);
 
 			List<MarkerData> markers = handler.generateMarkerData(project, model, location);
-			for (MarkerData markerData : markers) {
-				IResource resource = markerData.getResource();
-				if (resource != null && resource.exists()) {
-					String typeOverride = markerData.getTypeOverride();
-					IMarker marker = resource.createMarker(typeOverride != null ? typeOverride : markerType);
-					marker.setAttribute(IMarker.SEVERITY, severity);
-					marker.setAttribute("$bndType", type);
+			if (!markers.isEmpty()) {
+				for (MarkerData markerData : markers) {
+					IResource resource = markerData.getResource();
+					if (resource != null && resource.exists()) {
+						String typeOverride = markerData.getTypeOverride();
+						IMarker marker = resource.createMarker(typeOverride != null ? typeOverride : markerType);
+						marker.setAttribute(IMarker.SEVERITY, severity);
+						marker.setAttribute("$bndType", type);
 
-					//
-					// Set location information
-					if (location.header != null)
-						marker.setAttribute(BNDTOOLS_MARKER_HEADER_ATTR, location.header);
-					if (location.context != null)
-						marker.setAttribute(BNDTOOLS_MARKER_CONTEXT_ATTR, location.context);
-					if (location.file != null)
-						marker.setAttribute(BNDTOOLS_MARKER_FILE_ATTR, location.file);
-					if (location.reference != null)
-						marker.setAttribute(BNDTOOLS_MARKER_REFERENCE_ATTR, location.reference);
+						//
+						// Set location information
+						if (location.header != null)
+							marker.setAttribute(BNDTOOLS_MARKER_HEADER_ATTR, location.header);
+						if (location.context != null)
+							marker.setAttribute(BNDTOOLS_MARKER_CONTEXT_ATTR, location.context);
+						if (location.file != null)
+							marker.setAttribute(BNDTOOLS_MARKER_FILE_ATTR, location.file);
+						if (location.reference != null)
+							marker.setAttribute(BNDTOOLS_MARKER_REFERENCE_ATTR, location.reference);
 
-					marker.setAttribute(BNDTOOLS_MARKER_PROJECT_ATTR, project.getName());
+						marker.setAttribute(BNDTOOLS_MARKER_PROJECT_ATTR, project.getName());
 
-					marker.setAttribute(BuildErrorDetailsHandler.PROP_HAS_RESOLUTIONS, markerData.hasResolutions());
-					for (Entry<String, Object> attrib : markerData.getAttribs()
-						.entrySet())
-						marker.setAttribute(attrib.getKey(), attrib.getValue());
+						marker.setAttribute(BuildErrorDetailsHandler.PROP_HAS_RESOLUTIONS, markerData.hasResolutions());
+						for (Entry<String, Object> attrib : markerData.getAttribs()
+							.entrySet())
+							marker.setAttribute(attrib.getKey(), attrib.getValue());
+					}
 				}
+				return;
 			}
-			return;
 		}
 
 		String defaultResource = model instanceof Project ? Project.BNDFILE


### PR DESCRIPTION
If you export a package form another bundle and that
package has a baseline error, then this error is lost.

The bndlib project exports a package aQute.bnd.annotation.plugin
from the biz.aQute.bnd.annotation project. 

I added a Capability header to the BndPlugin and then
suddenly the bndlib was no longer built, but no errors
were marked.

After debugging it became clear that biz.aQute.bnd.annotation
was not baselined but the aQute.bnd.annotation.plugin
package caused a baseline error in bndlib.

The BaselineErrorHandler could not find 
the package when it tried to create a marker. It
therefore returned zero markers. The MarkerSupport
did not take the case into account where the
Error Handler had zero markers after it indicated
that it had a handler and returned.

This fix will create a default error on bnd when
the handler creates no markers. 

Took some effort to run this in the debugger :-(

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>