### PR TITLE
unmodifiable: Hash using open addressing with linear probing

### DIFF
--- a/aQute.libg/src/aQute/lib/unmodifiable/ImmutableList.java
+++ b/aQute.libg/src/aQute/lib/unmodifiable/ImmutableList.java
@@ -14,11 +14,12 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 final class ImmutableList<E> extends AbstractList<E> implements List<E>, RandomAccess {
+	final static ImmutableList<?>	EMPTY	= new ImmutableList<>();
 	final E[] elements;
 
 	@SafeVarargs
 	ImmutableList(E... elements) {
-		this.elements = requireNonNull(elements);
+		this.elements = elements;
 		for (E element : elements) {
 			requireNonNull(element);
 		}

--- a/aQute.libg/src/aQute/lib/unmodifiable/Lists.java
+++ b/aQute.libg/src/aQute/lib/unmodifiable/Lists.java
@@ -10,7 +10,7 @@ public class Lists {
 	private Lists() {}
 
 	public static <E> List<E> of() {
-		return new ImmutableList<>();
+		return (List<E>) ImmutableList.EMPTY;
 	}
 
 	public static <E> List<E> of(E e1) {
@@ -55,12 +55,19 @@ public class Lists {
 
 	@SafeVarargs
 	public static <E> List<E> of(E... elements) {
-		return new ImmutableList<>((E[]) Arrays.copyOf(elements, elements.length, Object[].class));
+		int length = elements.length;
+		if (length == 0) {
+			return of();
+		}
+		return new ImmutableList<>((E[]) Arrays.copyOf(elements, length, Object[].class));
 	}
 
 	public static <E> List<E> copyOf(Collection<? extends E> collection) {
 		if (collection instanceof ImmutableList) {
 			return (List<E>) collection;
+		}
+		if (collection.isEmpty()) {
+			return of();
 		}
 		return new ImmutableList<>((E[]) collection.toArray());
 	}

--- a/aQute.libg/src/aQute/lib/unmodifiable/Maps.java
+++ b/aQute.libg/src/aQute/lib/unmodifiable/Maps.java
@@ -10,7 +10,7 @@ public class Maps {
 	private Maps() {}
 
 	public static <K, V> Map<K, V> of() {
-		return new ImmutableMap<>();
+		return (Map<K, V>) ImmutableMap.EMPTY;
 	}
 
 	public static <K, V> Map<K, V> of(K k1, V v1) {
@@ -64,12 +64,19 @@ public class Maps {
 
 	@SafeVarargs
 	public static <K, V> Map<K, V> ofEntries(Entry<? extends K, ? extends V>... entries) {
-		return new ImmutableMap<>(entries(Arrays.copyOf(entries, entries.length, Entry[].class)));
+		int length = entries.length;
+		if (length == 0) {
+			return of();
+		}
+		return new ImmutableMap<>(entries(Arrays.copyOf(entries, length, Entry[].class)));
 	}
 
 	public static <K, V> Map<K, V> copyOf(Map<? extends K, ? extends V> map) {
 		if (map instanceof ImmutableMap) {
 			return (Map<K, V>) map;
+		}
+		if (map.isEmpty()) {
+			return of();
 		}
 		return new ImmutableMap<>(entries(map.entrySet()
 			.toArray(new Entry[0])));

--- a/aQute.libg/src/aQute/lib/unmodifiable/Sets.java
+++ b/aQute.libg/src/aQute/lib/unmodifiable/Sets.java
@@ -10,7 +10,7 @@ public class Sets {
 	private Sets() {}
 
 	public static <E> Set<E> of() {
-		return new ImmutableSet<>();
+		return (Set<E>) ImmutableSet.EMPTY;
 	}
 
 	public static <E> Set<E> of(E e1) {
@@ -55,12 +55,19 @@ public class Sets {
 
 	@SafeVarargs
 	public static <E> Set<E> of(E... elements) {
-		return new ImmutableSet<>((E[]) Arrays.copyOf(elements, elements.length, Object[].class));
+		int length = elements.length;
+		if (length == 0) {
+			return of();
+		}
+		return new ImmutableSet<>((E[]) Arrays.copyOf(elements, length, Object[].class));
 	}
 
 	public static <E> Set<E> copyOf(Collection<? extends E> collection) {
 		if (collection instanceof ImmutableSet) {
 			return (Set<E>) collection;
+		}
+		if (collection.isEmpty()) {
+			return of();
 		}
 		return new ImmutableSet<>((E[]) collection.stream()
 			.distinct()

--- a/aQute.libg/test/aQute/lib/unmodifiable/MapsTest.java
+++ b/aQute.libg/test/aQute/lib/unmodifiable/MapsTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +21,12 @@ public class MapsTest {
 		Map<String, String> map = Maps.of();
 		assertThat(map).hasSize(0)
 			.isEmpty();
+		assertThat(map.containsKey("k3")).isFalse();
+		assertThat(map.containsKey(null)).isFalse();
+		assertThat(map.containsValue("v3")).isFalse();
+		assertThat(map.containsValue(null)).isFalse();
+		assertThat(map.get("k3")).isEqualTo(null);
+		assertThat(map.get(null)).isEqualTo(null);
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> map.put("a", "b"));
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> map.remove("a"));
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> map.clear());
@@ -334,6 +341,23 @@ public class MapsTest {
 		hashMap.put("k2", "v2");
 		hashMap.put("k3", "v3");
 		assertThat(map).isNotEqualTo(hashMap);
+	}
+
+	@Test
+	public void entry_set_contains() {
+		Set<Entry<String, String>> entrySet = Maps.of("k1", "v1", "k2", "v2")
+			.entrySet();
+		assertThat(entrySet).containsExactly(new SimpleEntry<>("k1", "v1"), new SimpleEntry<>("k2", "v2"));
+
+		assertThat(entrySet.contains(new SimpleEntry<>("k1", "v1"))).isTrue();
+		assertThat(entrySet.contains(new SimpleEntry<>("k2", "v2"))).isTrue();
+		assertThat(entrySet.contains(new SimpleEntry<>("k1", "v2"))).isFalse();
+		assertThat(entrySet.contains(null)).isFalse();
+
+		entrySet = Maps.<String, String> of()
+			.entrySet();
+		assertThat(entrySet.contains(new SimpleEntry<>("k1", "v2"))).isFalse();
+		assertThat(entrySet.contains(null)).isFalse();
 	}
 
 }

--- a/aQute.libg/test/aQute/lib/unmodifiable/SetsTest.java
+++ b/aQute.libg/test/aQute/lib/unmodifiable/SetsTest.java
@@ -222,6 +222,10 @@ public class SetsTest {
 		assertThat(set.contains("e5")).isTrue();
 		assertThat(set.contains("e6")).isFalse();
 		assertThat(set.contains(null)).isFalse();
+
+		set = Sets.of();
+		assertThat(set.contains("e6")).isFalse();
+		assertThat(set.contains(null)).isFalse();
 	}
 
 	@Test

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -21,6 +21,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Verifier;
 import aQute.bnd.version.Version;
 import aQute.lib.strings.Strings;
+import aQute.lib.unmodifiable.Maps;
 
 public class Syntax implements Constants {
 	final String							header;
@@ -731,41 +732,34 @@ public class Syntax implements Constants {
 			"-x-overwritestrategy=gc", "(classic|delay|gc|windows-only-disposable-names|disposable-names)", null)
 	};
 
-	public final static Map<String, Syntax>	HELP					= new HashMap<>();
+	final static Map<Class<?>, Pattern>		BASE_PATTERNS			= Maps.ofEntries(
+		Maps.entry(Byte.class, Verifier.NUMBERPATTERN), Maps.entry(byte.class, Verifier.NUMBERPATTERN),
+		Maps.entry(Short.class, Verifier.NUMBERPATTERN), Maps.entry(short.class, Verifier.NUMBERPATTERN),
+		Maps.entry(Integer.class, Verifier.NUMBERPATTERN), Maps.entry(int.class, Verifier.NUMBERPATTERN),
+		Maps.entry(Long.class, Verifier.NUMBERPATTERN), Maps.entry(long.class, Verifier.NUMBERPATTERN),
+		Maps.entry(Float.class, Verifier.FLOATPATTERN), Maps.entry(float.class, Verifier.FLOATPATTERN),
+		Maps.entry(Double.class, Verifier.FLOATPATTERN), Maps.entry(double.class, Verifier.FLOATPATTERN),
+		Maps.entry(Boolean.class, Verifier.BOOLEANPATTERN), Maps.entry(boolean.class, Verifier.BOOLEANPATTERN));
 
-	final static Map<Class<?>, Pattern>		BASE_PATTERNS			= new HashMap<>();
-
+	public final static Map<String, Syntax>	HELP;
 	static {
-		BASE_PATTERNS.put(Byte.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(byte.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(Short.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(short.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(Integer.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(int.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(Long.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(long.class, Verifier.NUMBERPATTERN);
-		BASE_PATTERNS.put(Float.class, Verifier.FLOATPATTERN);
-		BASE_PATTERNS.put(float.class, Verifier.FLOATPATTERN);
-		BASE_PATTERNS.put(Double.class, Verifier.FLOATPATTERN);
-		BASE_PATTERNS.put(double.class, Verifier.FLOATPATTERN);
-		BASE_PATTERNS.put(Boolean.class, Verifier.BOOLEANPATTERN);
-		BASE_PATTERNS.put(boolean.class, Verifier.BOOLEANPATTERN);
-
+		Map<String, Syntax> help = new HashMap<>();
 		for (Syntax s : syntaxes) {
-			add(s);
+			add(help, s);
 		}
-		add(BuilderInstructions.class);
-		add(LauncherInstructions.class);
-		add(ResolutionInstructions.class);
+		add(help, BuilderInstructions.class);
+		add(help, LauncherInstructions.class);
+		add(help, ResolutionInstructions.class);
+		HELP = Maps.copyOf(help);
 	}
 
-	private static void add(Syntax s) {
-		HELP.put(s.header, s);
+	private static void add(Map<String, Syntax> help, Syntax s) {
+		help.put(s.header, s);
 	}
 
-	private static void add(Class<?> class1) {
+	private static void add(Map<String, Syntax> help, Class<?> class1) {
 		for (Syntax syntax : create(class1, Syntax::toInstruction, true)) {
-			add(syntax);
+			add(help, syntax);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
@@ -1,10 +1,9 @@
 package aQute.bnd.osgi;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.TreeMap;
 
 import aQute.bnd.version.Version;
+import aQute.lib.unmodifiable.Maps;
 
 /**
  * This package contains a number of classes that assists by analyzing JARs and
@@ -219,24 +218,22 @@ public class About {
 		"It is now possible to specify a URL on a plugin path so that if the resource is not on the file system it will get downloaded."
 	};
 
-	public static final Map<Version, String[]>	CHANGES		= new TreeMap<>(Collections.reverseOrder());
-
-	static {
-		CHANGES.put(_5_2, CHANGES_5_2);
-		CHANGES.put(_5_1, CHANGES_5_1);
-		CHANGES.put(_5_0, CHANGES_5_0);
-		CHANGES.put(_4_3, CHANGES_4_3);
-		CHANGES.put(_4_2, CHANGES_4_2);
-		CHANGES.put(_4_1, CHANGES_4_1);
-		CHANGES.put(_4_0, CHANGES_4_0);
-		CHANGES.put(_3_5, CHANGES_3_5);
-		CHANGES.put(_3_4, CHANGES_3_4);
-		CHANGES.put(_3_3, CHANGES_3_3);
-		CHANGES.put(_3_2, CHANGES_3_2);
-		CHANGES.put(_3_1, CHANGES_3_1);
-		CHANGES.put(_3_0, CHANGES_3_0);
-		CHANGES.put(_2_4, CHANGES_2_4);
-		CHANGES.put(_2_3, CHANGES_2_3);
-	}
+	public static final Map<Version, String[]>	CHANGES		= Maps.ofEntries(
+		// In decreasing order
+		Maps.entry(_5_2, CHANGES_5_2),																																							//
+		Maps.entry(_5_1, CHANGES_5_1),																																							//
+		Maps.entry(_5_0, CHANGES_5_0),																																							//
+		Maps.entry(_4_3, CHANGES_4_3),																																							//
+		Maps.entry(_4_2, CHANGES_4_2),																																							//
+		Maps.entry(_4_1, CHANGES_4_1),																																							//
+		Maps.entry(_4_0, CHANGES_4_0),																																							//
+		Maps.entry(_3_5, CHANGES_3_5),																																							//
+		Maps.entry(_3_4, CHANGES_3_4),																																							//
+		Maps.entry(_3_3, CHANGES_3_3),																																							//
+		Maps.entry(_3_2, CHANGES_3_2),																																							//
+		Maps.entry(_3_1, CHANGES_3_1),																																							//
+		Maps.entry(_3_0, CHANGES_3_0),																																							//
+		Maps.entry(_2_4, CHANGES_2_4),																																							//
+		Maps.entry(_2_3, CHANGES_2_3));
 
 }


### PR DESCRIPTION
For sets and maps, we hash using open addressing with linear probing to
get O(1) lookup. This will make the types more useful for larger
unmodifiable sets and maps.