### PR TITLE
[quickfix] Test to wait for build to complete before running proposals

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -43,6 +43,7 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -382,6 +383,12 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			problem = null;
 			locs = null;
 			this.source = source;
+			// Wait for build to finish
+			Job.getJobManager()
+				.join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
+			Job.getJobManager()
+				.join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+
 			// First create our AST
 			ICompilationUnit icu = pack.createCompilationUnit(className + ".java", source, true, null);
 
@@ -408,17 +415,13 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			// System.err.println("Unfiltered problems: ");
 			// dumpProblems(Stream.of(cu.getProblems()));
 			// When you hover in the GUI, if there are multiple overlapping
-			// problems
-			// at the point where you are hovering, only one of them is fetched
-			// and
-			// passed in to the quick fix processors to calculate proposals.
-			// To emulate this, we filter the problems that contain the hover
-			// region,
-			// and then we find the smallest such problem. This seems to be what
-			// Eclipse does, but also finding the smallest means that we can
-			// directly
-			// test the other problems if we want by specifying a hover point
-			// somewhere else in the bigger region.
+			// problems at the point where you are hovering, only one of them is
+			// fetched and passed in to the quick fix processors to calculate
+			// proposals. To emulate this, we filter the problems that contain
+			// the hover region, and then we find the smallest such problem.
+			// This seems to be what Eclipse does, but also finding the smallest
+			// means that we can directly test the other problems if we want by
+			// specifying a hover point somewhere else in the bigger region.
 			problem = Stream.of(cu.getProblems())
 				// Find problems that contain the "hover point"
 				.filter(problem -> (problem.getSourceEnd() >= offset && problem.getSourceStart() <= (offset + length)))

--- a/bndtools.core.test/src/bndtools/core/test/utils/WorkbenchExtension.java
+++ b/bndtools.core.test/src/bndtools/core/test/utils/WorkbenchExtension.java
@@ -47,17 +47,12 @@ public class WorkbenchExtension implements BeforeAllCallback {
 			.getBundleContext();
 
 		// The bndtools.core plugin must be initialized on the UI thread or else
-		// it will
-		// cause an NPE. Because BundleEngine/Jupiter will probably not be
-		// running on
-		// the main thread, we cannot rely on the automatic OSGi class loading
-		// to
-		// load the bundle the first time that the class is accessed, as then
-		// the bundle
-		// will be started by the tester thread and we'll get the NPE. So we
-		// check if
-		// it's already running, and if not then we manually start it on the UI
-		// thread.
+		// it will cause an NPE. Because BundleEngine/Jupiter will probably not
+		// be running on the main thread, we cannot rely on the automatic OSGi
+		// class loading to load the bundle the first time that the class is
+		// accessed, as then the bundle will be started by the tester thread and
+		// we'll get the NPE. So we check if it's already running, and if not
+		// then we manually start it on the UI thread.
 
 		// Make sure bndtools.core is started, if not we start it on the UI
 		// thread
@@ -129,8 +124,7 @@ public class WorkbenchExtension implements BeforeAllCallback {
 		log("done waiting for import to complete");
 
 		// Wait for Central to be initialized before continuing; hopefully by
-		// now it's
-		// ready anyway
+		// now it's ready anyway
 		Central central = Central.getInstance();
 		while (central == null) {
 			Thread.sleep(100);


### PR DESCRIPTION
@bjhargrave  reported that simpleReference_toWorkspaceClass_suggestsBundles() was failing intermittently. I was able to reproduce in my workspace. Doing a clean before building seemed to make it pass.

When I tried it in my own workspace I had the same problem both in Gradle and through Bndtools. It would fail very consistently. When I tried to hook up the debugger and set a breakpoint on the test in question, it would pass consistently even with no other code changes.

I suspected a race condition: `local-proj` was not finished building/being indexed before the code was run. Added a wait in `proposalsFor()` (just before building the AST that generates the `IProblem` markers) to make sure that building was finished (so that the indexing would be finished) before running the test. This seems to have stabilised it in my testing.