### PR TITLE
-maven-release now supports merge properties

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -383,7 +383,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 		if (context == null)
 			return release;
 
-		Parameters p = new Parameters(context.getProperty(Constants.MAVEN_RELEASE), reporter);
+		Parameters p = new Parameters(context.mergeProperties(Constants.MAVEN_RELEASE), reporter);
 
 		release.type = storage.isLocalOnly() ? ReleaseType.LOCAL : ReleaseType.REMOTE;
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -670,6 +670,38 @@ public class MavenBndRepoTest {
 	}
 
 	@Test
+	public void testPutLocalSnapshotJavadocReleaseMergedProps() throws Exception {
+		Map<String, String> map = new HashMap<>();
+		map.put("releaseUrl", null);
+		map.put("snapshotUrl", null);
+		config(map);
+
+		try (Processor context = new Processor();) {
+			context.setProperty("-maven-release", "local");
+			context.setProperty("-maven-release.javadoc", "javadoc;force=true");
+			PutOptions put = new PutOptions();
+			put.context = context;
+
+			File jar = IO.getFile("testresources/snapshot.jar");
+			PutResult r = repo.put(new FileInputStream(jar), put);
+
+			assertIsFile(local,
+				"biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.jar", 0);
+			assertIsFile(local,
+				"biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT.pom", 0);
+			assertFileNotExists(local,
+				"biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT-sources.jar");
+			assertIsFile(local,
+				"biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/biz.aQute.bnd.maven-3.2.0-SNAPSHOT-javadoc.jar", 0);
+			assertIsFile(local, "biz/aQute/bnd/biz.aQute.bnd.maven/3.2.0-SNAPSHOT/maven-metadata-local.xml", 0);
+
+			String s = IO.collect(index);
+			// snapshots added to index
+			assertThat(s).contains("biz.aQute.bnd.maven");
+		}
+	}
+
+	@Test
 	public void testPutLocalSnapshotJavadocRelease() throws Exception {
 		Map<String, String> map = new HashMap<>();
 		map.put("releaseUrl", null);


### PR DESCRIPTION
I don't see, where I can set the maint-candidate lable. Maybe I don't have the proper rights for it. 

Regardless. According to the the instruction doc of -maven-release it uses merged properties. Well, now it actually does.

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>