### PR TITLE
[bndtools test] Wait for cnf workspace before proceeding

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,7 +24,6 @@ env:
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
     -Dmaven.wagon.http.retryHandler.count=3
-  BNDTOOLS_CORE_TEST_NOJUNITOSGI: true
 
 defaults:
   run:

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -230,6 +230,7 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			if (buildPath != null && !buildPath.isEmpty()) {
 				model.setBuildPath(Collections.emptyList());
 				model.saveChanges();
+				Central.refresh(bndProject);
 				waitForClasspathUpdate("clearBuildpath()");
 			} else {
 				log("buildpath was not set; not trying to clear it");
@@ -248,6 +249,7 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 				model.addPath(new VersionedClause(bundleName, null), Constants.BUILDPATH);
 			}
 			model.saveChanges();
+			Central.refresh(bndProject);
 			waitForClasspathUpdate("addBundleToBuildpath");
 		} catch (Exception e) {
 			throw Exceptions.duck(e);

--- a/bndtools.core.test/src/bndtools/core/test/utils/TaskUtils.java
+++ b/bndtools.core.test/src/bndtools/core/test/utils/TaskUtils.java
@@ -4,11 +4,22 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
 
 import aQute.lib.exceptions.Exceptions;
 
 public class TaskUtils {
+
+	static IResourceVisitor VISITOR = resource -> {
+		IPath path = resource.getFullPath();
+		log(path == null ? "null" : path.toString());
+		return true;
+	};
 
 	private TaskUtils() {}
 
@@ -46,5 +57,15 @@ public class TaskUtils {
 
 	public static void synchronously(MonitoredTask task) {
 		synchronously(null, task);
+	}
+
+	public static void dumpWorkspace() {
+		IWorkspace ws = ResourcesPlugin.getWorkspace();
+		try {
+		ws.getRoot()
+			.accept(VISITOR);
+		} catch (CoreException e) {
+			throw Exceptions.duck(e);
+		}
 	}
 }


### PR DESCRIPTION
In order to try and overcome race conditions at startup, put in a callback that causes the tester to wait for the Workspace to be ready before proceeding.

This is a bit of a hack, but it seems to stabilise the tests - I ran it in my own CI instance on GitHub a few times and it seems to have succeeded on all platforms each time.