### PR TITLE
bndtools: fix the messages dialog for missing workspace

### DIFF
--- a/bndtools.core/src/bndtools/utils/MessageHyperlinkAdapter.java
+++ b/bndtools.core/src/bndtools/utils/MessageHyperlinkAdapter.java
@@ -35,8 +35,11 @@ public class MessageHyperlinkAdapter implements IHyperlinkListener {
 		Hyperlink link = (Hyperlink) e.getSource();
 		link.setToolTipText(null);
 
-		if (popupDialog != null)
+		if (popupDialog != null) {
 			popupDialog.close();
+			popupDialog = null;
+			return;
+		}
 
 		IMessage[] messages = (IMessage[]) e.data;
 

--- a/bndtools.core/src/bndtools/utils/MessagesPopupDialog.java
+++ b/bndtools.core/src/bndtools/utils/MessagesPopupDialog.java
@@ -122,9 +122,8 @@ public class MessagesPopupDialog extends PopupDialog {
 					fixLink.addHyperlinkListener(new HyperlinkAdapter() {
 						@Override
 						public void linkActivated(HyperlinkEvent e) {
-							fix.run();
 							close();
-							// part.getSite().getPage().activate(part);
+							fix.run();
 							part.setFocus();
 						}
 					});


### PR DESCRIPTION
Signed-off-by: Raymond Augé <raymond.auge@liferay.com>

solves this issue:
![Screenshot from 2020-05-30 10-40-50](https://user-images.githubusercontent.com/146764/83331130-29342780-a262-11ea-8181-9d07bcc9f66b.png)
