### PR TITLE
[bndtools] Gracefully handle missing cnf

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
+++ b/bndtools.builder/src/org/bndtools/builder/MarkerSupport.java
@@ -98,7 +98,7 @@ class MarkerSupport {
 		IProject cnf = ResourcesPlugin.getWorkspace()
 			.getRoot()
 			.getProject("cnf");
-		if (cnf != null) {
+		if (cnf != null && cnf.isOpen()) {
 			IMarker[] markers = cnf.findMarkers(markerType, true, IResource.DEPTH_INFINITE);
 			if (markers != null) {
 				for (IMarker marker : markers) {


### PR DESCRIPTION
Without this fix, Bndtools generates an NPE during building if the cnf project is missing and continues to fail building even after the cnf project is added. This fixes #4401.

As a side effect, also introduces an error marker if the Bnd project is not inside the Bnd workspace. This fixes #4203.

This seems to work in my testing and not to break anything else, but it's hard to be sure without a decent set of regression tests. It would be good for us to smoke-test it on dev for a while before release.