### PR TITLE
maven central check: Improve checking and add tests

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/CentralCheckVerifierPluginTest.java
+++ b/biz.aQute.bndlib.tests/test/test/CentralCheckVerifierPluginTest.java
@@ -1,0 +1,362 @@
+package test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.function.BiConsumer;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.w3c.dom.Document;
+
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
+import aQute.bnd.plugin.maven.CentralCheck;
+import aQute.lib.exceptions.Exceptions;
+import aQute.lib.strings.Strings;
+import aQute.lib.xml.XML;
+
+@ExtendWith(SoftAssertionsExtension.class)
+public class CentralCheckVerifierPluginTest {
+	final static DocumentBuilderFactory	dbf;
+	final static XPath					xpath;
+
+	static {
+		dbf = XML.newDocumentBuilderFactory();
+		dbf.setNamespaceAware(false);
+		XPathFactory xpathFactory = XPathFactory.newInstance();
+		xpath = xpathFactory.newXPath();
+	}
+
+	enum PomAssertions implements BiConsumer<SoftAssertions, Document> {
+		groupId("project/groupId/text()"),
+		artifactId("project/artifactId/text()"),
+		version("project/version/text()"),
+		name("project/name/text()"),
+		description("project/description/text()"),
+		url("project/url/text()"),
+		licenses("count(project/licenses/license/*)") {
+			@Override
+			public void accept(SoftAssertions softly, Document doc) {
+				try {
+					softly.assertThat(Integer.parseInt(expr.evaluate(doc)))
+						.as("project %s", name())
+						.isPositive();
+				} catch (XPathExpressionException e) {
+					softly.fail("failed to evaluate xpath expression", e);
+				}
+			}
+		},
+		developers("count(project/developers/developer/*)") {
+			@Override
+			public void accept(SoftAssertions softly, Document doc) {
+				try {
+					softly.assertThat(Integer.parseInt(expr.evaluate(doc)))
+						.as("project %s", name())
+						.isPositive();
+				} catch (XPathExpressionException e) {
+					softly.fail("failed to evaluate xpath expression", e);
+				}
+			}
+		},
+		scm("count(project/scm/*)") {
+			@Override
+			public void accept(SoftAssertions softly, Document doc) {
+				try {
+					softly.assertThat(Integer.parseInt(expr.evaluate(doc)))
+						.as("project %s", name())
+						.isPositive();
+				} catch (XPathExpressionException e) {
+					softly.fail("failed to evaluate xpath expression", e);
+				}
+			}
+		};
+
+		final XPathExpression expr;
+
+		PomAssertions(String expr) {
+			try {
+				this.expr = xpath.compile(expr);
+			} catch (XPathExpressionException e) {
+				throw Exceptions.duck(e);
+			}
+		}
+
+		@Override
+		public void accept(SoftAssertions softly, Document doc) {
+			try {
+				softly.assertThat(Strings.trim(expr.evaluate(doc)))
+					.as("project %s", name())
+					.isNotEmpty();
+			} catch (XPathExpressionException e) {
+				softly.fail("failed to evaluate xpath expression", e);
+			}
+		}
+	}
+
+	@Test
+	void no_POM(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "false");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check())
+				.isTrue();
+		}
+	}
+
+	@Test
+	void missing_all(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "true");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly
+				.assertThat(b.check("-groupid not set", "Bundle-Version not set", "Bundle-DocURL not set",
+					"Bundle-License not set", "Bundle-Developers not set", "Bundle-SCM not set"))
+				.isTrue();
+		}
+	}
+
+	@Test
+	void pom_instruction_groupid(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "groupid=g1,artifactid=p1.p2,version=4.5.6");
+			b.setProperty("Bundle-SymbolicName", "bsn1");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-DocURL", "https://bnd.bndtools.org/");
+			b.setProperty("Bundle-License", "\"Apache-2.0\";" //
+				+ "description=\"This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0\";" //
+				+ "link=\"https://opensource.org/licenses/Apache-2.0\"");
+			b.setProperty("Bundle-Developers", "pkriens;" //
+				+ "email=Peter.Kriens@aQute.biz;" //
+				+ "name=\"Peter Kriens\";" //
+				+ "organization=Bndtools;"//
+				+ "organizationUrl=https://github.com/bndtools;" //
+				+ "roles=\"architect,developer\";" //
+				+ "timezone=1");
+			b.setProperty("Bundle-SCM", "url=https://github.com/bndtools/bnd," //
+				+ "connection=scm:git:https://github.com/bndtools/bnd.git,"//
+				+ "developerConnection=scm:git:git@github.com:bndtools/bnd.git,"//
+				+ "tag=HEAD");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check())
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(), EnumSet.allOf(PomAssertions.class));
+		}
+	}
+
+	@Test
+	void groupid_instruction(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "true");
+			b.setProperty("-groupid", "g1");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-DocURL", "https://bnd.bndtools.org/");
+			b.setProperty("Bundle-License", "\"Apache-2.0\";" //
+				+ "description=\"This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0\";" //
+				+ "link=\"https://opensource.org/licenses/Apache-2.0\"");
+			b.setProperty("Bundle-Developers", "pkriens;" //
+				+ "email=Peter.Kriens@aQute.biz;" //
+				+ "name=\"Peter Kriens\";" //
+				+ "organization=Bndtools;"//
+				+ "organizationUrl=https://github.com/bndtools;" //
+				+ "roles=\"architect,developer\";" //
+				+ "timezone=1");
+			b.setProperty("Bundle-SCM", "url=https://github.com/bndtools/bnd," //
+				+ "connection=scm:git:https://github.com/bndtools/bnd.git,"//
+				+ "developerConnection=scm:git:git@github.com:bndtools/bnd.git,"//
+				+ "tag=HEAD");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check())
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(), EnumSet.allOf(PomAssertions.class));
+		}
+	}
+
+	void validate_POM(SoftAssertions softly, InputStream in,
+		Collection<? extends BiConsumer<? super SoftAssertions, ? super Document>> assertions) throws Exception {
+		assertThat(in).as("pom inputstream")
+			.isNotNull();
+
+		DocumentBuilder db = dbf.newDocumentBuilder();
+		Document doc = db.parse(in);
+		assertThat(doc).as("pom document")
+			.isNotNull();
+
+		assertions.forEach(assertion -> assertion.accept(softly, doc));
+	}
+
+	@Test
+	void missing_DocURL(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "groupid=g1");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-License", "\"Apache-2.0\";" //
+				+ "description=\"This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0\";" //
+				+ "link=\"https://opensource.org/licenses/Apache-2.0\"");
+			b.setProperty("Bundle-Developers", "pkriens;" //
+				+ "email=Peter.Kriens@aQute.biz;" //
+				+ "name=\"Peter Kriens\";" //
+				+ "organization=Bndtools;"//
+				+ "organizationUrl=https://github.com/bndtools;" //
+				+ "roles=\"architect,developer\";" //
+				+ "timezone=1");
+			b.setProperty("Bundle-SCM", "url=https://github.com/bndtools/bnd," //
+				+ "connection=scm:git:https://github.com/bndtools/bnd.git,"//
+				+ "developerConnection=scm:git:git@github.com:bndtools/bnd.git,"//
+				+ "tag=HEAD");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check("Bundle-DocURL not set"))
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(), EnumSet.complementOf(EnumSet.of(PomAssertions.url)));
+		}
+	}
+
+	@Test
+	void missing_License(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "groupid=g1");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-DocURL", "https://bnd.bndtools.org/");
+			b.setProperty("Bundle-Developers", "pkriens;" //
+				+ "email=Peter.Kriens@aQute.biz;" //
+				+ "name=\"Peter Kriens\";" //
+				+ "organization=Bndtools;"//
+				+ "organizationUrl=https://github.com/bndtools;" //
+				+ "roles=\"architect,developer\";" //
+				+ "timezone=1");
+			b.setProperty("Bundle-SCM", "url=https://github.com/bndtools/bnd," //
+				+ "connection=scm:git:https://github.com/bndtools/bnd.git,"//
+				+ "developerConnection=scm:git:git@github.com:bndtools/bnd.git,"//
+				+ "tag=HEAD");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check("Bundle-License not set"))
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(),
+				EnumSet.complementOf(EnumSet.of(PomAssertions.licenses)));
+		}
+	}
+
+	@Test
+	void missing_Developers(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "groupid=g1");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-DocURL", "https://bnd.bndtools.org/");
+			b.setProperty("Bundle-License", "\"Apache-2.0\";" //
+				+ "description=\"This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0\";" //
+				+ "link=\"https://opensource.org/licenses/Apache-2.0\"");
+			b.setProperty("Bundle-SCM", "url=https://github.com/bndtools/bnd," //
+				+ "connection=scm:git:https://github.com/bndtools/bnd.git,"//
+				+ "developerConnection=scm:git:git@github.com:bndtools/bnd.git,"//
+				+ "tag=HEAD");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check("Bundle-Developers not set"))
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(),
+				EnumSet.complementOf(EnumSet.of(PomAssertions.developers)));
+		}
+	}
+
+	@Test
+	void missing_SCM(SoftAssertions softly) throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty("-pom", "groupid=g1");
+			b.setProperty("Bundle-SymbolicName", "p1.p2");
+			b.setProperty("Bundle-Version", "1.2.3");
+			b.setProperty("Bundle-DocURL", "https://bnd.bndtools.org/");
+			b.setProperty("Bundle-License", "\"Apache-2.0\";" //
+				+ "description=\"This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0\";" //
+				+ "link=\"https://opensource.org/licenses/Apache-2.0\"");
+			b.setProperty("Bundle-Developers", "pkriens;" //
+				+ "email=Peter.Kriens@aQute.biz;" //
+				+ "name=\"Peter Kriens\";" //
+				+ "organization=Bndtools;"//
+				+ "organizationUrl=https://github.com/bndtools;" //
+				+ "roles=\"architect,developer\";" //
+				+ "timezone=1");
+			b.setExportPackage("test.activator");
+			b.addClasspath(new File("bin_test"));
+			b.getPlugins()
+				.add(new CentralCheck());
+
+			Jar jar = b.build();
+			softly.assertThat(b.check("Bundle-SCM not set"))
+				.isTrue();
+
+			Resource pomResource = jar.getResource("META-INF/maven/g1/p1.p2/pom.xml");
+			assertThat(pomResource).isNotNull();
+			validate_POM(softly, pomResource.openInputStream(), EnumSet.complementOf(EnumSet.of(PomAssertions.scm)));
+		}
+	}
+
+}

