### PR TITLE
gradle: Use archiveClassifier in generated Bundle-SymbolicName value

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
@@ -183,6 +183,7 @@ public class Bndrun extends DefaultTask {
    */
   protected void worker(def run) {
     logger.info 'Running {} in {}', run.getPropertiesFile(), run.getBase()
+    logger.debug 'Run properties: {}', run.getProperties()
     ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor()
     try {
       run.getProjectLauncher().withCloseable() { pl ->

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BundleTaskConvention.groovy
@@ -255,6 +255,7 @@ class BundleTaskConvention {
         File archiveFile = unwrap(task.getArchiveFile())
         String archiveFileName = unwrap(task.getArchiveFileName())
         String archiveBaseName = unwrap(task.getArchiveBaseName())
+        String archiveClassifier = unwrap(task.getArchiveClassifier())
         String archiveVersion = unwrap(task.getArchiveVersion(), true)
 
         // Include entire contents of Jar task generated jar (except the manifest)
@@ -298,7 +299,8 @@ class BundleTaskConvention {
         // set bundle symbolic name from tasks's archiveBaseName property if necessary
         String bundleSymbolicName = builder.getProperty(Constants.BUNDLE_SYMBOLICNAME)
         if (isEmpty(bundleSymbolicName)) {
-          builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, archiveBaseName)
+          bundleSymbolicName = archiveClassifier.empty ? archiveBaseName : "${archiveBaseName}-${archiveClassifier}"
+          builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, bundleSymbolicName)
         }
 
         // set bundle version from task's archiveVersion if necessary

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
@@ -168,6 +168,7 @@ public class Export extends Bndrun {
     String exporterName = unwrap(getExporter())
     File destinationDirFile = unwrap(getDestinationDirectory())
     logger.info 'Exporting {} to {} with exporter {}', run.getPropertiesFile(), destinationDirFile, exporterName
+    logger.debug 'Run properties: {}', run.getProperties()
     try {
       def export = run.export(exporterName, [:])
       if (exporterName == RUNBUNDLES) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
@@ -101,6 +101,7 @@ public class Resolve extends Bndrun {
    */
   protected void worker(def run) {
     logger.info 'Resolving runbundles required for {}', run.getPropertiesFile()
+    logger.debug 'Run properties: {}', run.getProperties()
     try {
       def result = run.resolve(failOnChanges, writeOnChanges)
       logger.info '{}: {}', Constants.RUNBUNDLES, result

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -90,6 +90,7 @@ public class TestOSGi extends Bndrun {
   @Override
   protected void worker(def run) {
     logger.info 'Running tests for {} in {}', run.getPropertiesFile(), run.getBase()
+    logger.debug 'Run properties: {}', run.getProperties()
     try {
       run.test(resultsDir, tests);
     } finally {

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -36,7 +36,7 @@ class TestBundlePlugin extends Specification {
           jartask_bundle.isFile()
           JarFile jartask_jar = new JarFile(jartask_bundle)
           Attributes jartask_manifest = jartask_jar.getManifest().getMainAttributes()
-          File bundletask_bundle = new File(testProjectBuildDir, "libs/${testProject}_bundle-1.1.0.jar")
+          File bundletask_bundle = new File(testProjectBuildDir, "libs/${testProject}-1.1.0-bundle.jar")
           bundletask_bundle.isFile()
           JarFile bundletask_jar = new JarFile(bundletask_bundle)
           Attributes bundletask_manifest = bundletask_jar.getManifest().getMainAttributes()
@@ -81,12 +81,12 @@ class TestBundlePlugin extends Specification {
           jartask_jar.getEntry('commons-lang-2.6.jar')
           jartask_jar.close()
 
-          bundletask_manifest.getValue('Bundle-SymbolicName') == "${testProject}_bundle"
+          bundletask_manifest.getValue('Bundle-SymbolicName') == "${testProject}-bundle"
           bundletask_manifest.getValue('Bundle-Version') == '1.1.0'
           bundletask_manifest.getValue('My-Header') == 'my-value'
           bundletask_manifest.getValue('Export-Package') =~ /doubler\.impl/
           !bundletask_manifest.getValue('X-SomeProperty')
-          bundletask_manifest.getValue('Bundle-Name') == "test.bnd.gradle:${testProject}_bundle"
+          bundletask_manifest.getValue('Bundle-Name') == "test.bnd.gradle:${testProject}-bundle"
           bundletask_manifest.getValue('Project-Name') == "${testProject}"
           new File(bundletask_manifest.getValue('Project-Dir')).canonicalFile == testProjectDir
           new File(bundletask_manifest.getValue('Project-Output')).canonicalFile == testProjectBuildDir

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -39,13 +39,13 @@ task bundle(type: Bundle) {
    description 'Bundle'
    group 'build'
    from sourceSets.test.output
-   archiveBaseName = "${project.archivesBaseName}_bundle"
+   archiveClassifier = 'bundle'
    bnd = '''
 -exportcontents: doubler.impl
 -sources: true
 My-Header: my-value
 text: TEXT
-Bundle-Name: ${project.group}:${task.archiveBaseName}
+Bundle-Name: ${project.group}:${task.archiveBaseName}-${task.archiveClassifier}
 Project-Name: ${project.name}
 Project-Dir: ${project.dir}
 Project-Output: ${project.output}


### PR DESCRIPTION
When making test bundles for OSGi integration testing, we want the
generated Bundle-SymbolicName value to not conflict with that of the
main artifact. So if the archiveClassifier property is set, we append
it to the archiveBaseName to generate the Bundle-SymbolicName.