### PR TITLE
classindex: Avoid returning duplicate bundle ids

### DIFF
--- a/aQute.libg/src/aQute/lib/collections/package-info.java
+++ b/aQute.libg/src/aQute/lib/collections/package-info.java
@@ -1,4 +1,4 @@
-@Version("3.4.0")
+@Version("4.0.0")
 package aQute.lib.collections;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceClassIndex.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceClassIndex.java
@@ -84,7 +84,7 @@ class WorkspaceClassIndex implements AutoCloseable {
 				return Result.err(error);
 			}
 		}
-		return Result.ok(result.transpose());
+		return Result.ok(result.transpose(true));
 	}
 
 	/*

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -397,10 +397,13 @@ public class Analyzer extends Processor {
 			for (PackageRef exported : exports.keySet()) {
 				List<PackageRef> used = uses.get(exported);
 				if (used != null) {
-					Set<PackageRef> privateReferences = new TreeSet<>(apiUses.get(exported));
-					privateReferences.retainAll(privatePackages);
-					if (!privateReferences.isEmpty())
-						msgs.Export_Has_PrivateReferences_(exported, privateReferences.size(), privateReferences);
+					List<PackageRef> apiUsed = apiUses.get(exported);
+					if (apiUsed != null) {
+						Set<PackageRef> privateReferences = new TreeSet<>(apiUsed);
+						privateReferences.retainAll(privatePackages);
+						if (!privateReferences.isEmpty())
+							msgs.Export_Has_PrivateReferences_(exported, privateReferences.size(), privateReferences);
+					}
 				}
 			}
 

--- a/bndtools.utils/src/org/bndtools/utils/collections/CollectionUtils.java
+++ b/bndtools.utils/src/org/bndtools/utils/collections/CollectionUtils.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import aQute.lib.collections.MultiMap;
-
 public class CollectionUtils {
 	/**
 	 * Move the selected items down one position in the list.
@@ -93,20 +91,6 @@ public class CollectionUtils {
 				return true;
 		}
 		return false;
-	}
-
-	public static <K, V> MultiMap<V, K> invertMultiMap(MultiMap<K, V> input) {
-		MultiMap<V, K> result = new MultiMap<>();
-
-		for (Entry<K, List<V>> inputEntry : input.entrySet()) {
-			K inputKey = inputEntry.getKey();
-			List<V> inputList = inputEntry.getValue();
-			for (V inputVal : inputList) {
-				result.add(inputVal, inputKey);
-			}
-		}
-
-		return result;
 	}
 
 	public static <K, V> Map<V, Set<K>> invertMapOfCollection(Map<K, ? extends Collection<V>> mapOfCollection) {


### PR DESCRIPTION
We create and use a new MultiMap.transpose(boolean noduplicates) method
to avoid duplicate bundle ids.

Fixes #4226