### PR TITLE
[AlsoLauncherTest] fix failure

### DIFF
--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -772,7 +772,7 @@ public class AlsoLauncherTest {
 
 			softly.assertThat(report)
 				.as("System Bundle")
-				.containsPattern("\\n0\\s+\\d+\\s*ACTIV\\s+[<][>]\\s+System Bundle");
+				.containsPattern("\\n0\\s+\\d*\\s*ACTIV\\s+[<][>]\\s+System Bundle");
 
 			final DateTimeFormatter f = DateTimeFormatter.ofPattern("YYYYMMddHHmm")
 				.withZone(ZoneOffset.UTC);


### PR DESCRIPTION
The check appears to occasionally contain an additional number of digits

    [System Bundle]
    Expecting:
      "Id    Levl State Modified      Location
    0     # Found bundle without a bsn [7], ignoring
    0   ACTIV <>            System Bundle
    1     10  ACTIV 201810132223  file:/home/runner/work/bnd/bnd/maven/target/m2/org/apache/felix/org.apache.felix.scr/2.1.12/org.apache.felix.scr-2.1.12.jar
    2     11  ACTIV 201810132026  file:/home/runner/work/bnd/bnd/maven/target/m2/org/apache/felix/org.apache.felix.configadmin/1.9.10/org.apache.felix.configadmin-1.9.10.jar
    3     12  ACTIV 202009131314  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.jar
    4     12  ACTIV 202009131314  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.jar
    5     12  ACTIV 202011110524  file:/home/runner/work/bnd/bnd/maven/target/m2/org/assertj/assertj-core/3.18.1/assertj-core-3.18.1.jar
    6     12  ACTIV 201906061924  file:/home/runner/work/bnd/bnd/maven/target/m2/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar
    7     12  ACTIV 201906061907  file:/home/runner/work/bnd/bnd/maven/target/m2/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar
    8     12  ACTIV 202009131314  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.jar
    9     12  ACTIV 202009131315  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.jar
    10    12  ACTIV 202009131315  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.jar
    11    12  ACTIV 202011041016  file:/home/runner/work/bnd/bnd/maven/target/m2/org/apache/servicemix/bundles/org.apache.servicemix.bundles.junit/4.13.1_1/org.apache.servicemix.bundles.junit-4.13.1_1.jar
    12    12  ACTIV 202009131315  file:/home/runner/work/bnd/bnd/maven/target/m2/org/junit/vintage/junit-vintage-engine/5.7.0/junit-vintage-engine-5.7.0.jar
    13    12  ACTIV 202101042206  file:/home/runner/work/bnd/bnd/biz.aQute.bndall.tests/generated/tmp/test/biz.aQute.launcher.AlsoLauncherTest/testReporting_notUsingReferences/test%20ws/demo/generated/demo.jar
    # framework=org.apache.felix.framework [0]
    # setting launcher service registration to launcher.ready=true
    # will call main
    Running in main
    before joining
    Stopping framework
    After stopping framework, sleeping
    Goodbye world
    # framework event org.osgi.framework.FrameworkEvent[source=org.apache.felix.framework [0]] 64
    # framework event stopped
    "
    to contain pattern:
      "\n0\s+\d+\s*ACTIV\s+[<][>]\s+System Bundle"

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>