### PR TITLE
add org.bndtools.applaunch to distribution

### DIFF
--- a/dist/bnd.bnd
+++ b/dist/bnd.bnd
@@ -36,6 +36,7 @@
             bndtools.m2e, \
             bndtools.pde, \
             bndtools.release, \
+            org.bndtools.applaunch, \
             org.bndtools.headless.build.manager, \
             org.bndtools.headless.build.plugin.ant, \
             org.bndtools.headless.build.plugin.gradle, \


### PR DESCRIPTION
hey @bjhargrave  I tested this in my app and was able to swap out the older `bndtools.runtime.applaunch.eclipse4` bundle with the new `org.bndtools.applaunch` bundle.