### PR TITLE
[resolve] Allow inclusion of the system resource

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -223,6 +223,12 @@ public interface Constants {
 
 	String				RESOLVE										= "-resolve";
 
+	/**
+	 * Exclude the system resource from the resulting wiring in resolve. The
+	 * default is true
+	 */
+	String				RESOLVE_EXCLUDESYSTEM						= "-resolve.excludesystem";
+
 	String				RUNNOREFERENCES								= "-runnoreferences";
 	String				RUNFRAMEWORKRESTART							= "-runframeworkrestart";
 	String				RUNOPTIONS									= "-runoptions";

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -193,7 +193,8 @@ public class ResolveProcess {
 		}
 
 		Map<Resource, List<Wire>> result = invertWirings(wirings, rc2);
-		removeFrameworkAndInputResources(result, rc2);
+		if (Processor.isTrue(properties.getProperty(Constants.RESOLVE_EXCLUDESYSTEM, "true")))
+			removeFrameworkAndInputResources(result, rc2);
 		required.putAll(result);
 		optional = tidyUpOptional(wirings, discoveredOptional, log);
 		return result;

--- a/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
@@ -7,8 +7,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.AfterEach;
@@ -58,6 +60,22 @@ public class RunResolutionTest {
 		Bndrun bndrun = Bndrun.createBndrun(workspace, IO.getFile(ws.toFile(), "test.simple/resolve.bndrun"));
 		String resolve = bndrun.resolve(false, false);
 		assertThat(bndrun.check()).isTrue();
+	}
+
+	@Test
+	public void testExcludeSystemResource() throws Exception {
+		Bndrun bndrun = Bndrun.createBndrun(workspace, IO.getFile(ws.toFile(), "test.simple/resolve.bndrun"));
+		RunResolution resolve = RunResolution.resolve(bndrun, null);
+		Set<Resource> noFramework = resolve.getRequired()
+			.keySet();
+
+		bndrun.setProperty(Constants.RESOLVE_EXCLUDESYSTEM, "false");
+		resolve = RunResolution.resolve(bndrun, null);
+		Set<Resource> withFramework = new HashSet<>(resolve.getRequired()
+			.keySet());
+
+		withFramework.removeAll(noFramework);
+		assertThat(withFramework).hasSize(1);
 	}
 
 	@Test

--- a/docs/_instructions/resolve.excludesystem.md
+++ b/docs/_instructions/resolve.excludesystem.md
@@ -1,0 +1,10 @@
+---
+layout: default
+class: Runtime
+title: -resolve.excludesystem true|false
+summary: A property used by the resolver, if set to true (default) it excludes the system resource
+---
+
+This property has no meaning in the normal configuration. It is used by code that needs to
+have the _system resource_ in the wiring. Normally the wiring excludes the system resource.
+However, sometimes it is necessary to see the full solution.


### PR DESCRIPTION
I had a use case where I also needed access to
the system resource. However, this is unfortunately
explicitly removed from the result.

This introduces a instruction -resolve.excludesystem
that by default excludes it but can be set to false
to include it in the result.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>