### PR TITLE
Prepare for Java 16 and Gradle 7

### DIFF
--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -8,8 +8,9 @@ dependencies {
   compileOnly localGroovy()
   compileOnly gradleApi()
   testImplementation gradleTestKit()
-  testImplementation('org.spockframework:spock-core:1.1-groovy-2.4')  {
-    exclude module: 'groovy-all'
+  testImplementation("org.spockframework:spock-core:2.0-M4-groovy-${GroovySystem.shortVersion}") {
+        exclude group: 'org.codehaus.groovy'
+        exclude group: 'org.junit.platform'
   }
 }
 
@@ -19,22 +20,30 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
   }
 }
 
+def pluginUnderTestResources = project.layout.buildDirectory.dir('plugin-under-test')
+
 def pluginUnderTestMetadata = tasks.register('pluginUnderTestMetadata', WriteProperties.class) {
  def pluginClasspath = project.providers.provider({ ->
     return project.files(configurations.runtimeClasspath.allArtifacts.files,
      configurations.runtimeClasspath.resolvedConfiguration.files)
   })
   inputs.files(pluginClasspath).withPropertyName('pluginClasspath')
-  outputFile = tasks.named('compileTestJava').flatMap { it.destinationDirectory.file('plugin-under-test-metadata.properties') }
+  outputFile = pluginUnderTestResources.map { it.file('plugin-under-test-metadata.properties') }
   doFirst {
     property('implementation-classpath',  pluginClasspath.get().asPath)
   }
 }
 
