### PR TITLE
allow the use of macros in the gpg property

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -194,7 +194,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				}
 
 				logger.debug("Put release {}", pom.getRevision());
-				try (Release releaser = storage.release(pom.getRevision(), options.context.getProperties())) {
+				try (Release releaser = storage.release(pom.getRevision(), options.context.getFlattenedProperties())) {
 					if (releaser == null) {
 						logger.debug("Already released {}", pom.getRevision());
 						return result;


### PR DESCRIPTION
the gpg command can be extended and replaced, by putting a property gpg somewhere in the workspace. Till now, it was not possible to use macros and variables here. This commit chances this.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>