### PR TITLE
analyzer: Allow resolution directive on java imports

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1969,10 +1969,14 @@ public class Analyzer extends Processor {
 				Attrs importAttributes = imports.get(packageRef);
 				//
 				// Check if we have a java.* package. If so, we should remove
-				// all attributes to have a plain import.
+				// all attributes (except resolution:) to have a plain import.
 				//
 				if (packageRef.isJava()) {
+					String resolution = importAttributes.get(Constants.RESOLUTION_DIRECTIVE);
 					importAttributes.clear();
+					if (resolution != null) {
+						importAttributes.put(Constants.RESOLUTION_DIRECTIVE, resolution);
+					}
 					continue;
 				}
 				Attrs defaultAttrs = new Attrs();


### PR DESCRIPTION
Per request from @tjwatson, we now allow the resolution directive on
java imports to support optional resolution of a java import. This is
interesting to the [Apache Felix Atomos project][1].

[1]: https://github.com/apache/felix-atomos