### PR TITLE
tester: Use standard location for test reports

### DIFF
--- a/biz.aQute.tester.test/.gitignore
+++ b/biz.aQute.tester.test/.gitignore
@@ -1,4 +1,3 @@
 /bin/
 /bin_test/
 /generated/
-/testdir/

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
@@ -358,13 +358,14 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorCommonTest {
 		}
 
 		@BeforeEach
-		public void setUp(TestInfo info) {
+		public void setUp(TestInfo info) throws Exception {
 			this.info = info;
 			builder = new LaunchpadBuilder();
 			builder.bndrun(tester + ".bndrun")
 				.excludeExport("aQute.tester.bundle.*")
 				.excludeExport("org.junit*")
 				.excludeExport("junit.*");
+			setResultsDir();
 			if (DEBUG) {
 				builder.debug()
 					.set(TESTER_TRACE, "true");
@@ -511,7 +512,7 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorCommonTest {
 				.excludeExport("org.junit*")
 				.excludeExport("junit*");
 			this.builder = builder;
-			setTmpDir();
+			setResultsDir();
 			TestRunData result = runTestsEclipse(JUnit5AbortTest.class, JUnit4AbortTest.class);
 			assertThat(result).hasErroredTest("Initialization Error",
 				new JUnitException("Couldn't find any registered TestEngines"));
@@ -553,7 +554,7 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorCommonTest {
 				.excludeExport("org.junit*")
 				.excludeExport("junit*");
 			this.builder = builder;
-			setTmpDir();
+			setResultsDir();
 			Class<?>[] tests = {
 				JUnit3ComparisonTest.class, JUnit5Test.class, JUnit5SimpleComparisonTest.class
 			};
@@ -622,7 +623,8 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorCommonTest {
 		final ExitCode exitCode = runTests(JUnit3Test.class, With1Error1Failure.class, With2Failures.class);
 
 		final String fileName = "TEST-" + testBundle.getSymbolicName() + "-" + testBundle.getVersion() + ".xml";
-		File xmlFile = new File(getTmpDir(), fileName);
+		File xmlFile = getResultsDir().resolve(fileName)
+			.toFile();
 		Assertions.assertThat(xmlFile)
 			.as("xmlFile")
 			.exists();

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/GogoShellTests.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/GogoShellTests.java
@@ -67,6 +67,7 @@ public class GogoShellTests extends AbstractActivatorTest {
 			.excludeExport("aQute.tester.bundle.*")
 			.excludeExport("org.junit*")
 			.excludeExport("junit.*");
+		setResultsDir();
 		if (DEBUG) {
 			builder.debug()
 				.set(TESTER_TRACE, "true");

--- a/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
@@ -128,7 +128,8 @@ public class ActivatorTest extends AbstractActivatorCommonTest {
 		final ExitCode exitCode = runTests(JUnit3Test.class, With1Error1Failure.class, With2Failures.class);
 
 		final String fileName = "TEST-" + testBundle.getSymbolicName() + "-" + testBundle.getVersion() + ".xml";
-		File xmlFile = new File(getTmpDir(), fileName);
+		File xmlFile = getResultsDir().resolve(fileName)
+			.toFile();
 		Assertions.assertThat(xmlFile)
 			.as("xmlFile")
 			.exists();

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorCommonTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorCommonTest.java
@@ -6,7 +6,6 @@ import static aQute.junit.constants.TesterConstants.TESTER_SEPARATETHREAD;
 import static aQute.junit.constants.TesterConstants.TESTER_TRACE;
 
 import java.lang.reflect.Method;
-import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -191,17 +190,13 @@ public abstract class AbstractActivatorCommonTest extends AbstractActivatorTest 
 		Method testMethod = info.getTestMethod()
 			.get();
 		name = getClass().getName() + "/" + testMethod.getName();
-		tmpDir = Paths.get("generated/tmp/test", name)
-			.toAbsolutePath();
-		IO.delete(tmpDir);
-		IO.mkdirs(tmpDir);
 
 		builder = new LaunchpadBuilder();
 		builder.bndrun(tester + ".bndrun")
 			.excludeExport("aQute.tester.bundle.*")
 			.excludeExport("org.junit*")
 			.excludeExport("junit.*");
-		setTmpDir();
+		setResultsDir();
 		if (DEBUG) {
 			builder.debug()
 				.set(TESTER_TRACE, "true");

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorTest.java
@@ -4,11 +4,11 @@ import static aQute.junit.constants.TesterConstants.TESTER_DIR;
 import static aQute.junit.constants.TesterConstants.TESTER_PORT;
 import static aQute.junit.constants.TesterConstants.TESTER_TRACE;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Permission;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -63,7 +63,8 @@ public class AbstractActivatorTest implements StandardSoftAssertionsProvider {
 
 	protected Launchpad			lp;
 	protected SecurityManager	oldManager;
-	protected Path				tmpDir;
+	private final Path			resultsDir	= Paths.get("generated", "test-reports", "test")
+		.toAbsolutePath();
 	protected int				eclipseJUnitPort;
 	protected TestInfo			info;
 
@@ -81,14 +82,14 @@ public class AbstractActivatorTest implements StandardSoftAssertionsProvider {
 	protected String	name;
 	protected Bundle	testBundle;
 
-	protected File getTmpDir() {
-		return tmpDir.toFile();
+	protected Path getResultsDir() {
+		return resultsDir;
 	}
 
-	protected LaunchpadBuilder setTmpDir() throws IOException {
-		// Create tmp dir for test reports to go into as the default is in the
+	protected LaunchpadBuilder setResultsDir() throws IOException {
+		// Sets report dir for test reports to go into as the default is in the
 		// project root, which can mess up build dependencies.
-		return builder.set(TESTER_DIR, getTmpDir().getAbsolutePath());
+		return builder.set(TESTER_DIR, getResultsDir().toString());
 	}
 
 	protected BundleSpecBuilder bundle() {

--- a/biz.aQute.tester/src/aQute/junit/constants/TesterConstants.java
+++ b/biz.aQute.tester/src/aQute/junit/constants/TesterConstants.java
@@ -32,7 +32,7 @@ public interface TesterConstants {
 
 	/**
 	 * A directory to put the test reports. If the directory does not exist, no
-	 * reports are generated. The default is tester-dir.
+	 * reports are generated. The default is {@code testdir}.
 	 */
 	String	TESTER_DIR				= "tester.dir";
 


### PR DESCRIPTION
We also fix javadoc for TESTER_DIR to state the correct default.

