### PR TITLE
resolve: Avoid presenting duplicate capabilities to the resolver

### DIFF
--- a/biz.aQute.bnd.gradle/bnd.bnd
+++ b/biz.aQute.bnd.gradle/bnd.bnd
@@ -22,8 +22,8 @@ bnd_version: ${replace;${bnd_plugin};.*:(.*);$1}
 # Use groovydoc task generated doc for -javadoc.jar
 -sources: false
 -maven-release: pom;path=JAR,\
- sources;path=${src},\
- javadoc;path=${target}/docs/groovydoc
+ sources;path="${src}",\
+ javadoc;path="${target}/docs/groovydoc"
 
 # Stop Eclipse whining about the bnd files using specific Bundle-SymbolicNames
 -fixupmessages.bndtools: "Eclipse: The Bundle Symbolic * name"

--- a/biz.aQute.bndlib/src/aQute/bnd/classindex/ClassIndexerAnalyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/classindex/ClassIndexerAnalyzer.java
@@ -31,13 +31,13 @@ public class ClassIndexerAnalyzer implements AnalyzerPlugin {
 			if (classspace.isEmpty())
 				continue;
 
-			List<Integer> hashes = new ArrayList<>();
+			List<Long> hashes = new ArrayList<>();
 			for (Clazz c : classspace) {
 				TypeRef tr = c.getClassName();
 				if (tr.isArray() || tr.isNested())
 					continue;
 
-				int hash = tr.getShorterName()
+				long hash = tr.getShorterName()
 					.hashCode();
 				hashes.add(hash);
 			}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -100,7 +100,8 @@ public class CapReqBuilder {
 			}
 		}
 
-		if (name.equals(ResourceUtils.getVersionAttributeForNamespace(getNamespace()))) {
+		if ((value instanceof aQute.bnd.version.Version)
+			|| name.equals(ResourceUtils.getVersionAttributeForNamespace(getNamespace()))) {
 			value = toVersions(value);
 		}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -757,13 +757,13 @@ public class ResourceBuilder {
 			return;
 		}
 
-		List<Integer> hashes = resources.stream()
+		List<Long> hashes = resources.stream()
 			.map(NamedNode::name)
 			.filter(Descriptors::isBinaryClass)
 			.map(Descriptors::binaryToSimple)
 			.distinct()
 			.filter(simple -> !Verifier.isNumber(simple))
-			.map(ClassIndexerAnalyzer::hash)
+			.map(simple -> Long.valueOf(ClassIndexerAnalyzer.hash(simple)))
 			.collect(toList());
 		if (hashes.isEmpty()) {
 			return;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.resource.Capability;
@@ -98,33 +99,21 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 		if (this == other)
 			return true;
 
-		if (other == null || !(other instanceof Resource))
+		if (!(other instanceof Resource))
 			return false;
 
 		Map<URI, String> thisLocations = getLocations();
-		Map<URI, String> otherLocations;
-
-		if (other instanceof ResourceImpl) {
-			otherLocations = ((ResourceImpl) other).getLocations();
-		} else {
-			otherLocations = ResourceUtils.getLocations((Resource) other);
-		}
+		Map<URI, String> otherLocations = (other instanceof ResourceImpl) ? ((ResourceImpl) other).getLocations()
+			: ResourceUtils.getLocations((Resource) other);
 
 		Collection<URI> overlap = retain(thisLocations.keySet(), otherLocations.keySet());
 
-		for (URI uri : overlap) {
-			String thisSha = thisLocations.get(uri);
-			String otherSha = otherLocations.get(uri);
-			if (thisSha == otherSha)
-				return true;
-
-			if (thisSha != null && otherSha != null) {
-				if (thisSha.equals(otherSha))
-					return true;
-			}
-		}
-
-		return false;
+		return overlap.stream()
+			.anyMatch(uri -> {
+				String thisSha = thisLocations.get(uri);
+				String otherSha = otherLocations.get(uri);
+				return Objects.equals(thisSha, otherSha);
+			});
 	}
 
 	private Map<URI, String> getLocations() {

--- a/biz.aQute.resolve/test/biz/aQute/resolve/BndrunResolveContextTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/BndrunResolveContextTest.java
@@ -591,15 +591,15 @@ public class BndrunResolveContextTest extends TestCase {
 		List<Capability> providers = context.findProviders(requirement);
 
 		assertEquals(3, providers.size());
-		assertEquals(IO.getFile("testdata/repo4/x.1.jar")
+		assertEquals(IO.getFile("testdata/repo4/x.3.jar")
 			.toURI(),
 			findContentURI(providers.get(0)
 				.getResource()));
-		assertEquals(IO.getFile("testdata/repo4/x.3.jar")
+		assertEquals(IO.getFile("testdata/repo4/x.2.jar")
 			.toURI(),
 			findContentURI(providers.get(1)
 				.getResource()));
-		assertEquals(IO.getFile("testdata/repo4/x.2.jar")
+		assertEquals(IO.getFile("testdata/repo4/x.1.jar")
 			.toURI(),
 			findContentURI(providers.get(2)
 				.getResource()));

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
@@ -622,8 +622,8 @@ public class ResolveTest extends TestCase {
 			System.out.println(runbundles);
 			assertThat(bndrun.check()).isTrue();
 			Parameters p = new Parameters(runbundles);
-			assertThat(p.keySet()).hasSize(5)
-				.contains("org.apache.felix.scr", "test.log", "org.apache.felix.log.extension",
+			assertThat(p.keySet()).contains("org.apache.felix.scr", "test.log",
+				"org.apache.felix.log.extension",
 					"org.apache.felix.gogo.command", "org.apache.felix.gogo.runtime");
 		}
 	}

--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -322,7 +322,7 @@
 	org.w3c.dom.events;version='[3.0.0,3.0.1)',\
 	org.w3c.dom.smil;version='[1.0.1,1.0.2)',\
 	org.w3c.dom.svg;version='[1.1.0,1.1.1)',\
-	assertj-core;version='[3.18.0,3.18.1)',\
+	assertj-core;version='[3.18.1,3.18.2)',\
 	org.eclipse.core.net;version='[1.3.400,1.3.401)',\
 	org.eclipse.ui.ide.application;version='[1.3.100,1.3.101)',\
 	org.eclipse.urischeme;version='[1.0.100,1.0.101)'


### PR DESCRIPTION
Multiple repositories can reference the same resources. For example an index generated in maven can refer to files in the local maven repo and the ImplicitFileSetRepository can also reference them. These repositories are constructed in different ways and they were not consistent. And we ended up with capabilities from each repository which should have been equals (and same hashCode) but were not. Bnd Versions cannot be compared with OSGi Versions. bnd.hashes attributes were not consistently present. Integers cannot be compared with Longs.

So this PR fixes these issues to avoid presenting equivalent capabilities to the resolver which horrible confused it.
 
Fixes #4382