### PR TITLE
fixed plugin refresh on workspace load

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -417,7 +417,10 @@ public class Workspace extends Processor {
 				}
 			}
 		}
-
+		// getPlugins may have been called during the load of the properties.
+		// E.g. there is an include of a http url. So we have to clear the
+		// plugins to be sure
+		clearPlugins();
 		super.propertiesChanged();
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -966,13 +966,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		for (Closeable c : toBeClosed) {
 			IO.close(c);
 		}
-		synchronized (this) {
-			plugins = null;
-		}
-		if (pluginLoader != null) {
-			IO.close(pluginLoader);
-			pluginLoader = null;
-		}
+		clearPlugins();
 
 		toBeClosed.clear();
 	}
@@ -1249,13 +1243,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	public boolean refresh() {
-		synchronized (this) {
-			plugins = null; // We always refresh our plugins
-		}
-		if (pluginLoader != null) {
-			IO.close(pluginLoader);
-			pluginLoader = null;
-		}
+		clearPlugins();
 
 		if (propertiesFile == null)
 			return false;
@@ -1272,6 +1260,16 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			return true;
 		}
 		return false;
+	}
+
+	protected void clearPlugins() {
+		synchronized (this) {
+			plugins = null; // We always refresh our plugins
+		}
+		if (pluginLoader != null) {
+			IO.close(pluginLoader);
+			pluginLoader = null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
I stumbled upon this issue as I had  `-include` with a http source in one of my cnf/ext files. The moment the include happened, we internally used `getPlugin(HttpClient.class)`. This initialized the plugins with the properties that has been read up to this point. After all ext files have been loaded, the plugin definitions that came after this would not have been recognized. 

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>