--- a/biz.aQute.bndlib.tests/test/test/VerifierPluginTest.java
+++ b/biz.aQute.bndlib.tests/test/test/VerifierPluginTest.java
@@ -1,7 +1,11 @@
 package test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Descriptors.PackageRef;
@@ -9,11 +13,11 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Packages;
 import aQute.bnd.service.AnalyzerPlugin;
 import aQute.bnd.service.verifier.VerifierPlugin;
-import junit.framework.TestCase;
 
-public class VerifierPluginTest extends TestCase {
+public class VerifierPluginTest {
 
-	public static void testNoVerifierPluginExecution() throws Exception {
+	@Test
+	void testNoVerifierPluginExecution() throws Exception {
 		final AtomicBoolean executedCheck = new AtomicBoolean(false);
 
 		AnalyzerPlugin analyzerPlugin = analyzer -> {
@@ -37,10 +41,11 @@ public class VerifierPluginTest extends TestCase {
 
 			Jar jar = b.build();
 		}
-		assertTrue(executedCheck.get());
+		assertThat(executedCheck).isTrue();
 	}
 
-	public static void testVerifierPluginExecution() throws Exception {
+	@Test
+	void testVerifierPluginExecution() throws Exception {
 		final AtomicBoolean executedCheck = new AtomicBoolean(false);
 
 		VerifierPlugin verifier = analyzer -> {
@@ -65,7 +70,8 @@ public class VerifierPluginTest extends TestCase {
 
 			Jar jar = b.build();
 		}
-		assertTrue(executedCheck.get());
+
+		assertThat(executedCheck).isTrue();
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/plugin/maven/CentralCheck.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/plugin/maven/CentralCheck.java
@@ -1,36 +1,57 @@
 package aQute.bnd.plugin.maven;
 
 import aQute.bnd.annotation.plugin.BndPlugin;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.osgi.Analyzer;
 import aQute.bnd.osgi.Constants;
-import aQute.bnd.service.AnalyzerPlugin;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.service.verifier.VerifierPlugin;
 
 /**
  * Sets a warning when a header is missing to publish at Central. The Sonatype
  * Nexus does some verifications and it is pretty annoying if they fail.
+ *
+ * @see <a href=
+ *      "https://central.sonatype.org/pages/requirements.html#sufficient-metadata">Sufficient
+ *      Metadata</a>
  */
 
-@BndPlugin(name = "Central")
-public class CentralCheck implements AnalyzerPlugin {
+@BndPlugin(name = "CentralCheck")
+public class CentralCheck implements VerifierPlugin {
 
 	@Override
-	public boolean analyzeJar(Analyzer analyzer) throws Exception {
-		if (analyzer.getProperty(Constants.POM) == null)
-			return false;
+	public void verify(Analyzer analyzer) throws Exception {
+		String pom = analyzer.getProperty(Constants.POM);
+		if (!Processor.isTrue(pom))
+			return;
+		Attrs pomProperties = OSGiHeader.parseProperties(pom);
+		String groupId = pomProperties.get("groupid");
+		if (groupId == null) {
+			check(analyzer, Constants.GROUPID);
+		}
+		String version = pomProperties.get("version");
+		if (version == null) {
+			check(analyzer, Constants.BUNDLE_VERSION);
+		}
 
-		check(analyzer, Constants.GROUPID);
-		check(analyzer, Constants.BUNDLE_VERSION);
-		check(analyzer, Constants.BUNDLE_LICENSE);
-		check(analyzer, Constants.BUNDLE_SCM);
-		check(analyzer, Constants.BUNDLE_DEVELOPERS);
+		// name defaults to groupId:artifactId
+
+		// description defaults to name
+
 		check(analyzer, Constants.BUNDLE_DOCURL);
-		return false;
+
+		check(analyzer, Constants.BUNDLE_LICENSE);
+
+		check(analyzer, Constants.BUNDLE_DEVELOPERS);
+
+		check(analyzer, Constants.BUNDLE_SCM);
 	}
 
 	private void check(Analyzer analyzer, String key) throws Exception {
 		String value = analyzer.getProperty(key);
 		if (value == null) {
-			analyzer.warning("Maven Central: %s not set", key);
+			analyzer.warning("Maven Central Check: %s not set", key);
 		}
 	}
 


### PR DESCRIPTION
We convert the plugin to a VerifierPlugin and enhance the header
checks. The verifier plugin assumes that the proper POM is created from
the manifest headers.

The test verifies warnings are emitted when headers are missing and
also does some checks on the generated POMs.

Fixes https://github.com/bndtools/bnd/issues/1479
