### PR TITLE
Fixes possible NPE, if e.g. the check reaches java.lang.Object

### DIFF
--- a/bndtools.core/src/bndtools/launch/JUnitShortcut.java
+++ b/bndtools.core/src/bndtools/launch/JUnitShortcut.java
@@ -228,16 +228,19 @@ public class JUnitShortcut extends AbstractLaunchShortcut {
 		for (IMethod m : z.getMethods()) {
 			if (Flags.isPublic(m.getFlags())) {
 				for (IAnnotation annotation : m.getAnnotations()) {
-					String[][] names = m.getDeclaringType()
-						.resolveType(annotation.getElementName());
-					for (String[] pair : names) {
-						if (pair[0].contains("org.junit"))
-							return true;
+					IType declaringType = m.getDeclaringType();
+					if (declaringType != null) {
+						String[][] names = declaringType.resolveType(annotation.getElementName());
+						if (names != null) {
+							for (String[] pair : names) {
+								if (pair[0].contains("org.junit"))
+									return true;
+							}
+						}
 					}
 				}
 			}
 		}
-
 		return false;
 	}
 


### PR DESCRIPTION
I somehow produced the case, that Eclipse gave me the following Exception, when I tried to call Run as -> BND OSGi Testlauncher (JUnit):
```
java.lang.NullPointerException
	at bndtools.launch.JUnitShortcut.isJUnit4(JUnitShortcut.java:233)
	at bndtools.launch.JUnitShortcut.isTestable(JUnitShortcut.java:216)
	at bndtools.launch.JUnitShortcut.gatherTests(JUnitShortcut.java:155)
	at bndtools.launch.JUnitShortcut.gatherTests(JUnitShortcut.java:179)
	at bndtools.launch.JUnitShortcut.gatherTests(JUnitShortcut.java:179)
	at bndtools.launch.JUnitShortcut.gatherTests(JUnitShortcut.java:179)
	at bndtools.launch.JUnitShortcut.gatherTests(JUnitShortcut.java:179)
	at bndtools.launch.JUnitShortcut.customise(JUnitShortcut.java:129)
	at bndtools.launch.JUnitShortcut.launchJavaElements(JUnitShortcut.java:91)
	at bndtools.launch.api.AbstractLaunchShortcut.launchSelectedObject(AbstractLaunchShortcut.java:95)
	at bndtools.launch.api.AbstractLaunchShortcut.launch(AbstractLaunchShortcut.java:65)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchShortcutExtension.launch(LaunchShortcutExtension.java:430)
	at org.eclipse.debug.internal.ui.actions.LaunchShortcutAction.runInternal(LaunchShortcutAction.java:88)
	at org.eclipse.debug.internal.ui.actions.LaunchShortcutAction.runWithEvent(LaunchShortcutAction.java:135)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:580)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:414)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4209)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1037)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1061)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1046)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:760)
	at org.eclipse.jface.action.ActionContributionItem.lambda$8(ActionContributionItem.java:1209)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4209)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1037)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4026)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3626)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1157)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1046)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:644)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:551)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:156)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:152)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1461)
```

For some unclear reason, it went down as far as java.lang.Object and then a NPE appeared.

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>