### PR TITLE
Test fixes

### DIFF
--- a/aQute.libg/src/aQute/lib/strings/Strings.java
+++ b/aQute.libg/src/aQute/lib/strings/Strings.java
@@ -101,11 +101,11 @@ public class Strings {
 		return "";
 	}
 
-	public static String join(String[] strings) {
+	public static String join(String... strings) {
 		return join(Arrays.asList(strings));
 	}
 
-	public static String join(Object[] strings) {
+	public static String join(Object... strings) {
 		return join(Arrays.asList(strings));
 	}
 

--- a/biz.aQute.bnd.runtime/test/aQute/bnd/runtime/snapshot/SnapshotTest.java
+++ b/biz.aQute.bnd.runtime/test/aQute/bnd/runtime/snapshot/SnapshotTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 
 import org.apache.felix.service.command.CommandProcessor;
 import org.apache.felix.service.command.CommandSession;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -18,33 +17,26 @@ import aQute.launchpad.Service;
 import aQute.lib.io.IO;
 
 public class SnapshotTest {
+	static final String	org_apache_felix_framework		= "org.apache.felix.framework;version='[5.6.10,5.6.11)'";
+	static final String	org_apache_felix_scr			= "org.apache.felix.scr;version='[2.1.12,2.1.13)'";
+	static final String	org_apache_felix_log			= "org.apache.felix.log;version='[1.2.0,1.2.1)'";
+	static final String	org_apache_felix_configadmin	= "org.apache.felix.configadmin;version='[1.9.10,1.9.11)'";
+	static final String	org_apache_felix_gogo_runtime	= "org.apache.felix.gogo.runtime;version='[1.1.0,1.1.0]'";
 	static File tmp = IO.getFile("generated/snapshot");
 
 	@BeforeClass
 	static public void before() {
 		IO.delete(tmp);
 		tmp.mkdirs();
-		System.setProperty("snapshot.dir", tmp.getAbsolutePath());
 	}
 
-	@AfterClass
-	static public void after() {
-		System.getProperties()
-			.remove("snapshot.dir");
-	}
-	// static Workspace w;
-	// static {
-	// try {
-	// Workspace.findWorkspace(IO.work);
-	// } catch (Exception e) {
-	// // TODO Auto-generated catch block
-	// e.printStackTrace();
-	// }
-	// }
-
-	LaunchpadBuilder	builder	= new LaunchpadBuilder().runfw("org.apache.felix.framework")
-		.bundles(
-			"biz.aQute.bnd.runtime.snapshot, org.apache.felix.log, org.apache.felix.configadmin, org.apache.felix.scr, org.apache.felix.gogo.runtime");
+	LaunchpadBuilder	builder	= new LaunchpadBuilder().runfw(org_apache_felix_framework)
+		.bundles("biz.aQute.bnd.runtime.snapshot")
+		.bundles(org_apache_felix_log)
+		.bundles(org_apache_felix_configadmin)
+		.bundles(org_apache_felix_scr)
+		.bundles(org_apache_felix_gogo_runtime)
+		.set("snapshot.dir", tmp.getAbsolutePath());
 
 	@Service
 	CommandProcessor	gogo;

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -16,10 +16,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
@@ -774,17 +770,10 @@ public class AlsoLauncherTest {
 				.as("System Bundle")
 				.containsPattern("\\n0\\s+\\d*\\s*ACTIV\\s+[<][>]\\s+System Bundle");
 
-			final DateTimeFormatter f = DateTimeFormatter.ofPattern("YYYYMMddHHmm")
-				.withZone(ZoneOffset.UTC);
-
 			for (String bundle : expected) {
-				final Path file = Paths.get(r.process("${repo;" + bundle + ";latest}"));
-				final String lastModified = f.format(java.nio.file.Files.getLastModifiedTime(file)
-					.toInstant());
-
 				softly.assertThat(report)
 					.as(bundle)
-					.containsPattern("ACTIV\\s+" + lastModified + "\\s+.*?\\Q" + file.getFileName() + "\\E");
+					.containsPattern("ACTIV\\s+\\d{12}\\s+.*\\Q" + bundle + "\\E");
 			}
 		}
 	}

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/BeforeAfterTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/BeforeAfterTest.java
@@ -15,8 +15,12 @@ import aQute.launchpad.junit.LaunchpadRunner;
 @RunWith(LaunchpadRunner.class)
 public class BeforeAfterTest {
 
-	static LaunchpadBuilder	builder	= new LaunchpadBuilder().runfw("org.apache.felix.framework")
-		.bundles("assertj-core, org.apache.felix.scr")
+	static final String		org_apache_felix_framework	= "org.apache.felix.framework;version='[5.6.10,5.6.11)'";
+	static final String		org_apache_felix_scr		= "org.apache.felix.scr;version='[2.1.12,2.1.13)'";
+
+	static LaunchpadBuilder	builder						= new LaunchpadBuilder().runfw(org_apache_felix_framework)
+		.bundles("assertj-core")
+		.bundles(org_apache_felix_scr)
 		.debug();
 
 	@Service

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.Closeable;
+import java.io.File;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -18,8 +19,10 @@ import aQute.launchpad.junit.LaunchpadRunner;
 
 @RunWith(LaunchpadRunner.class)
 public class FO {
+	static File				tmp		= new File("generated/snapshot");
 
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
+		.set("snapshot.dir", tmp.getAbsolutePath())
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.bundles(
 			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, assertj-core, org.apache.servicemix.bundles.junit")

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadConfigurationTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadConfigurationTest.java
@@ -20,8 +20,10 @@ import aQute.launchpad.junit.LaunchpadRunner;
 @SuppressWarnings("restriction")
 @RunWith(LaunchpadRunner.class)
 public class LaunchpadConfigurationTest {
+	static File				tmp		= new File("generated/snapshot");
 
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
+		.set("snapshot.dir", tmp.getAbsolutePath())
 		.bndrun("runsystempackages.bndrun")
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.export("*")

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
@@ -3,6 +3,7 @@ package aQute.xlaunchpad;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Closeable;
+import java.io.File;
 import java.util.Set;
 
 import org.junit.Test;
@@ -19,8 +20,10 @@ import aQute.libg.parameters.ParameterMap;
 @SuppressWarnings("restriction")
 @RunWith(LaunchpadRunner.class)
 public class LaunchpadRunnerBasicTest {
+	static File				tmp		= new File("generated/snapshot");
 
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
+		.set("snapshot.dir", tmp.getAbsolutePath())
 		.bndrun("runsystempackages.bndrun")
 		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
 		.export("*")

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/Manual.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/Manual.java
@@ -21,7 +21,11 @@ import aQute.launchpad.LaunchpadBuilder;
 import aQute.launchpad.Service;
 
 public class Manual {
-	LaunchpadBuilder	builder	= new LaunchpadBuilder().runfw("org.apache.felix.framework");
+	static final String	org_apache_felix_framework		= "org.apache.felix.framework;version='[5.6.10,5.6.11)'";
+	static final String	org_apache_felix_scr			= "org.apache.felix.scr;version='[2.1.12,2.1.13)'";
+	static final String	org_apache_felix_log			= "org.apache.felix.log;version='[1.2.0,1.2.1)'";
+	static final String	org_apache_felix_configadmin	= "org.apache.felix.configadmin;version='[1.9.10,1.9.11)'";
+	LaunchpadBuilder	builder						= new LaunchpadBuilder().runfw(org_apache_felix_framework);
 
 	@Service
 	BundleContext		context;
@@ -133,9 +137,9 @@ public class Manual {
 
 	@Test
 	public void component() throws Exception {
-		try (Launchpad launchpad = builder.bundles("org.apache.felix.log")
-			.bundles("org.apache.felix.scr")
-			.bundles("org.apache.felix.configadmin")
+		try (Launchpad launchpad = builder.bundles(org_apache_felix_log)
+			.bundles(org_apache_felix_scr)
+			.bundles(org_apache_felix_configadmin)
 			.create()) {
 
 			launchpad.component(C.class);
@@ -147,9 +151,9 @@ public class Manual {
 
 	@Test
 	public void debug() throws Exception {
-		try (Launchpad launchpad = builder.bundles("org.apache.felix.log")
-			.bundles("org.apache.felix.scr")
-			.bundles("org.apache.felix.configadmin")
+		try (Launchpad launchpad = builder.bundles(org_apache_felix_log)
+			.bundles(org_apache_felix_scr)
+			.bundles(org_apache_felix_configadmin)
 			.debug()
 			.create()) {
 			//
@@ -193,7 +197,7 @@ public class Manual {
 
 	@Test
 	public void testHiding() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.nostart()
 			.create()
 			.inject(this)) {
@@ -232,7 +236,7 @@ public class Manual {
 
 	@Test
 	public void testHidingViaBuilder() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.hide(String.class)
 			.create()) {
 

--- a/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
+++ b/biz.aQute.launchpad/test/aQute/launchpad/LaunchpadTest.java
@@ -43,6 +43,9 @@ import aQute.lib.io.IO;
 import aQute.libg.parameters.ParameterMap;
 
 public class LaunchpadTest {
+	static final String					org_apache_felix_framework	= "org.apache.felix.framework;version='[5.6.10,5.6.11)'";
+	static final String					org_apache_felix_scr		= "org.apache.felix.scr;version='[2.1.12,2.1.13)'";
+	static final String					org_apache_felix_log		= "org.apache.felix.log;version='[1.2.0,1.2.1)'";
 	@Rule
 	public final JUnitSoftAssertions	softly	= new JUnitSoftAssertions();
 
@@ -62,7 +65,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testExportExcludes() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.excludeExport("org.slf4j*,aQute.lib*")
 			.create()) {
 			Set<String> p = new ParameterMap(fw.getBundleContext()
@@ -73,7 +76,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testRunsystemPackages() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.bndrun("runsystempackages.bndrun")
 			.create()) {
 			Set<String> p = new ParameterMap(fw.getBundleContext()
@@ -134,7 +137,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testInjectionInherited() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()) {
 
 			Foo foo = fw.newInstance(Foo.class);
@@ -146,7 +149,7 @@ public class LaunchpadTest {
 	@Test
 	public void testBundleActivatorCalled() throws Exception {
 
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.debug()
 			.create()) {
 
@@ -184,7 +187,7 @@ public class LaunchpadTest {
 	@Test
 	public void testConfiguration() throws Exception {
 
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()
 			.inject(this)) {
 
@@ -231,8 +234,9 @@ public class LaunchpadTest {
 
 	@Test
 	public void testComponent() throws Exception {
-		try (Launchpad fw = builder.bundles("org.apache.felix.log, org.apache.felix.scr")
-			.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.bundles(org_apache_felix_log)
+			.bundles(org_apache_felix_scr)
+			.runfw(org_apache_felix_framework)
 			.create()) {
 
 			Bundle comp = fw.component(Comp.class);
@@ -260,7 +264,7 @@ public class LaunchpadTest {
 		}
 		X x = new X();
 		try (Launchpad fw = builder.bundles()
-			.runfw("org.apache.felix.framework")
+			.runfw(org_apache_felix_framework)
 			.create()
 			.inject(x)) {
 
@@ -270,7 +274,7 @@ public class LaunchpadTest {
 	@Test
 	public void testTimeoutWithInvisibleAndFiltered() throws Exception {
 		try {
-			try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+			try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 				.create()) {
 
 				Hashtable<String, Object> properties = new Hashtable<>();
@@ -309,7 +313,7 @@ public class LaunchpadTest {
 	@Test
 	public void testTimeoutWithPrivatePackage() throws Exception {
 		try {
-			try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+			try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 				.create()) {
 
 				Bundle a = fw.bundle()
@@ -338,7 +342,7 @@ public class LaunchpadTest {
 	@Test
 	public void testReportingHiddenService() throws Exception {
 		try {
-			try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+			try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 				.create()) {
 
 				fw.framework.getBundleContext()
@@ -364,7 +368,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testReportingUnimportedExport() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()) {
 
 			Bundle a = fw.bundle()
@@ -379,7 +383,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testGetService() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()) {
 
 			assertThat(fw.getService(String.class)).isEmpty();
@@ -388,7 +392,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testRegisterService() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()) {
 			fw.register(String.class, "Hello", "a", 1, "b", 2, "c", new int[] {
 				3, 4, 5
@@ -414,8 +418,9 @@ public class LaunchpadTest {
 
 	@Test
 	public void componentWithExternalReferences() throws Exception {
-		try (Launchpad fw = builder.bundles("org.apache.felix.log, org.apache.felix.scr")
-			.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.bundles(org_apache_felix_log)
+			.bundles(org_apache_felix_scr)
+			.runfw(org_apache_felix_framework)
 			.create()) {
 			fw.component(ExternalRefComp.class);
 		}
@@ -423,7 +428,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testAutoname() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create()) {
 			assertThat(fw.getName()).isEqualTo("testAutoname");
 			assertThat(fw.getClassName()).isEqualTo(LaunchpadTest.class.getName());
@@ -432,7 +437,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testSetName() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create("foo")) {
 			assertThat(fw.getName()).isEqualTo("foo");
 			assertThat(fw.getClassName()).isEqualTo(LaunchpadTest.class.getName());
@@ -441,7 +446,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void testSetNameAndClassName() throws Exception {
-		try (Launchpad fw = builder.runfw("org.apache.felix.framework")
+		try (Launchpad fw = builder.runfw(org_apache_felix_framework)
 			.create("foo", "bar")) {
 			assertThat(fw.getName()).isEqualTo("foo");
 			assertThat(fw.getClassName()).isEqualTo("bar");
@@ -454,8 +459,9 @@ public class LaunchpadTest {
 		List<Throwable> e = new CopyOnWriteArrayList<>();
 		Random r = new Random();
 		Semaphore semaphore = new Semaphore(0);
-		builder.bundles("org.apache.felix.log, org.apache.felix.scr")
-			.runfw("org.apache.felix.framework");
+		builder.bundles(org_apache_felix_log)
+			.bundles(org_apache_felix_scr)
+			.runfw(org_apache_felix_framework);
 
 		int n = 20;
 		for (int i = 0; i < n; i++) {
@@ -512,7 +518,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void instantiateInFramework_instantiatesTheClass_insideTheFramework() throws Exception {
-		try (Launchpad lp = builder.runfw("org.apache.felix.framework")
+		try (Launchpad lp = builder.runfw(org_apache_felix_framework)
 			.create()) {
 			Supplier<Bundle> b = lp.instantiateInFramework(TestClass.class);
 			assertThat(b).as("inside")
@@ -527,7 +533,7 @@ public class LaunchpadTest {
 
 	@Test
 	public void instantiateInFramework_withNoDefaultConstructor_throwsException() throws Exception {
-		try (Launchpad lp = builder.runfw("org.apache.felix.framework")
+		try (Launchpad lp = builder.runfw(org_apache_felix_framework)
 			.create()) {
 			assertThatThrownBy(() -> lp.instantiateInFramework(TestClass2.class))
 				.isInstanceOf(NoSuchMethodException.class);

--- a/demo/bnd.bnd
+++ b/demo/bnd.bnd
@@ -14,7 +14,7 @@ Bundle-SymbolicName: demo
 	org.apache.felix.framework;version='[5.6.8,6)', \
 	biz.aQute.launcher; version=snapshot
 
--runbundles: org.apache.felix.scr;startlevel=10,\
+-runbundles: org.apache.felix.scr;version='[2.1.12,2.1.13)';startlevel=10,\
 	org.apache.felix.configadmin;startlevel=11, \
 	${junit}
 


### PR DESCRIPTION
Some testing fixes.

Some tests are sensitive to the versions of certain bundles. Using later versions of the
bundles can cause the tests to fail. Later versions of Felix SCR no
longer provide DS packages and the OSGi DS api bundle requires Core R7.
The Felix framework used is Core R6 and the launchpad API uses Core R6.
