### PR TITLE
Launchpad resolve support

### DIFF
--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/build.bnd
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/build.bnd
@@ -1,0 +1,7 @@
+-remoteworkspace: true
+-plugin:\
+    aQute.bnd.repository.maven.provider.MavenBndRepository;\
+        name="Maven Central";\
+        releaseUrl=https://repo.maven.apache.org/maven2;\
+        index="${.}/central.mvn";\
+        readOnly=true,\

--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/central.mvn
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/central.mvn
@@ -1,0 +1,12 @@
+org.apache.felix:org.apache.felix.configadmin:1.9.10
+org.apache.felix:org.apache.felix.log:1.2.0
+org.apache.felix:org.apache.felix.framework:4.2.1
+org.apache.felix:org.apache.felix.framework:5.6.10
+org.apache.felix:org.apache.felix.gogo.command:1.0.2
+org.apache.felix:org.apache.felix.gogo.runtime:1.1.0
+org.apache.felix:org.apache.felix.gogo.shell:1.1.0
+org.apache.felix:org.apache.felix.resolver:2.0.0
+org.apache.felix:org.apache.felix.scr:2.1.12
+org.apache.felix:org.apache.felix.inventory:1.0.6
+org.apache.felix:org.apache.felix.logback:1.0.2
+biz.aQute.bnd:biz.aQute.launcher:5.1.0

--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/batch-with-bundles.bndrun
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/batch-with-bundles.bndrun
@@ -1,0 +1,5 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)'
+-runfw: org.apache.felix.framework;version='[5.6.10,5.6.10]'
+-runee: JavaSE-1.8
+-resolve: batch
+-runbundles org.apache.felix.gogo.runtime

--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/batch.bndrun
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/batch.bndrun
@@ -1,0 +1,4 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)'
+-runfw: org.apache.felix.framework;version='[5.6.10,5.6.10]'
+-runee: JavaSE-1.8
+-resolve: batch

--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/beforelaunch.bndrun
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/p1/beforelaunch.bndrun
@@ -1,0 +1,4 @@
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.shell)'
+-runfw: org.apache.felix.framework;version='[5.6.10,5.6.10]'
+-runee: JavaSE-1.8
+-resolve: beforelaunch

