### PR TITLE
[quickfix] Prevent StackOverflow on recursive types

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -181,6 +182,10 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 			if (qualifiedName.startsWith("java.")) {
 				return;
 			}
+			// Prevent infinite recursion
+			if (!visited.add(binding)) {
+				return;
+			}
 			// A "recovered" type binding indicates the type has not been
 			// fully resolved - usually because it's not on the classpath.
 			if (binding.isRecovered()) {
@@ -229,6 +234,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 	private boolean						test;
 	private Workspace					workspace;
 	Map<BundleId, Map<String, Boolean>>	proposals;
+	Set<ITypeBinding>					visited;
 	IProblemLocation					location;
 	final ASTVisitor					TYPE_VISITOR	= new ASTVisitor() {
 															@Override
@@ -259,6 +265,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 		try {
 			this.context = context;
 			proposals = new HashMap<>();
+			visited = new HashSet<>();
 
 			ICompilationUnit compUnit = context.getCompilationUnit();
 			IJavaProject java = compUnit.getJavaProject();

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
@@ -1027,6 +1027,18 @@ public class BuildpathQuickFixProcessorTest {
 	}
 
 	@Test
+	void withUnknownMethod_forRecursiveGenericHierarchy_avoidsStackOverflow() {
+		addBundlesToBuildpath("bndtools.core.test.fodder.simple");
+
+		String header = "package test; import simple.pkg.RecursiveClass; class " + DEFAULT_CLASS_NAME + " {\n"
+			+ "void myMethod() { new RecursiveClass().";
+		source = header + "unknownMethod(); } " + "}";
+
+		// unknownMethod
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).isEmpty();
+	}
+
+	@Test
 	void withFQClassLiteral_asAnnotationParameter_suggestsBundles() {
 		addBundlesToBuildpath("bndtools.core.test.fodder.simple");
 

--- a/bndtools.core.test/src/simple/pkg/RecursiveClass.java
+++ b/bndtools.core.test/src/simple/pkg/RecursiveClass.java
@@ -1,0 +1,5 @@
+package simple.pkg;
+
+public class RecursiveClass extends RecursiveParameterizedClass<RecursiveClass> {
+
+}

--- a/bndtools.core.test/src/simple/pkg/RecursiveParameterizedClass.java
+++ b/bndtools.core.test/src/simple/pkg/RecursiveParameterizedClass.java
@@ -1,0 +1,6 @@
+package simple.pkg;
+
+public class RecursiveParameterizedClass<T extends RecursiveParameterizedClass<T>> {
+
+	public void method() {}
+}


### PR DESCRIPTION
Track types that have been examined in a `Set` and skip any if they've already been examined. Main reason is to prevent recursion (fixes #4369).
