### PR TITLE
mavenbndrepo: Report no metadata only after asking all backing repos

### DIFF
--- a/biz.aQute.repository/src/aQute/maven/provider/MavenBackingRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenBackingRepository.java
@@ -154,7 +154,6 @@ public abstract class MavenBackingRepository implements Closeable {
 	public List<Archive> getSnapshotArchives(Revision revision) throws Exception {
 		Optional<RevisionMetadata> metadata = getMetadata(revision);
 		if (!metadata.isPresent()) {
-			reporter.error("No metadata for revision %s", revision);
 			return Collections.emptyList();
 		}
 		return metadata.get().snapshotVersions.stream()
@@ -166,7 +165,6 @@ public abstract class MavenBackingRepository implements Closeable {
 	public MavenVersion getVersion(Revision revision) throws Exception {
 		Optional<RevisionMetadata> metadata = getMetadata(revision);
 		if (!metadata.isPresent()) {
-			reporter.error("No metadata for revision %s", revision);
 			return null;
 		}
 


### PR DESCRIPTION
Since there can be multiple URLs for snapshotUrl, an individual
backing repo cannot report no metadata, since the revision can be
present in a later backing repo. So we change to report no metadata
after all backing repos have been queried.

Fixes https://github.com/bndtools/bnd/issues/4204
