### PR TITLE
Fixes to digest algorithms

### DIFF
--- a/aQute.libg/src/aQute/lib/json/Decoder.java
+++ b/aQute.libg/src/aQute/lib/json/Decoder.java
@@ -83,7 +83,7 @@ public class Decoder implements Closeable {
 
 	public Decoder mark() throws NoSuchAlgorithmException {
 		if (digest == null)
-			digest = MessageDigest.getInstance("SHA1");
+			digest = MessageDigest.getInstance("SHA-1");
 		digest.reset();
 		return this;
 	}

--- a/aQute.libg/src/aQute/lib/json/Encoder.java
+++ b/aQute.libg/src/aQute/lib/json/Encoder.java
@@ -48,7 +48,7 @@ public class Encoder implements Appendable, Closeable, Flushable {
 
 	public Encoder mark() throws NoSuchAlgorithmException {
 		if (digest == null)
-			digest = MessageDigest.getInstance("SHA1");
+			digest = MessageDigest.getInstance("SHA-1");
 		digest.reset();
 		return this;
 	}

--- a/aQute.libg/src/aQute/libg/cafs/CAFS.java
+++ b/aQute.libg/src/aQute/libg/cafs/CAFS.java
@@ -191,7 +191,7 @@ public class CAFS implements Closeable, Iterable<SHA1> {
 			SHA1 rsha1 = new SHA1(readSha1);
 
 			if (!sha1.equals(rsha1))
-				throw new IOException("SHA1 read and asked mismatch: " + sha1 + " " + rsha1);
+				throw new IOException("SHA-1 read and asked mismatch: " + sha1 + " " + rsha1);
 
 			short crc = store.readShort(); // Read CRC
 			if (crc != checksum(flags, compressedLength, uncompressedLength, readSha1))
@@ -321,7 +321,7 @@ public class CAFS implements Closeable, Iterable<SHA1> {
 				SHA1 calculatedSha1 = new SHA1(digestx.digest());
 				if (!sha1.equals(calculatedSha1))
 					throw (new IOException(
-						"SHA1 caclulated and asked mismatch, asked: " + sha1 + ", \nfound: " + calculatedSha1));
+						"SHA-1 caclulated and asked mismatch, asked: " + sha1 + ", \nfound: " + calculatedSha1));
 			}
 
 			@Override

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -971,6 +971,8 @@ public class AlsoLauncherTest {
 	public void testOlderLauncherOnRunpath() throws Exception {
 		try (Run run = new Run(project.getWorkspace(), project.getFile("old-launcher.bndrun"))) {
 			run.setProperty(Constants.RUNTRACE, "true");
+			// old launcher has a bug which tries to use invalid "MD-5" digest
+			run.setProperty(Constants.DIGESTS, "SHA-1");
 
 			File file = new File(testDir, "packaged.jar");
 			try (Jar pack = run.pack(null)) {

--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -926,7 +926,7 @@ public class BuilderTest {
 			Attributes attrs = manifest.getAttributes("org/osgi/framework/BundleActivator.class");
 			assertNotNull(attrs);
 			assertEquals("RTRhr3kadnulINegRhpmog==", attrs.getValue("MD5-Digest"));
-			assertEquals("BfVfpnE3Srx/0UWwtzNecrAGf8A=", attrs.getValue("SHA-Digest"));
+			assertEquals("BfVfpnE3Srx/0UWwtzNecrAGf8A=", attrs.getValue("SHA1-Digest"));
 			other.close();
 		} finally {
 			b.close();

--- a/biz.aQute.bndlib.tests/test/test/JarSignerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/JarSignerTest.java
@@ -71,7 +71,7 @@ public class JarSignerTest extends TestCase {
 		properties.put("keypass", "testtest");
 		properties.put("storepass", "testtest");
 		properties.put("sigFile", "test");
-		properties.put("digestalg", "SHA1");
+		properties.put("digestalg", "SHA-1");
 		signer.setProperties(properties);
 
 		Jar jar = new Jar(IO.getFile("testresources/test.jar"));
@@ -97,7 +97,7 @@ public class JarSignerTest extends TestCase {
 
 			Attributes a = m.getAttributes("aQute/rendezvous/DNS.class");
 			assertNotNull(a);
-			assertEquals("G0/1CIZlB4eIVyY8tU/ZfMCqZm4=", a.getValue("SHA1-Digest"));
+			assertEquals("G0/1CIZlB4eIVyY8tU/ZfMCqZm4=", a.getValue("SHA-1-Digest"));
 
 			// Check if all resources are named
 			for (String name : names) {

--- a/biz.aQute.bndlib.tests/test/test/ManifestTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ManifestTest.java
@@ -27,6 +27,7 @@ public class ManifestTest extends TestCase {
 		Builder b = new Builder();
 		b.setProperty("Export-Package", "org.osgi.framework");
 		b.addClasspath(IO.getFile("jar/osgi.jar"));
+		b.setProperty("-digests", "SHA-1");
 
 		Jar jar = b.build();
 		jar.calcChecksums(null);
@@ -58,7 +59,7 @@ public class ManifestTest extends TestCase {
 
 		Attributes sl = m.getAttributes("org/osgi/framework/ServiceListener.class");
 		assertNotNull(sl);
-		assertEquals("nzDRN19MrTJG+LP8ayKZITZ653g=", sl.getValue("SHA-Digest"));
+		assertEquals("nzDRN19MrTJG+LP8ayKZITZ653g=", sl.getValue("SHA-1-Digest"));
 
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -637,7 +637,7 @@ public class Jar implements Closeable {
 			write(f);
 			try (Jar tmp = new Jar(f)) {
 				tmp.setCompression(compression);
-				tmp.calcChecksums(algorithms);
+				tmp.calcChecksums(algs);
 				tmp.write(out);
 			} finally {
 				IO.delete(f);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -1072,7 +1072,7 @@ public class Jar implements Closeable {
 		check();
 		if (algorithms == null)
 			algorithms = new String[] {
-				"SHA", "MD5"
+				"SHA1", "MD5"
 			};
 
 		Manifest m = getManifest();

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -33,6 +33,7 @@ import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectLauncher;
 import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.help.instructions.LauncherInstructions.Executable;
 import aQute.bnd.help.instructions.LauncherInstructions.RunOption;
@@ -400,14 +401,11 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		String embeddedLauncherName = main.getValue(MAIN_CLASS);
 		logger.debug("Use '{}' launcher class", embeddedLauncherName);
 		doStart(jar, embeddedLauncherName);
-		if (getProject().getProperty(Constants.DIGESTS) != null)
-			jar.setDigestAlgorithms(getProject().getProperty(Constants.DIGESTS)
-				.trim()
-				.split("\\s*,\\s*"));
-		else
-			jar.setDigestAlgorithms(new String[] {
-				"SHA-1", "MD-5"
-			});
+		Parameters digests = OSGiHeader.parseHeader(getProject().getProperty(DIGESTS));
+		if (!digests.isEmpty()) {
+			jar.setDigestAlgorithms(digests.keySet()
+				.toArray(new String[0]));
+		}
 		jar.setManifest(m);
 
 		String moduleInstruction = getProject().getProperty(Constants.JPMS_MODULE_INFO);


### PR DESCRIPTION
The big fix here is that the `-digests` instruction's value is now actually used. Previously the value of the `-digests` instruction was ignored but using the instruction caused the default digest algorithms to be used.

There was also a bug in `ProjectLauncherImpl.executable()` which used the invalid "MD-5" digest algorithm name when `-digests` was not set. The bug above which ignored set digest values meant the invalid "MD-5" digest algorithm name was silently ignored. With the above bug fixed, using an older launcher with a newer bndlib will result in an `java.security.NoSuchAlgorithmException: MD-5 MessageDigest not available` exception unless `-digests` is set to a valid value.