### PR TITLE
[build] Unused packages

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
@@ -57,6 +57,11 @@ class ProjectTracker implements AutoCloseable {
 	 */
 	synchronized Optional<Project> getProject(String name) {
 		update();
+		if (!models.containsKey(name) && workspace.getFile(name + "/" + Project.BNDFILE)
+			.isFile()) {
+			changed = true;
+			update();
+		}
 		return Optional.ofNullable(models.get(name));
 	}
 


### PR DESCRIPTION
- The unused packages did not report the proper 
instruction name used and it
- When a wildcard was used, it reported zero matches

Finds the proper header and wildcards are removed from
the unused packages for inclusion


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>