### PR TITLE
analyzer: Avoid regex errors on windows

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -215,7 +215,9 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 
 	void visitTypeDeclaration(TypeDeclaration node) {
 		visitType(node.getSuperclassType());
-		for (Type iface : (List<Type>) node.superInterfaceTypes()) {
+		@SuppressWarnings("unchecked")
+		List<Type> superInterfaceTypes = node.superInterfaceTypes();
+		for (Type iface : superInterfaceTypes) {
 			visitType(iface);
 		}
 	}


### PR DESCRIPTION
On windows, entries on `-classpath` instruction can be passed to
`getJarFromName` which may attempt to make a `Glob` from the entry. On
Windows, the entry values can have backslashes which upset regex. So
we change to normalize the entry before passing to `Glob` which will
convert any backslash to forward slash. Since we only match file names
with the `Glob`, a pattern with forward slashes or backslashes wont match
the file name.

We also refactor to move shared logic into a private method.

Closes #4386