### PR TITLE
[quickfix] Handle undefined hierarchy when superclass is not fully-qualified

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessorTest.java
@@ -912,6 +912,17 @@ public class BuildpathQuickFixProcessorTest {
 	}
 
 	@Test
+	void withMissingMethod_fromUnknownSimpleSuperclass_suggestsBundles() {
+		String header = "package test; class ";
+		String source = header + DEFAULT_CLASS_NAME + " extends MyForeignClass {\n" + "  void myMethod() {"
+			+ "    bMethod();" + "  }" + "}";
+
+		// UnknownMethod is on the method at [73,80]
+		assertThatProposals(proposalsFor(74, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignClass"));
+	}
+
+	@Test
 	void withMissingSuperMethod_fromClassFromAnotherBundle_suggestsBundles() {
 		addBundlesToBuildpath("bndtools.core.test.fodder.simple");
 


### PR DESCRIPTION
Will fix the following case:

```java
package my.test.pkg;

class CustomSoftAssertions extends SoftAssertions {
    CustomAssert assertThat(Custom actual) {
        return proxy(CustomAssert.class, Custom.class, actual);
    }
}
```

If assertj-core is not on `-buildpath`, then the above will generate an "Unknown type" for `SoftAssertions` and an "Unknown Method" for `proxy()`. Hovering over `SoftAssertions` would give you the quick fix, but hovering over `proxy()` would not. This is because Eclipse generates a placehold type binding of `my.test.pkg.SoftAssertions` for the missing type, and then the quick fix processor will look specifically in that package for the missing class - not finding it, it won't return any proposals.

This fix will instead search for the bare class name only if the package of the missing type is the same as the package of the current compilation unit.