### PR TITLE
Emit service capability for services of factory components

### DIFF
--- a/biz.aQute.bnd.test/src/aQute/bnd/test/XmlTester.java
+++ b/biz.aQute.bnd.test/src/aQute/bnd/test/XmlTester.java
@@ -1,7 +1,6 @@
 package aQute.bnd.test;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -68,46 +67,50 @@ public class XmlTester {
 	public void assertExactAttribute(String value, String expr) throws XPathExpressionException {
 		System.err.println(expr);
 		String o = (String) xpath.evaluate(expr, document, XPathConstants.STRING);
-		assertNotNull(o);
-		assertEquals(value, o);
+		assertThat(o).isEqualTo(value);
 	}
 
 	public void assertAttribute(String value, String expr) throws XPathExpressionException {
 		System.err.println(expr);
 		String o = (String) xpath.evaluate(expr, document, XPathConstants.STRING);
-		assertNotNull(o);
-		assertEquals(value, o.trim());
+		assertThat(o).usingComparator((s1, s2) -> s1.trim()
+			.compareTo(s2))
+			.isEqualTo(value);
 	}
 
 	public void assertTrimmedAttribute(String value, String expr) throws XPathExpressionException {
 		System.err.println(expr);
 		String o = (String) xpath.evaluate(expr, document, XPathConstants.STRING);
-		assertNotNull(o);
-		assertEquals(value, o.trim()
-			.replaceAll("\n", "\\\\n"));
+		assertThat(o).usingComparator((s1, s2) -> s1.trim()
+			.replaceAll("\n", "\\\\n")
+			.compareTo(s2))
+			.isEqualTo(value);
 	}
 
 	public void assertNoAttribute(String expr) throws XPathExpressionException {
 		System.err.println(expr);
 		String o = (String) xpath.evaluate(expr, document, XPathConstants.STRING);
-		assertEquals("", o);
+		assertThat(o).isEmpty();
 	}
 
 	public void assertNamespace(String namespace) {
 		Element element = document.getDocumentElement();
 		String xmlns = element.getNamespaceURI();
-		assertEquals(namespace, xmlns);
+		assertThat(xmlns).isEqualTo(namespace);
 	}
 
 	public void assertNumber(Double value, String expr) throws XPathExpressionException {
 		System.err.println(expr);
 		Double o = (Double) xpath.evaluate(expr, document, XPathConstants.NUMBER);
-		assertNotNull(o);
-		assertEquals(value, o);
+		assertThat(o).isEqualTo(value);
 	}
 
 	public void assertCount(int value, String expr) throws XPathExpressionException {
-		assertNumber(Double.valueOf(value), "count(" + expr + ")");
+		expr = "count(" + expr + ")";
+		System.err.println(expr);
+		String o = (String) xpath.evaluate(expr, document, XPathConstants.STRING);
+		assertThat(o).containsOnlyDigits();
+		assertThat(Integer.parseInt(o)).isEqualTo(value);
 	}
 
 }

--- a/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
@@ -612,8 +612,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("java.io.Serializable", "component/service/provide[1]/@interface");
 			xt.assertAttribute("java.lang.Runnable", "component/service/provide[2]/@interface");
 
-			xt.assertAttribute("0", "count(component/properties)");
-			xt.assertAttribute("0", "count(component/property)");
+			xt.assertCount(0, "component/properties");
+			xt.assertCount(0, "component/property");
 
 			xt.assertAttribute("xsetLogService", "component/reference[1]/@name");
 			xt.assertAttribute("", "component/reference[1]/@target");
@@ -669,8 +669,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 			xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
 			xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -714,8 +714,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 			xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
 			xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -759,8 +759,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 			xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
 			xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -803,8 +803,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 			xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			xt.assertAttribute("xsetLogService", "scr:component/reference[1]/@name");
 			xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -841,10 +841,10 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("close", "scr:component/@deactivate");
 			xt.assertAttribute("changed", "scr:component/@modified");
 			xt.assertAttribute("java.lang.Object", "scr:component/service/provide[1]/@interface");
