### PR TITLE
[resolver] Increase number of ticks in resolver progress

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ResolutionProgressCallback.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ResolutionProgressCallback.java
@@ -23,7 +23,7 @@ public class ResolutionProgressCallback implements ResolutionCallback {
 		subMonitor.setTaskName("Resolving requirement: " + requirement);
 		// split() also does the cancel check for us and throws
 		// OperationCanceledException
-		subMonitor.setWorkRemaining(100)
+		subMonitor.setWorkRemaining(1000)
 			.split(1);
 	}
 


### PR DESCRIPTION
The initial implementation of the resolver progress would allocation 1% of the remaining ticks for each new requirement. I noticed that on any resolve of sufficient complexity that the progress bar was actually useful, this still resulted in the progress getting to 100% very quickly even while there was still a fair bit of work to do. Increasing this to 0.1% on each requirement make the progress bar a bit more useful.
