### PR TITLE
[hover] BndEditor macro expansion

### DIFF
--- a/biz.aQute.bndlib.tests/testresources/standalone.bndrun
+++ b/biz.aQute.bndlib.tests/testresources/standalone.bndrun
@@ -2,3 +2,5 @@
 a: A
 b: B
 c: C
+
+here: ${.}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.5.0")
+@Version("3.6.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.6.0")
+@org.osgi.annotation.versioning.Version("1.7.0")
 package aQute.bnd.junit;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("1.10.0")
+@Version("1.11.0")
 package aQute.bnd.maven;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -98,7 +98,7 @@ import aQute.libg.reporter.ReporterAdapter;
 import aQute.service.reporter.Reporter;
 
 public class Processor extends Domain implements Reporter, Registry, Constants, Closeable {
-	private static final Logger	logger	= LoggerFactory.getLogger(Processor.class);
+	private static final Logger	logger			= LoggerFactory.getLogger(Processor.class);
 	public static Reporter		log;
 
 	static {
@@ -2991,5 +2991,14 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (f != null)
 			l.add(f);
 		return l;
+	}
+
+	/**
+	 * Set the properties file but do **not** load the properties.
+	 *
+	 * @param source the properties file
+	 */
+	public void setPropertiesFile(File source) {
+		this.propertiesFile = source;
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("1.11.0")
+@Version("1.12.0")
 package aQute.bnd.osgi.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package aQute.bnd.print;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package aQute.bnd.service.generate;

--- a/bndtools.core/src/bndtools/editor/completion/BndHover.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndHover.java
@@ -36,6 +36,10 @@ public class BndHover extends DefaultTextHover {
 				if (key.indexOf('$') >= 0) {
 					Processor properties = bndEditor.getModel()
 						.getProperties();
+
+					properties.setProperty(".", properties.getBase()
+						.getAbsolutePath());
+
 					String replaced = properties.getReplacer()
 						.process(key);
 					if (properties.isOk())


### PR DESCRIPTION
The macro expansion was not handling the expansion
of ${.} and the base correctly because the
BndEditModel did not properly set it.

I cleaned up the getProperties() method to be in
line with the use of inheritance of Processors. 
This made one test case fail. 

The BndEdit model has maintains a delta list for
the editor and a set of properties. In the previous
implementation of the getProperties() method the
returned Processor had these properties + the delta
as its properties. However, it also inherited from
the parent processor, which had the originals, which
by definition are supposed to be the same.

I removed this redundancy because I did not like the
shadowing and it made the code simpler. So
the untouched properties are now directly inherited from
the BndEditModel's project or workspace.

This caused a test in BndEditModelTest to fail 
because it assumed that after it saved the changes
to a document the removed properties would contain
the changes. However, the logic is that after a save
the BndEditMode's parent is updated. This normally
happens through a reload.

I changed the test case to do this reloading. This
is a slight incompatibility but I do not think 
this is a problem in the normal usage of the BndEditModel.


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>