### PR TITLE
verifier: Update to not complain about versionless imports of system pkg

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -364,7 +364,8 @@ public class BuilderTest {
 		b.addClasspath(IO.getFile("jar/osgi.jar"));
 		b.setPrivatePackage("!org.osgi.service.event,org.osgi.service.*");
 		b.build();
-		assertTrue(b.check());
+		assertTrue(b.check(
+			"Import Package clauses without version range: \\[javax.servlet, javax.microedition.io, javax.servlet.http\\]"));
 	}
 
 	/*

--- a/biz.aQute.bndlib.tests/test/test/VerifierTest.java
+++ b/biz.aQute.bndlib.tests/test/test/VerifierTest.java
@@ -203,7 +203,7 @@ public class VerifierTest extends TestCase {
 				"\\QImport Package org.osgi.framework has an invalid version range syntax ${range;[==,+)}\\E",
 				"\\QNo translation found for macro: range;[==,+)\\E",
 				"\\QExport-Package or -exportcontents refers to missing package 'org.osgi.service.eventadmin'\\E",
-				"Import Package clauses without version range \\(excluding javax\\.\\*\\):",
+				"Import Package clauses without version range:",
 				"Import Package bar has an invalid version range syntax \\[1,x2\\)",
 				"Import Package baz2 has an empty version range syntax \\(1,1\\), likely want to use \\[1.0.0,1.0.0\\]",
 				"Import Package baz has an invalid version range syntax \\[2,1\\): Low Range is higher than High Range: 2.0.0-1.0.0",

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_6.properties
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_6.properties
@@ -208,4 +208,6 @@ org.osgi.framework.system.packages = \
  org.w3c.dom.xpath,\
  org.xml.sax,\
  org.xml.sax.ext,\
- org.xml.sax.helpers
+ org.xml.sax.helpers,\
+ sun.misc,\
+ sun.reflect

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_7.properties
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_7.properties
@@ -214,4 +214,6 @@ org.osgi.framework.system.packages = \
  org.w3c.dom.xpath,\
  org.xml.sax,\
  org.xml.sax.ext,\
- org.xml.sax.helpers
+ org.xml.sax.helpers,\
+ sun.misc,\
+ sun.reflect

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_8.properties
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/JavaSE_1_8.properties
@@ -221,4 +221,6 @@ org.osgi.framework.system.packages = \
  org.w3c.dom.xpath,\
  org.xml.sax,\
  org.xml.sax.ext,\
- org.xml.sax.helpers
+ org.xml.sax.helpers,\
+ sun.misc,\
+ sun.reflect

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -720,6 +721,10 @@ public class Verifier extends Processor {
 			Set<String> noimports = new HashSet<>();
 			Set<String> toobroadimports = new HashSet<>();
 
+			Parameters eePackages = Optional.ofNullable(analyzer.getHighestEE())
+				.map(ee -> EE.parse(ee.getEE()))
+				.map(EE::getPackages)
+				.orElseGet(Parameters::new);
 			for (Entry<String, Attrs> e : map.entrySet()) {
 
 				String key = Processor.removeDuplicateMarker(e.getKey());
@@ -734,7 +739,7 @@ public class Verifier extends Processor {
 				String version = e.getValue()
 					.get(Constants.VERSION_ATTRIBUTE);
 				if (version == null) {
-					if (!key.startsWith("javax.")) {
+					if (!eePackages.containsKey(key)) {
 						noimports.add(key);
 					}
 				} else {
@@ -771,7 +776,7 @@ public class Verifier extends Processor {
 			}
 
 			if (!noimports.isEmpty()) {
-				Location location = error("Import Package clauses without version range (excluding javax.*): %s",
+				Location location = error("Import Package clauses without version range: %s",
 					noimports).location();
 				location.header = Constants.IMPORT_PACKAGE;
 			}

--- a/biz.aQute.resolve/test/biz/aQute/resolve/BndrunResolveContextTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/BndrunResolveContextTest.java
@@ -773,7 +773,7 @@ public class BndrunResolveContextTest extends TestCase {
 		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
 
 		Requirement req = new CapReqBuilder("osgi.wiring.package")
-			.addDirective("filter", "(osgi.wiring.package=sun.reflect)")
+			.addDirective("filter", "(osgi.wiring.package=sun.nio)")
 			.buildSyntheticRequirement();
 		List<Capability> providers = context.findProviders(req);
 
@@ -787,12 +787,12 @@ public class BndrunResolveContextTest extends TestCase {
 		BndEditModel runModel = new BndEditModel();
 		runModel.setRunFw("org.apache.felix.framework");
 		runModel.setEE(EE.JavaSE_1_6);
-		runModel.setSystemPackages(Collections.singletonList(new ExportedPackage("sun.reflect", new Attrs())));
+		runModel.setSystemPackages(Collections.singletonList(new ExportedPackage("sun.nio", new Attrs())));
 
 		BndrunResolveContext context = new BndrunResolveContext(runModel, registry, log);
 
 		Requirement req = new CapReqBuilder("osgi.wiring.package")
-			.addDirective("filter", "(osgi.wiring.package=sun.reflect)")
+			.addDirective("filter", "(osgi.wiring.package=sun.nio)")
 			.buildSyntheticRequirement();
 		List<Capability> providers = context.findProviders(req);
 

--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -322,7 +322,7 @@
 	org.w3c.dom.events;version='[3.0.0,3.0.1)',\
 	org.w3c.dom.smil;version='[1.0.1,1.0.2)',\
 	org.w3c.dom.svg;version='[1.1.0,1.1.1)',\
-	assertj-core;version='[3.17.2,3.17.3)',\
+	assertj-core;version='[3.18.0,3.18.1)',\
 	org.eclipse.core.net;version='[1.3.400,1.3.401)',\
 	org.eclipse.ui.ide.application;version='[1.3.100,1.3.101)',\
 	org.eclipse.urischeme;version='[1.0.100,1.0.101)'


### PR DESCRIPTION
We use the EEs system packages, instead of a hard coded "javax." prefix,
to avoid complaining about imports without versions.

Fixes #4388