### PR TITLE
osgi: Support for new OSGi Referenced annotation

### DIFF
--- a/biz.aQute.bndlib.tests/bnd.bnd
+++ b/biz.aQute.bndlib.tests/bnd.bnd
@@ -5,6 +5,7 @@
 -nobundles: true
 
 -testpath: \
+	org.osgi.annotation.bundle;version=latest,\
 	osgi.annotation;version=latest,\
 	osgi.core;version=latest,\
 	org.osgi.namespace.extender;version=latest,\

--- a/biz.aQute.bndlib.tests/test/test/ReferencedAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ReferencedAnnotationTest.java
@@ -1,0 +1,29 @@
+package test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Packages;
+
+public class ReferencedAnnotationTest {
+
+	@Test
+	public void testReferenced() throws Exception {
+		try (Builder builder = new Builder()) {
+			builder.addClasspath(new File("bin_test"));
+
+			builder.setIncludePackage("test.referenced.annotation.testReferenced");
+			builder.build();
+			builder.check();
+			Packages imports = builder.getImports();
+			assertThat(imports).containsOnlyKeys(builder.getPackageRef("test.export.annotation.testCalculated"),
+				builder.getPackageRef("test.export.annotation.testConsumer"),
+				builder.getPackageRef("test.export.annotation.testProvider"));
+		}
+	}
+
+}

--- a/biz.aQute.bndlib.tests/test/test/referenced/annotation/testReferenced/TestReferenced.java
+++ b/biz.aQute.bndlib.tests/test/test/referenced/annotation/testReferenced/TestReferenced.java
@@ -1,0 +1,16 @@
+package test.referenced.annotation.testReferenced;
+
+import org.osgi.annotation.bundle.Referenced;
+
+import test.export.annotation.testConsumer.ConsumerInterface;
+import test.export.annotation.testProvider.ProviderInterface;
+
+@Referenced({
+	ProviderInterface.class, ConsumerInterface.class
+})
+public class TestReferenced {
+
+	public TestReferenced() {
+	}
+
+}

--- a/biz.aQute.bndlib.tests/test/test/referenced/annotation/testReferenced/package-info.java
+++ b/biz.aQute.bndlib.tests/test/test/referenced/annotation/testReferenced/package-info.java
@@ -1,0 +1,6 @@
+@Referenced(CalculatedInterface.class)
+package test.referenced.annotation.testReferenced;
+
+import org.osgi.annotation.bundle.Referenced;
+
+import test.export.annotation.testCalculated.CalculatedInterface;

--- a/cnf/ext/osgi-snapshots.mvn
+++ b/cnf/ext/osgi-snapshots.mvn
@@ -1,2 +1,2 @@
 org.osgi:org.osgi.framework:1.10.0-SNAPSHOT
-
+org.osgi:org.osgi.annotation.bundle:1.1.0-SNAPSHOT


### PR DESCRIPTION
Source code can now use `@Referenced(SomeClass.class)` to make a reference
to the specified types. This will cause Bnd to record a reference to the
type which can result in an Import-Package clause.

The Referenced annotation allows a non-code reference in source code.
This can be helpful if the referenced types are not directly referenced
in the source code but may be needed for some reflective purpose at
runtime and the developer wants to ensure that the necessary
Import-Package clause is generated.

