### PR TITLE
[quickfix] Suggestions for overloaded methods

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -92,7 +92,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 	// super(null, message, id, null, 0, 0, 0, 0, 0);
 	// }
 	// }
-
+	//
 	@Override
 	public boolean hasCorrections(ICompilationUnit unit, int problemId) {
 		// System.err.println(PROBLEM_TYPES.get(problemId));
@@ -370,6 +370,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 						@SuppressWarnings("unchecked")
 						List<Expression> args = invocation.arguments();
 						args.forEach(this::visitExpressionHierarchy);
+						visitExpressionHierarchy(invocation.getExpression());
 						continue;
 					}
 					case IProblem.ImportNotFound : {

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
@@ -1020,6 +1020,22 @@ public class BuildpathQuickFixProcessorTest {
 	}
 
 	@Test
+	void withOverloadedMethod_onInconsistentHierarchy_forComplicatedGenericHierarchy_suggestsBundles() {
+		addBundlesToBuildpath("bndtools.core.test.fodder.simple");
+
+		String header = "package test; import java.util.List;" + "import simple.pkg.MyParameterizedClass;"
+			+ "import simple.MyClass;" + "import simple.pkg.ClassExtendingAbstractExtendingMyParameterizedClass;"
+			+ "class ";
+		String source = header + DEFAULT_CLASS_NAME + "{\n"
+			+ "  ClassExtendingAbstractExtendingMyParameterizedClass var;\n" + "  void myMethod() {"
+			+ "    var.myOverloadedMethod(\"something\");" + "  }" + "}";
+
+		// ParameterMismatch [265, 283]
+		assertThatProposals(proposalsFor(266, 0, source)).haveExactly(1, suggestsBundle(
+			"bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.ClassExtendingMyParameterizedClass"));
+	}
+
+	@Test
 	void withFQClassLiteral_asAnnotationParameter_suggestsBundles() {
 		addBundlesToBuildpath("bndtools.core.test.fodder.simple");
 

--- a/bndtools.core.test/src/simple/pkg/ClassExtendingAbstractExtendingMyParameterizedClass.java
+++ b/bndtools.core.test/src/simple/pkg/ClassExtendingAbstractExtendingMyParameterizedClass.java
@@ -2,4 +2,8 @@ package simple.pkg;
 
 public class ClassExtendingAbstractExtendingMyParameterizedClass extends AbstractExtendingMyParameterizedClass {
 
+	// Overloads a method in one of the superclasses.
+	public void myOverloadedMethod(int value) {
+
+	}
 }

--- a/bndtools.core.test/src/simple/pkg/MyParameterizedClass.java
+++ b/bndtools.core.test/src/simple/pkg/MyParameterizedClass.java
@@ -6,4 +6,6 @@ public class MyParameterizedClass<T> {
 
 	public class MyInner {}
 
+	// This is overloaded in a subclass to test a particular error
+	protected void myOverloadedMethod(String param) {}
 }


### PR DESCRIPTION
Sometimes you get a "no such method" or "parameter mismatch" because the version of the method that you're trying to call is defined in a superclass that is not on the classpath. This patch will catch such occurrences and suggest adding the missing supertype.