### PR TITLE
Add support for importing java.* packages for OSGi Core R7 

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ImportJavaTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ImportJavaTest.java
@@ -1,0 +1,138 @@
+package test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.Jar;
+
+public class ImportJavaTest {
+	private Builder	builder;
+
+	@BeforeEach
+	public void setUp(TestInfo testInfo) throws Exception {
+		builder = new Builder();
+		builder.addClasspath(new File("bin_test"));
+		builder.setProperty("Bundle-Name", testInfo.getTestMethod()
+			.map(Method::getName)
+			.get());
+	}
+
+	@AfterEach
+	public void testDown() throws Exception {
+		builder.close();
+	}
+
+	@Test
+	public void import_java_all() throws Exception {
+		builder.setProperty("Import-Package", "org.osgi.framework;version=\"[1.9,2)\",*");
+		builder.setProperty("-includepackage", "test.importjava");
+		builder.setProperty("-noimportjava", "false");
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("org.osgi.framework", "java.io", "java.lang", "java.lang.invoke",
+			"java.lang.reflect", "java.util", "java.util.function", "java.util.stream");
+	}
+
+	@Test
+	public void import_java_some() throws Exception {
+		builder.setProperty("Import-Package", "org.osgi.framework;version=\"[1.9,2)\",java.util.*,!java.*,*");
+		builder.setProperty("-includepackage", "test.importjava");
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("org.osgi.framework", "java.util", "java.util.function",
+			"java.util.stream");
+	}
+
+	@Test
+	public void import_java_none() throws Exception {
+		builder.setProperty("Import-Package", "org.osgi.framework;version=\"[1.9,2)\",!java.*,*");
+		builder.setProperty("-includepackage", "test.importjava");
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("org.osgi.framework");
+	}
+
+	@Test
+	public void no_import_java() throws Exception {
+		builder.setProperty("Import-Package", "org.osgi.framework;version=\"[1.9,2)\",*");
+		builder.setProperty("-includepackage", "test.importjava");
+		builder.setProperty("-noimportjava", "true");
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("org.osgi.framework");
+	}
+
+	@Test
+	public void import_java_old_framework() throws Exception {
+		builder.setProperty("Import-Package", "org.osgi.framework;version=\"[1.8,2)\",*");
+		builder.setProperty("-includepackage", "test.importjava");
+		builder.setProperty("-noimportjava", "false");
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("org.osgi.framework");
+	}
+
+	@Test
+	public void import_java_all_java11() throws Exception {
+		builder.setProperty("-classpath", "compilerversions/compilerversions.jar");
+		builder.setProperty("-includepackage", "test.importjava,jdk_11_0");
+		builder.setProperty("-noimportjava", "false");
+
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("java.io", "java.lang", "java.lang.invoke", "java.lang.reflect",
+			"java.util", "java.util.function", "java.util.stream", "javax.swing");
+	}
+
+	@Test
+	public void no_import_java_java11() throws Exception {
+		builder.setProperty("-classpath", "compilerversions/compilerversions.jar");
+		builder.setProperty("-includepackage", "test.importjava,jdk_11_0");
+		builder.setProperty("-noimportjava", "true");
+
+		Jar jar = builder.build();
+		assertTrue(builder.check());
+		Manifest manifest = jar.getManifest();
+		manifest.write(System.err);
+		Domain d = Domain.domain(manifest);
+		Parameters imports = d.getImportPackage();
+		assertThat(imports).containsOnlyKeys("javax.swing");
+	}
+
+}

