### PR TITLE
[central] Update workspace if directory has changed

### DIFF
--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -240,9 +240,10 @@ public class Central implements IStartupParticipant {
 				// one
 				File workspaceDirectory = getWorkspaceDirectory();
 				// Check to see if we need to convert it...
-				if (workspaceDirectory != null && ws.isDefaultWorkspace()) {
+				if (workspaceDirectory != null && !workspaceDirectory.equals(ws.getBase())) {
 					// There is a "cnf" project and the current workspace is
-					// the default, so switch the workspace to the directory
+					// not the same as the directory the cnf project is in,
+					// so switch the workspace to the directory
 					ws.setFileSystem(workspaceDirectory, Workspace.CNFDIR);
 					ws.forceRefresh();
 					ws.refresh();


### PR DESCRIPTION
The existing code assumed that the bnd ws would always be changing direct from default to a cnf workspace, or direct from a cnf workspace to a default. This is most probably the case nearly all the time. However, just to be a bit more defensive, put code in here to handle the case where we change direct from one cnf to another.