### PR TITLE
bndtools: Resolve special `${.}` here macro in BndEditModel properties

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ResolveOperation.java
@@ -1,10 +1,8 @@
 package org.bndtools.core.resolve;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import org.bndtools.core.resolve.ResolutionResult.Outcome;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -18,12 +16,9 @@ import org.osgi.service.coordinator.Coordination;
 import org.osgi.service.coordinator.Coordinator;
 import org.osgi.service.resolver.ResolutionException;
 
-import aQute.bnd.build.Project;
 import aQute.bnd.build.model.BndEditModel;
-import aQute.bnd.osgi.Processor;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.exceptions.RunnableWithException;
-import aQute.lib.utf8properties.UTF8Properties;
 import biz.aQute.resolve.ResolutionCallback;
 import biz.aQute.resolve.ResolverLogger;
 import biz.aQute.resolve.RunResolution;
@@ -57,20 +52,8 @@ public class ResolveOperation implements IRunnableWithProgress {
 				List<ResolutionCallback> operationCallbacks = new ArrayList<>(callbacks.size() + 1);
 				operationCallbacks.addAll(callbacks);
 				operationCallbacks.add(new CancelOperationCallback(monitor));
-				Project project = model.getProject();
-				Processor actualProperties = model.getProperties();
-				File source = model.getBndResource();
-				if (source == null) {
-					source = project.getPropertiesFile();
-				}
-				if (source != null) {
-					Properties properties = actualProperties.getProperties();
-					UTF8Properties copy = new UTF8Properties(properties);
-					copy.putAll(properties);
-					UTF8Properties here = copy.replaceHere(source.getParentFile());
-					actualProperties = new Processor(actualProperties, here, false);
-				}
-				RunResolution resolution = RunResolution.resolve(project, actualProperties, operationCallbacks, logger);
+				RunResolution resolution = RunResolution.resolve(model.getProject(), model.getProperties(),
+					operationCallbacks, logger);
 				if (resolution.isOK()) {
 					result = new ResolutionResult(Outcome.Resolved, resolution, status, logger);
 				} else if (resolution.exception != null) {


### PR DESCRIPTION
Before returning the model properties, we resolve the special
`${.}` here macro.

Fixes https://github.com/bndtools/bnd/issues/4396
