### PR TITLE
gradle: Update gradle code regarding configuration caching

### DIFF
--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -5,47 +5,40 @@ repositories {
 }
 
 dependencies {
-    compileOnly localGroovy()
-    compileOnly gradleApi()
-    testImplementation gradleTestKit()
-    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4')  {
-        exclude module: 'groovy-all'
-    }
+  compileOnly localGroovy()
+  compileOnly gradleApi()
+  testImplementation gradleTestKit()
+  testImplementation('org.spockframework:spock-core:1.1-groovy-2.4')  {
+    exclude module: 'groovy-all'
+  }
 }
 
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
-    tasks.withType(GroovyCompile.class).configureEach {
-        groovyOptions.fork 'jvmArgs': jpmsOptions
-    }
+  tasks.withType(GroovyCompile.class).configureEach {
+    groovyOptions.fork 'jvmArgs': jpmsOptions
+  }
+}
+
+def pluginUnderTestMetadata = tasks.register('pluginUnderTestMetadata', WriteProperties.class) {
+ def pluginClasspath = project.providers.provider({ ->
+    return project.files(configurations.runtimeClasspath.allArtifacts.files,
+     configurations.runtimeClasspath.resolvedConfiguration.files)
+  })
+  inputs.files(pluginClasspath).withPropertyName('pluginClasspath')
+  outputFile = tasks.named('compileTestJava').flatMap { it.destinationDirectory.file('plugin-under-test-metadata.properties') }
+  doFirst {
+    property('implementation-classpath',  pluginClasspath.get().asPath)
+  }
+}
+
+def testresources = tasks.register('testresources', Sync.class) {
+  from project.file('testresources')
+  into project.layout.buildDirectory.dir('testresources')
 }
 
 tasks.named('test') {
-    inputs.files tasks.named('jar')
-    systemProperty 'bnd_version', bnd('bnd_version')
-    def source = project.file('testresources')
-    def target = project.layout.buildDirectory.dir('testresources')
-    doFirst { // copy test resources into build dir
-        project.delete(target)
-        copy {
-            from source
-            into target
-        }
-    }
-}
-
-tasks.named('testClasses') {
-    def pluginClasspath = { project.files(configurations.runtimeClasspath.allArtifacts.files,
-       configurations.runtimeClasspath.resolvedConfiguration.files) }
-    inputs.files(pluginClasspath).withPropertyName('pluginClasspath')
-    def pluginClasspathFile = { new File(tasks.getByName('compileTestJava').destinationDir, 'plugin-under-test-metadata.properties') }
-    outputs.file(pluginClasspathFile).withPropertyName('pluginClasspathFile')
-    doLast {
-        Properties properties = new Properties()
-        properties.setProperty('implementation-classpath', pluginClasspath().asPath)
-        pluginClasspathFile().withOutputStream {
-          properties.store(it, 'plugin-under-test-metadata')
-        }
-    }
+  inputs.files tasks.named('jar'), pluginUnderTestMetadata, testresources
+  systemProperty 'bnd_version', bnd('bnd_version')
 }
 
 tasks.named('release') {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndBuilderPlugin.groovy
@@ -85,8 +85,8 @@ public class BndBuilderPlugin implements Plugin<Project> {
         Task baselineTask = tasks.getByName('baseline')
         Task bundleTask = baselineTask.getBundleTask()
         if (bundleTask) {
-          String archiveBaseName = unwrap(bundleTask.archiveBaseName)
-          String archiveVersion = unwrap(bundleTask.archiveVersion)
+          String archiveBaseName = unwrap(bundleTask.getArchiveBaseName())
+          String archiveVersion = unwrap(bundleTask.getArchiveVersion(), true)
           logger.debug 'Searching for default baseline {}:{}:(0,{}[', group, archiveBaseName, archiveVersion
           Dependency baselineDep = dependencies.create('group': group, 'name': archiveBaseName) {
             version {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -54,8 +54,13 @@ class BndUtils {
 
   @CompileStatic
   public static Object unwrap(Object value) {
+    return unwrap(value, false)
+  }
+
+  @CompileStatic
+  public static Object unwrap(Object value, boolean optional) {
     if (value instanceof Provider) {
-      value = value.getOrNull()
+      value = optional ? value.getOrNull() : value.get()
     } 
     if (value instanceof FileSystemLocation) {
       value = value.getAsFile()

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
@@ -48,6 +48,7 @@ package aQute.bnd.gradle
 import static aQute.bnd.exporter.executable.ExecutableJarExporter.EXECUTABLE_JAR
 import static aQute.bnd.exporter.runbundles.RunbundlesExporter.RUNBUNDLES
 import static aQute.bnd.gradle.BndUtils.logReport
+import static aQute.bnd.gradle.BndUtils.unwrap
 
 import aQute.lib.io.IO
 
@@ -122,7 +123,7 @@ public class Export extends Bndrun {
   @Deprecated
   @ReplacedBy('destinationDirectory')
   public File getDestinationDir() {
-    return project.file(getDestinationDirectory())
+    return unwrap(getDestinationDirectory())
   }
 
   @Deprecated
@@ -164,8 +165,8 @@ public class Export extends Bndrun {
    */
   @Override
   protected void worker(def run) {
-    String exporterName = getExporter().get()
-    File destinationDirFile = project.file(getDestinationDirectory())
+    String exporterName = unwrap(getExporter())
+    File destinationDirFile = unwrap(getDestinationDirectory())
     logger.info 'Exporting {} to {} with exporter {}', run.getPropertiesFile(), destinationDirFile, exporterName
     try {
       def export = run.export(exporterName, [:])

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
@@ -25,7 +25,7 @@ class PropertiesWrapper extends Properties {
       Object value = props.drop(1).inject(get(props.first())) { obj, prop ->
         obj?."${prop}"
       }
-      value = unwrap(value)
+      value = unwrap(value, true)
       return (value != null) ? value.toString() : defaultValue(key)
     } catch (MissingPropertyException mpe) {
       return defaultValue(key)

--- a/maven/build.gradle
+++ b/maven/build.gradle
@@ -7,15 +7,17 @@ if (localrepo) {
   localrepo = relativePath(uri(gradle.startParameter.currentDir).resolve(localrepo))
 }
 def dist = parent.project(bnd_build)
+def windows = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')
+def mvnw = rootProject.file(windows ? 'mvnw.cmd' : 'mvnw')
 
 def deploy = tasks.register('deploy', Exec.class) {
   def releaserepo = uri(bnd('releaserepo', dist.file('bundles'))) /* Release repository. */
   dependsOn dist.tasks.named('releaseDependencies')
-  if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+  if (windows) {
     executable 'cmd'
-    args '/c', rootProject.file('mvnw.cmd')
+    args '/c', mvnw
   } else {
-    executable rootProject.file('mvnw')
+    executable mvnw
   }
   args '--batch-mode'
   args '--no-transfer-progress'
@@ -32,16 +34,18 @@ def deploy = tasks.register('deploy', Exec.class) {
 
 def deployJFrog = tasks.register('deployJFrog', Exec.class) {
   enabled !bnd('-releaserepo.jfrog', '').empty
+  def settings = parent.project('cnf').file('ext/jfrog-settings.xml')
+  def deployState = deploy.map { it.state }
   onlyIf {
-    def state = deploy.get().state
+    def state = deployState.get()
     state.didWork && (state.failure == null)
   }
   dependsOn deploy
-  if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+  if (windows) {
     executable 'cmd'
-    args '/c', rootProject.file('mvnw.cmd')
+    args '/c', mvnw
   } else {
-    executable rootProject.file('mvnw')
+    executable mvnw
   }
   args '--batch-mode'
   args '--no-transfer-progress'
@@ -49,7 +53,7 @@ def deployJFrog = tasks.register('deployJFrog', Exec.class) {
     args '--debug'
   }
   args '-Pjfrog'
-  args "--settings=${parent.project('cnf').file('ext/jfrog-settings.xml')}"
+  args "--settings=${settings}"
   if (localrepo) {
     args "-Dmaven.repo.local=${localrepo}"
   }
@@ -60,18 +64,24 @@ deploy.configure {
   finalizedBy deployJFrog
 }
 
-tasks.named('clean') {
-  doFirst {
-    exec {
-      if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
-        executable 'cmd'
-        args '/c', rootProject.file('mvnw.cmd')
-      } else {
-        executable rootProject.file('mvnw')
-      }
-      args '--batch-mode'
-      args '--no-transfer-progress'
-      args 'clean'
-    }.assertNormalExitValue()
+def mvnClean = tasks.register('mvnClean', Exec.class) {
+ if (windows) {
+    executable 'cmd'
+    args '/c', mvnw
+  } else {
+    executable mvnw
   }
+  args '--batch-mode'
+  args '--no-transfer-progress'
+  if (logger.isDebugEnabled()) {
+    args '--debug'
+  }
+  if (localrepo) {
+    args "-Dmaven.repo.local=${localrepo}"
+  }
+  args 'clean'
+}
+
+tasks.named('clean') {
+  dependsOn mvnClean
 }

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -4,6 +4,13 @@
 
 import aQute.bnd.osgi.Jar
 import org.apache.tools.ant.filters.ReplaceTokens
+import javax.inject.Inject
+
+interface Injected {
+    @Inject ObjectFactory getObjects() 
+    @Inject ExecOperations getExec() 
+    @Inject FileSystemOperations getFs() 
+}
 
 /* Configure this project */
 String masterVersion = String.format('%s-%s-g%.7s',
@@ -20,9 +27,11 @@ def p2Plugins = tasks.register('p2Plugins', Sync.class) {
 def p2FeatureProperties = tasks.register('p2FeatureProperties', WriteProperties.class) {
   inputs.files p2Plugins
   outputFile = project.layout.buildDirectory.file('feature.properties')
+  def injected = project.objects.newInstance(Injected) 
+  def p2PluginsDir = p2Plugins.map { it.destinationDir }
   doFirst {
     property('base-version', bnd('base.version'))
-    fileTree(p2Plugins.get().destinationDir).each {
+    injected.objects.fileTree().from(p2PluginsDir).each {
       new Jar(it).withCloseable { jar ->
         property("${jar.getBsn()}-version", jar.getVersion())
       }
@@ -36,9 +45,10 @@ def p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
   archiveFileName = 'bndtools.main.feature.jar'
   from             'features/bndtools.main'
   include          'feature.xml'
+  def propertiesFile = p2FeatureProperties.map { it.outputFile }
   doFirst {
     Properties properties = new Properties()
-    p2FeatureProperties.get().outputFile.withInputStream {
+    propertiesFile.get().withInputStream {
         properties.load(it)
         properties['master-version'] = masterVersion
     }
@@ -52,9 +62,10 @@ def p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
   archiveFileName    = 'bndtools.m2e.feature.jar'
   from             'features/bndtools.m2e'
   include          'feature.xml'
+  def propertiesFile = p2FeatureProperties.map { it.outputFile }
   doFirst {
     Properties properties = new Properties()
-    p2FeatureProperties.get().outputFile.withInputStream {
+    propertiesFile.get().withInputStream {
         properties.load(it)
         properties['master-version'] = masterVersion
     }
@@ -68,9 +79,10 @@ def p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
   archiveFileName    = 'bndtools.pde.feature.jar'
   from             'features/bndtools.pde'
   include          'feature.xml'
+  def propertiesFile = p2FeatureProperties.map { it.outputFile }
   doFirst {
     Properties properties = new Properties()
-    p2FeatureProperties.get().outputFile.withInputStream {
+    propertiesFile.get().withInputStream {
         properties.load(it)
         properties['master-version'] = masterVersion
     }
@@ -83,11 +95,14 @@ def p2 = tasks.register('p2') {
   group       'release'
   enabled JavaVersion.current().isJava8()
   inputs.files p2Plugins, p2FeatureMain, p2FeatureM2e, p2FeaturePde, 'p2.xml', 'features/category.xml'
-  ext.destinationDirectory = project.layout.buildDirectory.dir('p2')
+  def injected = project.objects.newInstance(Injected) 
+  def buildDirectoryProperty = project.layout.buildDirectory
+  ext.destinationDirectory = buildDirectoryProperty.dir('p2')
   outputs.dir destinationDirectory
+  def eclipseDir = file('eclipse-3.5.2')
+  def categoryURI = uri('features/category.xml')
   doLast {
-    def eclipseDir = file('eclipse-3.5.2')
-    javaexec {
+    injected.exec.javaexec {
       classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
       main = 'org.eclipse.equinox.launcher.Main'
       if (logger.isDebugEnabled()) {
@@ -96,7 +111,7 @@ def p2 = tasks.register('p2') {
       args '-application'
       args 'org.eclipse.ant.core.antRunner'
       args '-data'
-      args file(project.layout.buildDirectory)
+      args buildDirectoryProperty.get().asFile
       if (logger.isDebugEnabled()) {
         args '-debug'
       } else {
@@ -107,7 +122,7 @@ def p2 = tasks.register('p2') {
       args 'p2Bndtools'
     }.assertNormalExitValue()
 
-    javaexec {
+    injected.exec.javaexec {
       classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
       main = 'org.eclipse.equinox.launcher.Main'
       if (logger.isDebugEnabled()) {
@@ -116,20 +131,22 @@ def p2 = tasks.register('p2') {
       args '-application'
       args 'org.eclipse.equinox.p2.publisher.CategoryPublisher'
       args '-data'
-      args file(project.layout.buildDirectory)
+      args buildDirectoryProperty.get().asFile
       args '-metadataRepository'
-      args uri(destinationDirectory)
+      args destinationDirectory.get().asFile.toURI()
       args '-categoryDefinition'
-      args uri('features/category.xml')
+      args categoryURI
       args '-compress'
     }.assertNormalExitValue()
 
-    delete fileTree(eclipseDir).include('configuration/*.log'),
-      "${eclipseDir}/configuration/org.eclipse.core.runtime",
-      "${eclipseDir}/configuration/org.eclipse.equinox.app",
-      "${eclipseDir}/configuration/org.eclipse.osgi",
-      "${eclipseDir}/p2"
-  }
+    injected.fs.delete {
+      delete fileTree(eclipseDir).include('configuration/*.log'),
+        "${eclipseDir}/configuration/org.eclipse.core.runtime",
+        "${eclipseDir}/configuration/org.eclipse.equinox.app",
+        "${eclipseDir}/configuration/org.eclipse.osgi",
+        "${eclipseDir}/p2"
+      }
+    }
 }
 
 tasks.named('jar') {


### PR DESCRIPTION
Gradle is introducing the ability to cache gradle configuration to
improve build start time. These changes are minor changes inline with
enabling this support. It will likely take gradle several releases to
get complete configuration caching to work and we will need to make
more changes as they do.
