### PR TITLE
[junit-platform] Add pruning functionality

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
@@ -1,13 +1,5 @@
 package aQute.tester.bundle.engine;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.platform.engine.ConfigurationParameters;
-import org.junit.platform.engine.EngineExecutionListener;
-import org.junit.platform.engine.ExecutionRequest;
-import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.osgi.framework.Bundle;
@@ -17,7 +9,6 @@ public class BundleDescriptor extends AbstractTestDescriptor {
 
 	final private Bundle							bundle;
 	final private BundleException					bundleException;
-	final private Map<TestDescriptor, TestEngine>	engineMap	= new HashMap<>();
 
 	public static String displayNameOf(Bundle bundle) {
 		return "[" + bundle.getBundleId() + "] " + bundle.getSymbolicName() + ';'
@@ -38,17 +29,6 @@ public class BundleDescriptor extends AbstractTestDescriptor {
 		return bundle;
 	}
 
-	public void addChild(TestDescriptor descriptor, TestEngine engine) {
-		engineMap.put(descriptor, engine);
-		addChild(descriptor);
-	}
-
-	public void executeChild(TestDescriptor descriptor, EngineExecutionListener listener, ConfigurationParameters params) {
-		TestEngine engine = engineMap.get(descriptor);
-		ExecutionRequest er = new ExecutionRequest(descriptor, listener, params);
-		engine.execute(er);
-
-	}
 	@Override
 	public Type getType() {
 		return bundleException == null ? Type.CONTAINER : Type.TEST;

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngine.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngine.java
@@ -1,31 +1,27 @@
 package aQute.tester.bundle.engine;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.junit.platform.commons.JUnitException;
-import org.junit.platform.commons.util.Preconditions;
-import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
-import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
-import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
-import org.opentest4j.TestAbortedException;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
+import aQute.tester.bundle.engine.discovery.BundleEnginePruner;
 import aQute.tester.bundle.engine.discovery.BundleSelectorResolver;
 
 @ServiceProvider(value = TestEngine.class, resolution = Resolution.OPTIONAL)
 public class BundleEngine implements TestEngine {
 
 	public static final String				CHECK_UNRESOLVED	= "aQute.bnd.junit.bundle.engine.checkUnresolved";
+	public static final String				PRUNE				= "aQute.bnd.junit.bundle.engine.prune";
 
 	public static final String				ENGINE_ID			= "bnd-bundle-engine";
 
@@ -56,93 +52,36 @@ public class BundleEngine implements TestEngine {
 		BundleEngineDescriptor descriptor = new BundleEngineDescriptor(uniqueId);
 
 		if (!context.isPresent()) {
-			descriptor.addChild(new StaticFailureDescriptor(uniqueId.append("test", "noFramework"), "Initialization Error",
-				new JUnitException("BundleEngine must run inside an OSGi framework")));
+			descriptor.addChild(new StaticFailureDescriptor(uniqueId.append("test", "noFramework"),
+				"Initialization Error", new JUnitException("BundleEngine must run inside an OSGi framework")));
 			return descriptor;
 		}
 		BundleSelectorResolver.resolve(context.get(), request, descriptor);
+
+		Optional<String> prune = request.getConfigurationParameters()
+			.get(PRUNE);
+
+		if (prune.isPresent()) {
+			try {
+				new BundleEnginePruner(prune.get()).prune(descriptor);
+			} catch (IllegalArgumentException e) {
+				StaticFailureDescriptor sd = new StaticFailureDescriptor(descriptor.getUniqueId()
+					.append("test", "invalidConfig"), "Malformed prune directive", e);
+				descriptor.addChild(sd);
+			}
+		}
 		return descriptor;
+	}
+
+	void dump(String indent, TestDescriptor desc) {
+		System.err.println(indent + desc.getDisplayName());
+		for (TestDescriptor child : desc.getChildren()) {
+			dump(indent + "  ", child);
+		}
 	}
 
 	@Override
 	public void execute(ExecutionRequest request) {
-		final TestDescriptor root = request.getRootTestDescriptor();
-		final EngineExecutionListener listener = request.getEngineExecutionListener();
-		final ConfigurationParameters params = request.getConfigurationParameters();
-
-		Preconditions.condition(root instanceof BundleEngineDescriptor,
-			"Root descriptor should be an instance of BundleEngineDescriptor, was " + root.getClass());
-		Preconditions.condition(root.getChildren()
-			.stream()
-			.allMatch(descriptor -> descriptor instanceof BundleDescriptor || descriptor instanceof StaticFailureDescriptor),
-			"Child descriptors should all be BundleDescriptors or StaticFailureDescriptors");
-		listener.executionStarted(root);
-		try {
-			Optional<StaticFailureDescriptor> staticFailureDescriptor = root.getChildren()
-				.stream()
-				.filter(StaticFailureDescriptor.class::isInstance)
-				.map(StaticFailureDescriptor.class::cast)
-				.peek(childDescriptor -> childDescriptor.execute(listener))
-				.reduce((first, second) -> first);
-
-			Stream<BundleDescriptor> childDescriptors = root.getChildren()
-				.stream()
-				.filter(BundleDescriptor.class::isInstance)
-				.map(BundleDescriptor.class::cast);
-			if (staticFailureDescriptor.isPresent()) {
-				String reason = staticFailureDescriptor.map(StaticFailureDescriptor::getError)
-					.map(Throwable::getMessage)
-					.orElseGet(() -> staticFailureDescriptor.get()
-						.getDisplayName());
-				childDescriptors.forEach(childDescriptor -> listener.executionSkipped(childDescriptor, reason));
-			} else {
-				childDescriptors
-					.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params));
-			}
-			listener.executionFinished(root, TestExecutionResult.successful());
-		} catch (Throwable t) {
-			System.err.println("Unrecoverable error while executing tests: " + t);
-			t.printStackTrace(System.err);
-			listener.executionFinished(root, TestExecutionResult.failed(t));
-		}
-	}
-
-	private static void executeBundle(BundleDescriptor descriptor, EngineExecutionListener listener,
-		ConfigurationParameters params) {
-		listener.executionStarted(descriptor);
-		TestExecutionResult result;
-		if (descriptor.getException() == null) {
-			try {
-				descriptor.getChildren()
-					.stream()
-					.filter(childDescriptor -> !(childDescriptor instanceof BundleDescriptor
-						|| childDescriptor instanceof StaticFailureDescriptor))
-					.forEach(childDescriptor -> descriptor.executeChild(childDescriptor, listener, params));
-				result = TestExecutionResult.successful();
-			} catch (TestAbortedException abort) {
-				result = TestExecutionResult.aborted(abort);
-			} catch (OutOfMemoryError | StackOverflowError t) {
-				throw t;
-			} catch (Throwable t) {
-				result = TestExecutionResult.failed(t);
-			}
-			descriptor.getChildren()
-				.stream()
-				.filter(BundleDescriptor.class::isInstance)
-				.map(BundleDescriptor.class::cast)
-				.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params));
-			descriptor.getChildren()
-				.stream()
-				.filter(StaticFailureDescriptor.class::isInstance)
-				.map(StaticFailureDescriptor.class::cast)
-				.forEach(childDescriptor -> childDescriptor.execute(listener));
-		} else {
-			result = TestExecutionResult.failed(descriptor.getException());
-			descriptor.getChildren()
-				.forEach(childDescriptor -> {
-					listener.executionSkipped(childDescriptor, "Bundle did not resolve");
-				});
-		}
-		listener.executionFinished(descriptor, result);
+		new BundleEngineExecutor(request).execute();
 	}
 }

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngineDescriptor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngineDescriptor.java
@@ -1,10 +1,134 @@
 package aQute.tester.bundle.engine;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
