### PR TITLE
Remote index for MavenBndRepository

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -946,7 +946,22 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 	}
 
 	public File getIndexFile() {
-		return IO.getFile(base, configuration.index(name.toLowerCase() + ".mvn"));
+		String configIndex = configuration.index(name.toLowerCase() + ".mvn");
+		File indexFile = IO.getFile(base, configIndex);
+		if (indexFile != null && indexFile.exists()) {
+			return indexFile;
+		} else {
+			try {
+				URI uri = URI.create(configIndex);
+				uri = base.toURI()
+					.resolve(uri);
+				return client.build()
+					.get(File.class)
+					.go(uri);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		}
 	}
 
 	public Set<Archive> getArchives() {

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
@@ -262,6 +263,41 @@ public class MavenBndRepoTest {
 		assertNull(file2);
 		file3 = repo.get("group:artifact:jar:1003", Version.parseVersion(multi_version), null);
 		assertNull(file3);
+	}
+
+	@Test
+	public void testLocalUriIndexFile() throws Exception {
+		Map<String, String> config = new HashMap<>();
+		config.put("index", index.toURI()
+			.toString());
+		config(config);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0.0"), null);
+		assertNotNull(file);
+		assertTrue(file.isFile());
+	}
+
+	@Test
+	public void testLocalUriRelativeIndexFile() throws Exception {
+		URI uri = index.toURI();
+		Map<String, String> config = new HashMap<>();
+		config.put("index", IO.work.toURI()
+			.relativize(uri)
+			.toString());
+		config(config);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0.0"), null);
+		assertNotNull(file);
+		assertTrue(file.isFile());
+	}
+
+	@Test
+	public void testRemoteUriIndexFile() throws Exception {
+		Map<String, String> config = new HashMap<>();
+		config.put("index",
+			"https://raw.githubusercontent.com/bndtools/bnd/master/biz.aQute.repository/testresources/mavenrepo/index.maven");
+		config(config);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0.0"), null);
+		assertNotNull(file);
+		assertTrue(file.isFile());
 	}
 
 	@Test


### PR DESCRIPTION
We and independent of us one of our customer came up with the idea of providing the maven repo index remotely, to have a central easy to maintain dependency definition for certain features. By and large this could be accomplished via an index xml or a Bom, but the idea was to have something that is easy to maintain. The index could thus point to a git repository or somewhere in a maven repository.

This PR has 2 commits. The first one simply enables the getIndexFile to handle URIs as well as simple paths. After I implemented this, I realized that the Maven Repo can handle uploads as well and would update the index file accordingly. Thus this should work with a remote file as well, even if this is better suited to a read only repo. But as usual someone will eventually come along and expect it to work...
Thus, this is implemented in the second commit. I hope I covered everything, but I would really need somebody to review this.