### PR TITLE
Tree refresh when reload, reporting framework errors, detecting plugins

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/plugin/maven/CentralCheck.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/plugin/maven/CentralCheck.java
@@ -1,0 +1,37 @@
+package aQute.bnd.plugin.maven;
+
+import aQute.bnd.annotation.plugin.BndPlugin;
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.service.AnalyzerPlugin;
+
+/**
+ * Sets a warning when a header is missing to publish at Central. The Sonatype
+ * Nexus does some verifications and it is pretty annoying if they fail.
+ */
+
+@BndPlugin(name = "Central")
+public class CentralCheck implements AnalyzerPlugin {
+
+	@Override
+	public boolean analyzeJar(Analyzer analyzer) throws Exception {
+		if (analyzer.getProperty(Constants.POM) == null)
+			return false;
+
+		check(analyzer, Constants.GROUPID);
+		check(analyzer, Constants.BUNDLE_VERSION);
+		check(analyzer, Constants.BUNDLE_LICENSE);
+		check(analyzer, Constants.BUNDLE_SCM);
+		check(analyzer, Constants.BUNDLE_DEVELOPERS);
+		check(analyzer, Constants.BUNDLE_DOCURL);
+		return false;
+	}
+
+	private void check(Analyzer analyzer, String key) throws Exception {
+		String value = analyzer.getProperty(key);
+		if (value == null) {
+			analyzer.warning("Maven Central: %s not set", key);
+		}
+	}
+
+}

--- a/bndtools.core/src/bndtools/central/InternalPluginTracker.java
+++ b/bndtools.core/src/bndtools/central/InternalPluginTracker.java
@@ -25,7 +25,7 @@ import aQute.bnd.osgi.Processor;
 public class InternalPluginTracker extends BundleTracker<List<InternalPluginDefinition>> {
 
 	public InternalPluginTracker(BundleContext context) {
-		super(context, Bundle.ACTIVE + Bundle.STARTING, null);
+		super(context, Bundle.ACTIVE + Bundle.STARTING + Bundle.RESOLVED, null);
 	}
 
 	@Override

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -15,6 +15,7 @@ import org.bndtools.build.api.AbstractBuildListener;
 import org.bndtools.build.api.BuildListener;
 import org.bndtools.core.ui.icons.Icons;
 import org.bndtools.utils.swt.FilterPanelPart;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -370,6 +371,8 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 						setImageDescriptor(Icons.desc("refresh.disable"));
 						setEnabled(false);
 						Job.create("Reload", (monitor) -> {
+							IContainer parent = workspaceBuildFile.getParent().getParent();
+							parent.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 							workspaceBuildFile.touch(monitor);
 							Display.getDefault()
 								.asyncExec(() -> {


### PR DESCRIPTION
- When the reload button is hit in the BndtoolsExplorer, the tree is also refreshed from disk
- Launcher reports errors during startup to the console, after startup it traces them
- Plugins were not detected because bndlib stayed in resolve and was never activated

