### PR TITLE
[resolver] Add tester dependencies to << INITIAL >>

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -498,6 +498,26 @@ public class BndrunResolveContext extends AbstractResolveContext {
 			resBuilder.addRequirements(requires);
 		}
 
+		String tester = properties.mergeProperties(Constants.TESTER);
+		if (tester != null) {
+			tester = tester.trim();
+			if (!tester.isEmpty()) {
+				List<Container> containers = project.getBundles(Strategy.HIGHEST, tester, null);
+
+				if (containers == null || containers.isEmpty()) {
+					CapReqBuilder testerReq = new CapReqBuilder(IdentityNamespace.IDENTITY_NAMESPACE)
+						.addDirective("filter", "(osgi.identity=" + tester.trim() + ")");
+					resBuilder.addRequirement(testerReq);
+				} else {
+					Manifest m = containers.get(0)
+						.getManifest();
+					ResourceBuilder testerRes = new ResourceBuilder();
+					testerRes.addManifest(Domain.domain(m));
+					resBuilder.addRequirements(testerRes.getRequirements());
+				}
+			}
+		}
+
 		return resBuilder.build();
 	}
 


### PR DESCRIPTION
Looks for the -tester directive and if present makes sure that the chosen tester's requirements are added to the list of initial
requirements.

Fixes #3795.

This is a draft - no test cases at the moment, plus the GUI feedback could be better (user won't necessarily know why the tester's requirements have been added to the initial requirements). But thought to elicit some feedback on the concept.