### PR TITLE
repository: Fix findProviders result to include input requirements

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -1,14 +1,17 @@
 package aQute.bnd.repository.maven.pom.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -247,7 +250,8 @@ public class BndPomRepository extends BaseRepository
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
 		if (!init()) {
-			return Collections.emptyMap();
+			return requirements.stream()
+				.collect(toMap(identity(), requirement -> new ArrayList<>()));
 		}
 		return repoImpl.findProviders(requirements);
 	}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -1,7 +1,9 @@
 package aQute.bnd.repository.maven.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import java.io.Closeable;
@@ -13,6 +15,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -882,8 +885,10 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-		if (!init())
-			return Collections.emptyMap();
+		if (!init()) {
+			return requirements.stream()
+				.collect(toMap(identity(), requirement -> new ArrayList<>()));
+		}
 
 		return index.getBridge()
 			.getRepository()


### PR DESCRIPTION
The Repository spec requires the return Map value of findProviders to
have each input requirement as a key. In some cases, an empty map was
incorrectly returned.

Fixes https://github.com/bndtools/bnd/issues/4416
