### PR TITLE
maven: Simplify junit5 enum value

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/TestCases.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/TestCases.java
@@ -4,11 +4,7 @@ public enum TestCases {
 
 	junit3("${classes;EXTENDS;junit.framework.TestCase;CONCRETE}"),
 	junit4("${classes;HIERARCHY_ANNOTATED;org.junit.Test;CONCRETE}"),
-	junit5("${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.Test;CONCRETE},"
-		+ "${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.RepeatedTest;CONCRETE},"
-		+ "${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.params.ParameterizedTest;CONCRETE},"
-		+ "${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.TestFactory;CONCRETE},"
-		+ "${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.jupiter.api.TestTemplate;CONCRETE}"),
+	junit5("${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}"),
 	all(junit3.filter() + "," + junit4.filter() + "," + junit5.filter()),
 	useTestCasesHeader("<<UNUSED>>");
 


### PR DESCRIPTION
We now use the marker annotation
org.junit.platform.commons.annotation.Testable.