--- a/biz.aQute.bndlib.tests/test/test/importjava/ImportJava.java
+++ b/biz.aQute.bndlib.tests/test/test/importjava/ImportJava.java
@@ -1,0 +1,20 @@
+package test.importjava;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class ImportJava {
+
+	public ImportJava() {
+		Collection<Object> coll = new ArrayList<>();
+
+		Method[] methods = coll.getClass()
+			.getMethods();
+
+		Arrays.stream(methods)
+			.forEach(m -> System.out.printf("Method %s%n", m));
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -556,6 +556,8 @@ public class Syntax implements Constants {
 		new Syntax(NOCLASSFORNAME, "Do not calculate " + IMPORT_PACKAGE
 			+ " references for 'Class.forName(\"some.Class\")' usage found in method bodies during class processing.",
 			NOCLASSFORNAME + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
+		new Syntax(NOIMPORTJAVA, "Do not calculate " + IMPORT_PACKAGE + " references for java.* packages.",
+			NOIMPORTJAVA + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
 
 		new Syntax(NOEE, "Do not calculate the osgi.ee name space Execution Environment from the class file version.",
 			NOEE + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -196,6 +196,7 @@ public interface Constants {
 	String				MANIFEST_NAME								= "-manifest-name";
 	String				NOUSES										= "-nouses";
 	String				NOCLASSFORNAME								= "-noclassforname";
+	String				NOIMPORTJAVA								= "-noimportjava";
 	String				NOBUNDLES									= "-nobundles";
 	String				OUTPUTMASK									= "-outputmask";																																						// default
 																																																											// ${@bsn}.jar
@@ -316,7 +317,7 @@ public interface Constants {
 		RUNREPOS, INIT, MAVEN_RELEASE, BUILDREPO, CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE,
 		REPRODUCIBLE, INCLUDEPACKAGE, CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK,
 		MAVEN_SCOPE, RUNSTARTLEVEL, RUNOPTIONS, NOCLASSFORNAME, EXPORT_APIGUARDIAN, RESOLVE, DEFINE_CONTRACT, GENERATE,
-		RUNFRAMEWORKRESTART
+		RUNFRAMEWORKRESTART, NOIMPORTJAVA
 
 	};
 

--- a/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/Version.java
@@ -204,7 +204,7 @@ public class Version implements Comparable<Version> {
 	}
 
 	public static boolean isVersion(String version) {
-		return version != null && VERSION.matcher(version)
+		return (version != null) && VERSION.matcher(version)
 			.matches();
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
@@ -284,6 +284,24 @@ public class VersionRange {
 		return high == Version.HIGHEST;
 	}
 
+	/**
+	 * Returns whether this version range is empty. A version range is empty if
+	 * the set of versions defined by the interval is empty.
+	 *
+	 * @return {@code true} if this version range is empty; {@code false}
+	 *         otherwise.
+	 */
+	public boolean isEmpty() {
+		if (isSingleVersion()) { // infinity
+			return false;
+		}
+		int comparison = low.compareTo(high);
+		if (comparison == 0) { // endpoints equal
+			return !includeLow() || !includeHigh();
+		}
+		return comparison > 0; // true if low > high
+	}
+
 	public static VersionRange likeOSGi(String version) {
 		if (version == null) {
 			return new VersionRange(Version.LOWEST, Version.HIGHEST);

--- a/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/VersionRange.java
@@ -224,7 +224,7 @@ public class VersionRange {
 	}
 
 	public static boolean isVersionRange(String stringRange) {
-		return RANGE.matcher(stringRange)
+		return (stringRange != null) && RANGE.matcher(stringRange)
 			.matches();
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/version/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/version/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.1.1")
+@Version("2.2.0")
 package aQute.bnd.version;
 
 import org.osgi.annotation.versioning.Version;

--- a/docs/_instructions/noimportjava.md
+++ b/docs/_instructions/noimportjava.md
@@ -1,0 +1,25 @@
+---
+layout: default
+class: Analyzer
+title: -noimportjava BOOLEAN
+summary: Do not import java.* packages.
+---
+
+Prior to OSGi Core R7, it was invalid for the Import-Package header to include `java.*` packages. So Bnd would never include them in the generated Import-Package header. In [OSGi Core R7](https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#framework.module-execution.environment), or later, it is now permitted to include `java.*` packages in the Import-Package header. This allows the OSGi framework validate the execution environment can supply all the java packages required by a bundle. This can avoid a `NoClassDefFoundError` during execution of the bundle due to a missing `java.*` package required by the bundle. 
+
+Bnd will now generate the Import-Package header including referenced `java.*` packages when either the bundle imports the `org.osgi.framework` package from OSGi Core R7, or later, or when the bundle includes class files targeting Java 11, or later.
+
+The `-noimportjava` instruction can be used to tell Bnd not to include referenced `java.*` packages in the generated Import-Package header.
+
+For example:
+
+	-noimportjava: true
+
+You can use the `Import-Package` instruction to control which referenced `java.*` packages should be imported.
+
+For example:
+
+	Import-Package: java.util.*, !java.*, *
+
+will only import `java.util.*` packages and no other `java.*` packages.
+


### PR DESCRIPTION
This can be disabled with `-noimportjava: true`. The support allows
control over the specific java packages imported via the `Import-Package`
instruction. The support is only enabled if either the bundle imports
the `org.osgi.framework` package at version 1.9 (Core R7), or higher, or
if the bundle includes class files for Java 11, or higher.

Fixes #2507