### PR TITLE
p2: Switch test to use a dedicated virtual p2 repo

### DIFF
--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
@@ -66,7 +66,7 @@ public class P2IndexerTest extends TestCase {
 			client.setCache(IO.getFile(tmp, "cache"));
 
 			try (P2Indexer p2 = new P2Indexer(new Unpack200(), new Slf4jReporter(P2IndexerTest.class), tmp, client,
-				new URI("https://bndtools.jfrog.io/bndtools/update-snapshot"), getName())) {
+				new URI("https://bndtools.jfrog.io/bndtools/bnd-test-p2"), getName())) {
 				List<String> bsns = p2.list(null);
 				System.out.println(bsns);
 				assertThat(bsns).contains("org.bndtools.templating.gitrepo", "org.bndtools.headless.build.manager",
@@ -175,7 +175,7 @@ public class P2IndexerTest extends TestCase {
 			client.setCache(IO.getFile(tmp, "cache"));
 
 			try (P2Indexer p2 = new P2Indexer(new Unpack200(), new Slf4jReporter(P2IndexerTest.class), tmp, client,
-				new URI("https://bndtools.jfrog.io/bndtools/update-snapshot"), getName())) {
+				new URI("https://bndtools.jfrog.io/bndtools/bnd-test-p2"), getName())) {
 
 				assertThat(p2.versions("bndtools.core")).hasSize(1);
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
@@ -52,7 +52,7 @@ public class P2RepositoryTest {
 			p2r.setRegistry(w);
 
 			Map<String, String> config = new HashMap<>();
-			config.put("url", "https://bndtools.jfrog.io/bndtools/update-snapshot");
+			config.put("url", "https://bndtools.jfrog.io/bndtools/bnd-test-p2");
 			config.put("name", "test");
 			p2r.setProperties(config);
 


### PR DESCRIPTION
This avoids any issues with the contents of update-snapshot changing
and breaking the tests.
