### PR TITLE
Use nanoTime values for timeout computations

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -2,6 +2,8 @@ name: CI Build
 
 on:
   push:
+    branches-ignore:
+    - 'dependabot/**'
     paths-ignore:
     - 'docs/**'
     - '.github/**/*docs*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "CodeQL"
 
 on:
   push:
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - '**.java'
     - '.github/**/*codeql*'

--- a/.github/workflows/docsbuild.yml
+++ b/.github/workflows/docsbuild.yml
@@ -2,6 +2,8 @@ name: Docs Build
 
 on:
   push:
+    branches-ignore:
+    - 'dependabot/**'
     paths:
     - 'docs/**'
     - '.github/**/*docs*'

--- a/aQute.libg/src/aQute/lib/link/Link.java
+++ b/aQute.libg/src/aQute/lib/link/Link.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -465,7 +466,8 @@ public class Link<L, R> extends Thread implements Closeable {
 
 	@SuppressWarnings("unchecked")
 	<T> T waitForResult(int id, Type type) throws Exception {
-		long deadline = System.currentTimeMillis() + 300000;
+		final long deadline = 300000L;
+		final long startNanos = System.nanoTime();
 		Result result = promises.get(id);
 
 		try {
@@ -493,13 +495,16 @@ public class Link<L, R> extends Thread implements Closeable {
 						return value;
 					}
 
-					long delay = deadline - System.currentTimeMillis();
-					if (delay <= 0) {
+					long elapsed = System.nanoTime() - startNanos;
+					long delay = deadline - TimeUnit.NANOSECONDS.toMillis(elapsed);
+					if (delay <= 0L) {
 						return null;
 					}
 					trace("start delay " + delay);
 					result.wait(delay);
-					trace("end delay " + (delay - (deadline - System.currentTimeMillis())));
+					elapsed = System.nanoTime() - startNanos;
+					delay = deadline - TimeUnit.NANOSECONDS.toMillis(elapsed);
+					trace("end delay " + delay);
 				}
 			} while (true);
 		} finally {

--- a/aQute.libg/src/aQute/libg/filelock/DirectoryLock.java
+++ b/aQute.libg/src/aQute/libg/filelock/DirectoryLock.java
@@ -1,6 +1,7 @@
 package aQute.libg.filelock;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 public class DirectoryLock {
 	final File					lock;
@@ -10,7 +11,7 @@ public class DirectoryLock {
 	public DirectoryLock(File directory, long timeout) {
 		this.lock = new File(directory, LOCKNAME);
 		this.lock.deleteOnExit();
-		this.timeout = timeout;
+		this.timeout = TimeUnit.MILLISECONDS.toNanos(timeout);
 	}
 
 	public void release() {
@@ -21,11 +22,11 @@ public class DirectoryLock {
 		if (lock.mkdir())
 			return;
 
-		long deadline = System.currentTimeMillis() + timeout;
-		while (System.currentTimeMillis() < deadline) {
+		final long startNanos = System.nanoTime();
+		while ((System.nanoTime() - startNanos) < timeout) {
 			if (lock.mkdir())
 				return;
-			Thread.sleep(50);
+			Thread.sleep(50L);
 		}
 	}
 }

--- a/biz.aQute.bnd/src/aQute/bnd/main/RemoteCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/RemoteCommand.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -221,11 +222,11 @@ class RemoteCommand extends Processor {
 	interface PingOptions extends Options {}
 
 	public void _ping(PingOptions opts) throws Exception {
-		long start = System.currentTimeMillis();
+		long startNanos = System.nanoTime();
 		if (agent.ping())
-			bnd.out.println("Ok " + (System.currentTimeMillis() - start) + "ms");
+			bnd.out.printf("Ok %s ms%n", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
 		else
-			bnd.out.println("Could not reach " + host + ":" + port);
+			bnd.out.printf("Could not reach %s:%s%n", host, port);
 	}
 
 	/**

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.jar.Attributes;
@@ -2170,7 +2171,7 @@ public class bnd extends Processor {
 				tester.addTest(testname);
 			}
 		}
-		long start = System.currentTimeMillis();
+		long startNanos = System.nanoTime();
 		try {
 			int errors = tester.test();
 
@@ -2227,8 +2228,9 @@ public class bnd extends Processor {
 			exception(e, "Exception in run %s", e);
 			return 1;
 		} finally {
-			long duration = System.currentTimeMillis() - start;
-			test.addAttribute("duration", (duration + 500) / 1000);
+			long duration = System.nanoTime() - startNanos;
+			test.addAttribute("duration",
+				TimeUnit.NANOSECONDS.toMillis(duration + TimeUnit.MILLISECONDS.toNanos(500L)));
 			getInfo(project, project.toString() + ": ");
 		}
 	}
@@ -3047,7 +3049,7 @@ public class bnd extends Processor {
 	 */
 	@Description("Digests a number of files")
 	public void _digest(hashOptions o) throws NoSuchAlgorithmException, Exception {
-		long start = System.currentTimeMillis();
+		long startNanos = System.nanoTime();
 		long total = 0;
 		List<Alg> algs = o.algorithm();
 		if (algs == null)
@@ -3058,7 +3060,7 @@ public class bnd extends Processor {
 			if (f.isFile()) {
 
 				outer: for (Alg alg : algs) {
-					long now = System.currentTimeMillis();
+					long algNanos = System.nanoTime();
 					byte[] digest;
 
 					switch (alg) {
@@ -3109,7 +3111,7 @@ public class bnd extends Processor {
 					}
 					if (o.process()) {
 						sb.append(del)
-							.append(System.currentTimeMillis() - now)
+							.append(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - algNanos))
 							.append(" ms ")
 							.append(f.length() / 1000)
 							.append(" Kb");
@@ -3121,8 +3123,8 @@ public class bnd extends Processor {
 				error("file does not exist %s", f);
 		}
 		if (o.process()) {
-			long time = (System.currentTimeMillis() - start);
-			float mb = total / 1000000;
+			long time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+			float mb = total / 1000000L;
 			out.format("Total %s Mb, %s ms, %s Mb/sec %s files\n", mb, time, (total / time) / 1024, o._arguments()
 				.size());
 		}

--- a/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
+++ b/biz.aQute.launchpad/src/aQute/launchpad/Launchpad.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -1102,7 +1103,8 @@ public class Launchpad implements AutoCloseable {
 				return t;
 			});
 
-			long deadline = System.currentTimeMillis() + timeout;
+			final long startNanos = System.nanoTime();
+			timeout = TimeUnit.MILLISECONDS.toNanos(timeout);
 
 			while (true) {
 
@@ -1145,7 +1147,8 @@ public class Launchpad implements AutoCloseable {
 					return matchedReferences;
 				}
 
-				if (deadline < System.currentTimeMillis()) {
+				long elapsed = System.nanoTime() - startNanos;
+				if (elapsed > timeout) {
 					String error = "Injection of service " + className;
 					if (target != null)
 						error += " with target " + target;
@@ -1186,7 +1189,7 @@ public class Launchpad implements AutoCloseable {
 						}
 					}
 
-					if (exception && timeout > 1)
+					if (exception && timeout > 1L)
 						throw new TimeoutException(error);
 
 					return Collections.emptyList();

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
@@ -44,7 +44,7 @@ public class P2IndexerTest extends TestCase {
 			client.setCache(IO.getFile(tmp, "cache"));
 
 			try (P2Indexer p2 = new P2Indexer(new Unpack200(), new Slf4jReporter(P2IndexerTest.class), tmp, client,
-				new URI("https://download.eclipse.org/egit/updates-4.7.1/"), getName())) {
+				new URI("https://archive.eclipse.org/egit/updates-4.7.1/"), getName())) {
 				List<String> bsns = p2.list(null);
 				System.out.println(bsns);
 				assertThat(bsns).contains("org.kohsuke.args4j", "org.slf4j.api", "org.apache.httpcomponents.httpclient",

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/JUnitEclipseListener.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -184,7 +185,7 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 
 	private final Connection<DataInputStream, OutputStream>	control;
 	private Connection<Reader, PrintWriter>					client;
-	private long											startTime;
+	private long											startNanos;
 	private TestPlan										testPlan;
 	private final boolean									verbose	= false;
 
@@ -306,12 +307,12 @@ public class JUnitEclipseListener implements TestExecutionListener, Closeable {
 				}
 			}
 		}
-		startTime = System.currentTimeMillis();
+		startNanos = System.nanoTime();
 	}
 
 	@Override
 	public void testPlanExecutionFinished(TestPlan testPlan) {
-		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
+		message("%RUNTIME", Long.toString(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos)));
 		info("JUnitEclipseListener: testPlanExecutionFinished: Waiting .25 seconds");
 		try {
 			Thread.sleep(250L);

--- a/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
@@ -13,6 +13,7 @@ import java.net.SocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.SocketChannel;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Bundle;
 
@@ -22,7 +23,7 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 public class JUnitEclipseReport implements TestReporter {
-	private long							startTime;
+	private long							startNanos;
 	private List<Test>						tests;
 	private final boolean					verbose	= false;
 	private Connection<Reader, PrintWriter>	client;
@@ -97,12 +98,12 @@ public class JUnitEclipseReport implements TestReporter {
 		message("%TESTC  ", Integer.toString(realcount)
 			.concat(" v2"));
 		report(tests);
-		startTime = System.currentTimeMillis();
+		startNanos = System.nanoTime();
 	}
 
 	@Override
 	public void end() {
-		message("%RUNTIME", Long.toString(System.currentTimeMillis() - startTime));
+		message("%RUNTIME", Long.toString(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos)));
 		if (verbose) {
 			System.err.println("Test run ended; waiting .25 seconds");
 		}

--- a/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
+++ b/bndtools.builder/src/org/bndtools/builder/BuildLogger.java
@@ -1,6 +1,7 @@
 package org.bndtools.builder;
 
 import java.util.Formatter;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 
@@ -11,7 +12,7 @@ public class BuildLogger {
 	private final int			level;
 	private final String		name;
 	private final int			kind;
-	private final long			start		= System.currentTimeMillis();
+	private final long			startNanos	= System.nanoTime();
 	private final StringBuilder	sb			= new StringBuilder();
 	private final Formatter		formatter	= new Formatter(sb);
 	private boolean				used		= false;
@@ -65,8 +66,10 @@ public class BuildLogger {
 	}
 
 	public String format() {
-		long end = System.currentTimeMillis();
-		full("Duration %.2f sec", (end - start) / 1000f);
+		long millis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+		long seconds = TimeUnit.MILLISECONDS.toSeconds(millis);
+		long decimal = millis % TimeUnit.SECONDS.toMillis(1L);
+		full("Duration %d.%03d sec", seconds, decimal);
 		String kindString;
 		switch (kind) {
 			case IncrementalProjectBuilder.FULL_BUILD :


### PR DESCRIPTION
We avoid currentTimeMillis as it can change as the system clock is
changed. nanoTime only changes with the advancement of time.