### PR TITLE
Maven Test-Cases header

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MacroTest.java
@@ -1341,25 +1341,29 @@ public class MacroTest {
 
 	/**
 	 * Check the uniq command
+	 *
+	 * @throws Exception
 	 */
 
 	@Test
-	public void testUniq() {
-		Builder builder = new Builder();
-		Properties p = new Properties();
-		p.setProperty("a", "${uniq;1}");
-		p.setProperty("b", "${uniq;1,2}");
-		p.setProperty("c", "${uniq;1;2}");
-		p.setProperty("d", "${uniq;1; 1,  2 , 3}");
-		p.setProperty("e", "${uniq;1; 1 , 2 ;      3;3,4,5,6}");
-		builder.setProperties(p);
-		assertEquals("1,2,3", builder.getProperty("d"));
-		assertEquals("1,2", builder.getProperty("b"));
-		assertEquals("1", builder.getProperty("a"));
-		assertEquals("1,2", builder.getProperty("c"));
-		assertEquals("1,2,3", builder.getProperty("d"));
-		assertEquals("1,2,3,4,5,6", builder.getProperty("e"));
-
+	public void testUniq() throws Exception {
+		try (Builder builder = new Builder()) {
+			Properties p = new Properties();
+			p.setProperty("a", "${uniq;1}");
+			p.setProperty("b", "${uniq;1,2}");
+			p.setProperty("c", "${uniq;1;2}");
+			p.setProperty("d", "${uniq;1; 1,  2 , 3}");
+			p.setProperty("e", "${uniq;1; 1 , 2 ;      3;3,4,5,6}");
+			p.setProperty("f", "${uniq;}");
+			builder.setProperties(p);
+			assertThat(builder.getProperty("d")).isEqualTo("1,2,3");
+			assertThat(builder.getProperty("b")).isEqualTo("1,2");
+			assertThat(builder.getProperty("a")).isEqualTo("1");
+			assertThat(builder.getProperty("c")).isEqualTo("1,2");
+			assertThat(builder.getProperty("d")).isEqualTo("1,2,3");
+			assertThat(builder.getProperty("e")).isEqualTo("1,2,3,4,5,6");
+			assertThat(builder.getProperty("f")).isEmpty();
+		}
 	}
 
 	/**
@@ -1658,9 +1662,10 @@ public class MacroTest {
 		Processor p = new Processor();
 		p.setProperty("a", "aaaa");
 		Macro m = new Macro(p);
-		assertEquals("aa,bb,cc,dd,ee,ff", m.process("${sort;aa,bb,cc,dd,ee,ff}"));
-		assertEquals("aa,bb,cc,dd,ee,ff", m.process("${sort;ff,ee,cc,bb,dd,aa}"));
-		assertEquals("aaaa,bb,cc,dd,ee,ff", m.process("${sort;ff,ee,cc,bb,dd,$<a>}"));
+		assertThat(m.process("${sort;aa,bb,cc,dd,ee,ff}")).isEqualTo("aa,bb,cc,dd,ee,ff");
+		assertThat(m.process("${sort;ff,ee,cc,bb,dd,aa}")).isEqualTo("aa,bb,cc,dd,ee,ff");
+		assertThat(m.process("${sort;ff,ee,cc,bb,dd,$<a>}")).isEqualTo("aaaa,bb,cc,dd,ee,ff");
+		assertThat(m.process("${sort;}")).isEmpty();
 	}
 
 	@Test
@@ -1668,7 +1673,8 @@ public class MacroTest {
 		Processor p = new Processor();
 		p.setProperty("a", "02");
 		Macro m = new Macro(p);
-		assertEquals("1,02,10", m.process("${nsort;$<a>,1,10}"));
+		assertThat(m.process("${nsort;$<a>,1,10}")).isEqualTo("1,02,10");
+		assertThat(m.process("${nsort;}")).isEmpty();
 	}
 
 	@Test

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -562,7 +562,7 @@ public class Macro {
 	static final String _sortHelp = "${sort;<list>...}";
 
 	public String _sort(String[] args) {
-		verifyCommand(args, _sortHelp, null, 2, Integer.MAX_VALUE);
+		verifyCommand(args, _sortHelp, null, 1, Integer.MAX_VALUE);
 		String result = Arrays.stream(args, 1, args.length)
 			.flatMap(Strings::splitQuotedAsStream)
 			.sorted()
@@ -573,7 +573,7 @@ public class Macro {
 	static final String _nsortHelp = "${nsort;<list>...}";
 
 	public String _nsort(String[] args) {
-		verifyCommand(args, _nsortHelp, null, 2, Integer.MAX_VALUE);
+		verifyCommand(args, _nsortHelp, null, 1, Integer.MAX_VALUE);
 
 		String result = Arrays.stream(args, 1, args.length)
 			.flatMap(Strings::splitAsStream)

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -580,7 +580,7 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 		return new Xpp3Dom("configuration");
 	}
 
-	private void reportErrorsAndWarnings(Builder builder) throws MojoFailureException {
+	protected void reportErrorsAndWarnings(Builder builder) throws MojoFailureException {
 		@SuppressWarnings("unchecked")
 		Collection<File> markedFiles = (Collection<File>) buildContext.getValue(MARKED_FILES);
 		if (markedFiles == null) {

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -71,8 +71,7 @@ import aQute.lib.utf8properties.UTF8Properties;
 import aQute.service.reporter.Report.Location;
 
 public abstract class AbstractBndMavenPlugin extends AbstractMojo {
-	private static final Logger						logger					= LoggerFactory
-		.getLogger(AbstractBndMavenPlugin.class);
+	protected final Logger	logger					= LoggerFactory.getLogger(getClass());
 	static final String						MANIFEST_LAST_MODIFIED	= "aQute.bnd.maven.plugin.BndMavenPlugin.manifestLastModified";
 	static final String						MARKED_FILES			= "aQute.bnd.maven.plugin.BndMavenPlugin.markedFiles";
 	static final String						PACKAGING_JAR			= "jar";

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
@@ -118,10 +118,20 @@ public class BndMavenTestsPlugin extends AbstractBndMavenPlugin {
 
 		if (testCases != TestCases.useTestCasesHeader) {
 			builder.setProperty(Constants.TESTCASES, "${sort;${uniq;" + testCases.filter() + "}}");
-		} else if (builder.getProperty(Constants.TESTCASES) == null) {
+		} else if (builder.getUnexpandedProperty(Constants.TESTCASES) == null) {
 			throw new MojoFailureException(
 				"<testCases> specified " + TestCases.useTestCasesHeader + " but no Test-Cases header was found");
 		}
+	}
+
+	@Override
+	protected void reportErrorsAndWarnings(Builder builder) throws MojoFailureException {
+		if (builder.getProperty(Constants.TESTCASES, "")
+			.trim()
+			.isEmpty()) {
+			builder.warning("The Test-Cases header is empty. No test case classes were found.");
+		}
+		super.reportErrorsAndWarnings(builder);
 	}
 
 }


### PR DESCRIPTION
Stop erroring if sort list is empty. Warn is Test-Cases header is empty for bnd-process-tests.

See https://github.com/bndtools/bnd/issues/4213.