### PR TITLE
PomRepository should read maven GAV with Type and Classifier

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -52,7 +52,6 @@ import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.libg.reporter.slf4j.Slf4jReporter;
 import aQute.maven.api.Archive;
-import aQute.maven.api.Revision;
 import aQute.maven.provider.MavenBackingRepository;
 import aQute.maven.provider.MavenRepository;
 import aQute.service.reporter.Reporter;
@@ -74,7 +73,7 @@ public class BndPomRepository extends BaseRepository
 	private Reporter			reporter			= new Slf4jReporter(BndPomRepository.class);
 	private File				localRepo;
 	private InnerRepository		repoImpl;
-	private List<Revision>		revisions;
+	private List<Archive>		archives;
 	private BridgeRepository	bridge;
 	private List<URI>			pomFiles;
 	private String				query;
@@ -122,22 +121,22 @@ public class BndPomRepository extends BaseRepository
 				})
 				.collect(toList());
 			if (pomFiles.isEmpty()) {
-				status("Pom is neither a file nor a revision " + configuration.pom());
+				status("Pom is neither a file nor a archive " + configuration.pom());
 			}
 		} else if (configuration.revision() != null) {
-			revisions = Strings.split(configuration.revision())
+			archives = Strings.split(configuration.revision())
 				.stream()
-				.map(Revision::valueOf)
+				.map(Archive::valueOf)
 				.filter(Objects::nonNull)
 				.collect(toList());
-			if (revisions.isEmpty()) {
-				status("Revision is neither a file nor a revision " + configuration.revision());
+			if (archives.isEmpty()) {
+				status("Archive is neither a file nor a revision " + configuration.revision());
 			}
 		} else if (configuration.query() != null) {
 			this.query = configuration.query();
 			this.queryUrl = configuration.queryUrl("http://search.maven.org/solrsearch/select");
 		} else {
-			status("Neither pom, revision nor query property are set");
+			status("Neither pom, archive nor query property are set");
 		}
 
 		initialized = Processor.getPromiseFactory()
@@ -172,8 +171,8 @@ public class BndPomRepository extends BaseRepository
 
 			if (pomFiles != null) {
 				repoImpl = new PomRepository(repository, client, location, transitive).uris(pomFiles);
-			} else if (revisions != null) {
-				repoImpl = new PomRepository(repository, client, location, transitive).revisions(revisions);
+			} else if (archives != null) {
+				repoImpl = new PomRepository(repository, client, location, transitive).archives(archives);
 			} else if (query != null) {
 				repoImpl = new SearchRepository(repository, location, query, queryUrl, workspace, client, transitive);
 			} else {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.1")
+@Version("2.0.2")
 package aQute.bnd.repository.maven.pom.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -622,7 +622,7 @@ public class PomRepositoryTest extends TestCase {
 			config.put("name", "test");
 			mcsr.setProperties(config);
 			mcsr.prepare();
-			assertEquals("Neither pom, revision nor query property are set", mcsr.getStatus());
+			assertEquals("Neither pom, archive nor query property are set", mcsr.getStatus());
 		}
 	}
 
@@ -692,7 +692,9 @@ public class PomRepositoryTest extends TestCase {
 
 			String revisions = Strings.join(new String[] {
 				"biz.aQute.bnd:biz.aQute.junit:3.3.0", "biz.aQute.bnd:biz.aQute.launcher:3.3.0",
-				"biz.aQute.bnd:biz.aQute.remote.launcher:3.3.0", "biz.aQute.bnd:biz.aQute.tester:3.3.0"
+				"biz.aQute.bnd:biz.aQute.remote.launcher:3.3.0", "biz.aQute.bnd:biz.aQute.tester:3.3.0",
+				"org.jacoco:org.jacoco.agent:jar:runtime:0.8.6",
+				"org.apache.felix:org.apache.felix.framework:bin:zip:1.4.0"
 			});
 
 			config.put("revision", revisions);
@@ -707,10 +709,16 @@ public class PomRepositoryTest extends TestCase {
 
 			RequirementBuilder builder = mcsr.newRequirementBuilder("osgi.identity");
 			builder.addAttribute("filter", "(osgi.identity=biz.aQute.tester)");
-
 			Promise<Collection<Resource>> providers = mcsr.findProviders(builder.buildExpression());
 			Collection<Resource> resources = providers.getValue();
 			assertFalse(resources.isEmpty());
+
+			assertThat(mcsr.list("*")).contains("biz.aQute.remote.launcher",
+				"biz.aQute.launcher", "biz.aQute.junit", "biz.aQute.tester", //
+				"org.jacoco:org.jacoco.agent", // with classifier
+				"org.apache.felix:org.osgi.foundation",// from zip
+				"org.apache.felix:org.apache.felix.framework" // from zip
+				);
 		}
 	}
 

--- a/docs/_plugins/pomrepo.md
+++ b/docs/_plugins/pomrepo.md
@@ -64,7 +64,7 @@ The query must return a JSON response.
 | `local`          | `PATH`| `~/.m2/repository` | The file path to the local Maven repository.  |
 |                  |       |                    | If specified, it should use forward slashes. If the directory does not exist, the plugin will attempt to create it.|
 |                  |       |         | The default can be overridden with the `maven.repo.local` System property.|
-| `revision`       | `GAV...` |      | A comma separated list of Maven coordinates. The GAV will be searched in the normal way.|
+| `revision`       | `GAV...` |      | A comma separated list of Maven coordinates. The GAV will be searched in the normal way. For further information about Coordinates & Terminology please see MavenBndRepositoryPlugin|
 | `pom`            | `URI...` |      | A comma separated list of URLs to POM files.|
 | `location`       | `PATH` | `cnf/cache/pom-<name>.xml` | Optional cached index of the parsed POMs. |
 | `query`          | `STRING` |      | A Solr query string. This is the part after `?` and must be properly URL encoded|


### PR DESCRIPTION
At the moment the PomRepository  can only read a maven-revision, a G:A:V without Type and Classifier.
When reading an Archive instead of an Revision , like BndPomRepository does, this could be fixed.
