### PR TITLE
Create a lazy DirectoryProperty for TestOSGi results directory.

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -447,6 +447,10 @@ multiple times to specify multiple test classes to run.
 
 Use a colon (`:`) to specify a test method to run on the specified test class.
 
+### resultsDirectory
+
+The directory for the test results. The default is _${project.buildDir}/${project.testResultsDirName}/${task.name}_.
+
 ## Create a task of the `Index` type
 
 The `Index` task type

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestTestOSGiTask.groovy
@@ -204,7 +204,7 @@ class TestTestOSGiTask extends Specification {
 
         when:
           String taskname = 'testosgiIgnoreFail'
-          File testxml = new File(testProjectBuildDir, "test-results/${taskname}/TEST-${testProject}-1.0.0.xml")
+          File testxml = new File(testProjectBuildDir, "testing-results/${taskname}/TEST-${testProject}-1.0.0.xml")
           assert testxml.isFile()
           def testsuite = new XmlSlurper().parse(testxml)
         then:
@@ -218,7 +218,7 @@ class TestTestOSGiTask extends Specification {
 
         when:
           taskname = 'testosgiFail'
-          testxml = new File(testProjectBuildDir, "test-results/${taskname}/TEST-${testProject}-1.0.0.xml")
+          testxml = new File(testProjectBuildDir, "${taskname}-results/TEST-${testProject}-1.0.0.xml")
           assert testxml.isFile()
           testsuite = new XmlSlurper().parse(testxml)
         then:

--- a/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask4/build.gradle
@@ -9,6 +9,7 @@ plugins {
 }
 
 version = '1.0.0'
+testResultsDirName = 'testing-results'
 
 repositories {
     mavenLocal().metadataSources { mavenPom(); artifact() }
@@ -34,6 +35,7 @@ task testosgiFail(type: TestOSGi) {
    inputs.files jar
    bndrun "${name}.bndrun"
    ignoreFailures = false
+   resultsDirectory = file("${buildDir}/${name}-results")
 }
 
 check {


### PR DESCRIPTION
We have a use-case for being able to rename the `TestOSGi` task's test result directory, if necessary. So update the task to use Gradle's modern `DirectoryProperty` API.