### PR TITLE
[quickfix] Configurable version handling

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -553,9 +553,9 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			private final Pattern p;
 
 			public MatchDisplayString(String bundle, String version, String fqName, boolean test) {
-				super(String.format("Suggestion to add '%s %s' to -%spath for class %s", bundle, version,
+				super(String.format("Suggestion to add '%s' to -%spath for class %s", bundle,
 					test ? "test" : "build", fqName));
-				String re = String.format("^Add \\Q%s\\E \\Q%s\\E to -\\Q%s\\Epath [(]found \\Q%s\\E[)]", bundle, version,
+				String re = String.format("^Add \\Q%s\\E to -\\Q%s\\Epath [(]found \\Q%s\\E[)]", bundle,
 					test ? "test" : "build", fqName);
 				p = Pattern.compile(re);
 			}
@@ -572,9 +572,8 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 
 	protected void assertThatContainsFrameworkBundles(IJavaCompletionProposal[] proposals, String fqName) {
 		assertThatProposals(proposals).withRepresentation(PROPOSAL)
-			.hasSize(2)
-			.haveExactly(1, suggestsBundle("org.osgi.framework", "1.8.0", fqName))
-			.haveExactly(1, suggestsBundle("org.osgi.framework", "1.9.0", fqName));
+			.hasSize(1)
+			.haveExactly(1, suggestsBundle("org.osgi.framework", "1.8.0", fqName));
 	}
 
 	protected static Condition<IJavaCompletionProposal> suggestsBundle(String bundle, String version, String fqName) {

--- a/bndtools.core/src/bndtools/preferences/BndPreferences.java
+++ b/bndtools.core/src/bndtools/preferences/BndPreferences.java
@@ -64,6 +64,7 @@ public class BndPreferences {
 			"https://raw.githubusercontent.com/bndtools/bundle-hub/master/index.xml.gz");
 		store.setDefault(PREF_WORKSPACE_OFFLINE, false);
 		store.setDefault(PREF_USE_ALIAS_REQUIREMENTS, true);
+		store.setDefault(QuickFixVersioning.PREFERENCE_KEY, QuickFixVersioning.DEFAULT.toString());
 		store.setDefault(PREF_EXPLORER_PROMPT, "");
 	}
 
@@ -349,6 +350,17 @@ public class BndPreferences {
 
 	public void setBuildBeforeLaunch(boolean b) {
 		store.setValue(PREF_BUILDBEFORELAUNCH, b);
+	}
+
+	public QuickFixVersioning getQuickFixVersioning() {
+		return QuickFixVersioning.parse(store.getString(QuickFixVersioning.PREFERENCE_KEY));
+	}
+
+	public void setQuickFixVersioning(QuickFixVersioning qfv) {
+		if (qfv == null) {
+			qfv = QuickFixVersioning.DEFAULT;
+		}
+		store.setValue(QuickFixVersioning.PREFERENCE_KEY, qfv.toString());
 	}
 
 	public boolean isWorkspaceOffline() {

--- a/bndtools.core/src/bndtools/preferences/QuickFixVersioning.java
+++ b/bndtools.core/src/bndtools/preferences/QuickFixVersioning.java
@@ -1,0 +1,19 @@
+package bndtools.preferences;
+
+public enum QuickFixVersioning {
+
+	noversion,
+	latest;
+
+	public static final String				PREFERENCE_KEY	= "quickfixVersioning";
+	public static final QuickFixVersioning	DEFAULT			= noversion;
+
+	public static QuickFixVersioning parse(String string) {
+		try {
+			return valueOf(string);
+		} catch (Exception e) {
+			return DEFAULT;
+		}
+	}
+
+}

--- a/bndtools.core/src/bndtools/preferences/ui/BndPreferencePage.java
+++ b/bndtools.core/src/bndtools/preferences/ui/BndPreferencePage.java
@@ -18,6 +18,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import bndtools.preferences.BndPreferences;
+import bndtools.preferences.QuickFixVersioning;
 
 public class BndPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
 	public BndPreferencePage() {}
@@ -29,6 +30,7 @@ public class BndPreferencePage extends PreferencePage implements IWorkbenchPrefe
 	private boolean					buildBeforeLaunch	= true;
 	private boolean					editorOpenSourceTab	= false;
 	private boolean					workspaceIsOffline	= false;
+	private QuickFixVersioning		quickfixVersioning	= QuickFixVersioning.DEFAULT;
 	private final BndPreferences	prefs				= new BndPreferences();
 
 	private Text					prompt;
@@ -118,6 +120,41 @@ public class BndPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		// headless already done
 		// versionControlIgnores already done
 
+		Group quickfixVersioningGroup = new Group(composite, SWT.NONE);
+		quickfixVersioningGroup.setLayout(new GridLayout(1, false));
+		quickfixVersioningGroup.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		quickfixVersioningGroup.setText(Messages.BndPreferencePage_quickfixVersioningGroup);
+
+		final Button btnNoVersion = new Button(quickfixVersioningGroup, SWT.RADIO);
+		btnNoVersion.setText(Messages.BndPreferencePage_quickfixVersioning_btnNoVersion);
+		btnNoVersion.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				quickfixVersioning = QuickFixVersioning.noversion;
+			}
+		});
+		btnNoVersion.setToolTipText(Messages.BndPreferencePage_quickfixVersioning_btnNoVersion_tt);
+
+		final Button btnLatest = new Button(quickfixVersioningGroup, SWT.RADIO);
+		btnLatest.setText(Messages.BndPreferencePage_quickfixVersioning_btnLatest);
+		btnLatest.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				quickfixVersioning = QuickFixVersioning.latest;
+			}
+		});
+		btnLatest.setToolTipText(Messages.BndPreferencePage_quickfixVersioning_btnLatest_tt);
+
+		// Set initial values
+		switch (quickfixVersioning) {
+			case noversion :
+				btnNoVersion.setSelection(true);
+				break;
+			case latest :
+				btnLatest.setSelection(true);
+				break;
+		}
+
 		layout = new GridLayout(1, false);
 		composite.setLayout(layout);
 
