### PR TITLE
[bndtools.core] Fixed type of service.ranking for ReposTemplateLoader

### DIFF
--- a/bndtools.core/src/org/bndtools/core/templating/repobased/ReposTemplateLoader.java
+++ b/bndtools.core/src/org/bndtools/core/templating/repobased/ReposTemplateLoader.java
@@ -47,7 +47,7 @@ import bndtools.preferences.BndPreferences;
 
 @Component(name = "org.bndtools.templating.repos", property = {
 	"source=workspace", Constants.SERVICE_DESCRIPTION + "=Load templates from the Workspace and Repositories",
-	Constants.SERVICE_RANKING + "=" + ReposTemplateLoader.RANKING
+	Constants.SERVICE_RANKING + ":Integer=" + ReposTemplateLoader.RANKING
 })
 public class ReposTemplateLoader implements TemplateLoader {
 


### PR DESCRIPTION
Fixes an error I noticed in the Eclipse log.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>