### PR TITLE
Some minor fixes

### DIFF
--- a/biz.aQute.bndlib.tests/build.gradle
+++ b/biz.aQute.bndlib.tests/build.gradle
@@ -6,6 +6,4 @@ tasks.named('test') {
   // set heap size for the test JVM(s)
   minHeapSize = "1024m"
   maxHeapSize = "2048m"
-  // Some test's depend upon `-dependson` which are `jar` task dependencies.
-  inputs.files tasks.named('jar')
 }

--- a/bndtools.core.test/build.gradle
+++ b/bndtools.core.test/build.gradle
@@ -18,7 +18,4 @@ tasks.named('testOSGi') {
     enabled false
     println 'Tests will not run unless on Windows, Mac or Unix'
   }
-  // These tests are currently flaky and often fail.
-  // https://github.com/bndtools/bnd/issues/4253
-  ignoreFailures = true
 }


### PR DESCRIPTION
Slight refactoring of the gradle task registration code for the bndrun-based tasks.

With the Bnd Gradle plugin change to include -dependson dependencies for the test task, we remove an explicit dependency on the jar task which was made for the same purpose.

Since we don't run the `:bndtools.core.test:testOSGi` task in the CI build, I removed the support for ignoring failures which did not really work as expected for the specific failure issues in the test execution.