### PR TITLE
lib: Fix bnd duplicate export warning

### DIFF
--- a/aQute.libg/src/aQute/libg/map/package-info.java
+++ b/aQute.libg/src/aQute/libg/map/package-info.java
@@ -1,3 +1,2 @@
-@org.osgi.annotation.bundle.Export
 @org.osgi.annotation.versioning.Version("1.4.0")
 package aQute.libg.map;


### PR DESCRIPTION
All packages in aQute.libg are exported via the `-exportcontents`
instruction in the bnd file. The Export annotation caused Bnd to emit
a duplicate export warning.

