### PR TITLE
[quickfix] Handle bound mismatches

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -110,6 +110,9 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.ParameterMismatch :
 				// System.out.println("ParameterMismatch");
 				return true;
+			case IProblem.TypeArgumentMismatch :
+				// System.out.println("TypeArgumentMismatch");
+				return true;
 			case IProblem.TypeMismatch :
 				// System.out.println("TypeMismatch");
 				return true;
@@ -312,6 +315,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 			for (IProblemLocation location : locations) {
 				this.location = location;
 				switch (location.getProblemId()) {
+					case IProblem.TypeArgumentMismatch :
 					case IProblem.HierarchyHasProblems : {
 						// This error often doesn't directly give us information
 						// as

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -7,6 +7,7 @@ import static org.eclipse.jdt.core.compiler.IProblem.HierarchyHasProblems;
 import static org.eclipse.jdt.core.compiler.IProblem.ImportNotFound;
 import static org.eclipse.jdt.core.compiler.IProblem.IsClassPathCorrect;
 import static org.eclipse.jdt.core.compiler.IProblem.ParameterMismatch;
+import static org.eclipse.jdt.core.compiler.IProblem.TypeArgumentMismatch;
 import static org.eclipse.jdt.core.compiler.IProblem.TypeMismatch;
 import static org.eclipse.jdt.core.compiler.IProblem.UndefinedConstructor;
 import static org.eclipse.jdt.core.compiler.IProblem.UndefinedField;
@@ -77,6 +78,7 @@ import aQute.bnd.deployer.repository.LocalIndexedRepo;
 import aQute.bnd.osgi.Constants;
 import aQute.lib.exceptions.Exceptions;
 import aQute.lib.io.IO;
+import aQute.lib.unmodifiable.Sets;
 import bndtools.central.Central;
 import bndtools.core.test.utils.WorkbenchTest;
 
@@ -329,10 +331,9 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	private static final String CLASS_HEADER = "package test; import java.util.List;\n" + "" + "class "
 			+ DEFAULT_CLASS_NAME + " {";
 	private static final String CLASS_FOOTER = " var};";
-	protected static final Set<Integer> SUPPORTED = Stream
-			.of(ImportNotFound, UndefinedType, IsClassPathCorrect, HierarchyHasProblems, ParameterMismatch, TypeMismatch,
-				UndefinedConstructor, UndefinedField, UndefinedMethod, UndefinedName, UnresolvedVariable)
-			.collect(Collectors.toSet());
+	protected static final Set<Integer> SUPPORTED = Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect, HierarchyHasProblems, ParameterMismatch, TypeMismatch,
+			UndefinedConstructor, UndefinedField, UndefinedMethod, UndefinedName, UnresolvedVariable,
+			TypeArgumentMismatch);
 
 	protected IJavaCompletionProposal[] proposalsForStaticImport(String imp) {
 		return proposalsFor(29, 0, "package test; import static " + imp + ";");

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -86,21 +86,21 @@ import bndtools.core.test.utils.WorkbenchTest;
 @WorkbenchTest
 abstract class AbstractBuildpathQuickFixProcessorTest {
 
-	static IPackageFragment pack;
-	static Class<? extends IQuickFixProcessor> sutClass;
+	static IPackageFragment						pack;
+	static Class<? extends IQuickFixProcessor>	sutClass;
 	// Injected by WorkbenchExtension
 	// static WorkspaceImporter importer;
 	static IProject								eclipseProject;
 	static Project								bndProject;
 	// Injected by SoftAssertionsExtension
 	@InjectSoftAssertions
-	protected SoftAssertions softly;
-	protected IQuickFixProcessor sut;
-	protected IProblemLocation[] locs;
-	protected List<IProblem> problems;
-	IProblem problem;
-	AssistContext assistContext;
-	protected String source;
+	protected SoftAssertions					softly;
+	protected IQuickFixProcessor				sut;
+	protected IProblemLocation[]				locs;
+	protected List<IProblem>					problems;
+	IProblem									problem;
+	AssistContext								assistContext;
+	protected String							source;
 
 	@SuppressWarnings("unchecked")
 	static void initSUTClass() throws Exception {
@@ -118,9 +118,9 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	}
 
 	static IResourceVisitor VISITOR = resource -> {
-			System.err.println(resource.getFullPath());
-			return true;
-		};
+		System.err.println(resource.getFullPath());
+		return true;
+	};
 
 	static void dumpWorkspace() throws CoreException {
 		IWorkspace ws = ResourcesPlugin.getWorkspace();
@@ -328,12 +328,12 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 		sut = sutClass.newInstance();
 	}
 
-	private static final String CLASS_HEADER = "package test; import java.util.List;\n" + "" + "class "
-			+ DEFAULT_CLASS_NAME + " {";
-	private static final String CLASS_FOOTER = " var};";
-	protected static final Set<Integer> SUPPORTED = Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect, HierarchyHasProblems, ParameterMismatch, TypeMismatch,
-			UndefinedConstructor, UndefinedField, UndefinedMethod, UndefinedName, UnresolvedVariable,
-			TypeArgumentMismatch);
+	private static final String			CLASS_HEADER	= "package test; import java.util.List;\n" + "" + "class "
+		+ DEFAULT_CLASS_NAME + " {";
+	private static final String			CLASS_FOOTER	= " var};";
+	protected static final Set<Integer>	SUPPORTED		= Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect,
+		HierarchyHasProblems, ParameterMismatch, TypeMismatch, UndefinedConstructor, UndefinedField, UndefinedMethod,
+		UndefinedName, UnresolvedVariable, TypeArgumentMismatch);
 
 	protected IJavaCompletionProposal[] proposalsForStaticImport(String imp) {
 		return proposalsFor(29, 0, "package test; import static " + imp + ";");
@@ -497,11 +497,11 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	}
 
 	// This is just to give nice error feedback
-		protected static class DummyProblem extends DefaultProblem {
-			public DummyProblem(int id, String message) {
-				super(null, message, id, null, 0, 0, 0, 0, 0);
-			}
+	protected static class DummyProblem extends DefaultProblem {
+		public DummyProblem(int id, String message) {
+			super(null, message, id, null, 0, 0, 0, 0, 0);
 		}
+	}
 
 	static final IJavaCompletionProposal[] EMPTY_LIST = new IJavaCompletionProposal[0];
 
@@ -517,16 +517,17 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	}
 
 	static final Representation PROPOSAL = new StandardRepresentation() {
-			@Override
-			public String toStringOf(Object object) {
-				if (object instanceof IJavaCompletionProposal) {
-					return ((IJavaCompletionProposal) object).getDisplayString();
-				}
-				return super.toStringOf(object);
+		@Override
+		public String toStringOf(Object object) {
+			if (object instanceof IJavaCompletionProposal) {
+				return ((IJavaCompletionProposal) object).getDisplayString();
 			}
-		};
+			return super.toStringOf(object);
+		}
+	};
 
-	protected ProxyableObjectArrayAssert<IJavaCompletionProposal> assertThatProposals(IJavaCompletionProposal[] proposals) {
+	protected ProxyableObjectArrayAssert<IJavaCompletionProposal> assertThatProposals(
+		IJavaCompletionProposal[] proposals) {
 		String desc = toString(problem);
 		if (proposals == null) {
 			return softly.assertThat(EMPTY_LIST)
@@ -563,25 +564,25 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	}
 
 	protected static class MatchDisplayString extends Condition<IJavaCompletionProposal> {
-			private final Pattern p;
+		private final Pattern p;
 
-			public MatchDisplayString(String bundle, String version, String fqName, boolean test) {
-				super(String.format("Suggestion to add '%s' to -%spath for class %s", bundle,
-					test ? "test" : "build", fqName));
-				String re = String.format("^Add \\Q%s\\E to -\\Q%s\\Epath [(]found \\Q%s\\E[)]", bundle,
-					test ? "test" : "build", fqName);
-				p = Pattern.compile(re);
-			}
-
-			@Override
-			public boolean matches(IJavaCompletionProposal value) {
-				if (value == null || value.getDisplayString() == null) {
-					return false;
-				}
-				final Matcher m = p.matcher(value.getDisplayString());
-				return m.find();
-			}
+		public MatchDisplayString(String bundle, String version, String fqName, boolean test) {
+			super(String.format("Suggestion to add '%s' to -%spath for class %s", bundle, test ? "test" : "build",
+				fqName));
+			String re = String.format("^Add \\Q%s\\E to -\\Q%s\\Epath [(]found \\Q%s\\E[)]", bundle,
+				test ? "test" : "build", fqName);
+			p = Pattern.compile(re);
 		}
+
+		@Override
+		public boolean matches(IJavaCompletionProposal value) {
+			if (value == null || value.getDisplayString() == null) {
+				return false;
+			}
+			final Matcher m = p.matcher(value.getDisplayString());
+			return m.find();
+		}
+	}
 
 	protected void assertThatContainsFrameworkBundles(IJavaCompletionProposal[] proposals, String fqName) {
 		assertThatProposals(proposals).withRepresentation(PROPOSAL)

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
@@ -52,6 +52,19 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 	}
 
 	@Test
+	void withMissingBound_fromClassWithMethodReturningBoundFromAnotherBundle_suggestsBundles() {
+		String header = "package test; class ";
+		String source = header + DEFAULT_CLASS_NAME + "{\n"
+			+ "  simple.pkg.ClassWithMethodReturningBoundFromAnotherBundle<simple.pkg.ClassWithInterfaceFromAnotherBundle> var;\n"
+			+ "  void myMethod() {"
+			+ "    java.util.List<simple.pkg.ClassWithInterfaceFromAnotherBundle> ret = var.aMethod();" + "  }" + "}";
+
+		// BoundMismatch occurs at [86, 132]
+		assertThatProposals(proposalsFor(87, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyInterface"));
+	}
+
+	@Test
 	void withMissingMethod_fromInterfaceFromAnotherBundle_suggestsBundles() {
 		String header = "package test; class ";
 		String source = header + DEFAULT_CLASS_NAME + "{\n"

--- a/bndtools.core.test/src/simple/pkg/ClassWithMethodReturningBoundFromAnotherBundle.java
+++ b/bndtools.core.test/src/simple/pkg/ClassWithMethodReturningBoundFromAnotherBundle.java
@@ -1,0 +1,12 @@
+package simple.pkg;
+
+import java.util.List;
+
+import iface.bundle.MyInterface;
+
+public class ClassWithMethodReturningBoundFromAnotherBundle<T extends MyInterface> {
+
+	public List<T> aMethod() {
+		return null;
+	}
+}


### PR DESCRIPTION
Handles case where a type bound doesn't pass because of a missing common supertype.

Based on a real-world case that I encountered recently.