### PR TITLE
[junit-platform] Disable integration test

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
@@ -56,6 +56,7 @@ import aQute.lib.io.IO;
 import bndtools.central.Central;
 import bndtools.core.test.utils.WorkbenchTest;
 
+@Disabled("Currently disabled due to startup flakiness, see https://github.com/bndtools/bnd/issues/4253")
 @ExtendWith(SoftAssertionsExtension.class)
 @WorkbenchTest
 class BuildpathQuickFixProcessorTest {


### PR DESCRIPTION
Refer #4253 - temporarily disabling the integration test until we can determine the source of the flakiness.