### PR TITLE
[gradle] support filtering executable tasks

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -50,12 +50,16 @@ public class BndPlugin implements Plugin<Project> {
   private ProjectLayout layout
   private ObjectFactory objects
   private aQute.bnd.build.Project bndProject
+  private BndPluginExtension extension
 
   /**
    * Apply the {@code biz.aQute.bnd} plugin to the specified project.
    */
   @Override
   public void apply(Project p) {
+    extension = p.getExtensions()
+      .create("bnd", BndPluginExtension.class);
+
     p.configure(p) { Project project ->
       this.project = project
       this.layout = project.layout
@@ -447,6 +451,7 @@ public class BndPlugin implements Plugin<Project> {
           t.description "Export the ${runFile.name} file."
           t.dependsOn 'assemble'
           t.group 'export'
+          t.enabled runFile.name.matches(extension.getExportFilter());
           t.bndrun = runFile
           t.exporter = EXECUTABLE_JAR
         }
@@ -479,6 +484,7 @@ public class BndPlugin implements Plugin<Project> {
           t.description "Resolve the runbundles required for ${runFile.name} file."
           t.dependsOn 'assemble'
           t.group 'export'
+          t.enabled runFile.name.matches(extension.getResolveFilter());
           t.bndrun = runFile
         }
       }
@@ -503,6 +509,7 @@ public class BndPlugin implements Plugin<Project> {
           t.description "Runs the OSGi JUnit tests in the bndrun file ${runFile.name}."
           t.dependsOn 'assemble'
           t.group 'verification'
+          t.enabled runFile.name.matches(extension.getTestrunFilter());
           t.bndrun = runFile
         }
       }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginExtension.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginExtension.groovy
@@ -1,0 +1,32 @@
+package aQute.bnd.gradle;
+
+public class BndPluginExtension {
+	private String	exportFilter	= ".*.bndrun";
+	private String	resolveFilter	= ".*.bndrun";
+	private String	testrunFilter	= ".*.bndrun";
+
+	public String getTestrunFilter() {
+		return testrunFilter;
+	}
+
+	public void setTestrunFilter(String testrunFilter) {
+		this.testrunFilter = testrunFilter;
+	}
+
+	public String getExportFilter() {
+		return exportFilter;
+	}
+
+	public void setExportFilter(String exportFilter) {
+		this.exportFilter = exportFilter;
+	}
+
+	public String getResolveFilter() {
+		return resolveFilter;
+	}
+
+	public void setResolveFilter(String resolveFilter) {
+		this.resolveFilter = resolveFilter;
+	}
+
+}


### PR DESCRIPTION
The goal is to control the testrun, resolve and export task by using context properties like
```
bnd {
  properties {
    property "bnd.testrun.filter", "test(.*)?\.bndrun" 
    property "bnd.export.filter", "export(.*)?\.bndrun"
    property "bnd.resolve.filter", "(test|export)(.*)?\.bndrun"
}}
```

and an option to exclude bnd.bnd files from the `testOSGi` task.

the commands then should run only filterd bndruns
```
./gradlew resolve
./gradlew export
./gradlew testrun
```

This is my first time with groovy and gradle..... Help is welcome!!!