### PR TITLE
[resource] Main-Class attribute not trimmed

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
@@ -4,6 +4,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -39,11 +40,16 @@ class WorkspaceRepositoryDynamic extends BaseRepository implements Repository, W
 	}
 
 	private List<Capability> findProvider(Collection<? extends Resource> resources, Requirement requirement) {
+		List<Capability> l = new ArrayList<>();
 		String namespace = requirement.getNamespace();
-		return resources.stream()
-			.flatMap(resource -> ResourceUtils.capabilityStream(resource, namespace))
-			.filter(ResourceUtils.matcher(requirement))
-			.collect(ResourceUtils.toCapabilities());
+		for (Resource r : resources) {
+			for (Capability c : r.getCapabilities(namespace)) {
+				if (ResourceUtils.matches(requirement, c)) {
+					l.add(c);
+				}
+			}
+		}
+		return l;
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MainClassNamespace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MainClassNamespace.java
@@ -4,6 +4,7 @@ import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 
 import aQute.bnd.osgi.Domain;
+import aQute.lib.strings.Strings;
 
 /**
  * Represents the Manifest Main-Class header.
@@ -27,10 +28,11 @@ public class MainClassNamespace {
 		if (mainClass == null)
 			return;
 
-		mainClass = mainClass.replace('/', '.'); // yeah, it happens!
+		mainClass = Strings.trim(mainClass.replace('/', '.')); // yeah, it
+																// happens!
 
 		mc.addAttribute(MainClassNamespace.MAINCLASS_NAMESPACE, mainClass);
-		String versionString = manifest.getBundleVersion();
+		String versionString = Strings.trim(manifest.getBundleVersion());
 		if ((versionString != null) && aQute.bnd.version.Version.isVersion(versionString)) {
 			Version version = Version.parseVersion(versionString);
 			mc.addAttribute(VERSION_ATTRIBUTE, version);


### PR DESCRIPTION
The Main-Class attribute was not trimmed. This
caused extraneous spaces to be at the end sometimes.

This trims the Main-Class and Bundle-Version now.

Also unrolled a stream loop because the check for
capabilities was 20 levels deep in a stream. This makes it impossible to single step or debug.

Unless there  is a demonstrable _and_ significant speed gain we should stop replacing plain old loops by streaming. Not only because it is hard to debug, it also looses the earlier context when you want to report something. Maybe if Java had true closures and no checked exception it might have been useful.





Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>