### PR TITLE
central: Better handle multiple projects referring to build.bnd file

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -179,18 +179,19 @@ public class Central implements IStartupParticipant {
 	}
 
 	public static IFile getWorkspaceBuildFile() throws Exception {
-		File file = Central.getWorkspace()
-			.getPropertiesFile();
-		IFile[] matches = ResourcesPlugin.getWorkspace()
-			.getRoot()
-			.findFilesForLocationURI(file.toURI());
-
-		if (matches == null || matches.length != 1) {
+		Workspace ws = Central.getWorkspace();
+		if ((ws == null) || (ws.isDefaultWorkspace())) {
+			return null;
+		}
+		File file = ws.getPropertiesFile();
+		IPath path = toPathMustBeInEclipseWorkspace(file);
+		if (path == null) {
 			logger.logError("Cannot find workspace location for bnd configuration file " + file, null);
 			return null;
 		}
-
-		return matches[0];
+		return ResourcesPlugin.getWorkspace()
+			.getRoot()
+			.getFile(path);
 	}
 
 	public static EclipseWorkspaceRepository getEclipseWorkspaceRepository() {

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -62,7 +62,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
-import aQute.bnd.build.Workspace;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.exceptions.FunctionWithException;
 import aQute.lib.io.IO;
@@ -366,11 +365,10 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 			@Override
 			public void run() {
 				try {
-					Workspace ws = Central.getWorkspace();
-					if ((ws != null) && (!ws.isDefaultWorkspace())) {
+					IFile workspaceBuildFile = Central.getWorkspaceBuildFile();
+					if (workspaceBuildFile != null) {
 						setImageDescriptor(Icons.desc("refresh.disable"));
 						setEnabled(false);
-						IFile workspaceBuildFile = Central.getWorkspaceBuildFile();
 						Job.create("Reload", (monitor) -> {
 							workspaceBuildFile.touch(monitor);
 							Display.getDefault()


### PR DESCRIPTION
The logic for finding an IFile for the workspace build file (e.g.
cnf/build.bnd) failed to address the case were multiple projects could
refer to the file. The main example is where the root of the workspace
is an Eclipse project which can be done to allow easy editing of files
in the root of the repository.

So now we better handle this case and just pick one of the IFile
references.

Fixes https://github.com/bndtools/bnd/issues/4140
