### PR TITLE
Improved classloading for Plugins

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
@@ -213,9 +213,13 @@ class ActivelyClosingClassLoader extends URLClassLoader implements Closeable {
 				if (bundle == null) {
 					throw nfe;
 				}
-				Bundle system = bundle.getBundleContext()
-					.getBundle(0);
-				return system.loadClass(name);
+				try {
+					return bundle.loadClass(name);
+				} catch (ClassNotFoundException anotherNfe) {
+					Bundle system = bundle.getBundleContext()
+						.getBundle(0);
+					return system.loadClass(name);
+				}
 			}
 		} catch (Throwable t) {
 


### PR DESCRIPTION
- ActivelyClosingClassLoader will try to figure out its own bundle in
OSGi and tries to load classes from there if non can be found before
refering to the system bundle.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>