### PR TITLE
jareditor: Use `EFS.getStore` to access URIs for printing jars

### DIFF
--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
@@ -1,5 +1,6 @@
 package bndtools.jareditor.internal;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -8,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -357,13 +360,13 @@ public class JARPrintPage extends FormPage {
 	}
 
 	private static String print(URI uri) throws Exception {
-		try (JarPrinter printer = new JarPrinter()) {
-			int options = -1;
-			try (Jar jar = new Jar(uri.toString(), uri.toURL()
-				.openStream())) {
-				printer.doPrint(jar, options, false, false);
-				return printer.toString();
-			}
+		int options = -1;
+		IFileStore fileStore = EFS.getStore(uri);
+		try (InputStream in = fileStore.openInputStream(EFS.NONE, null);
+			Jar jar = new Jar(fileStore.getName(), in);
+			JarPrinter printer = new JarPrinter()) {
+			printer.doPrint(jar, options, false, false);
+			return printer.toString();
 		}
 	}
 


### PR DESCRIPTION
We use a JarFileSystem to view jar files. But the `jarf` scheme is only
known to the Eclipse File System (EFS) and not the JRE. So converting a
`jarf` URI to a URL fails. We use `EFS.getStore` to access URIs for
printing the jar. `EFS.getStore` also properly handles `file` URIs
for non-nested jar files.

Fixes https://github.com/bndtools/bnd/issues/4276
