### PR TITLE
[bndtools launch] Launching fixes

### DIFF
--- a/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
@@ -155,7 +155,7 @@ public abstract class AbstractOSGiLaunchDelegate extends JavaLaunchDelegate {
 	public boolean buildForLaunch(ILaunchConfiguration configuration, String mode, IProgressMonitor monitor)
 		throws CoreException {
 		BndPreferences prefs = new BndPreferences();
-		boolean result = !prefs.getBuildBeforeLaunch() || super.buildForLaunch(configuration, mode, monitor);
+		boolean result = prefs.getBuildBeforeLaunch();
 
 		try {
 			run = LaunchUtils.createRun(configuration, getRunMode());

--- a/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
+++ b/bndtools.core/src/bndtools/launch/AbstractOSGiLaunchDelegate.java
@@ -155,7 +155,12 @@ public abstract class AbstractOSGiLaunchDelegate extends JavaLaunchDelegate {
 	public boolean buildForLaunch(ILaunchConfiguration configuration, String mode, IProgressMonitor monitor)
 		throws CoreException {
 		BndPreferences prefs = new BndPreferences();
-		boolean result = prefs.getBuildBeforeLaunch();
+		return prefs.getBuildBeforeLaunch();
+	}
+
+	@Override
+	public boolean finalLaunchCheck(ILaunchConfiguration configuration, String mode, IProgressMonitor monitor)
+		throws CoreException {
 
 		try {
 			run = LaunchUtils.createRun(configuration, getRunMode());
@@ -166,12 +171,6 @@ public abstract class AbstractOSGiLaunchDelegate extends JavaLaunchDelegate {
 				new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Error initialising bnd launcher", e));
 		}
 
-		return result;
-	}
-
-	@Override
-	public boolean finalLaunchCheck(ILaunchConfiguration configuration, String mode, IProgressMonitor monitor)
-		throws CoreException {
 		// Check for existing launches of same resource
 		BndPreferences prefs = new BndPreferences();
 		if (prefs.getWarnExistingLaunches()) {


### PR DESCRIPTION
Two commits:

1. Change to honour the workspace settings pertaining to "build before launch" (fixes #4089).
2. Move the bnd launcher initialisation out of `buildForLaunch()` into `finalLaunchCheck()` (fixes #4095).

While I think these are nice fixes there is probably no rush to get them into 5.1-RC2. Who knows how long the "buildForLaunch" flag hasn't been honoured...