### PR TITLE
resolve: improve error message

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -3,6 +3,7 @@ package biz.aQute.resolve;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.osgi.resource.Requirement;
 import org.osgi.service.resolver.ResolutionException;
@@ -14,6 +15,7 @@ import aQute.bnd.build.Run;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.HeaderClause;
+import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.build.model.conversions.CollectionFormatter;
 import aQute.bnd.build.model.conversions.Converter;
 import aQute.bnd.build.model.conversions.HeaderClauseFormatter;
@@ -127,10 +129,11 @@ public class Bndrun extends Run {
 	}
 
 	public boolean update(RunResolution resolution, boolean failOnChanges, boolean writeOnChanges) throws Exception {
+		List<VersionedClause> runBundlesBeforeUpdate = model.getRunBundles();
 		if (resolution.updateBundles(model)) {
 			if (failOnChanges) {
 				error("Fail on changes set to true (--xchange,-x) and there are changes");
-				error("   Existing runbundles   %s", model.getRunBundles());
+				error("   Existing runbundles   %s", runBundlesBeforeUpdate);
 				error("   Calculated runbundles %s", resolution.getRunBundles());
 			} else {
 				if (writeOnChanges) {

--- a/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
@@ -254,7 +254,8 @@ public class RunResolutionTest {
 		bndrun.getModel()
 			.setRunBundles(Collections.emptyList());
 		resolution = bndrun.resolve(true, false);
-		assertThat(bndrun.check("Fail on changes set to ", "Existing runbundles", "Calculated runbundles")).isTrue();
+		assertThat(bndrun.check("Fail on changes set to ", "Existing runbundles   \\[\\]", "Calculated runbundles"))
+			.isTrue();
 
 		// Now succeed because there are no changes
 		resolution = bndrun.resolve(false, false);


### PR DESCRIPTION
As discussed in #4082, the error message when `failOnChanges` is true is misleading.

The `Existing runbundles` line should display the current status in the `*.bndrun` file and not something modified.

Fixes: https://github.com/bndtools/bnd/issues/4082