### PR TITLE
[projecttracker] Missing bnd files

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTracker.java
@@ -57,6 +57,11 @@ class ProjectTracker implements AutoCloseable {
 	 */
 	synchronized Optional<Project> getProject(String name) {
 		update();
+		if (!models.containsKey(name) && workspace.getFile(name + "/" + Project.BNDFILE)
+			.isFile()) {
+			changed = true;
+			update();
+		}
 		return Optional.ofNullable(models.get(name));
 	}
 


### PR DESCRIPTION
The project tracker (suddenly?) needs bnd files
to be present in the project. However, if you
create this file, the error is not cleared until the project tracker updates again.

This patch will force an update if the bnd file exist but it is not in the project tracker.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>