### PR TITLE
bndtools: Use model Project as the properties for resolving

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
@@ -52,7 +52,7 @@ public class ResolveOperation implements IRunnableWithProgress {
 				List<ResolutionCallback> operationCallbacks = new ArrayList<>(callbacks.size() + 1);
 				operationCallbacks.addAll(callbacks);
 				operationCallbacks.add(new CancelOperationCallback(monitor));
-				RunResolution resolution = RunResolution.resolve(model.getProject(), model.getProperties(),
+				RunResolution resolution = RunResolution.resolve(model.getProject(), model.getProject(),
 					operationCallbacks, logger);
 				if (resolution.isOK()) {
 					result = new ResolutionResult(Outcome.Resolved, resolution, status, logger);


### PR DESCRIPTION
The model properties are not properly resolved for the special here
`${.}` macro. Using the model Project as the resolve properties is
consistent with all other callers to RunResolution.resolve.

Fixes https://github.com/bndtools/bnd/issues/4396
