### PR TITLE
[launchpad] Use Bndrun instead of Run

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/remoteworkspace/server/RemoteWorkspaceServer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/remoteworkspace/server/RemoteWorkspaceServer.java
@@ -156,7 +156,7 @@ public class RemoteWorkspaceServer implements Closeable {
 					return project.getSpecification();
 
 				} else {
-					try (Run run = new Run(workspace, file)) {
+					try (Run run = Run.createRun(workspace, file)) {
 						return run.getSpecification();
 					}
 				}


### PR DESCRIPTION
Project.getSpecification directly created a Run
instead of using the static Run.createRun method.

This meant that getRunBundles() was not resolved
if the auto resolve was set.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>