### PR TITLE
[quickfix] Better handling for subclasses of recursive classes

### DIFF
--- a/bndtools.core.test/src/iface/bundle/MyForeignRecursiveClass.java
+++ b/bndtools.core.test/src/iface/bundle/MyForeignRecursiveClass.java
@@ -1,0 +1,10 @@
+package iface.bundle;
+
+import simple.pkg.RecursiveParameterizedClass;
+
+public class MyForeignRecursiveClass<T extends MyForeignRecursiveClass<T>> extends RecursiveParameterizedClass<T> {
+
+	protected String bField;
+
+	public void bMethod() {}
+}

--- a/bndtools.core.test/src/simple/pkg/ClassExtendingForeignRecursiveClass.java
+++ b/bndtools.core.test/src/simple/pkg/ClassExtendingForeignRecursiveClass.java
@@ -1,0 +1,12 @@
+package simple.pkg;
+
+import iface.bundle.MyForeignRecursiveClass;
+
+public class ClassExtendingForeignRecursiveClass<T extends ClassExtendingForeignRecursiveClass<T>>
+	extends MyForeignRecursiveClass<T> {
+
+	public void aMethod() {
+
+	}
+
+}

--- a/bndtools.core.test/src/simple/pkg/GrandchildOfForeignRecursiveClass.java
+++ b/bndtools.core.test/src/simple/pkg/GrandchildOfForeignRecursiveClass.java
@@ -1,0 +1,10 @@
+package simple.pkg;
+
+public class GrandchildOfForeignRecursiveClass<T extends GrandchildOfForeignRecursiveClass<T>>
+	extends ClassExtendingForeignRecursiveClass<T> {
+
+	public void grandchildMethod() {
+
+	}
+
+}

--- a/bndtools.core.test/src/simple/pkg/RecursiveParameterizedClass.java
+++ b/bndtools.core.test/src/simple/pkg/RecursiveParameterizedClass.java
@@ -2,5 +2,7 @@ package simple.pkg;
 
 public class RecursiveParameterizedClass<T extends RecursiveParameterizedClass<T>> {
 
+	String field;
+
 	public void method() {}
 }


### PR DESCRIPTION
When Eclipse is unable to resolve the supertype of a class, it can incorrectly report the supertype binding of the class as being `java.lang.Object`. This fix instead looks at the type declaration's representation of the supertype instead of looking at the binding's representation of the supertype.