-			xt.assertAttribute("1", "count(scr:component/service/provide)");
+			xt.assertCount(1, "scr:component/service/provide");
 
-			xt.assertAttribute("1", "count(scr:component/properties)");
-			xt.assertAttribute("2", "count(scr:component/property)");
+			xt.assertCount(1, "scr:component/properties");
+			xt.assertCount(2, "scr:component/property");
 
 			xt.assertAttribute("(objectclass=*)", "scr:component/reference[1]/@target");
 			xt.assertAttribute("setLogService", "scr:component/reference[1]/@bind");
@@ -854,8 +854,8 @@ public class DSAnnotationTest extends TestCase {
 			xt.assertAttribute("dynamic", "scr:component/reference[1]/@policy");
 			xt.assertAttribute("(objectclass=*)", "scr:component/reference[1]/@target");
 
-			xt.assertAttribute("2", "count(scr:component/property)");
-			xt.assertAttribute("1", "count(scr:component/properties)");
+			xt.assertCount(2, "scr:component/property");
+			xt.assertCount(1, "scr:component/properties");
 			xt.assertAttribute("resource.props", "scr:component/properties[1]/@entry");
 			xt.assertAttribute("greedy", "scr:component/reference[1]/@policy-option");
 		}
@@ -896,8 +896,8 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("deactivate", "scr:component/@deactivate");
 		xt.assertAttribute("", "scr:component/@modified");
 
-		xt.assertAttribute("0", "count(scr:component/properties)");
-		xt.assertAttribute("0", "count(scr:component/property)");
+		xt.assertCount(0, "scr:component/properties");
+		xt.assertCount(0, "scr:component/property");
 
 		xt.assertAttribute("LogService", "scr:component/reference[1]/@name");
 		xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -1141,8 +1141,8 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("0", "count(scr:component/properties)");
-		xt.assertAttribute("0", "count(scr:component/property)");
+		xt.assertCount(0, "scr:component/properties");
+		xt.assertCount(0, "scr:component/property");
 
 		xt.assertAttribute("LogService", "scr:component/reference[1]/@name");
 		xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -2187,8 +2187,8 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("0", "count(scr:component/properties)");
-		xt.assertAttribute("0", "count(scr:component/property)");
+		xt.assertCount(0, "scr:component/properties");
+		xt.assertCount(0, "scr:component/property");
 
 		xt.assertAttribute("LogService", "scr:component/reference[1]/@name");
 		xt.assertAttribute("", "scr:component/reference[1]/@target");
