### PR TITLE
Extend findproviders macro to select repositories to search

### DIFF
--- a/biz.aQute.bndlib.tests/testresources/build-repo/ws/p1/bnd.bnd
+++ b/biz.aQute.bndlib.tests/testresources/build-repo/ws/p1/bnd.bnd
@@ -1,0 +1,1 @@
+Provide-Capability: osgi.service;objectClass:List<String>="test"

--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceClassIndex.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceClassIndex.java
@@ -17,6 +17,7 @@ import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.service.repository.Repository;
 
+import aQute.bnd.build.Workspace.ResourceRepositoryStrategy;
 import aQute.bnd.classindex.ClassIndexerAnalyzer;
 import aQute.bnd.osgi.BundleId;
 import aQute.bnd.osgi.Descriptors;
@@ -187,7 +188,7 @@ class WorkspaceClassIndex implements AutoCloseable {
 		rb.filter(filter);
 		Requirement requirement = rb.buildSyntheticRequirement();
 
-		Repository repository = workspace.getResourceRepository();
+		Repository repository = workspace.getResourceRepository(ResourceRepositoryStrategy.ALL);
 		Collection<Capability> caps = repository.findProviders(Collections.singleton(requirement))
 			.get(requirement);
 		Map<Resource, List<Capability>> index = ResourceUtils.getIndexedByResource(caps);

--- a/docs/_instructions/dsannotations.md
+++ b/docs/_instructions/dsannotations.md
@@ -11,6 +11,6 @@ The value of this instruction is a comma delimited list of fully qualified class
 
 The default value of this instruction is `*`, which means that by default **bnd** will process all bundle classes looking for DS annotations.
 
-The behavior of DS annotation processing can be further configured using the [-dsannotations-options](./dsannotations-options.md) instruction.
+The behavior of DS annotation processing can be further configured using the [-dsannotations-options](dsannotations-options.html) instruction.
 
 [source](https://github.com/bndtools/bnd/blob/master/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotations.java)

--- a/docs/_macros/findproviders.md
+++ b/docs/_macros/findproviders.md
@@ -1,18 +1,28 @@
 ---
 layout: default
 class: Workspace
-title: findproviders  ';' namespace ( ';' FILTER )?
-summary: find resources in the workspace repository matching the given namespace and optional filter. EXPERIMENTAL
+title: findproviders  ';' namespace ( ';' FILTER ( ';' STRATEGY)? )?
+summary: find resources in the workspace repository matching the given namespace and optional filter. Intended for use in bndrun files. STRATEGY can one of ALL, REPOS or WORKSPACE.
 ---
 
 The `findproviders` macro gives access to the resources in the Workspace repositories, including the projects itself. Its semantics match the OSGi `Repository.findProviders()` method.
 
-It was added to support the use case of including a set of plugins in a resolve to create an executable. Since it is impossible to add a requirement that will add all matching resources, the `findproviders` macro can be used to find these resources and then turn them into initial requirements. However, this macro will likely find many other use cases since it is quite versatile.
+It was added to support the use case of including a set of plugins in a resolve to create an executable. Since it is impossible to add a requirement that will add all matching resources, the `findproviders` macro can be used to find these resources and then turn them into initial requirements. However, this macro will likely find many other use cases since it is quite versatile. If used outside of `bndrun` files, it can cause circular builds because it might want to search the project that is used in. Use the REPOS Strategy in this case.
 
-    findproviders ::= namespace ( ';' FILTER )?
+    findproviders ::= namespace ( ';' FILTER ( ';' STRATEGY)? )?
     namespace     ::= ... OSGi namespace
+    FILTER        ::= Any LDAP Styled Filter
+    STRATEGY      ::= 'ALL' | 'WORKSPACE' | 'REPOS'
 
-If no filter is given then all resources that have a capability in the given namespace are returned.
+If no filter is given or the filter attribute is empty, then all resources that have a capability in the given namespace are returned.
+
+The following strategies are available:
+
+| Strategy  | Description                                               |
+| --------- | --------------------------------------------------------- |
+| ALL       | Searches in the Workspace and all configured Repositories |
+| REPOS     | Searches only in configured Repositories                  |
+| WORKSPACE | Searches in Workspace projects only                        |
 
 The result is in `PARAMETERS` format, to common format in bnd and OSGi. In this case the _key_ will be the Bundle Symbolic Name and the attributes will _at least_ contain the Bundle version. For example:
 
@@ -27,10 +37,12 @@ This finds all resources that have an `osgi.service` capability. This could retu
     org.apache.felix.eventadmin;version=1.5.0,
     ...
 
-This `PARAMETERS` format is _structured_ because it has attributes; that makes it harder to use with all kind of other macros. The [`${template}`](template.md) macro was intended to help out. This macro takes the name of macro and then treats the contents as a  `PARAMETERS`. It then applies a _template_ to each clause in the PARAMETERS. For example:
+This `PARAMETERS` format is _structured_ because it has attributes; that makes it harder to use with all kind of other macros. The [`template`](template.html) macro was intended to help out. This macro takes the name of macro and then treats the contents as a  `PARAMETERS`. It then applies a _template_ to each clause in the PARAMETERS. For example:
 
-    my.plugins = ${findproviders;osgi.service;(objectClass=com.example.my.Plugin)}
-    -runrequires.plugins = ${template;my.plugins;osgi.identity;filter:='(osgi.identity=${@})'}
+    my.plugins = ${findproviders;osgi.service;\
+      (objectClass=com.example.my.Plugin)}
+    -runrequires.plugins = ${template;my.plugins;\
+      osgi.identity;filter:='(osgi.identity=${@})'}
 
 This would turn the previous example into:
 


### PR DESCRIPTION
The current findproviders macro can be used in bndrun files. If used in
a bnd file, it causes a circular build because it wants to search the
projects as well. This version of the macro can be used to exclude the
workspace.

Closes #4494.