### PR TITLE
Update classes macro to add STATIC and INNER queries

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ClazzTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ClazzTest.java
@@ -1,6 +1,10 @@
 package test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -11,7 +15,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import aQute.bnd.component.DSAnnotationReader;
@@ -29,12 +35,11 @@ import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Instruction;
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Macro;
 import aQute.bnd.xmlattribute.XMLAttributeFinder;
 import aQute.lib.io.IO;
-import junit.framework.TestCase;
 
-@SuppressWarnings("restriction")
-public class ClazzTest extends TestCase {
+public class ClazzTest {
 
 	/**
 	 * <pre>
@@ -48,6 +53,7 @@ public class ClazzTest extends TestCase {
 	 * @throws Exception
 	 */
 
+	@Test
 	public void testJiniPlatformClasses() throws Exception {
 		try (Builder b = new Builder()) {
 			b.addClasspath(IO.getFile("jar/jsk-platform.jar"));
@@ -77,6 +83,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCaughtExceptions() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
@@ -92,11 +99,12 @@ public class ClazzTest extends TestCase {
 	 * There is an unused class constant in the This actually looks wrong since
 	 */
 
+	@Test
 	public void testUnusedClassConstant() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
 			c.parseClassFile(new FileInputStream("testresources/TestWeavingHook.jclass"), new ClassDataCollector() {});
-			// TODO test someething here
+			// TODO test something here
 			System.out.println(c.getReferred());
 		}
 	}
@@ -106,6 +114,7 @@ public class ClazzTest extends TestCase {
 	 * <S:Z>()V;} This actually looks wrong since
 	 */
 
+	@Test
 	public void test375() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			a.getMethodSignature("<S:[LFoo;>()V");
@@ -115,6 +124,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNoClassBound() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			// From aQute.lib.collections.SortedList.fromIterator()
@@ -141,6 +151,7 @@ public class ClazzTest extends TestCase {
 	 * 15
 	 * </pre>
 	 */
+	@Test
 	public void testDynamicInstr() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
@@ -152,6 +163,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testModuleInfo() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
@@ -173,6 +185,7 @@ public class ClazzTest extends TestCase {
 	 * actually resemble a class name.
 	 */
 
+	@Test
 	public void testClassForNameFalsePickup() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
@@ -189,6 +202,7 @@ public class ClazzTest extends TestCase {
 	 * Test the uncamel
 	 */
 
+	@Test
 	public void testUncamel() throws Exception {
 		assertEquals("New", Clazz.unCamel("_new"));
 		assertEquals("An XMLMessage", Clazz.unCamel("anXMLMessage"));
@@ -197,6 +211,7 @@ public class ClazzTest extends TestCase {
 		assertEquals("A nice party", Clazz.unCamel("aNiceParty"));
 	}
 
+	@Test
 	public void testAnalyzerCrawlInvokeInterfaceAIOOBException() throws Exception {
 		try (Analyzer a = new Analyzer()) {
 			Clazz c = new Clazz(a, "", null);
@@ -212,6 +227,7 @@ public class ClazzTest extends TestCase {
 		String value() default "";
 	}
 
+	@Test
 	public void testRecursiveAnnotation() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$RecursiveAnno.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -227,6 +243,7 @@ public class ClazzTest extends TestCase {
 	@RecursiveAnno
 	public @interface MetaAnnotated {}
 
+	@Test
 	public void testIndirectlyAnnotated() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -238,6 +255,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testAnnotated() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -248,6 +266,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyAnnotated() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -259,6 +278,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyIndirectlyAnnotated() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -274,6 +294,7 @@ public class ClazzTest extends TestCase {
 	@MetaAnnotated
 	public static class MetaAnnotated_b {}
 
+	@Test
 	public void testIndirectlyAnnotated_b() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_b.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -285,6 +306,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testAnnotated_b() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_b.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -295,6 +317,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyAnnotated_b() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_b.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -305,6 +328,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyIndirectlyAnnotated_b() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_b.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -319,6 +343,7 @@ public class ClazzTest extends TestCase {
 
 	public static class MetaAnnotated_c extends MetaAnnotated_b {}
 
+	@Test
 	public void testIndirectlyAnnotated_c() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_c.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -331,6 +356,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testAnnotated_c() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_c.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -341,6 +367,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyAnnotated_c() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_c.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -354,6 +381,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHierarchyIndirectlyAnnotated_c() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$MetaAnnotated_c.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -370,6 +398,7 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNamed() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -379,12 +408,13 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testMultipleInstructions() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest.class");
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFile();
-			assertTrue(clazz.is(QUERY.EXTENDS, new Instruction("junit.framework.TestCase"), analyzer));
+			assertTrue(clazz.is(QUERY.EXTENDS, new Instruction("java.lang.Object"), analyzer));
 			assertTrue(clazz.is(QUERY.NAMED, new Instruction("!junit.framework.*"), analyzer));
 		}
 	}
@@ -398,6 +428,7 @@ public class ClazzTest extends TestCase {
 
 	public static class AnnotationsOnTypeUseExtends extends @TypeUse Bar {}
 
+	@Test
 	public void testAnnotationsOnTypeUseExtends() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnTypeUseExtends.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -429,6 +460,7 @@ public class ClazzTest extends TestCase {
 
 	public static class AnnotationsOnTypeUseImplements0 implements @TypeUse Foo<String> {}
 
+	@Test
 	public void testAnnotationsOnTypeUseImplements0() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnTypeUseImplements0.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -467,6 +499,7 @@ public class ClazzTest extends TestCase {
 		private static final long serialVersionUID = 1L;
 	}
 
+	@Test
 	public void testAnnotationsOnTypeUseImplements1() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnTypeUseImplements1.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -503,6 +536,7 @@ public class ClazzTest extends TestCase {
 		void bindChars(@TypeParameter Foo<Character> c) {}
 	}
 
+	@Test
 	public void testAnnotationsOnMethodParams0() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnMethodParams0.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -545,6 +579,7 @@ public class ClazzTest extends TestCase {
 		void bindChars(Foo<Character> c, @TypeParameter String s) {}
 	}
 
+	@Test
 	public void testAnnotationsOnMethodParams1() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnMethodParams1.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -587,6 +622,7 @@ public class ClazzTest extends TestCase {
 		public AnnotationsOnCtorParams0(@TypeParameter String s) {}
 	}
 
+	@Test
 	public void testAnnotationsOnCtorParams0() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnCtorParams0.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -629,6 +665,7 @@ public class ClazzTest extends TestCase {
 		public AnnotationsOnCtorParams1(String r, @TypeParameter String s) {}
 	}
 
+	@Test
 	public void testAnnotationsOnCtorParams1() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$AnnotationsOnCtorParams1.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -670,6 +707,7 @@ public class ClazzTest extends TestCase {
 	/**
 	 * See 4.7.20.2 in JVMS spec.
 	 */
+	@Test
 	public void testTypeUseTypePath() throws Exception {
 		File file = IO.getFile("bin_test/test/typeuse/TypePath.class");
 		try (Analyzer analyzer = new Analyzer()) {
@@ -834,38 +872,130 @@ public class ClazzTest extends TestCase {
 		}
 	}
 
+
+	@Test
+	public void testTopLevelClass() throws Exception {
+		File file = IO.getFile("bin_test/test/ClazzTest.class");
+		try (Analyzer analyzer = new Analyzer()) {
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			clazz.parseClassFile();
+			assertThat(clazz.isInnerClass()).isFalse();
+			assertThat(clazz.is(QUERY.STATIC, null, analyzer)).isTrue();
+			assertThat(clazz.is(QUERY.INNER, null, analyzer)).isFalse();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;STATIC}")).isEqualTo("test.ClazzTest");
+			assertThat(replacer.process("${classes;INNER}")).isEmpty();
+			assertThat(replacer.process("${classes;STATIC;INNER}")).isEmpty();
+		}
+	}
+
 	public static class Nested {}
 
-	public class Inner {}
-
+	@Test
 	public void testNestedClass() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$Nested.class");
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFile();
 			assertThat(clazz.isInnerClass()).isFalse();
+			assertThat(clazz.is(QUERY.STATIC, null, analyzer)).isTrue();
+			assertThat(clazz.is(QUERY.INNER, null, analyzer)).isFalse();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;STATIC}")).isEqualTo("test.ClazzTest$Nested");
+			assertThat(replacer.process("${classes;INNER}")).isEmpty();
+			assertThat(replacer.process("${classes;STATIC;INNER}")).isEmpty();
 		}
 	}
 
+	public class Inner {}
+
+	@Test
 	public void testInnerClass() throws Exception {
 		File file = IO.getFile("bin_test/test/ClazzTest$Inner.class");
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFile();
 			assertThat(clazz.isInnerClass()).isTrue();
+			assertThat(clazz.is(QUERY.STATIC, null, analyzer)).isFalse();
+			assertThat(clazz.is(QUERY.INNER, null, analyzer)).isTrue();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;STATIC}")).isEmpty();
+			assertThat(replacer.process("${classes;INNER}")).isEqualTo("test.ClazzTest$Inner");
+			assertThat(replacer.process("${classes;STATIC;INNER}")).isEmpty();
 		}
 	}
 
-	public static class AnonymousClassHolder {
+	@Test
+	public void testAnonymousClass() throws Exception {
 		Object anon = new Object() {};
-	}
-
-	public void testInnerAnonymousClass() throws Exception {
-		File file = IO.getFile("bin_test/test/ClazzTest$AnonymousClassHolder$1.class");
+		String name = anon.getClass()
+			.getName();
+		File file = IO.getFile("bin_test/" + name.replace('.', '/') + ".class");
+		assertThat(file).exists();
 		try (Analyzer analyzer = new Analyzer()) {
 			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
 			clazz.parseClassFile();
 			assertThat(clazz.isInnerClass()).isTrue();
+			assertThat(clazz.is(QUERY.STATIC, null, analyzer)).isFalse();
+			assertThat(clazz.is(QUERY.INNER, null, analyzer)).isTrue();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;STATIC}")).isEmpty();
+			assertThat(replacer.process("${classes;INNER}")).isEqualTo(name);
+			assertThat(replacer.process("${classes;STATIC;INNER}")).isEmpty();
+		}
+	}
+
+	@Test
+	public void testLocalClass() throws Exception {
+		class Local {}
+		Local local = new Local();
+		String name = local.getClass()
+			.getName();
+		File file = IO.getFile("bin_test/" + name.replace('.', '/') + ".class");
+		assertThat(file).exists();
+		try (Analyzer analyzer = new Analyzer()) {
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			clazz.parseClassFile();
+			assertThat(clazz.isInnerClass()).isTrue();
+			assertThat(clazz.is(QUERY.STATIC, null, analyzer)).isFalse();
+			assertThat(clazz.is(QUERY.INNER, null, analyzer)).isTrue();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;STATIC}")).isEmpty();
+			assertThat(replacer.process("${classes;INNER}")).isEqualTo(name);
+			assertThat(replacer.process("${classes;STATIC;INNER}")).isEmpty();
+		}
+	}
+
+	@Test
+	public void testVersion() throws Exception {
+		File file = IO.getFile("bin_test/test/ClazzTest.class");
+		try (Analyzer analyzer = new Analyzer()) {
+			Clazz clazz = new Clazz(analyzer, file.getPath(), new FileResource(file));
+			AtomicReference<String> version = new AtomicReference<>();
+			clazz.parseClassFileWithCollector(new ClassDataCollector() {
+				@Override
+				public void version(int minor, int major) {
+					version.set(major + "." + minor);
+				}
+			});
+			assertThat(clazz.is(QUERY.VERSION, new Instruction(version.get()), analyzer)).isTrue();
+			assertThat(clazz.is(QUERY.VERSION, new Instruction("46.0"), analyzer)).isFalse();
+			analyzer.getClassspace()
+				.put(clazz.getClassName(), clazz);
+			Macro replacer = analyzer.getReplacer();
+			assertThat(replacer.process("${classes;VERSION;" + version.get() + "}"))
+				.isEqualTo("test.ClazzTest");
+			assertThat(replacer.process("${classes;VERSION;46.0}")).isEmpty();
 		}
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -240,8 +240,9 @@ public class Clazz {
 		HIERARCHY_INDIRECTLY_ANNOTATED,
 		RUNTIMEANNOTATIONS,
 		CLASSANNOTATIONS,
-		DEFAULT_CONSTRUCTOR;
-
+		DEFAULT_CONSTRUCTOR,
+		STATIC,
+		INNER;
 	}
 
 	public final static EnumSet<QUERY>	HAS_ARGUMENT	= EnumSet.of(QUERY.IMPLEMENTS, QUERY.EXTENDS, QUERY.IMPORTS,
@@ -1834,6 +1835,13 @@ public class Clazz {
 
 			case DEFAULT_CONSTRUCTOR :
 				return hasPublicNoArgsConstructor();
+
+			case STATIC :
+				return !isInnerClass();
+
+			case INNER :
+				return isInnerClass();
+
 			default :
 				return instr == null ? false : instr.isNegated();
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -414,7 +414,8 @@ public class Descriptors {
 
 		@Override
 		public String getDottedOnly() {
-			return component.getDottedOnly();
+			return component.getDottedOnly()
+				.concat("[]");
 		}
 
 		@Override

--- a/docs/_macros/classes.md
+++ b/docs/_macros/classes.md
@@ -12,12 +12,13 @@ The classes macro provides a query function in an analyzed bundle. While analyzi
 
 The query language is conjunctive, that is, all entries form an AND. For example, if you want to find all PUBLIC classes that are also not abstract you would do:
 
-    PublicConcrete-Classes: ${classes;CONCRETE}
+    PublicConcrete-Classes: ${classes;PUBLIC;CONCRETE}
 
-The query can also parameters. This is a pattern that must match some aspect of the class. For example, it is possible to query for classes that extend a certain base class:
+Some query types can also take parameters. This is a pattern that must match some aspect of the class. For example, it is possible to query for classes that extend a certain base class or is annotated by a certain annotation type:
 
     Test-Cases: ${classes;CONCRETE;EXTENDS;junit.framework.TestCase}
-    Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.Test}
+    Test-Cases: ${classes;CONCRETE;HIERARCHY_ANNOTATED;org.junit.Test}
+    Test-Cases: ${classes;CONCRETE;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable}
 
 All pattern matching is based on fully qualified name and uses the globbing model.
 
@@ -25,29 +26,9 @@ The following table specifies what query options there are:
 
 <table>
   <tr>
-   <td><b>Query</b></td>
-   <td><b>Parameter</b></td>
-   <td><b>Description</b></td>
-  </tr>
-  <tr>
-    <td>IMPLEMENTS</td>
-    <td>PATTERN</td>
-    <td>The class must implement at least one interface that matches the given pattern. This takes inheritance into account as long as intermediates can be found the classpath</td>
-  </tr>
-  <tr>
-    <td>EXTENDS</td>
-    <td>PATTERN</td>
-    <td>The class must implement at least one interface that matches the given pattern. This takes inheritance into account as long as intermediates can be found the classpath.</td>
-  </tr>
-  <tr>
-    <td>IMPORTS</td>
-    <td>PATTERN</td>
-    <td>The class must use a type from another package that matches the given pattern</td>
-  </tr>
-  <tr>
-    <td>NAMED</td>
-    <td>PATTERN</td>
-    <td>The class fqn must match the given pattern.</td>
+   <th><b>Query</b></th>
+   <th><b>Parameter</b></th>
+   <th><b>Description</b></th>
   </tr>
   <tr>
     <td>ANY</td>
@@ -55,44 +36,89 @@ The following table specifies what query options there are:
     <td>Matches any class</td>
   </tr>
   <tr>
-    <td>VERSION</td>
-    <td>PATTERN</td>
-    <td>The class format of the given class must match the given version. The version is given as "major/minor", like "49/0". To select classes that are Java 6, do <code>${classes;VERSION;49/*}</code></td>
-  </tr>
-  <tr>
     <td>CONCRETE</td>
     <td></td>
-    <td>Class must not be abstract</td>
+    <td>Class must not be abstract.</td>
   </tr>
   <tr>
     <td>ABSTRACT</td>
     <td></td>
-    <td>Class must be abstract</td>
+    <td>Class must be abstract.</td>
   </tr>
   <tr>
     <td>PUBLIC</td>
     <td></td>
-    <td>Class must be public</td>
+    <td>Class must be public.</td>
   </tr>
   <tr>
-    <td>ANNOTATION</td>
+    <td>STATIC</td>
+    <td></td>
+    <td>Class must be explicitly or implicitly declared static. That is, the class must not be a inner class.</td>
+  </tr>
+  <tr>
+    <td>INNER</td>
+    <td></td>
+    <td>Class must be an inner class. That is, the class must be a nested class that is not explicitly or implicitly declared static. Inner classes include anonymous and local classes.</td>
+  </tr>
+  <tr>
+    <td>CLASSANNOTATIONS</td>
+    <td></td>
+    <td>The class must have some CLASS retention annotations.</td>
+  </tr>
+  <tr>
+    <td>RUNTIMEANNOTATIONS</td>
+    <td></td>
+    <td>The class must have some RUNTIME retention annotations.</td>
+  </tr>
+  <tr>
+    <td>DEFAULT_CONSTRUCTOR</td>
+    <td></td>
+    <td>The class must have a default constructor. That is, the class must have a public, no-argument constructor.</td>
+  </tr>
+  <tr>
+    <td>IMPLEMENTS</td>
     <td>PATTERN</td>
-    <td>The class must be directly annotated with an annotation that matches the pattern. The set of annotations is all annotations in the class, also the annotations on fields and methods.</td>
+    <td>The class must implement at least one fully qualified interface name that matches the given pattern. This takes inheritance into account as long as super types can be found on the classpath.  This query uses the Java source code fully qualified name where `.` (not `$`) separates the nested class name from the outer class name.</td>
+  </tr>
+  <tr>
+    <td>EXTENDS</td>
+    <td>PATTERN</td>
+    <td>The class must extend at least one fully qualified class name that matches the given pattern. This takes inheritance into account as long as super types can be found on the classpath. This query uses the Java source code fully qualified name where `.` (not `$`) separates the nested class name from the outer class name.</td>
+  </tr>
+  <tr>
+    <td>IMPORTS</td>
+    <td>PATTERN</td>
+    <td>The class must use a type from another package name that matches the given pattern</td>
+  </tr>
+  <tr>
+    <td>NAMED</td>
+    <td>PATTERN</td>
+    <td>The fully qualified name of the class must match the given pattern. This query uses the Java source code fully qualified name where `.` (not `$`) separates the nested class name from the outer class name.</td>
+  </tr>
+  <tr>
+    <td>VERSION</td>
+    <td>PATTERN</td>
+    <td>The class format of the given class must match the given version. The version is given as "major.minor", like "49.0". To select classes that are Java 6, do <code>${classes;VERSION;49.*}</code></td>
+  </tr>
+  <tr>
+    <td>ANNOTATED</td>
+    <td>PATTERN</td>
+    <td>The class must be directly annotated with a fully qualified annotation name that matches the pattern. The set of annotations is all annotations in the class, also the annotations on fields and methods. This query uses the Java class name fully qualified name where `$` (not `.`) separates the nested class name from the outer class name.</td>
   </tr>
   <tr>
     <td>INDIRECTLY_ANNOTATED</td>
     <td>PATTERN</td>
-    <td>The class must be directly or indirectly annotated with an annotation that matches the pattern. The set of annotations is all annotations in the class, the annotations on fields and methods, and all the annotations on those annotations recursively.</td>
+    <td>The class must be directly or indirectly annotated with a fully qualified annotation name that matches the pattern. The set of annotations is all annotations in the class, the annotations on fields and methods, and all the annotations on those annotations recursively. This query uses the Java class name fully qualified name where `$` (not `.`) separates the nested class name from the outer class name.</td>
   </tr>
   <tr>
     <td>HIERARCHY_ANNOTATED</td>
     <td>PATTERN</td>
-    <td>The class, or one of its super classes, must be directly annotated with an annotation that matches the pattern. The set of annotations is all annotations in the class, also the annotations on fields and methods.</td>
+    <td>The class, or one of its super classes, must be directly annotated with a fully qualified annotation name that matches the pattern. The set of annotations is all annotations in the class, also the annotations on fields and methods. This query uses the Java class name fully qualified name where `$` (not `.`) separates the nested class name from the outer class name.</td>
   </tr>
   <tr>
     <td>HIERARCHY_INDIRECTLY_ANNOTATED</td>
     <td>PATTERN</td>
-    <td>The class, or one of its super classes, must be directly or indirectly annotated with an annotation that matches the pattern. The set of annotations is all annotations in the class, the annotations on fields and methods, and all the annotations on those annotations recursively.</td>
+    <td>The class, or one of its super classes, must be directly or indirectly annotated with a fully qualified annotation name that matches the pattern. The set of annotations is all annotations in the class, the annotations on fields and methods, and all the annotations on those annotations recursively. This query uses the Java class name fully qualified name where `$` (not `.`) separates the nested class name from the outer class name.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
`STATIC` and `INNER` are opposites.

Documentation for the classes macro is also updated to document some query types that were previously undocumented.