### PR TITLE
Fixes #4367: Fixed typo in 'Refresh Repositories' job name.

### DIFF
--- a/bndtools.core/src/bndtools/RefreshReposHandler.java
+++ b/bndtools.core/src/bndtools/RefreshReposHandler.java
@@ -16,7 +16,7 @@ public class RefreshReposHandler extends AbstractHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		new WorkspaceJob("Refresing repositories...") {
+		new WorkspaceJob("Refreshing repositories...") {
 
 			@Override
 			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {


### PR DESCRIPTION
The typo 'Refresing repositories...' (missing h) was fixed.

Signed-off-by: Michael Gerlich <Michael.Gerlich@bruker.com>