### PR TITLE
Fixed Windows paths not properly being sanitized

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1759,7 +1759,7 @@ public class Analyzer extends Processor {
 	@Override
 	public Jar getJarFromName(String name, String from) {
 		Jar j = super.getJarFromName(name, from);
-		Glob g = new Glob(name);
+		Glob g = new Glob(name.replaceAll("\\\\", "\\\\"));
 		if (j == null) {
 			for (Jar entry : getClasspath()) {
 				if (entry.getSource() == null)
@@ -1780,7 +1780,7 @@ public class Analyzer extends Processor {
 		if (j != null)
 			return Collections.singletonList(j);
 
-		Glob g = new Glob(name);
+		Glob g = new Glob(name.replaceAll("\\\\", "\\\\"));
 		List<Jar> result = new ArrayList<>();
 		for (Jar entry : getClasspath()) {
 			if (entry.getSource() == null)


### PR DESCRIPTION
This bug occurs when sourceSets is used in Gradle. This unfortunately cannot be fixed on an exterior basis and requires the following transformation to be made. Since this specific method exclusively calls paths, it should not contain and escaping characters anyways. Henceforth, we can replace such by a proper regex-friendly name.

The following stacktrace occurs on Gradle:

> Caused by: java.util.regex.PatternSyntaxException: Illegal/unsupported escape sequence near index 3
C:\Users\sanja\Documents\GitHub\ASM-9-Fork\asm\build\classes\java\main
   ^
	at aQute.libg.glob.Glob.toPattern(Glob.java:157)
	at aQute.libg.glob.Glob.<init>(Glob.java:30)
	at aQute.libg.glob.Glob.<init>(Glob.java:26)
	at aQute.bnd.osgi.Analyzer.getJarFromName(Analyzer.java:1763)
	at aQute.bnd.osgi.Analyzer.getClasspath(Analyzer.java:2522)
	at aQute.bnd.osgi.Analyzer$getClasspath$0.call(Unknown Source)
	[omitted]
* Get more help at https://help.gradle.org

After further inspection in the project (OW2 ASM), the following was found to be causing the issue:
`sourceSets.main.java.srcDirs += project(':asm').sourceSets.main.java.srcDirs`

Unfortunately, this issue cannot be fixed internally within ASM. Upon investigating the stacktrace, we can find that the origin of this issue comes from the following:

```java
String cp = getProperty(CLASSPATH);
if (cp != null)
	for (String s : split(cp)) {
		Jar jar = getJarFromName(s, "getting classpath");
```

Hence, the property classpath on all windows device starts with you guessed it: C:**\**, an escaping character. This issue **will persist on every function calling getJarFromName**, hence the changes needed.
