### PR TITLE
Disable bndtools.core.test testOSGi task in CI build

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -17,6 +17,7 @@ on:
 env:
   LC_ALL: en_US.UTF-8
   GRADLE_OPTS: -Dorg.gradle.parallel=true
+  BNDTOOLS_CORE_TEST_NOJUNITOSGI: true
 
 defaults:
   run:

--- a/bndtools.core.test/bnd.bnd
+++ b/bndtools.core.test/bnd.bnd
@@ -2,6 +2,8 @@
 -include: ${workspace}/cnf/includes/jdt.bnd, ${workspace}/cnf/includes/bndtools.bnd
 -sub: *.bnd
 
+-nojunitosgi: ${env;BNDTOOLS_CORE_TEST_NOJUNITOSGI;false}
+
 -buildrepo:
 -releaserepo:
 

--- a/bndtools.core.test/build.gradle
+++ b/bndtools.core.test/build.gradle
@@ -1,17 +1,18 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import aQute.bnd.osgi.Constants
 
 tasks.named('testOSGi') {
   description 'Bndtools Core Integration tests'
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-    enabled true
+    enabled !bndis(Constants.NOJUNITOSGI)
     bndrun 'test.win32.x86_64.bndrun'
   } else if (Os.isFamily(Os.FAMILY_MAC)) {
     // This has to come before the check for Unix as MacOS also
     // returns true for Unix
-    enabled true
+    enabled !bndis(Constants.NOJUNITOSGI)
     bndrun 'test.cocoa.macosx.x86_64.bndrun'
   } else if (Os.isFamily(Os.FAMILY_UNIX)) {
-    enabled true
+    enabled !bndis(Constants.NOJUNITOSGI)
     bndrun 'test.gtk.linux.x86_64.bndrun'
   } else {
     enabled false


### PR DESCRIPTION
This task is annoyingly flaky and breaks many CI builds. Until we can
stabilize this test, we remove it from CI execution.

See #4253