### PR TITLE
central: Rework callbacks for workspace creation

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -115,6 +115,7 @@ public class Workspace extends Processor {
 	public static final String	EXT						= "ext";
 	public static final String	BUILDFILE				= "build.bnd";
 	public static final String	CNFDIR					= "cnf";
+	@Deprecated
 	public static final String	BNDDIR					= "bnd";
 	public static final String	CACHEDIR				= "cache/" + About.CURRENT;
 	public static final String	STANDALONE_REPO_CLASS	= "aQute.bnd.repository.osgi.OSGiRepository";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1262,9 +1262,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 
 		boolean changed = updateModified(propertiesFile.lastModified(), "properties file");
 		for (File file : getIncluded()) {
-			if (changed)
-				break;
-
 			changed |= !file.exists() || updateModified(file.lastModified(), "include file: " + file);
 		}
 

--- a/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
+++ b/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
@@ -35,10 +35,10 @@ public class CnfWatcher implements IResourceChangeListener {
 
 	@Override
 	public void resourceChanged(final IResourceChangeEvent event) {
-		if (Central.isWorkspaceInited()) {
+		if (Central.hasCnfWorkspace()) {
 			processEvent(event);
 		} else {
-			Central.onWorkspace(workspace -> processEvent(event));
+			Central.onCnfWorkspace(workspace -> processEvent(event));
 		}
 	}
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -68,7 +68,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 
 	public BndContainerInitializer() {
 		super();
-		Central.onWorkspace(workspace -> Central.getInstance()
+		Central.onCnfWorkspace(workspace -> Central.getInstance()
 			.addModelListener(BndContainerInitializer.this));
 		JavaRuntime.addContainerResolver(new BndContainerRuntimeClasspathEntryResolver(),
 			BndtoolsConstants.BND_CLASSPATH_ID.segment(0));
@@ -83,7 +83,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 		 * information, then update the container now.
 		 */
 		File containerFile = getContainerFile(project);
-		if (Central.isWorkspaceInited() || !containerFile.isFile()) {
+		if (Central.hasCnfWorkspace() || !containerFile.isFile()) {
 			Updater updater = new Updater(project, javaProject);
 			updater.updateClasspathContainer(true);
 			return;
@@ -96,7 +96,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 		 */
 		BndContainer container = loadClasspathContainer(project);
 		Updater.setClasspathContainer(javaProject, container);
-		Central.onWorkspace(
+		Central.onCnfWorkspace(
 			workspace -> requestClasspathContainerUpdate(BndtoolsConstants.BND_CLASSPATH_ID, javaProject, null));
 	}
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerSourceManager.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerSourceManager.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 
-import aQute.bnd.build.Workspace;
 import aQute.bnd.build.WorkspaceRepository;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.osgi.Domain;
@@ -143,14 +142,7 @@ public class BndContainerSourceManager {
 	}
 
 	private static File getSourceBundle(IPath path, Map<String, String> props) {
-		Workspace bndWorkspace;
-
-		try {
-			bndWorkspace = Central.getWorkspace();
-			if (bndWorkspace == null) {
-				return null;
-			}
-		} catch (final Exception e) {
+		if (Central.getWorkspaceIfPresent() == null) {
 			return null;
 		}
 

--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -25,7 +25,7 @@ public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProj
 	implements WorkspaceRepositoryMarker {
 	EclipseWorkspaceRepository() {
 		super();
-		Central.onWorkspace(this::initialize);
+		Central.onCnfWorkspace(this::initialize);
 	}
 
 	private void initialize(Workspace workspace) throws Exception {

--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -167,7 +167,7 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 
 	public void addViewer(TreeViewer viewer, RefreshModel model) {
 		this.viewers.put(viewer, model);
-		Central.onWorkspace(workspace -> new Job("Updating repositories") {
+		Central.onAnyWorkspace(workspace -> new Job("Updating repositories") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				List<RepositoryPlugin> repositories = model.getRepositories();

--- a/bndtools.core/src/bndtools/central/WorkspaceListener.java
+++ b/bndtools.core/src/bndtools/central/WorkspaceListener.java
@@ -26,7 +26,7 @@ public final class WorkspaceListener extends BndListener {
 				// so we use a job to refresh the file
 				final RefreshFileJob job = new RefreshFileJob(file, true);
 				if (job.needsToSchedule()) {
-					Central.onWorkspace(workspace -> job.schedule());
+					Central.onAnyWorkspace(workspace -> job.schedule());
 				}
 			} else {
 				Central.refreshFile(file, null, true);

--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -208,14 +208,14 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	}
 
 	private static boolean isMainWorkspaceConfig(String path, String projectName) {
-		if (Workspace.CNFDIR.equals(projectName) || Workspace.BNDDIR.equals(projectName)) {
+		if (Workspace.CNFDIR.equals(projectName)) {
 			return Workspace.BUILDFILE.equals(path);
 		}
 		return false;
 	}
 
 	private static boolean isExtWorkspaceConfig(String path, String projectName) {
-		if (Workspace.CNFDIR.equals(projectName) || Workspace.BNDDIR.equals(projectName)) {
+		if (Workspace.CNFDIR.equals(projectName)) {
 			return path.startsWith("ext/") && path.endsWith(".bnd");
 		}
 		return false;
@@ -449,7 +449,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 
 		showHighestPriorityPage();
 
-		if (!Central.isWorkspaceInited()) {
+		if (!Central.hasAnyWorkspace()) {
 			IFormPage activePage = getActivePageInstance();
 
 			if (activePage != null && activePage.getManagedForm() != null) {
@@ -561,7 +561,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 														// immediately
 					modelReady = loadEditModel();
 				} else { // a real ws will be resolved so we need to load async
-					modelReady = Central.onWorkspace(workspace -> loadEditModel());
+					modelReady = Central.onAnyWorkspace(workspace -> loadEditModel());
 				}
 			} else {
 				modelReady = Central.promiseFactory()

--- a/bndtools.core/src/bndtools/editor/common/BndEditorPart.java
+++ b/bndtools.core/src/bndtools/editor/common/BndEditorPart.java
@@ -60,7 +60,7 @@ public abstract class BndEditorPart extends SectionPart implements PropertyChang
 		if (!Central.hasWorkspaceDirectory()) {
 			refreshFromModel();
 		} else {
-			Central.onWorkspaceAsync(workspace -> {
+			Central.onAnyWorkspaceAsync(workspace -> {
 				model.setWorkspace(workspace);
 				ScrolledForm form = getManagedForm().getForm();
 				if (form.isDisposed())

--- a/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
+++ b/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
@@ -110,7 +110,7 @@ public class ProjectRunPage extends FormPage {
 		final ScrolledForm form = managedForm.getForm();
 		form.setText("Resolve/Run");
 
-		Central.onWorkspaceAsync(workspace -> {
+		Central.onAnyWorkspaceAsync(workspace -> {
 			model.setWorkspace(workspace);
 			updateFormImage(form);
 		});

--- a/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositorySelectionPart.java
@@ -379,7 +379,7 @@ public class RepositorySelectionPart extends BndEditorPart implements IResourceC
 			// Load the repos and clear the error message if the Workspace is
 			// initialised later.
 			Central
-				.onWorkspace(workspace -> SWTConcurrencyUtil.execForControl(runReposViewer.getControl(), true, () -> {
+				.onAnyWorkspace(workspace -> SWTConcurrencyUtil.execForControl(runReposViewer.getControl(), true, () -> {
 					allRepos.clear();
 					allRepos.addAll(workspace.getPlugins(Repository.class));
 					runReposViewer.setInput(allRepos);

--- a/bndtools.core/src/bndtools/editor/workspace/WorkspaceMainPart.java
+++ b/bndtools.core/src/bndtools/editor/workspace/WorkspaceMainPart.java
@@ -118,7 +118,7 @@ public class WorkspaceMainPart extends SectionPart {
 		fillLayout.marginHeight = fillLayout.marginWidth = 10;
 		labelParent.setLayout(fillLayout);
 
-		if (!Central.isWorkspaceInited()) {
+		if (!Central.hasAnyWorkspace()) {
 			Label label = new Label(labelParent, SWT.NONE);
 			label.setText("Workspace is loading, please wait...");
 			label.setBackground(container.getBackground());
@@ -128,7 +128,7 @@ public class WorkspaceMainPart extends SectionPart {
 		stackLayout.topControl = labelParent;
 		container.layout();
 
-		Central.onWorkspaceAsync(workspace -> {
+		Central.onAnyWorkspaceAsync(workspace -> {
 			IFile buildFile = Central.getWorkspaceBuildFile();
 			if (buildFile == null)
 				return;

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -63,7 +63,6 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 import aQute.bnd.build.Workspace;
-import aQute.bnd.build.WorkspaceLayout;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.exceptions.FunctionWithException;
 import aQute.lib.io.IO;
@@ -368,7 +367,7 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 			public void run() {
 				try {
 					Workspace ws = Central.getWorkspace();
-					if ((ws != null) && (ws.getLayout() != WorkspaceLayout.STANDALONE)) {
+					if ((ws != null) && (!ws.isDefaultWorkspace())) {
 						setImageDescriptor(Icons.desc("refresh.disable"));
 						setEnabled(false);
 						IFile workspaceBuildFile = Central.getWorkspaceBuildFile();


### PR DESCRIPTION
We now have two callback queues. One for the first workspace which may
not be a Bnd Workspace but may be a default workspace. And another for
each Bnd Workspace.

This allows m2e code to use the first workspace callback queue
(onAnyWorkspace) since the underlying promise will be resolved on the
first call to getWorkspace.

Code for Bnd Workspace models builds can use the second workspace
callback queue (onCnfWorkspace) whose underlying promise is not
resolved until a Bnd Workspace is created. If the workspace converts
back to a default workspace (when the cnf project is deleted), then a
new Bnd Workspace queue is created waiting for the workspace to get
a cnf project again.

This is not a complete replacement of the getWorkspace code in Central
but seems to be the least disruptive change to accomplish the main
goals given that we have to support a hybrid world where there must
be a workspace that may or may not be a Bnd Workspace.

Fixes https://github.com/bndtools/bnd/issues/4108