### PR TITLE
[junit-platform] Report total failure count, not just test failures

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
@@ -358,7 +358,7 @@ public class Activator implements BundleActivator, Runnable {
 			}
 
 			return summary.getSummary()
-				.getTestsFailedCount();
+				.getTotalFailureCount();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit4ContainerError.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit4ContainerError.java
@@ -1,0 +1,22 @@
+package aQute.tester.testclasses.junit.platform;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JUnit4ContainerError {
+
+	@BeforeClass
+	void beforeAll() {
+		throw new IllegalStateException();
+	}
+
+	@Test
+	void myTest() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void my2ndTest() {
+		throw new AssertionError();
+	}
+}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit4ContainerFailure.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit4ContainerFailure.java
@@ -1,0 +1,22 @@
+package aQute.tester.testclasses.junit.platform;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JUnit4ContainerFailure {
+
+	@BeforeClass
+	void beforeAll() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void myTest() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void my2ndTest() {
+		throw new AssertionError();
+	}
+}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerError.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerError.java
@@ -1,0 +1,22 @@
+package aQute.tester.testclasses.junit.platform;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JUnit5ContainerError {
+
+	@BeforeAll
+	void beforeAll() {
+		throw new IllegalStateException();
+	}
+
+	@Test
+	void myTest() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void my2ndTest() {
+		throw new AssertionError();
+	}
+}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerFailure.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerFailure.java
@@ -1,0 +1,22 @@
+package aQute.tester.testclasses.junit.platform;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JUnit5ContainerFailure {
+
+	@BeforeAll
+	void beforeAll() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void myTest() {
+		throw new AssertionError();
+	}
+
+	@Test
+	void my2ndTest() {
+		throw new AssertionError();
+	}
+}

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
@@ -54,6 +54,8 @@ import aQute.tester.testclasses.junit.platform.JUnit4AbortTest;
 import aQute.tester.testclasses.junit.platform.JUnit4ComparisonTest;
 import aQute.tester.testclasses.junit.platform.JUnit4Skipper;
 import aQute.tester.testclasses.junit.platform.JUnit5AbortTest;
+import aQute.tester.testclasses.junit.platform.JUnit5ContainerError;
+import aQute.tester.testclasses.junit.platform.JUnit5ContainerFailure;
 import aQute.tester.testclasses.junit.platform.JUnit5ContainerSkipped;
 import aQute.tester.testclasses.junit.platform.JUnit5ContainerSkippedWithCustomDisplayName;
 import aQute.tester.testclasses.junit.platform.JUnit5DisplayNameTest;
@@ -584,5 +586,12 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorTest {
 		XmlAssert.assertThat(doc)
 			.nodesByXPath(testCaseFailure(With2Failures.class, "test3", CustomAssertionError.class))
 			.hasSize(1);
+	}
+
+	// Unlike JUnit 4, Jupiter skips the tests when the parent container
+	// fails and does not report the children as test failures.
+	@Test
+	public void exitCode_countsJupiterContainerErrorsAndFailures() {
+		runTests(2, JUnit5ContainerFailure.class, JUnit5ContainerError.class);
 	}
 }

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
@@ -53,6 +53,8 @@ import aQute.tester.testclasses.JUnit3Test;
 import aQute.tester.testclasses.JUnit4Test;
 import aQute.tester.testclasses.With1Error1Failure;
 import aQute.tester.testclasses.With2Failures;
+import aQute.tester.testclasses.junit.platform.JUnit4ContainerError;
+import aQute.tester.testclasses.junit.platform.JUnit4ContainerFailure;
 
 // Because we're not in the same project as aQute.junit.TesterConstants and its bundle-private.
 public abstract class AbstractActivatorTest extends SoftAssertions {
@@ -514,6 +516,11 @@ public abstract class AbstractActivatorTest extends SoftAssertions {
 	public void exitCode_countsErrorsAndFailures() {
 		final ExitCode exitCode = runTests(JUnit4Test.class, With2Failures.class, With1Error1Failure.class);
 		assertThat(exitCode.exitCode).isEqualTo(4);
+	}
+
+	@Test
+	public void exitCode_countsContainerErrorsAndFailures() {
+		runTests(8, JUnit4ContainerFailure.class, JUnit4ContainerError.class);
 	}
 
 	protected TestRunData runTestsEclipse(Callback postCreateCallback, Class<?>... tests) {


### PR DESCRIPTION
This is necessary as Jupiter reports container failures separately from the children if the container fails before the children are executed.

Fixes #4175.