### PR TITLE
gradle: Avoid use of deprecated method to be removed in Gradle 7.0

### DIFF
--- a/.github/scripts/rebuild.sh
+++ b/.github/scripts/rebuild.sh
@@ -2,4 +2,4 @@
 unset JAVA_TOOL_OPTIONS _JAVA_OPTIONS
 ./gradlew --no-daemon --version
 ./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 :biz.aQute.bnd.gradle:build :biz.aQute.bnd.gradle:releaseNeeded
-./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles :buildscriptDependencies :build "$@"
+./gradlew --no-daemon -Dmaven.repo.local=maven/target/m2 -Pbnd_repourl=./dist/bundles --warning-mode=fail :buildscriptDependencies :build "$@"

--- a/.gradle-wrapper/gradle-wrapper.properties
+++ b/.gradle-wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -8,7 +8,7 @@ specified in the Bnd Workspace's `cnf/build.bnd` file and each project's
 `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins requires at least Gradle 5.1 for Java 8 to Java 12,
+These plugins requires at least Gradle 5.3 for Java 8 to Java 12,
 at least Gradle 6.0 for Java 13,
 and at least Gradle 6.3 for Java 14.
 

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -39,6 +39,7 @@ def testresources = tasks.register('testresources', Sync.class) {
 tasks.named('test') {
   inputs.files tasks.named('jar'), pluginUnderTestMetadata, testresources
   systemProperty 'bnd_version', bnd('bnd_version')
+  systemProperty 'org.gradle.warning.mode', gradle.startParameter.warningMode.name().toLowerCase()
 }
 
 tasks.named('release') {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
@@ -82,8 +82,8 @@ import org.gradle.api.tasks.TaskProvider
 
 public class Baseline extends DefaultTask {
   private final ProjectLayout layout
-  private final ProviderFactory providers
   private final ObjectFactory objects
+  private final ProviderFactory providers
   private ConfigurableFileCollection bundleCollection
   private ConfigurableFileCollection baselineCollection
   private final ListProperty<String> diffignore
@@ -121,8 +121,8 @@ public class Baseline extends DefaultTask {
     }))
     diffignore = objects.listProperty(String.class).empty()
     diffpackages = objects.listProperty(String.class).empty()
-    bundleCollection = project.files()
-    baselineCollection = project.files()
+    bundleCollection = objects.fileCollection()
+    baselineCollection = objects.fileCollection()
     dependsOn {
       [bundleCollection, baselineCollection]
     }
@@ -150,7 +150,7 @@ public class Baseline extends DefaultTask {
    * Project.files().
    */
   public void setBundle(Object file) {
-    bundleCollection = layout.configurableFiles(file)
+    bundleCollection = objects.fileCollection().from(file)
     builtBy(bundleCollection, file)
   }
 
@@ -175,7 +175,7 @@ public class Baseline extends DefaultTask {
    * Project.files().
    */
   public void setBaseline(Object file) {
-    baselineCollection = layout.configurableFiles(file)
+    baselineCollection = objects.fileCollection().from(file)
     builtBy(baselineCollection, file)
   }
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/FileSetRepositoryConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/FileSetRepositoryConvention.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.tasks.InputFiles
 
 
 class FileSetRepositoryConvention {
-  private final Project project
   private final ConfigurableFileCollection bundleCollection
 
   /**
@@ -33,8 +32,8 @@ class FileSetRepositoryConvention {
    *
    */
   FileSetRepositoryConvention(Task task) {
-    this.project = task.project
-    bundleCollection = project.files()
+    Project project = task.project
+    bundleCollection = project.objects.fileCollection()
     bundles(project.sourceSets.main.runtimeClasspath, project.configurations.archives.artifacts.files)
     // need to programmatically add to inputs since @InputFiles in a convention is not processed
     task.inputs.files(bundleCollection).withPropertyName('bundles')

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
@@ -61,7 +61,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -83,7 +82,6 @@ public class Index extends DefaultTask {
    * <code>false</code>.
    */
   @Input
-  @Optional
   boolean gzip = false
 
   /**
@@ -94,7 +92,7 @@ public class Index extends DefaultTask {
     super()
     indexName = 'index.xml'
     repositoryName = name
-    bundleCollection = project.files()
+    bundleCollection = project.objects.fileCollection()
     destinationDirectory = project.objects.directoryProperty().convention(project.layout.buildDirectory)
     baseProperty = project.objects.property(URI.class).convention(destinationDirectory.map({ directory ->
       return unwrap(directory).toURI()

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -425,7 +425,7 @@ class TestBndPlugin extends Specification {
           new File(testReports, 'testOSGi/TEST-testOSGi.xml').isFile()
 
         when:
-          result = TestHelper.getGradleRunner('4.6')
+          result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments("-Pbnd_plugin=${pluginClasspath}", '--parallel', '--stacktrace', '--debug', 'testrun.testOSGi2')
             .forwardOutput()
@@ -435,7 +435,7 @@ class TestBndPlugin extends Specification {
           result.task(':test.simple:testrun.testOSGi2').outcome == FAILED
 
         when:
-          result = TestHelper.getGradleRunner('4.6')
+          result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
             .withArguments("-Pbnd_plugin=${pluginClasspath}", '--parallel', '--stacktrace', '--debug', 'testrun.testOSGi2', '--tests=test.simple.Test')
             .forwardOutput()

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -30,6 +30,6 @@ class TestHelper {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
       return '6.0'
     }
-    return '5.1'
+    return '5.3'
   }
 }

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -10,17 +10,23 @@ class TestHelper {
   private TestHelper() { }
 
   public static GradleRunner getGradleRunner() {
-    return GradleRunner.create()
-            .withGradleVersion(gradleVersion())
+    return runner(gradleVersion())
   }
 
   public static GradleRunner getGradleRunner(String version) {
     String defaultversion = gradleVersion()
     if (MavenVersion.parseMavenString(defaultversion).compareTo(MavenVersion.parseMavenString(version)) > 0) {
-      version = defaultversion
+      return runner(defaultversion)
     }
-    return GradleRunner.create()
-            .withGradleVersion(version)
+    return runner(version)
+  }
+
+  private static GradleRunner runner(String version) {
+    GradleRunner runner = GradleRunner.create()
+    if (System.getProperty('org.gradle.warning.mode') == 'fail') { // if 'fail' we use the build gradle version
+      return runner
+    }
+    return runner.withGradleVersion(version)
   }
 
   private static String gradleVersion() {

--- a/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -57,7 +57,7 @@ Project-Buildpath: ${project.buildpath}
    sourceSet = sourceSets.test
    classpath = configurations.compileClasspath
    classpath jar
-   version = '1.1.0'
+   archiveVersion = '1.1.0'
 }
 
 artifacts {

--- a/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
@@ -57,7 +57,7 @@ Project-Buildpath: ${project.buildpath}
    sourceSet = sourceSets.test
    classpath = configurations.compileClasspath
    classpath jar
-   version = '1.1.0'
+   archiveVersion = '1.1.0'
 }
 
 artifacts {


### PR DESCRIPTION
We change to avoid using `ProjectLayout.configurableFiles` which Gradle
has announced will be removed in Gradle 7.0.

Fixes https://github.com/bndtools/bnd/issues/4451
