### PR TITLE
bndtools.core.test: Re-enable in CI build

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -32,6 +32,7 @@ defaults:
 jobs:
   Build_Matrix:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
         java: [ 11, 15 ]

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,7 +24,6 @@ env:
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
     -Dmaven.wagon.http.retryHandler.count=3
-  BNDTOOLS_CORE_TEST_NOJUNITOSGI: true
 
 defaults:
   run:


### PR DESCRIPTION
Let's see if the tests are stable again.