+import aQute.lib.collections.MultiMap;
+
 public class BundleEngineDescriptor extends EngineDescriptor {
+	final private Map<TestDescriptor, TestDescriptor>		engineDescriptorMap			= new HashMap<>();
+	final private MultiMap<TestDescriptor, TestDescriptor>	reverseEngineDescriptorMap	= new MultiMap<>(
+		TestDescriptor.class, TestDescriptor.class, true);
+	final private Map<TestDescriptor, TestEngine>			engineMap					= new HashMap<>();
+
 	public BundleEngineDescriptor(UniqueId uniqueId) {
 		super(uniqueId, "Bnd JUnit Platform Bundle Engine");
+	}
+
+	public void registerEngineFor(TestDescriptor ed, TestEngine engine) {
+		engineMap.put(ed, engine);
+	}
+
+	public void registerSubEngineDescriptorFor(TestDescriptor td, TestDescriptor engineDescriptor) {
+		engineDescriptorMap.put(td, engineDescriptor);
+		reverseEngineDescriptorMap.add(engineDescriptor, td);
+	}
+
+	public TestDescriptor getSubEngineDescriptorFor(TestDescriptor td) {
+		return engineDescriptorMap.get(td);
+	}
+
+	public void executeChildren(TestDescriptor descriptor, EngineExecutionListener listener,
+		ConfigurationParameters params) {
+		TestEngine engine = engineMap.get(descriptor);
+		ExecutionRequest er = new ExecutionRequest(descriptor, listener, params);
+		engine.execute(er);
+
+	}
+
+	public static class FilteredListener implements EngineExecutionListener {
+
+		final EngineExecutionListener	listener;
+		final TestDescriptor			filtered;
+		final TestDescriptor			altParent;
+
+		FilteredListener(EngineExecutionListener listener, TestDescriptor filtered, TestDescriptor altParent) {
+			this.listener = listener;
+			this.filtered = filtered;
+			this.altParent = altParent;
+		}
+
+		@Override
+		public void dynamicTestRegistered(TestDescriptor testDescriptor) {
+			listener.dynamicTestRegistered(testDescriptor);
+		}
+
+		@Override
+		public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+			if (testDescriptor != filtered) {
+				listener.executionSkipped(testDescriptor, reason);
+			}
+		}
+
+		@Override
+		public void executionStarted(TestDescriptor testDescriptor) {
+			if (testDescriptor != filtered) {
+				listener.executionStarted(testDescriptor);
+			}
+		}
+
+		@Override
+		public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
+			if (testDescriptor != filtered) {
+				listener.executionFinished(testDescriptor, testExecutionResult);
+			}
+		}
+
+		@Override
+		public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+			if (testDescriptor != filtered) {
+				listener.reportingEntryPublished(testDescriptor, entry);
+			}
+		}
+	}
+
+	public void executeChildrenOfPrunedEngine(TestDescriptor engineDescriptor, TestDescriptor parent,
+		EngineExecutionListener listener, ConfigurationParameters params) {
+		TestEngine engine = engineMap.get(engineDescriptor);
+		if (parent != engineDescriptor) {
+			// Re-insert the engine node into the hierarchy of the engine
+			// descriptor node before we pass it to the sub-engine for
+			// execution, because the engine may have preconditions that expect
+			// the same engine root node that it generated during the discovery
+			// phase.
+			reverseEngineDescriptorMap.get(engineDescriptor)
+				.forEach(child -> {
+					parent.removeChild(child);
+					engineDescriptor.addChild(child);
+				});
+		}
+		FilteredListener filtered = new FilteredListener(listener, engineDescriptor, parent);
+		ExecutionRequest er = new ExecutionRequest(engineDescriptor, filtered, params);
+		try {
+			engine.execute(er);
+		} finally {
+			if (parent != engineDescriptor) {
+				// Put them back into the original parent when we've finished so
+				// that the sub-engine node doesn't appear in the test output.
+				// Note that we don't simply re-use the original list from
+				// reverseEngineDescriptorMap above, as/ the sub-engine may have
+				// added dynamic tests to the test hierarchy during execution.
+				// Need to copy it though to avoid concurrent modification
+				// exception.
+				Stream.of(engineDescriptor.getChildren()
+					.stream()
+					.toArray(TestDescriptor[]::new))
+					.forEach(child -> {
+						engineDescriptor.removeChild(child);
+						parent.addChild(child);
+					});
+			}
+		}
 	}
 }

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngineExecutor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngineExecutor.java
@@ -1,0 +1,131 @@
+package aQute.tester.bundle.engine;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.opentest4j.TestAbortedException;
+
+public class BundleEngineExecutor {
+
+	final BundleEngineDescriptor	root;
+	final EngineExecutionListener	listener;
+	final ExecutionRequest			request;
+	final ConfigurationParameters	params;
+
+	public BundleEngineExecutor(ExecutionRequest request) {
+		TestDescriptor root = request.getRootTestDescriptor();
+		Preconditions.condition(root instanceof BundleEngineDescriptor,
+			() -> "Root descriptor should be an instance of BundleEngineDescriptor, was " + root.getClass());
+		this.request = request;
+		this.root = (BundleEngineDescriptor) root;
+		this.listener = request.getEngineExecutionListener();
+		this.params = request.getConfigurationParameters();
+	}
+
+	void dump(String indent, TestDescriptor desc) {
+		System.err.println(indent + desc.getDisplayName());
+		for (TestDescriptor child : desc.getChildren()) {
+			dump(indent + "  ", child);
+		}
+	}
+
+	public void execute() {
+		dump("", root);
+
+		BundleEngineDescriptor bundleEngineRoot = root;
+		listener.executionStarted(root);
+		try {
+			Optional<StaticFailureDescriptor> staticFailureDescriptor = root.getChildren()
+				.stream()
+				.filter(StaticFailureDescriptor.class::isInstance)
+				.map(StaticFailureDescriptor.class::cast)
+				.peek(childDescriptor -> childDescriptor.execute(listener))
+				.reduce((first, second) -> first);
+
+			if (staticFailureDescriptor.isPresent()) {
+				Stream<? extends TestDescriptor> childDescriptors = root.getChildren()
+					.stream()
+					.filter(BundleDescriptor.class::isInstance);
+				String reason = staticFailureDescriptor.map(StaticFailureDescriptor::getError)
+					.map(Throwable::getMessage)
+					.orElseGet(() -> staticFailureDescriptor.get()
+						.getDisplayName());
+				childDescriptors.forEach(childDescriptor -> listener.executionSkipped(childDescriptor, reason));
+			} else {
+				executeChildren(root);
+			}
+			listener.executionFinished(root, TestExecutionResult.successful());
+		} catch (Throwable t) {
+			System.err.println("Unrecoverable error while executing tests: " + t);
+			t.printStackTrace(System.err);
+			listener.executionFinished(root, TestExecutionResult.failed(t));
+		}
+	}
+
+	private void executeChildren(TestDescriptor descriptor) {
+		descriptor.getChildren()
+			.stream()
+			.filter(BundleDescriptor.class::isInstance)
+			.map(BundleDescriptor.class::cast)
+			.forEach(childDescriptor -> executeBundle(childDescriptor));
+		descriptor.getChildren()
+			.stream()
+			.filter(StaticFailureDescriptor.class::isInstance)
+			.map(StaticFailureDescriptor.class::cast)
+			.forEach(childDescriptor -> childDescriptor.execute(listener));
+		descriptor.getChildren()
+			.stream()
+			.filter(EngineDescriptor.class::isInstance)
+			.map(EngineDescriptor.class::cast)
+			.forEach(this::executeEngine);
+
+		Stream.of(descriptor.getChildren()
+			.stream()
+			.filter(childDescriptor -> !(childDescriptor instanceof BundleDescriptor
+				|| childDescriptor instanceof StaticFailureDescriptor || childDescriptor instanceof EngineDescriptor))
+			.map(root::getSubEngineDescriptorFor)
+			.distinct()
+			// We have to make a copy because executeChildrenOfPrunedEngine()
+			// will add and remove children from descriptor during its
+			// operation, which will cause ConcurrentModificationException
+			.toArray(TestDescriptor[]::new))
+			.forEach(subEngineDescriptor -> root.executeChildrenOfPrunedEngine(subEngineDescriptor, descriptor,
+				listener, params));
+	}
+
+	private void executeEngine(EngineDescriptor engineDescriptor) {
+		root.executeChildren(engineDescriptor, listener, params);
+	}
+
+	private void executeBundle(BundleDescriptor descriptor) {
+		listener.executionStarted(descriptor);
+		TestExecutionResult result;
+		if (descriptor.getException() == null) {
+			try {
+				executeChildren(descriptor);
+				result = TestExecutionResult.successful();
+			} catch (TestAbortedException abort) {
+				result = TestExecutionResult.aborted(abort);
+			} catch (OutOfMemoryError | StackOverflowError t) {
+				throw t;
+			} catch (Throwable t) {
+				t.printStackTrace();
+				result = TestExecutionResult.failed(t);
+			}
+		} else {
+			result = TestExecutionResult.failed(descriptor.getException());
+			descriptor.getChildren()
+				.forEach(childDescriptor -> {
+					listener.executionSkipped(childDescriptor, "Bundle did not resolve");
+				});
+		}
+		listener.executionFinished(descriptor, result);
+	}
+}

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleEnginePruner.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleEnginePruner.java
@@ -1,0 +1,162 @@
+package aQute.tester.bundle.engine.discovery;
+
+import static aQute.lib.strings.Strings.splitAsStream;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId.Segment;
+
+import aQute.tester.bundle.engine.BundleEngineDescriptor;
+
+public class BundleEnginePruner {
+
+	public enum PruneType {
+		NEVER,
+		ONLYCHILD,
+		ALWAYS
+	}
+
+	final Map<String, PruneType> directives;
+
+	final static Set<String>		ALLOWED_NODE_TYPES;
+
+	static {
+		Set<String> allowed = new HashSet<>();
+		allowed.add("bundle");
+		allowed.add("fragment");
+		allowed.add("sub-engine");
+		ALLOWED_NODE_TYPES = Collections.unmodifiableSet(allowed);
+	}
+
+	public BundleEnginePruner(String prune) {
+		directives = new HashMap<>();
+		splitAsStream(prune).forEach(pair -> {
+			int index = pair.indexOf('=');
+			if (index < 0) {
+				throw new IllegalArgumentException("Malformed prune directive: missing '='");
+			}
+			String nodeType = pair.substring(0, index);
+			if (!ALLOWED_NODE_TYPES.contains(nodeType)) {
+				throw new IllegalArgumentException("Malformed prune directive: unknown node type '" + nodeType
+					+ "'; expecting bundle, fragment or sub-engine");
+			}
+			String pruneType = pair.substring(index + 1);
+			try {
+				directives.put(nodeType, PruneType.valueOf(pruneType.toUpperCase()));
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException("Malformed prune directive: unknown prune type '" + pruneType
+					+ "'; expecting never, onlychild or always");
+			}
+		});
+	}
+
+	PruneType getDirective(String nodeType) {
+		return directives.getOrDefault(nodeType, PruneType.NEVER);
+	}
+
+	static Segment getLastSegment(TestDescriptor descriptor) {
+		List<Segment> uidSegments = descriptor.getUniqueId()
+			.getSegments();
+		return uidSegments.get(uidSegments.size() - 1);
+	}
+
+	static String getType(TestDescriptor descriptor) {
+		return getLastSegment(descriptor).getType();
+	}
+
+	boolean shouldPrune(TestDescriptor descriptor) {
+		String type = getType(descriptor);
+		if (currentBundleBeingPruned && type.equals("fragment")) {
+			return true;
+		}
+		PruneType directive = getDirective(type);
+		return directive == PruneType.ALWAYS || (directive == PruneType.ONLYCHILD && descriptor.getParent()
+			.get()
+			.getChildren()
+			.size() == 1);
+	}
+
+	public void prune(BundleEngineDescriptor rootDescriptor) {
+		new ArrayList<>(rootDescriptor.getChildren()).forEach(child -> pruneAndReparentChildren(child, rootDescriptor));
+	}
+
+	Predicate<TestDescriptor> withSameIdAs(TestDescriptor other) {
+		Segment lastSegment = getLastSegment(other);
+		String type = lastSegment.getType();
+		String value = lastSegment.getValue();
+		return descriptor -> {
+			Segment last = getLastSegment(descriptor);
+			return last.getType()
+				.equals(type)
+				&& last.getValue()
+					.equals(value);
+		};
+	}
+
+	// Optionally prunes the given descriptor, and reparents it (or its children
+	// if it is being pruned) to the given parent.
+	void pruneAndReparentChildren(TestDescriptor descriptor, TestDescriptor newParent) {
+		String type = getType(descriptor);
+
+		TestDescriptor currentParent = descriptor.getParent()
+			.get();
+
+		if (shouldPrune(descriptor)) {
+			if (type.equals("bundle")) {
+				currentBundleBeingPruned = true;
+			}
+			currentParent.removeChild(descriptor);
+			// Have to take a copy otherwise we get a
+			// ConcurrentModificationException
+			// while iterating, and the iterator doesn't support remove()
+			List<TestDescriptor> children = new ArrayList<>(descriptor.getChildren());
+			for (TestDescriptor child : children) {
+				pruneAndReparentChildren(child, newParent);
+			}
+			if (type.equals("bundle")) {
+				currentBundleBeingPruned = false;
+			}
+		} else {
+			if (newParent != currentParent) {
+				currentParent.removeChild(descriptor);
+				Optional<? extends TestDescriptor> existing = newParent.getChildren()
+					.stream()
+					.filter(withSameIdAs(descriptor))
+					.findAny();
+				if (existing.isPresent()) {
+					newParent = existing.get();
+				} else {
+					newParent.addChild(descriptor);
+					newParent = descriptor;
+				}
+			} else {
+				newParent = descriptor;
+			}
+			switch (type) {
+				case "bundle" :
+				case "fragment" :
+				case "sub-engine" :
+					// Copy to prevent ConcurrentModificationException
+					List<TestDescriptor> children = new ArrayList<>(descriptor.getChildren());
+					for (TestDescriptor child : children) {
+						pruneAndReparentChildren(child, newParent);
+					}
+					break;
+				default :
+					// Terminate the tree descent if we've already gone past the
+					// depth of sub-engine
+			}
+		}
+	}
+
+	boolean currentBundleBeingPruned = false;
+}

--- a/biz.aQute.tester.test/bundleenginetest-nojupiter.bndrun
+++ b/biz.aQute.tester.test/bundleenginetest-nojupiter.bndrun
@@ -1,0 +1,4 @@
+-include: bundleenginetest-noengines.bndrun
+
+-runbundles.engines: \
+	org.junit.vintage.engine;version='[5.3.1,5.3.2)'


### PR DESCRIPTION
Fixes #4128

This is a draft. I'd like some feedback on the syntax and functionality, once that's settled I'll write the doc and re-submit as a full PR.

There is a new tester directive called "tester.prune". It has the following syntax:

`tester.prune=<nodetype>=<prunemode>[,<nodetype>=<prunemode>]`

The supported node types are `bundle`, `fragment` and `sub-engine`.

The supported prune modes are `never` (default), `onlychild` (prune if the node has no siblings) and `always`.

Had to jump through a few hoops to make this work but this seems to do the trick.