### PR TITLE
maven: Add testng TestCases enum value

### DIFF
--- a/maven/bnd-maven-plugin/README.md
+++ b/maven/bnd-maven-plugin/README.md
@@ -250,11 +250,12 @@ Some details are predefined for simplicity:
 #### Test Cases
 
 Bnd's integration testing uses the manifest header `Test-Cases` to identify classes within a bundle that are test cases. This eliminates the need for runtime class scanning. The `bnd-process-tests` simplifies this configuration by creating several predefined specifications of test cases that use bnd's `classes` macro:
-- **`junit3`** - represents the filter `${classes;EXTENDS;junit.framework.TestCase;CONCRETE}`
-- **`junit4`** - represents the filter `${classes;HIERARCHY_ANNOTATED;org.junit.Test;CONCRETE}`
-- **`junit5`** - represents the filter `${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}`
-- **`all`** - represents the filter `junit3` + `junit4` + `junit5`
-- **`useTestCasesHeader`** - indicates that the the `Test-Cases` header in the bnd configuration should be used instead. The build will fail if this value is set and there is no `Test-Cases` header in the bnd configuration
+- **`junit3`** - represents the filter `${classes;EXTENDS;junit.framework.TestCase;CONCRETE}`.
+- **`junit4`** - represents the filter `${classes;HIERARCHY_ANNOTATED;org.junit.Test;CONCRETE}`.
+- **`junit5`** - represents the filter `${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}`.
+- **`all`** - represents all the JUnit filters: `junit3`, `junit4`, and `junit5`.
+- **`testng`** - represents the filter `${classes;HIERARCHY_ANNOTATED;org.testng.annotations.Test;CONCRETE}`. Note: A JUnit Platform engine for TestNG, or other means to run TestNG tests, must be in the test execution runtime.
+- **`useTestCasesHeader`** - indicates that the the `Test-Cases` header in the bnd configuration should be used instead. The build will fail if this value is set and there is no `Test-Cases` header in the bnd configuration.
 
 ### Maven JAR Plugin
 

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
@@ -44,7 +44,8 @@ public class BndMavenTestsPlugin extends AbstractBndMavenPlugin {
 	/**
 	 * Possible values are {@link TestCases#junit3 junit3},
 	 * {@link TestCases#junit4 junit4}, {@link TestCases#junit5 junit5},
-	 * {@link TestCases#all all} and {@link TestCases#useTestCasesHeader}
+	 * {@link TestCases#all all}, {@link TestCases#testng testng}, and
+	 * {@link TestCases#useTestCasesHeader}
 	 */
 	@Parameter(defaultValue = "junit5")
 	private TestCases								testCases;

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/TestCases.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/TestCases.java
@@ -2,10 +2,29 @@ package aQute.bnd.maven.plugin;
 
 public enum TestCases {
 
+	/**
+	 * JUnit 3.
+	 */
 	junit3("${classes;EXTENDS;junit.framework.TestCase;CONCRETE}"),
+	/**
+	 * JUnit 4.
+	 */
 	junit4("${classes;HIERARCHY_ANNOTATED;org.junit.Test;CONCRETE}"),
+	/**
+	 * JUnit Platform.
+	 */
 	junit5("${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}"),
+	/**
+	 * All JUnit: {@link #junit3}, {@link #junit4}, and {@link #junit5}.
+	 */
 	all(junit3.filter() + "," + junit4.filter() + "," + junit5.filter()),
+	/**
+	 * TestNG.
+	 */
+	testng("${classes;HIERARCHY_ANNOTATED;org.testng.annotations.Test;CONCRETE}"),
+	/**
+	 * The Test-Cases header defined in the bundle.
+	 */
 	useTestCasesHeader("<<UNUSED>>");
 
 	TestCases(String filter) {


### PR DESCRIPTION
Users can then specify the `testng` value in maven configuration.

Developers must make sure that a proper TestNG execution bundle is
present in the test runtime. For example, if using JUnit Platform, then
a TestNG TestEngine implementation bundle must be available.

Fixes https://github.com/bndtools/bnd/issues/4213
