### PR TITLE
[junit-platform] Make tester.names dynamic and work in continuous mode

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/utils/BundleUtils.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/utils/BundleUtils.java
@@ -87,4 +87,10 @@ public final class BundleUtils {
 		return Strings.splitQuotedAsStream(testCases, false)
 			.map(entry -> entry.replace(':', '#'));
 	}
+
+	// Returns the class name portion only of the test case selector.
+	public static String testCaseToClassName(String testcase) {
+		int index = testcase.indexOf('#');
+		return index < 0 ? testcase : testcase.substring(0, index);
+	}
 }


### PR DESCRIPTION
The current state of the tester is that if a `tester.names` filter is set the tester will run once and exit - the setting of `tester.continuous` is ignored. With this fix, the tester will instead continue to run if `tester.continuous` is set to true. It will respond to bundle updates, but it will only trigger a re-run of tests that match `tester.names`.

I've been wanting this feature when working on large and relatively slow integration tests (eg, `bndtools.core.test`). Often when you're working in a TDD scenario your focus is on a particular test method - you just want to quickly re-run that test while you're working on it to see the results. While working on the quick fix processor I found that the continuous testing really helped overcome the slow startup time of Eclipse, but this was counteracted somewhat as the number of test methods grew. This feature would allow you to combine continuous testing with also filtering the test suites being run using `tester.names`.

Additionally, on a related note, the gogo commandlet has been enhanced as follows:
* `set/getTesterNames()` commands have been added to allow you to set/get the current value of tester.names. So you can change the filter dynamically at runtime while testing.
* `runTests()` will now run all test bundles (filtered by `tester.names`) if it is invoked with no arguments. 

I'm anticipating that the addition of these features will also make it easier to implement #3709