### PR TITLE
Fix Domain.getBundleDocURL to return correct manifest header

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
@@ -545,7 +545,7 @@ public abstract class Domain implements Iterable<String> {
 	}
 
 	public String getBundleDocURL() {
-		return get(Constants.BUNDLE_COPYRIGHT);
+		return get(Constants.BUNDLE_DOCURL);
 	}
 
 	public String getBundleVendor() {


### PR DESCRIPTION
- getBundleDocURL not returns the BUNDLE_DOCURL Manifest header

Signed-off-by: Mark Hoffmann <m.hoffmann@data-in-motion.biz>