@@ -2234,10 +2234,10 @@ public class DSAnnotationTest extends TestCase {
 			r.write(System.err);
 			XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
 			xt.assertAttribute("ds14", "scr:component/@factory");
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
-			xt.assertAttribute("14", "count(scr:component/factory-property)");
-			xt.assertAttribute("1", "count(scr:component/factory-properties)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
+			xt.assertCount(14, "scr:component/factory-property");
+			xt.assertCount(1, "scr:component/factory-properties");
 
 			xt.assertAttribute("", "scr:component/factory-property[@name='a']/@value");
 			xt.assertAttribute("1\n2", "scr:component/factory-property[@name='a']/text()");
@@ -2527,8 +2527,8 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("0", "count(scr:component/properties)");
-		xt.assertAttribute("18", "count(scr:component/property)");
+		xt.assertCount(0, "scr:component/properties");
+		xt.assertCount(18, "scr:component/property");
 
 		xt.assertAttribute("foo", "scr:component/property[@name='myString']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='myString']/@type");
@@ -2662,7 +2662,7 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("6", "count(scr:component/property)");
+		xt.assertCount(6, "scr:component/property");
 
 		xt.assertAttribute("foo", "scr:component/property[@name='myString1']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='myString1']/@type");
@@ -2749,7 +2749,7 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("2", "count(scr:component/property)");
+		xt.assertCount(2, "scr:component/property");
 
 		xt.assertAttribute("foo", "scr:component/property[@name='test.my-String7']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='test.my-String7']/@type");
@@ -2818,7 +2818,7 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("2", "count(scr:component/property)");
+		xt.assertCount(2, "scr:component/property");
 
 		xt.assertAttribute("foo", "scr:component/property[@name='test.my-String7']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='test.my-String7']/@type");
@@ -2962,7 +2962,7 @@ public class DSAnnotationTest extends TestCase {
 		xt.assertAttribute("java.io.Serializable", "scr:component/service/provide[1]/@interface");
 		xt.assertAttribute("java.lang.Runnable", "scr:component/service/provide[2]/@interface");
 
-		xt.assertAttribute("4", "count(scr:component/property)");
+		xt.assertCount(4, "scr:component/property");
 
 		xt.assertAttribute("a", "scr:component/property[@name='a']/@value");
 		xt.assertAttribute("String", "scr:component/property[@name='a']/@type");
@@ -4227,8 +4227,8 @@ public class DSAnnotationTest extends TestCase {
 			assertNotNull(r);
 			r.write(System.err);
 			XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			// This test method depends upon the compiler generating
 			// MethodParameters attributes so that the DS annotations code will
@@ -4295,8 +4295,8 @@ public class DSAnnotationTest extends TestCase {
 			assertNotNull(r);
 			r.write(System.err);
 			XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.4.0");
-			xt.assertAttribute("0", "count(scr:component/properties)");
-			xt.assertAttribute("0", "count(scr:component/property)");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
 
 			xt.assertAttribute("3", "scr:component/@init");
 			xt.assertAttribute("activator", "scr:component/@activate");

--- a/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
@@ -7,23 +7,21 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
 
 import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.PermissionGenerator;
 import aQute.bnd.osgi.Resource;
-import junit.framework.TestCase;
 
-public class PermissionGeneratorTest extends TestCase {
+public class PermissionGeneratorTest {
 	private static Set<String> getPermissionsGeneratedFor(String permissionFile) throws Exception {
 		Builder b = new Builder();
 		b.setProperty(Constants.DSANNOTATIONS, "test.component.*_basic");
@@ -45,12 +43,14 @@ public class PermissionGeneratorTest extends TestCase {
 		Resource resource = jar.getResource("OSGI-INF/permissions.perm");
 		BufferedReader r = new BufferedReader(new InputStreamReader(resource.openInputStream()));
 
-		Set<String> permissions = new TreeSet<>();
+		Set<String> permissions = new HashSet<>();
 		String line = null;
 		while ((line = r.readLine()) != null) {
 			if (!line.isEmpty()) {
-				assertTrue("Found duplicate permission: " + line, permissions.add(line));
 				System.err.println("Permission read: " + line);
+				assertThat(permissions).as("Found duplicate permission: %s", line)
+					.doesNotContain(line);
+				permissions.add(line);
 			}
 		}
 
@@ -60,21 +60,23 @@ public class PermissionGeneratorTest extends TestCase {
 	}
 
 	private static Set<String> filterAndSubtract(Set<String> input, String regex) {
-		Set<String> result = new TreeSet<>();
+		Set<String> result = new HashSet<>();
 		Pattern pattern = Pattern.compile(regex);
 		for (Iterator<String> it = input.iterator(); it.hasNext();) {
 			String string = it.next();
 			Matcher matcher = pattern.matcher(string);
 			if (matcher.matches()) {
+				String selected = matcher.group(1);
+				result.add(selected);
 				it.remove();
-				result.add(matcher.group(1));
 			}
 		}
 		return result;
 	}
 
-	private static void assertNotingLeft(Set<String> permissions) {
-		assertEquals("No other permissions expected", Collections.emptySet(), permissions);
+	private static void assertNothingLeft(Set<String> permissions) {
+		assertThat(permissions).as("No other permissions expected")
+			.isEmpty();
 	}
 
 	private static void assertPackageAvailable(Set<String> permissions) {
@@ -84,7 +86,7 @@ public class PermissionGeneratorTest extends TestCase {
 			"^\\(org.osgi.framework.PackagePermission \"([^\"]+)\" \"export\"\\)$");
 
 		/* @formatter:off */
-		assertThat(importedPackages).containsExactly(
+		assertThat(importedPackages).containsExactlyInAnyOrder(
 			"aQute.bnd.differ",
             "aQute.bnd.header",
             "aQute.bnd.osgi",
@@ -100,12 +102,13 @@ public class PermissionGeneratorTest extends TestCase {
             "javax.xml.xpath",
             "junit.framework",
             "org.assertj.core.api",
+            "org.junit.jupiter.api",
             "org.osgi.framework",
             "org.osgi.service.component",
             "org.osgi.service.log",
             "org.w3c.dom",
             "org.xml.sax");
-		assertThat(exportedPackages).containsExactly("test.api");
+		assertThat(exportedPackages).containsExactlyInAnyOrder("test.api");
 		/* @formatter:on */
 	}
 
@@ -116,14 +119,14 @@ public class PermissionGeneratorTest extends TestCase {
 			"^\\(org.osgi.framework.ServicePermission \"([^\"]+)\" \"get\"\\)$");
 
 		/* @formatter:off */
-		assertEquals("Registered services",
-				new TreeSet<>(Arrays.asList("java.lang.Runnable",
-						"java.io.Serializable",
-						"org.osgi.service.component.ComponentFactory")),
-						registeredServices);
-		assertEquals("Required services",
-				new TreeSet<>(Arrays.asList("org.osgi.service.log.LogService")),
-						requiredServices);
+		assertThat(registeredServices).as("Registered services")
+			.containsExactlyInAnyOrder(
+				"java.io.Serializable",
+				"java.lang.Object",
+				"java.lang.Runnable",
+				"org.osgi.service.component.ComponentFactory");
+		assertThat(requiredServices).as("Required services")
+			.containsExactlyInAnyOrder("org.osgi.service.log.LogService");
 		/* @formatter:on */
 	}
 
@@ -133,118 +136,123 @@ public class PermissionGeneratorTest extends TestCase {
 		Set<String> providedCapabilities = filterAndSubtract(permissions,
 			"^\\(org.osgi.framework.CapabilityPermission \"([^\"]+)\" \"provide\"\\)$");
 
-		/* @formatter:off */
-		assertEquals("Provided capabilities",
-				new TreeSet<>(Arrays.asList("osgi.service")),
-				providedCapabilities);
-		assertEquals("Required capabilities",
-				new TreeSet<>(Arrays.asList("osgi.service")),
-						requiredCapabilities);
-		/* @formatter:on */
+		assertThat(providedCapabilities).as("Provided capabilities")
+			.containsExactlyInAnyOrder("osgi.service");
+		assertThat(requiredCapabilities).as("Required capabilities")
+			.containsExactlyInAnyOrder("osgi.service");
 	}
 
 	private static void assertAdminAvailable(Set<String> permissions) {
 		Set<String> adminCapabilities = filterAndSubtract(permissions, "^\\((org.osgi.framework.AdminPermission)\\)$");
-		assertEquals("Admin capabilities", 1, adminCapabilities.size());
+		assertThat(adminCapabilities).as("Admin capabilities")
+			.hasSize(1);
 	}
 
-	public static void testJustPackages() throws Exception {
+	@Test
+	public void testJustPackages() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;packages}");
 		assertPackageAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testJustServices() throws Exception {
+	@Test
+	public void testJustServices() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;services}");
 		assertServicesAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testJustCapabilities() throws Exception {
+	@Test
+	public void testJustCapabilities() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;capabilities}");
 		assertCapabilitiesAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testJustAdmin() throws Exception {
+	@Test
+	public void testJustAdmin() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;admin}");
 		assertAdminAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testConcatenatedPermissionsNoAdmin() throws Exception {
+	@Test
+	public void testConcatenatedPermissionsNoAdmin() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor(
 			"${permissions;packages}${permissions;services}${permissions;capabilities}");
 		assertPackageAvailable(permissions);
 		assertServicesAvailable(permissions);
 		assertCapabilitiesAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testInlinePermissionsNoAdmin() throws Exception {
+	@Test
+	public void testInlinePermissionsNoAdmin() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;packages;services;capabilities}");
 		assertPackageAvailable(permissions);
 		assertServicesAvailable(permissions);
 		assertCapabilitiesAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testInlinePermissions() throws Exception {
+	@Test
+	public void testInlinePermissions() throws Exception {
 		Set<String> permissions = getPermissionsGeneratedFor("${permissions;packages;services;capabilities;admin}");
 		assertPackageAvailable(permissions);
 		assertServicesAvailable(permissions);
 		assertCapabilitiesAvailable(permissions);
 		assertAdminAvailable(permissions);
-		assertNotingLeft(permissions);
+		assertNothingLeft(permissions);
 	}
 
-	public static void testCustomCapabilityParsing() throws Exception {
+	@Test
+	public void testCustomCapabilityParsing() throws Exception {
 		Builder b = new Builder();
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(objectClass=*)\"");
 		Set<String> services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.singleton("*"), services);
+		assertThat(services).containsExactlyInAnyOrder("*");
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(!(objectClass=*))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(!(objectClass=test.Helper))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(objectClass=test.*)\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.singleton("test.*"), services);
+		assertThat(services).containsExactlyInAnyOrder("test.*");
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(|(objectClass=test.*)(objectClass=test2.*))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(new HashSet<>(Arrays.asList("test.*", "test2.*")), services);
+		assertThat(services).containsExactlyInAnyOrder("test.*", "test2.*");
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(|(objectClass=test.*)(!(objectClass=test2.*)))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.singleton("test.*"), services);
+		assertThat(services).containsExactlyInAnyOrder("test.*");
 
 		// In the following cases, there is no way to determine the permissions
 		// needed, so nothing is generated. In these cases it is up to the user
 		// to generate the permission
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(objectClass=test2.*Helper)\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(objectClass=test*.*)\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(other=prop)\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(&(objectClass=test.*)(objectClass=*Helper))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 
 		b.setProperty("Require-Capability", "osgi.service;filter:=\"(!(&(objectClass=test.*)(objectClass=*Helper)))\"");
 		services = PermissionGenerator.getReferencedServices(b);
-		assertEquals(Collections.emptySet(), services);
+		assertThat(services).isEmpty();
 	}
 }

--- a/biz.aQute.bndlib.tests/test/test/metatype/SpecMetatypeTest.java
+++ b/biz.aQute.bndlib.tests/test/test/metatype/SpecMetatypeTest.java
@@ -923,8 +923,7 @@ public class SpecMetatypeTest extends TestCase {
 			assertEquals(optionLabels.length, optionValues.length);
 
 			// option count is correct
-			xt.assertNumber(Double.valueOf(optionLabels.length),
-				"count(metatype:MetaData/OCD/AD[@id='" + id + "']/Option)");
+			xt.assertCount(optionLabels.length, "metatype:MetaData/OCD/AD[@id='" + id + "']/Option");
 			for (int i = 0; i < optionLabels.length; i++) {
 				String expr = "metatype:MetaData/OCD/AD[@id='" + id + "']/Option[@label='" + optionLabels[i]
 					+ "']/@value";

--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java
@@ -280,7 +280,6 @@ public class DSAnnotations implements AnalyzerPlugin {
 			p.put(ServiceNamespace.SERVICE_NAMESPACE, a);
 			String s = p.toString();
 			provides.add(s);
-			return;
 		}
 
 		TypeRef[] services = definition.service;


### PR DESCRIPTION
If the factory component creates components which are services, also
provide the osgi.service capability for the service in addition to the
ComponentFactory service.

Fixes #4429