### PR TITLE
Properly handle ZIP extra fields

### DIFF
--- a/aQute.libg/src/aQute/lib/zip/package-info.java
+++ b/aQute.libg/src/aQute/lib/zip/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.1.0")
+@Version("1.2.0")
 package aQute.lib.zip;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -31,15 +31,20 @@ def pluginUnderTestMetadata = tasks.register('pluginUnderTestMetadata', WritePro
   }
 }
 
-def testresources = tasks.register('testresources', Sync.class) {
-  from project.file('testresources')
-  into project.layout.buildDirectory.dir('testresources')
-}
-
 tasks.named('test') {
-  inputs.files tasks.named('jar'), pluginUnderTestMetadata, testresources
+  def testresources = project.file('testresources')
+  def target = project.layout.buildDirectory.dir('testresources')
+  inputs.files tasks.named('jar'), pluginUnderTestMetadata
+  inputs.dir testresources
   systemProperty 'bnd_version', bnd('bnd_version')
   systemProperty 'org.gradle.warning.mode', gradle.startParameter.warningMode.name().toLowerCase()
+  doFirst { // copy test resources into build dir
+    project.delete(target)
+    copy {
+      from testresources
+      into target
+    }
+  }
 }
 
 tasks.named('release') {

--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -60,6 +60,7 @@ import aQute.lib.hex.Hex;
 import aQute.lib.io.FileTree;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
+import aQute.lib.zip.ZipUtil;
 import aQute.service.reporter.Report.Location;
 
 @SuppressWarnings("resource")
@@ -1944,10 +1945,10 @@ public class BuilderTest {
 
 			Resource r = jar.getResource("osgi.jar");
 			assertNotNull(r);
-			assertEquals("itworks", r.getExtra());
+			assertEquals("itworks", ZipUtil.stringFromExtraField(Resource.decodeExtra(r.getExtra())));
 			Resource r2 = jar.getResource("www/xyz.jar");
 			assertNotNull(r2);
-			assertEquals("italsoworks", r2.getExtra());
+			assertEquals("italsoworks", ZipUtil.stringFromExtraField(Resource.decodeExtra(r2.getExtra())));
 		} finally {
 			b.close();
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Resource.java
@@ -8,6 +8,8 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.CharBuffer;
 import java.nio.file.Path;
 import java.util.Locale;
 
@@ -21,8 +23,20 @@ public interface Resource extends Closeable {
 
 	long lastModified();
 
+	/**
+	 * Use {@link #encodeExtra(byte[])} to properly encode the ZIP extra field
+	 * structured binary data into the specified String.
+	 *
+	 * @param extra A String encoding the ZIP extra field.
+	 */
 	void setExtra(String extra);
 
+	/**
+	 * Use {@link #decodeExtra(String)} to properly decode the ZIP extra field
+	 * structured binary data from the returned String.
+	 *
+	 * @return A String encoding the ZIP extra field.
+	 */
 	String getExtra();
 
 	long size() throws Exception;
@@ -58,5 +72,63 @@ public interface Resource extends Closeable {
 			}
 		}
 		return new URLResource(url, protocol.equals("jrt") ? null : client);
+	}
+
+	/**
+	 * Encode the ZIP extra field as a String.
+	 * <p>
+	 * Since the Resource API uses a String as the storage format for the extra
+	 * field and the extra field is structured binary data, we encode the byte
+	 * array as a char array in a String. Since the byte array can have an odd
+	 * length, we must also encode the array length so that we can decode into
+	 * the correct byte array length.
+	 *
+	 * @param extra A ZIP extra field.
+	 * @return A String encoding of the specified ZIP extra field.
+	 * @see <a href=
+	 *      "https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT">Section
+	 *      4.5 - Extensible data fields</a>
+	 */
+	static String encodeExtra(byte[] extra) {
+		final int length = extra.length;
+		if (length > 0xFFFF) {
+			throw new IllegalArgumentException("extra data too long");
+		}
+		// we allocate an even length to hold all the bytes in chars
+		ByteBuffer bb = ByteBuffer.allocate(Short.BYTES + length + length % 2)
+			.order(ByteOrder.LITTLE_ENDIAN);
+		CharBuffer cb = bb.asCharBuffer();
+		bb.putShort((short) length);
+		bb.put(extra, 0, length);
+		return cb.toString();
+	}
+
+	/**
+	 * Decode a String to a ZIP extra field.
+	 * <p>
+	 * Since the Resource API uses a String as the storage format for the extra
+	 * field and the extra field is structured binary data, we encode the byte
+	 * array as a char array in a String. Since the byte array can have an odd
+	 * length, we must also encode the array length so that we can decode into
+	 * the correct byte array length.
+	 *
+	 * @param encoded A String encoding of the ZIP extra field.
+	 * @return The ZIP extra field encoded in the specified string.
+	 * @see <a href=
+	 *      "https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT">Section
+	 *      4.5 - Extensible data fields</a>
+	 */
+	static byte[] decodeExtra(String encoded) {
+		ByteBuffer bb = ByteBuffer.allocate(encoded.length() * Character.BYTES)
+			.order(ByteOrder.LITTLE_ENDIAN);
+		CharBuffer cb = bb.asCharBuffer();
+		cb.put(encoded);
+		final int length = Short.toUnsignedInt(bb.getShort());
+		if (length != (bb.remaining() - length % 2)) {
+			throw new IllegalArgumentException("invalid encoding");
+		}
+		byte[] extra = new byte[length];
+		bb.get(extra, 0, length);
+		return extra;
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ZipResource.java
@@ -1,7 +1,5 @@
 package aQute.bnd.osgi;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,11 +41,11 @@ public class ZipResource implements Resource {
 		this.zip = zip;
 		this.entry = entry;
 		this.closeZipFile = closeZipFile;
-		lastModified = -11L;
-		size = entry.getSize();
-		byte[] data = entry.getExtra();
-		if (data != null) {
-			extra = new String(data, UTF_8);
+		this.lastModified = -11L;
+		this.size = entry.getSize();
+		byte[] extra = entry.getExtra();
+		if (extra != null) {
+			this.extra = Resource.encodeExtra(extra);
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/print/JarPrinter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/JarPrinter.java
@@ -29,6 +29,7 @@ import aQute.bnd.osgi.Resource;
 import aQute.bnd.osgi.Verifier;
 import aQute.bnd.stream.MapStream;
 import aQute.lib.collections.MultiMap;
+import aQute.lib.hex.Hex;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.lib.unmodifiable.Sets;
@@ -197,8 +198,7 @@ public class JarPrinter extends Processor {
 					if (r != null) {
 						String extra = r.getExtra();
 						if (extra != null) {
-
-							out.format(" extra='%s'", escapeUnicode(extra));
+							out.format(" extra='%s'", Hex.toHexString(Resource.decodeExtra(extra)));
 						}
 					}
 					println();
@@ -290,29 +290,6 @@ public class JarPrinter extends Processor {
 			});
 		println(MultiMap.format(table));
 		return this;
-	}
-
-	private static char nibble(int i) {
-		return "0123456789ABCDEF".charAt(i & 0xF);
-	}
-
-	private static String escapeUnicode(String value) {
-		final int len = value.length();
-		StringBuilder sb = new StringBuilder(len);
-		for (int i = 0; i < len; i++) {
-			char c = value.charAt(i);
-			if (c >= ' ' && c <= '~' && c != '\\')
-				sb.append(c);
-			else {
-				sb.append('\\')
-					.append('u')
-					.append(nibble(c >> 12))
-					.append(nibble(c >> 8))
-					.append(nibble(c >> 4))
-					.append(nibble(c));
-			}
-		}
-		return (len == sb.length()) ? value : sb.toString();
 	}
 
 	/**

--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -322,7 +322,7 @@
 	org.w3c.dom.events;version='[3.0.0,3.0.1)',\
 	org.w3c.dom.smil;version='[1.0.1,1.0.2)',\
 	org.w3c.dom.svg;version='[1.1.0,1.1.1)',\
-	assertj-core;version='[3.18.1,3.18.2)',\
+	assertj-core;version='[3.19.0,3.19.1)',\
 	org.eclipse.core.net;version='[1.3.400,1.3.401)',\
 	org.eclipse.ui.ide.application;version='[1.3.100,1.3.101)',\
 	org.eclipse.urischeme;version='[1.0.100,1.0.101)'


### PR DESCRIPTION
ZIP extra fields are structured binary data. See section 4.5 of the
[ZIP File Format Specification][1]. We had incorrectly just placed UTF-8
encoded strings in the extra field and assumed that, when reading zip
files, we could decode the extra field as a UTF-8 encoded String.
However, the structured binary data of a ZIP extra field cannot be
safely decoded as UTF-8 data into a String and then re-encoded into
UTF-8 data when writing a ZIP file. This resulted in corrupting the
ZIP extra fields when wrapping a jar. It also means that use of the
"extra" attribute on certain instructions caused malformed ZIP extra
fields to be written to jars.

We fix Bnd to properly encode ZIP extra field information into Strings.
We do this to avoid making a breaking major change to the Resource API
where the setExtra/getExtra methods would take byte[] instead of String.
We also use a custom Header ID to store the "extra" attribute values in
the ZIP extra field in ZIP File Format Specification compliant manner.
This means that jars generate by Bnd will always successfully verify
with "unzip -t" or "zipdetails".

Fixes #4507

[1]: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT