### PR TITLE
[bndtools test] JUnit launching fixes

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -635,11 +635,12 @@
                            <!--  Java element (src-folder, package or JUnit class) -->
                            <adapt type="org.eclipse.jdt.core.IJavaElement">
                               <test property="org.bndtools.core.isInBndJavaProject" forcePluginActivation="true" />
-                              <test property="org.eclipse.jdt.junit.canLaunchAsJUnit" forcePluginActivation="true" />
                               <or>
                                  <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.Test" />
                                  <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="junit.framework.Test" />
+                                 <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.platform.commons.annotations.Testable" />
                                  <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.jupiter.api.Test" />
+                                 <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.jupiter.params.ParameterizedTest" />
                               </or>
                            </adapt>
 

--- a/bndtools.core/src/bndtools/launch/JUnitShortcut.java
+++ b/bndtools.core/src/bndtools/launch/JUnitShortcut.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -17,9 +19,18 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IParent;
+import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.text.ITextSelection;
@@ -50,6 +61,7 @@ public class JUnitShortcut extends AbstractLaunchShortcut {
 			//
 
 			if (editor instanceof JavaEditor) {
+
 				IJavaElement element = getSelectedJavaElement((JavaEditor) editor);
 				if (element == null) {
 					IEditorInput input = editor.getEditorInput();
@@ -133,6 +145,54 @@ public class JUnitShortcut extends AbstractLaunchShortcut {
 		}
 	}
 
+	private static String getParameterString(IMethod method) {
+		StringBuilder builder = new StringBuilder(128);
+		builder.append('(');
+
+		// If we don't have parameters there's no need to build an AST
+		if (method.getNumberOfParameters() > 0) {
+			// In the source, the parameters may have their simple names. But
+			// for biz.aQute.tester.junit-platform to recognise the parameters,
+			// it needs to be passed in the fully-qualified parameter names. The
+			// JavaModel (ie, IMethod) does not resolve the parameters into
+			// their fully-qualified type names, so we need to create an AST
+			// with resolved bindings to do this.
+
+			// Fetch the Java model compilation unit
+			ICompilationUnit cUnit = method.getCompilationUnit();
+			// Parse the source
+			// (the language specification version should suit your needs)
+			ASTParser parser = ASTParser.newParser(AST.JLS11);
+			parser.setSource(cUnit);
+			// Need the bindings to get the fully-qualified names.
+			parser.setResolveBindings(true);
+			// Fetch the AST node for the compilation unit
+			ASTNode unitNode = parser.createAST(null);
+			// It should be an AST compilation unit
+			if (unitNode instanceof CompilationUnit) {
+				CompilationUnit sourceUnit = (CompilationUnit) unitNode;
+				try {
+					ISourceRange sr = method.getNameRange();
+					NodeFinder nf = new NodeFinder(sourceUnit, sr.getOffset(), sr.getLength());
+					ASTNode elementNode = nf.getCoveringNode();
+					while (elementNode != null && !(elementNode instanceof MethodDeclaration)) {
+						elementNode = elementNode.getParent();
+					}
+					if (elementNode != null) {
+						MethodDeclaration methodDec = (MethodDeclaration) elementNode;
+						IMethodBinding binding = methodDec.resolveBinding();
+						builder.append(Stream.of(binding.getParameterTypes())
+							.map(ITypeBinding::getErasure)
+							.map(ITypeBinding::getQualifiedName)
+							.collect(Collectors.joining(",")));
+					}
+				} catch (JavaModelException e) {}
+			}
+		}
+		return builder.append(')')
+			.toString();
+	}
+
 	/*
 	 * Recursive method that traverses the children of a Java Element and
 	 * gathers test case types.
@@ -153,7 +213,7 @@ public class JUnitShortcut extends AbstractLaunchShortcut {
 			case IJavaElement.TYPE : {
 				IType type = (IType) element;
 				if (isTestable(type)) {
-					testNames.add((type).getFullyQualifiedName());
+					testNames.add(type.getFullyQualifiedName());
 				}
 			}
 				break;
@@ -166,7 +226,8 @@ public class JUnitShortcut extends AbstractLaunchShortcut {
 				IMethod method = (IMethod) element;
 				String typeName = ((IType) method.getParent()).getFullyQualifiedName();
 				String methodName = method.getElementName();
-				testNames.add(typeName + ":" + methodName);
+
+				testNames.add(typeName + ":" + methodName + getParameterString(method));
 			}
 				break;
 


### PR DESCRIPTION
Fixes #4524:

* Context-sensitive launch for JUnit was not available unless junit-platform-commons was on the path or JUnit 4 was on the path, even if you are using Jupiter annotations.
* Context-sensitive launch for test methods with parameters.
* Context-sensitive launch works better with various different types of Jupiter test class.