### PR TITLE
Handle null resolution in ResolutionResult

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ResolutionResult.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ResolutionResult.java
@@ -1,5 +1,8 @@
 package org.bndtools.core.resolve;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -26,10 +29,10 @@ public class ResolutionResult {
 	}
 
 	public ResolutionResult(Outcome outcome, RunResolution resolution, IStatus status, ResolverLogger logger) {
-		this.outcome = outcome;
+		this.outcome = requireNonNull(outcome);
 		this.resolution = resolution;
-		this.status = status;
-		this.logger = logger;
+		this.status = requireNonNull(status);
+		this.logger = requireNonNull(logger);
 	}
 
 	public Outcome getOutcome() {
@@ -37,16 +40,23 @@ public class ResolutionResult {
 	}
 
 	public Map<Resource, List<Wire>> getResourceWirings() {
-		return resolution.required;
+		if (resolution != null) {
+			return resolution.required;
+		}
+		return Collections.emptyMap();
 	}
 
 	public Map<Resource, List<Wire>> getOptionalResources() {
-		return resolution.optional;
+		if (resolution != null) {
+			return resolution.optional;
+		}
+		return Collections.emptyMap();
 	}
 
 	public ResolutionException getResolutionException() {
-		if (resolution.exception instanceof ResolutionException)
+		if ((resolution != null) && (resolution.exception instanceof ResolutionException)) {
 			return (ResolutionException) resolution.exception;
+		}
 		return null;
 	}
 
@@ -55,7 +65,10 @@ public class ResolutionResult {
 	}
 
 	public String getLog() {
-		return resolution.log;
+		if (resolution != null) {
+			return resolution.log;
+		}
+		return "";
 	}
 
 	public RunResolution getResolution() {

--- a/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
@@ -95,13 +95,15 @@ public class ResolveOperation implements IRunnableWithProgress {
 		if (coordinator == null)
 			inCoordination.run();
 		else {
-			Coordination coordination = coordinator.begin(ResolveOperation.class.getName(), 0);
 			try {
-				inCoordination.run();
-				coordination.end();
-			} catch (Exception e1) {
-				coordination.fail(e1);
-				throw e1;
+				Coordination coordination = coordinator.begin(ResolveOperation.class.getName(), 0);
+				try {
+					inCoordination.run();
+				} catch (Exception e) {
+					coordination.fail(e);
+				} finally {
+					coordination.end();
+				}
 			} finally {
 				bc.ungetService(coordSvcRef);
 			}


### PR DESCRIPTION
The change in 08946e7e38148570da8d51a81b3881b50aa10e01 to have ResolutionResult hold a RunResolution instead of the interesting parts did not account for the case where the ResolutionResult could be constructed with  a `null` RunResolution.

https://github.com/bndtools/bnd/blob/dceacf10560cde78cf3a11b115a0556f0d2e7eba/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java#L81

https://github.com/bndtools/bnd/commit/08946e7e38148570da8d51a81b3881b50aa10e01#diff-d02a251dfce54dc358769bd379554ec0R62