### PR TITLE
[remote] Caching of run path

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -146,6 +146,7 @@ public abstract class ProjectLauncher extends Processor {
 		// pkr: could not use this because this is killing the runtests.
 		// getProject().refresh();
 		runbundles.clear();
+		classpath.clear();
 
 		Collection<Container> run = getProject().getRunbundles();
 


### PR DESCRIPTION
The remote launcher did not properly set -runsystempackages
from the exported packages on the -runpath. This worked
on the first prepare, but the prepare did not clear the
class path. A second prepare cleared -runsystempackages
by recalculating it, but then the not cleared class path
prevented the analysis to see if it was exporting 
anything.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>