@@ -129,6 +166,7 @@ public class BndPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		layout = new GridLayout(1, false);
 		layout.verticalSpacing = 10;
 		editorGroup.setLayout(layout);
+		layout = new GridLayout(1, false);
 
 		return composite;
 	}
@@ -140,6 +178,7 @@ public class BndPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		prefs.setBuildBeforeLaunch(buildBeforeLaunch);
 		prefs.setEditorOpenSourceTab(editorOpenSourceTab);
 		prefs.setWorkspaceOffline(workspaceIsOffline);
+		prefs.setQuickFixVersioning(quickfixVersioning);
 		prefs.setPrompt(prompt.getText());
 		return true;
 	}
@@ -151,6 +190,7 @@ public class BndPreferencePage extends PreferencePage implements IWorkbenchPrefe
 		buildBeforeLaunch = prefs.getBuildBeforeLaunch();
 		editorOpenSourceTab = prefs.getEditorOpenSourceTab();
 		workspaceIsOffline = prefs.isWorkspaceOffline();
+		quickfixVersioning = prefs.getQuickFixVersioning();
 	}
 
 }

--- a/bndtools.core/src/bndtools/preferences/ui/Messages.java
+++ b/bndtools.core/src/bndtools/preferences/ui/Messages.java
@@ -31,6 +31,11 @@ public class Messages extends NLS {
 	public static String		BndPreferencePage_namedPluginDeprecated_text;
 	public static String		BndPreferencePage_btnOfflineWorkspace;
 	public static String		BndPreferencePage_decorOfflineWorkspace;
+	public static String		BndPreferencePage_quickfixVersioningGroup;
+	public static String		BndPreferencePage_quickfixVersioning_btnNoVersion;
+	public static String		BndPreferencePage_quickfixVersioning_btnNoVersion_tt;
+	public static String		BndPreferencePage_quickfixVersioning_btnLatest;
+	public static String		BndPreferencePage_quickfixVersioning_btnLatest_tt;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bndtools.core/src/bndtools/preferences/ui/messages.properties
+++ b/bndtools.core/src/bndtools/preferences/ui/messages.properties
@@ -27,3 +27,8 @@ BndPreferencePage_msgCheckValidVersionControlIgnores=At least one version contro
 BndPreferencePage_namedPluginDeprecated_text=\ (deprecated)
 BndPreferencePage_btnOfflineWorkspace=Use Bnd OSGi Workspace in offline mode
 BndPreferencePage_decorOfflineWorkspace=While offline, a Bnd OSGi Workspace will not use the network to download remote artifacts
+BndPreferencePage_quickfixVersioningGroup=QuickFix versioning policy
+BndPreferencePage_quickfixVersioning_btnNoVersion=Don't add version attribute
+BndPreferencePage_quickfixVersioning_btnNoVersion_tt=When the quick fix processor adds a bundle to the build/test path, it will not add a version attribute (Bndtools will use the lowest version in your workspace). This is usually the recommended setting.
+BndPreferencePage_quickfixVersioning_btnLatest=Add "version=latest"
+BndPreferencePage_quickfixVersioning_btnLatest_tt=When the quick fix processor adds a bundle to the build/test path, it will add the attribute "version=latest" (Bndtools will use the highest version in your workspace).


### PR DESCRIPTION
Includes the following changes to quickfix handling:
* BSNs are only listed once even if multiple versions are available
* There is a new Bndtools preference that specifies the version handling policy:
** No version attribute (lowest version)
** "version=latest" (latest version)
* `AddBundleCompletionProposal` will add the appropriate version attribute (or omit
  it entirely) according to the setting of that preference.

Fixes #4410.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>