### PR TITLE
Support bundle for maven must use same versions as maven plugins

### DIFF
--- a/biz.aQute.bnd.maven/bnd.bnd
+++ b/biz.aQute.bnd.maven/bnd.bnd
@@ -17,14 +17,14 @@ Import-Package: \
 	biz.aQute.resolve;version=latest,\
 	biz.aQute.repository;version=latest,\
 	org.eclipse.m2e.maven.runtime,\
-	org.apache.maven:maven-artifact,\
-	org.apache.maven:maven-core,\
-	org.apache.maven:maven-model,\
-	org.apache.maven:maven-plugin-api,\
-	org.apache.maven:maven-repository-metadata,\
-	org.apache.maven:maven-settings,\
+	org.apache.maven:maven-artifact;version=${maven.target.version},\
+	org.apache.maven:maven-core;version=${maven.target.version},\
+	org.apache.maven:maven-model;version=${maven.target.version},\
+	org.apache.maven:maven-plugin-api;version=${maven.target.version},\
+	org.apache.maven:maven-repository-metadata;version=${maven.target.version},\
+	org.apache.maven:maven-settings;version=${maven.target.version},\
 	org.codehaus.plexus:plexus-utils,\
-	org.eclipse.aether.api,\
+	org.eclipse.aether.api;version=${aether.version},\
 	org.slf4j.api;version=latest
 
 -conditionalpackage: aQute.lib*;-split-package:=first

--- a/biz.aQute.tester.test/.gitignore
+++ b/biz.aQute.tester.test/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 /bin_test/
 /generated/
+/testdir/

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -140,3 +140,11 @@ javax.json:javax.json-api:1.1.2
 javax.json.bind:javax.json.bind-api:1.0
 
 org.apiguardian:apiguardian-api:1.1.0
+
+org.apache.maven:maven-artifact:${maven.target.version}
+org.apache.maven:maven-core:${maven.target.version}
+org.apache.maven:maven-model:${maven.target.version}
+org.apache.maven:maven-plugin-api:${maven.target.version}
+org.apache.maven:maven-repository-metadata:${maven.target.version}
+org.apache.maven:maven-settings:${maven.target.version}
+org.eclipse.aether:aether-api:${aether.version}

--- a/cnf/ext/maven-plugin.bnd
+++ b/cnf/ext/maven-plugin.bnd
@@ -1,0 +1,4 @@
+# Versions used by Bnd's maven plugins. This should match the
+# same properties in maven/pom.xml
+maven.target.version: 3.1.1
+aether.version: 0.9.0.M2

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -15,10 +15,11 @@
 		<revision>5.2.0-SNAPSHOT</revision>
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.target.version>3.1.1</maven.target.version>
-		<aether.version>0.9.0.M2</aether.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
+		<!-- The following versions must match those in cnf/ext/maven-plugin.bnd -->
+		<maven.target.version>3.1.1</maven.target.version>
+		<aether.version>0.9.0.M2</aether.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
The support bundle used versions from the Eclipse m2e for 2018-12.
These versions are newer than that of 3.1.1 which is used as the base
maven version of the maven plugins. So this prevents the maven plugins
from operating on maven version prior to 3.5.3 which is a long way
from 3.1.1. So we change to use the same versions for the support bundle
as for the maven plugins.

Fixes #4327