### PR TITLE
deps: Fix gogo.runtime dependency to avoid Orbit version

### DIFF
--- a/biz.aQute.bnd.runtime/bnd.bnd
+++ b/biz.aQute.bnd.runtime/bnd.bnd
@@ -10,7 +10,7 @@
     org.osgi.service.component;version='[1.4,1.5)',\
     org.osgi.service.component.annotations;version='[1.4,1.5)';maven-scope=provided,\
     biz.aQute.bndlib;version=latest;maven-scope=provided,\
-    org.apache.felix.gogo.runtime;version=0.12,\
+    org.apache.felix.gogo.runtime,\
     org.apache.felix.gogo.command,\
     org.apache.felix.gogo.shell
 

--- a/biz.aQute.remote/bnd.bnd
+++ b/biz.aQute.remote/bnd.bnd
@@ -10,7 +10,7 @@ aQute.agent.server.port = 29998
 	osgi.core;version=latest;maven-scope=provided,\
     aQute.libg;version=project,\
     biz.aQute.bndlib;version=latest,\
-    org.apache.felix.gogo.runtime;version=latest
+    org.apache.felix.gogo.runtime
 
 -testpath: \
     ${junit},\


### PR DESCRIPTION
version=latest used the version from Orbit with a qualifier. This
artifact has useless maven metadata and update the dependencies section
of our maven metadata. So we now use the artifact from maven central.
