### PR TITLE
Clear plugins on properties changed

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Formatter;
@@ -404,6 +405,7 @@ public class Workspace extends Processor {
 		File extDir = new File(getBuildDir(), EXT);
 		File[] extensions = extDir.listFiles();
 		if (extensions != null) {
+			Arrays.sort(extensions); // alphabetical order
 			for (File extension : extensions) {
 				String extensionName = extension.getName();
 				if (extensionName.endsWith(".bnd")) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -335,7 +335,6 @@ public class Workspace extends Processor {
 			IO.store("", buildFile);
 		}
 		setProperties(buildFile, workspaceDir);
-		propertiesChanged();
 
 		//
 		// There is a nasty bug/feature in Java that gives errors on our

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -966,6 +966,13 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		for (Closeable c : toBeClosed) {
 			IO.close(c);
 		}
+
+		clearPlugins();
+
+		toBeClosed.clear();
+	}
+
+	private void clearPlugins() {
 		synchronized (this) {
 			plugins = null;
 		}
@@ -973,8 +980,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			IO.close(pluginLoader);
 			pluginLoader = null;
 		}
-
-		toBeClosed.clear();
 	}
 
 	public String _basedir(@SuppressWarnings("unused") String args[]) {
@@ -1249,13 +1254,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	public boolean refresh() {
-		synchronized (this) {
-			plugins = null; // We always refresh our plugins
-		}
-		if (pluginLoader != null) {
-			IO.close(pluginLoader);
-			pluginLoader = null;
-		}
+		clearPlugins(); // We always refresh our plugins
 
 		if (propertiesFile == null)
 			return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1094,15 +1094,15 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	public void setProperties(Properties properties) {
-		doIncludes(getBase(), properties);
-		getProperties0().putAll(properties);
-		mergeProperties(Constants.INIT); // execute macros in -init
-		getProperties0().remove(Constants.INIT);
+		setProperties(getBase(), properties);
 	}
 
 	public void setProperties(File base, Properties properties) {
 		doIncludes(base, properties);
 		getProperties0().putAll(properties);
+		mergeProperties(Constants.INIT); // execute macros in -init
+		getProperties0().remove(Constants.INIT);
+		propertiesChanged();
 	}
 
 	public void addProperties(File file) throws Exception {
@@ -1291,7 +1291,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		properties = (p != null) ? new UTF8Properties(p.getProperties0()) : new UTF8Properties();
 
 		setProperties(propertiesFile, base);
-		propertiesChanged();
 	}
 
 	public void propertiesChanged() {
@@ -1299,6 +1298,8 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (p != null) {
 			updateModified(p.lastModified(), "propertiesChanged");
 		}
+
+		clearPlugins(); // force plugins to reload since properties have changed
 	}
 
 	/**

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ subprojects {
     }
     tasks.named('test') {
       useJUnitPlatform()
+      reports {
+        junitXml {
+          outputPerTestCase = true
+          mergeReruns = true
+        }
+      }
       testLogging {
         exceptionFormat 'full'
       }


### PR DESCRIPTION
@juergen-albert:

> I stumbled upon this issue as I had -include with a http source in one of my cnf/ext files. The moment the include happened, we internally used getPlugin(HttpClient.class). This initialized the plugins with the properties that has been read up to this point. After all ext files have been loaded, the plugin definitions that came after this would not have been recognized.

Closes #4499 

We also fix the workspace to load the `cnf/ext/*.bnd` files in sorted order rather than however they are presented by the file system.