+sourceSets {
+   test {
+     output.dir(pluginUnderTestResources, builtBy: pluginUnderTestMetadata)
+   }
+}
+
 tasks.named('test') {
   def testresources = project.file('testresources')
   def target = project.layout.buildDirectory.dir('testresources')
-  inputs.files tasks.named('jar'), pluginUnderTestMetadata
+  inputs.files tasks.named('jar')
   inputs.dir testresources
   systemProperty 'bnd_version', bnd('bnd_version')
   systemProperty 'org.gradle.warning.mode', gradle.startParameter.warningMode.name().toLowerCase()

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -166,9 +166,11 @@ public class BndPlugin implements Plugin<Project> {
               if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
                 File destinationDir = java.outputDir
                 String compileTaskName = getCompileTaskName(lang)
+                String resourceTaskName = getProcessResourcesTaskName()
                 try {
                   tasks.named(compileTaskName) { t ->
                     t.destinationDir = destinationDir
+                    t.inputs.files(tasks.named(resourceTaskName))
                     if (generate) {
                       t.inputs.files(generate)
                     }
@@ -188,9 +190,11 @@ public class BndPlugin implements Plugin<Project> {
               if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
                 File destinationDir = java.outputDir
                 String compileTaskName = getCompileTaskName(lang)
+                String resourceTaskName = getProcessResourcesTaskName()
                 try {
                   tasks.named(compileTaskName) { t ->
                     t.destinationDir = destinationDir
+                    t.inputs.files(tasks.named(resourceTaskName))
                   }
                   sourceDirSet.srcDirs = java.srcDirs
                   sourceDirSet.outputDir = destinationDir

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -30,6 +30,9 @@ class TestHelper {
   }
 
   private static String gradleVersion() {
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+      return '7.0'
+    }
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
       return '6.7'
     }

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestIndexTask.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestIndexTask.groovy
@@ -23,7 +23,7 @@ class TestIndexTask extends Specification {
         when:
           def result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--parallel', '--stacktrace', '--debug', 'build', 'indexer', 'indexer2')
+            .withArguments('--parallel', '--stacktrace', '--debug', 'indexer', 'indexer2')
             .withPluginClasspath()
             .forwardOutput()
             .build()
@@ -132,7 +132,7 @@ class TestIndexTask extends Specification {
         when:
           result = TestHelper.getGradleRunner()
             .withProjectDir(testProjectDir)
-            .withArguments('--parallel', '--stacktrace', '--debug', 'build', 'indexer', 'indexer2')
+            .withArguments('--parallel', '--stacktrace', '--debug', 'indexer', 'indexer2')
             .withPluginClasspath()
             .forwardOutput()
             .build()

--- a/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
@@ -74,6 +74,7 @@ task indexer(type: Index) {
     exclude '**/*-latest.jar'
     exclude '**/*-sources.jar'
     exclude '**/*-javadoc.jar'
+    builtBy tasks.withType(Jar)
   }
 }
 
@@ -89,5 +90,6 @@ task indexer2(type: Index) {
     exclude '**/*-latest.jar'
     exclude '**/*-sources.jar'
     exclude '**/*-javadoc.jar'
+    builtBy tasks.withType(Jar)
   }
 }

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -15,7 +15,7 @@
   -Dorg.eclipse.swt.internal.carbon.smallFonts
 
 -runsystemcapabilities.macos: \
-	osgi.native;osgi.native.osname=macosx;osgi.native.processor=x86-64
+	osgi.native;osgi.native.osname:List<String>="macosx";osgi.native.processor:List<String>="x86-64"
 
 -runproperties.macos: \
 	osgi.ws=cocoa,\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -14,7 +14,7 @@
 	-XX:+UseStringDeduplication
 
 -runsystemcapabilities.linux: \
-	osgi.native;osgi.native.osname=linux;osgi.native.processor=x86-64
+	osgi.native;osgi.native.osname:List<String>="linux";osgi.native.processor:List<String>="x86-64"
 
 -runproperties.linux: \
 	osgi.ws=gtk,\

--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -2,7 +2,7 @@
 
 # Do not run this, use the platform-specific bndrun files (which "-include" this)
 
--runfw: org.eclipse.osgi;version='[3.15.300.v20200520-1959,3.15.300.v20200520-1959]'
+-runfw: org.eclipse.osgi;repo='Eclipse*'
 
 -runvm: \
   -Xmx2g, \

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -13,7 +13,7 @@
 -runvm.win32:
 
 -runsystemcapabilities.win32: \
-	osgi.native;osgi.native.osname=win32;osgi.native.processor=x86-64
+	osgi.native;osgi.native.osname:List<String>="win32";osgi.native.processor:List<String>="x86-64"
 
 -runproperties.win32: \
 	osgi.ws=win32,\

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ import aQute.lib.io.IO
 
 if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
   ext.jpmsOptions = [
-    '--illegal-access=warn',
     '--add-opens=java.base/java.lang=ALL-UNNAMED',
     '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
     '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -27,6 +27,8 @@
 		<!-- The following versions should match those in cnf/ext/junit.bnd -->
 		<junit4.version>4.13.2</junit4.version>
 		<assertj.version>3.19.0</assertj.version>
+		<jpmsOptions></jpmsOptions>
+		<mavenOpts>${jpmsOptions}</mavenOpts>
 	</properties>
 
 	<modules>
@@ -325,7 +327,7 @@
 						<scriptVariables>
 							<bndVersion>${project.version}</bndVersion>
 						</scriptVariables>
-						<mavenOpts>${env.MAVEN_OPTS}</mavenOpts>
+						<mavenOpts>${mavenOpts}</mavenOpts>
 						<goals>
 							<goal>--no-transfer-progress</goal>
 							<goal>package</goal>
@@ -505,6 +507,34 @@
 			</activation>
 			<properties>
 				<maven.compiler.release>${java.release}</maven.compiler.release>
+				<jpmsOptions>--add-opens=java.base/java.lang=ALL-UNNAMED
+					--add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+					--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+					--add-opens=java.base/java.io=ALL-UNNAMED
+					--add-opens=java.base/java.net=ALL-UNNAMED
+					--add-opens=java.base/java.nio=ALL-UNNAMED
+					--add-opens=java.base/java.util=ALL-UNNAMED
+					--add-opens=java.base/java.util.jar=ALL-UNNAMED
+					--add-opens=java.base/java.util.regex=ALL-UNNAMED
+					--add-opens=java.base/java.util.zip=ALL-UNNAMED
+					--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+					--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jpmsOptions>
+			</properties>
+		</profile>
+		<profile>
+			<id>maven-opts</id>
+			<activation>
+				<property>
+					<name>env.MAVEN_OPTS</name>
+				</property>
+			</activation>
+			<properties>
+				<mavenOpts>${env.MAVEN_OPTS} ${jpmsOptions}</mavenOpts>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
Java 16  is now released. But Java 16 requires Gradle 7. Gradle 7 now uses Groovy 3 for Java 16 support. Groovy 3 requires a different version of Spock for testing.

So lots of changes being made. So this PR makes preparation for adding a  Java 16 build to the CI once Gradle 7 is released. This has been tested on a Gradle 7 nightly build `7.0-20210322000034+0000`.