### PR TITLE
Maven build fixes

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -18,7 +18,12 @@ on:
 
 env:
   LC_ALL: en_US.UTF-8
-  GRADLE_OPTS: -Dorg.gradle.parallel=true
+  GRADLE_OPTS: >-
+    -Dorg.gradle.parallel=true
+  MAVEN_OPTS: >-
+    -Dhttp.keepAlive=false
+    -Dmaven.wagon.http.pool=false
+    -Dmaven.wagon.http.retryHandler.count=3
   BNDTOOLS_CORE_TEST_NOJUNITOSGI: true
 
 defaults:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,12 @@ on:
 
 env:
   LC_ALL: en_US.UTF-8
-  GRADLE_OPTS: -Dorg.gradle.parallel=true
+  GRADLE_OPTS: >-
+    -Dorg.gradle.parallel=true
+  MAVEN_OPTS: >-
+    -Dhttp.keepAlive=false
+    -Dmaven.wagon.http.pool=false
+    -Dmaven.wagon.http.retryHandler.count=3
 
 defaults:
   run:

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>1.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<distributionManagement>
 		<repository>
 			<id>Test Repo</id>

--- a/maven/bnd-export-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-export-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<modules>
 		<module>export</module>
 		<module>export-bundles-only</module>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<modules>
 		<module>non-transitive</module>
 		<module>transitive</module>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-bnd/pom.xml
@@ -9,6 +9,11 @@
 	<version>1.50.0</version>
 	<packaging>jar</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy-no-dist-mgmt/pom.xml
@@ -8,6 +8,11 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-deploy/pom.xml
@@ -8,6 +8,11 @@
 	<version>1.0.0</version>
 	<packaging>jar</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<distributionManagement>
 		<repository>
 			<id>deploymentRepo</id>

--- a/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/src/test/resources/integration-test/test/test-snapshot/pom.xml
@@ -9,6 +9,11 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/maven/bnd-reporter-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-reporter-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<modules>
 		<module>report-multi-project</module>
 		<module>report-multi-project-scoped</module>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<modules>
 		<module>resolve</module>
 		<module>resolve-from-defaults</module>

--- a/maven/bnd-run-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-run-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<artifactId>run-test</artifactId>
 	<version>0.0.1</version>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>

--- a/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-testing-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -7,6 +7,11 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
 	<distributionManagement>
 		<repository>
 			<id>Test Repo</id>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -15,6 +15,7 @@
 		<revision>5.4.0-SNAPSHOT</revision>
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<java.release>8</java.release>
 		<maven.compiler.target>${java.version}</maven.compiler.target>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -325,6 +325,7 @@
 						<scriptVariables>
 							<bndVersion>${project.version}</bndVersion>
 						</scriptVariables>
+						<mavenOpts>${env.MAVEN_OPTS}</mavenOpts>
 						<goals>
 							<goal>--no-transfer-progress</goal>
 							<goal>package</goal>


### PR DESCRIPTION
We remove some encoding warnings and configure maven to avoid connection resets in the GitHub Actions builds.