### PR TITLE
workspace: Process cnf/ext/*.bnd files in sorted case-sensitive order

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -15,6 +15,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -405,7 +406,10 @@ public class Workspace extends Processor {
 		File extDir = new File(getBuildDir(), EXT);
 		File[] extensions = extDir.listFiles();
 		if (extensions != null) {
-			Arrays.sort(extensions); // alphabetical order
+			Collator collator = Collator.getInstance(Locale.ROOT);
+			collator.setDecomposition(Collator.CANONICAL_DECOMPOSITION);
+			collator.setStrength(Collator.IDENTICAL); // case-sensitive order
+			Arrays.sort(extensions, (e1, e2) -> collator.compare(e1.getName(), e2.getName()));
 			for (File extension : extensions) {
 				String extensionName = extension.getName();
 				if (extensionName.endsWith(".bnd")) {


### PR DESCRIPTION
The documentation indicates the files are to be processed in
alphabetical order. However, File.compareTo uses a system dependent
ordering. On Windows, it is case-insensitive. On most Linux file systems
it would be case-sensitive. For consistency across all platforms, we
provide our own case-sensitive comparator to sort the file names. We
don't use case-insensitive since we could still get different orderings
based upon the order a case-sensitive file system returned case-variant
file names since the sort algorithm is stable.