--- a/biz.aQute.bndall.tests/test/aQute/launchpad/ResolveTest.java
+++ b/biz.aQute.bndall.tests/test/aQute/launchpad/ResolveTest.java
@@ -1,0 +1,98 @@
+package aQute.launchpad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.remoteworkspace.client.RemoteWorkspaceClientFactory;
+import aQute.bnd.service.remoteworkspace.RemoteWorkspace;
+import aQute.bnd.service.remoteworkspace.RemoteWorkspaceClient;
+import aQute.lib.io.IO;
+
+public class ResolveTest {
+
+	private LaunchpadBuilder	builder;
+	private Workspace			workspace;
+
+	@Before
+	public void before() throws Exception {
+		File tmp = IO.getFile("generated/tmpws1");
+		IO.delete(tmp);
+		tmp.mkdirs();
+		IO.copy(IO.getFile("resources/launchpad/ws1"), tmp);
+		workspace = new Workspace(tmp);
+		Project project = workspace.getProject("p1");
+		RemoteWorkspace remoteWs = RemoteWorkspaceClientFactory.create(project.getBase(),
+			new RemoteWorkspaceClient() {});
+		builder = new LaunchpadBuilder(remoteWs);
+	}
+
+	@After
+	public void after() throws Exception {
+		IO.closeAll(builder, workspace);
+	}
+
+	/*
+	 * No -runbundles, must resolve before calling getRunBundles()
+	 */
+	@Test
+	public void testLaunchpadBeforeLaunch() throws Exception {
+		Project project = workspace.getProject("p1");
+		try (Launchpad lp = builder.bndrun(project.getFile("beforelaunch.bndrun"))
+			.create()) {
+			assertThat(lp.getBundleContext()
+				.getBundles()).hasSize(4);
+		}
+	}
+
+	/*
+	 * No -runbundles, pretending running in BATCH mode, should resolve
+	 */
+	@Test
+	public void testLaunchpadBatchInBatchEnvironment() throws Exception {
+		workspace.setProperty("-gestalt", Constants.GESTALT_BATCH);
+		Project project = workspace.getProject("p1");
+		try (Launchpad lp = builder.bndrun(project.getFile("batch.bndrun"))
+			.create()) {
+			assertThat(lp.getBundleContext()
+				.getBundles()).hasSize(4);
+		}
+	}
+
+	/*
+	 * No -runbundles, not in batch mode, must resolve because there are no
+	 * runbundles set
+	 */
+	@Test
+	public void testLaunchpadBatchInNonBatchEnvironment() throws Exception {
+		workspace.setProperty("-gestalt", "");
+		Project project = workspace.getProject("p1");
+		try (Launchpad lp = builder.bndrun(project.getFile("batch.bndrun"))
+			.create()) {
+			assertThat(lp.getBundleContext()
+				.getBundles()).hasSize(4);
+		}
+	}
+
+	/*
+	 * No -runbundles, not in batch mode, must not resolve because there is 1
+	 * runbundle set (so one less than resolve would give us).
+	 */
+	@Test
+	public void testLaunchpadBatchInNonBatchEnvironmentWithRunbundles() throws Exception {
+		workspace.setProperty("-gestalt", "");
+		Project project = workspace.getProject("p1");
+		try (Launchpad lp = builder.bndrun(project.getFile("batch-with-bundles.bndrun"))
+			.create()) {
+			assertThat(lp.getBundleContext()
+				.getBundles()).hasSize(3);
+		}
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -3469,17 +3469,22 @@ public class Project extends Processor {
 
 		RunSpecification runspecification = new RunSpecification();
 		try {
-			ProjectLauncher l = getProjectLauncher();
 			runspecification.bin = getOutput().getAbsolutePath();
 			runspecification.bin_test = getTestOutput().getAbsolutePath();
 			runspecification.target = getTarget().getAbsolutePath();
 			runspecification.errors.addAll(getErrors());
 			runspecification.extraSystemCapabilities = getRunSystemCapabilities().toBasic();
 			runspecification.extraSystemPackages = getRunSystemPackages().toBasic();
-			runspecification.properties = l.getRunProperties();
 			runspecification.runbundles = toPaths(runspecification.errors, getRunbundles());
 			runspecification.runfw = toPaths(runspecification.errors, getRunFw());
 			runspecification.runpath = toPaths(runspecification.errors, getRunpath());
+
+			try {
+				ProjectLauncher l = getProjectLauncher();
+				runspecification.properties = l.getRunProperties();
+			} catch (IllegalArgumentException iae) {
+				runspecification.properties = null;
+			}
 
 			for (String key : Iterables.iterable(getProperties().propertyNames(), String.class::cast)) {
 				// skip non instructions to prevent macro expansions we do not

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
@@ -72,8 +72,14 @@ public interface ResolutionInstructions {
 		@SyntaxAnnotation(lead = "A resolve will take place before launching")
 		beforelaunch,
 
+		/**
+		 * Run the resolver before launching during batch mode
+		 */
+		@SyntaxAnnotation(lead = "A resolve will take place before launching when in batch mode (e.g. Gradle) but not in IDE mode (e.g. Eclipse)")
+		batch,
+
 	}
 
-	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch)")
+	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched, batchlaunch is like beforelaunch but only in batch mode", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch|batch)")
 	ResolveMode resolve();
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.3.0")
+@org.osgi.annotation.versioning.Version("1.4.0")
 package aQute.bnd.help.instructions;

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/BeforeAfterTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/BeforeAfterTest.java
@@ -16,7 +16,7 @@ import aQute.launchpad.junit.LaunchpadRunner;
 public class BeforeAfterTest {
 
 	static LaunchpadBuilder	builder	= new LaunchpadBuilder().runfw("org.apache.felix.framework")
-		.bundles("org.assertj.core, org.apache.felix.scr")
+		.bundles("assertj-core, org.apache.felix.scr")
 		.debug();
 
 	@Service

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
@@ -22,7 +22,7 @@ public class FO {
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.bundles(
-			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, org.assertj.core, org.apache.servicemix.bundles.junit")
+			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, assertj-core, org.apache.servicemix.bundles.junit")
 		.debug();
 
 	@Component(service = X.class, enabled = false)

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadConfigurationTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadConfigurationTest.java
@@ -26,7 +26,7 @@ public class LaunchpadConfigurationTest {
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.export("*")
 		.bundles(
-			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, jar/org.apache.felix.configadmin-1.9.8.jar;version=file, jar/org.apache.felix.configurator-1.0.8.jar;version=file, org.assertj.core")
+			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, jar/org.apache.felix.configadmin-1.9.8.jar;version=file, jar/org.apache.felix.configurator-1.0.8.jar;version=file, assertj-core")
 		.debug();
 
 	@Component(name = "TestService", service = X.class, configurationPolicy = ConfigurationPolicy.REQUIRE)

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
@@ -25,7 +25,7 @@ public class LaunchpadRunnerBasicTest {
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.export("*")
 		.bundles(
-			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, org.assertj.core")
+			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, assertj-core")
 		.debug();
 
 	@Component(service = X.class, enabled = false)

--- a/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/BundleSpecBuilder.java
@@ -988,7 +988,7 @@ public interface BundleSpecBuilder {
 	default Bundle install() throws Exception {
 		BundleBuilder x = x();
 		BuilderSpecification spec = x.spec;
-		byte[] build = LaunchpadBuilder.workspace.build(LaunchpadBuilder.projectDir.getAbsolutePath(), spec);
+		byte[] build = x.ws.workspace.build(LaunchpadBuilder.projectDir.getAbsolutePath(), spec);
 		String location;
 		if (spec.location == null) {
 			String name = spec.bundleSymbolicName.toString();

--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -55,6 +55,7 @@ import org.osgi.framework.wiring.FrameworkWiring;
 //import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 import org.osgi.util.tracker.ServiceTracker;
 
+import aQute.bnd.service.remoteworkspace.RemoteWorkspace;
 import aQute.bnd.service.specifications.RunSpecification;
 import aQute.launchpad.internal.ProbeImpl;
 import aQute.lib.converter.Converter;
@@ -102,6 +103,7 @@ public class Launchpad implements AutoCloseable {
 	final RunSpecification						runspec;
 	final boolean								hasTestBundle;
 	final StartLevelRuntimeHandler				startlevels;
+	final RemoteWorkspace						workspace;
 
 	Bundle										testbundle;
 	boolean										debug;
@@ -113,8 +115,9 @@ public class Launchpad implements AutoCloseable {
 	private Bundle								proxyBundle;
 	private Probe								probe					= new ProbeImpl();
 
-	Launchpad(Framework framework, String name, String className, RunSpecification runspec, long closeTimeout,
-		boolean debug, boolean hasTestBundle, boolean byReference) {
+	Launchpad(RemoteWorkspace workspace, Framework framework, String name, String className, RunSpecification runspec,
+		long closeTimeout, boolean debug, boolean hasTestBundle, boolean byReference) {
+		this.workspace = workspace;
 		this.runspec = runspec;
 		this.closeTimeout = closeTimeout;
 		this.hasTestBundle = hasTestBundle;
@@ -251,7 +254,7 @@ public class Launchpad implements AutoCloseable {
 	 */
 	public List<Bundle> bundles(String specification) {
 		try {
-			return LaunchpadBuilder.workspace.getLatestBundles(projectDir.getAbsolutePath(), specification)
+			return workspace.getLatestBundles(projectDir.getAbsolutePath(), specification)
 				.stream()
 				.map(File::new)
 				.map(this::bundle)

--- a/biz.aQute.launchpad/src/aQute/launchpad/package-info.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.2.1")
+@org.osgi.annotation.versioning.Version("1.3.0")
 package aQute.launchpad;

--- a/docs/_instructions/resolve.md
+++ b/docs/_instructions/resolve.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 class: Workspace
-title: -resolve (manual|auto|beforelaunch)
+title: -resolve (manual|auto|beforelaunch|batch)
 summary: Defines when/how resolving is done to calculate the -runbundles
 ---
 
@@ -12,7 +12,8 @@ The values are:
 * `manual` – It is up to the user to resolve the initial requirements
 * `auto` – Whenever the initial requirements are saved, the resolver will be used to set new `-runbundles`
 * `beforelaunch` – Calculate the `-runbundles` on demand. This ignores the value of the `-runbundles` and runs the resolver. The results of the resolver are cached. This cache works by creating a checksum over all the properties of the project.
-
+* `batch` – When running in batch mode, the run bundles will be resolved. In all other modes this will only resolve when the `-runbundles` are empty.
+ 
 ## Example
 
     -resolve beforelaunch


### PR DESCRIPTION
A previous commit added resolve support for launchpad, this continues with some extra lp support.

- Able to set Remote Workspace on a build instead of always using auto discovery, for testing
- New resolve mode to reduce lag in IDE
- Some ban errors fixed, which makes me worry if these tests were running?