### PR TITLE
Gradle 7 fixes

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -321,9 +321,9 @@ This property must be set.
 
 ### outputBndrun
 
-This is an optional output file for the calculated `-runbundles` property.
-This output file will `-include` the input `bndrun` file and can be thus be used by other tasks, such as `TestOSGi` as a resolved input `bndrun` file.
-This property is optional, and if not set, the input `bndrun` file will be updated in place.
+This is the output file for the calculated `-runbundles` property.
+The default is the input `bndrun` file which means the input `bndrun` file will be updated in place.
+If the output file is set to a different file than the input `bndrun` file, the generated output file will `-include` the input `bndrun` file and can be thus be used by other tasks, such as `TestOSGi`, as a resolved input `bndrun` file.
 
 ### workingDirectory
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
@@ -270,7 +270,7 @@ public class Baseline extends DefaultTask {
       processor.addClose(newer)
       Jar older = new Jar(baseline)
       processor.addClose(older)
-      logger.debug 'Baseline bundle {} against baseline {}', bundle, baseline
+      logger.debug('Baseline bundle {} against baseline {}', bundle, baseline)
 
       def differ = new DiffPluginImpl()
       differ.setIgnore(new Parameters(unwrap(getDiffignore()).join(','), processor))
@@ -278,29 +278,29 @@ public class Baseline extends DefaultTask {
       def infos = baseliner.baseline(newer, older, new Instructions(new Parameters(unwrap(getDiffpackages()).join(','), processor))).sort {it.packageName}
       def bundleInfo = baseliner.getBundleInfo()
       new Formatter(report, 'UTF-8', Locale.US).withCloseable { Formatter f ->
-        f.format '===============================================================%n'
-        f.format '%s %s %s-%s',
+        f.format('===============================================================%n')
+        f.format('%s %s %s-%s',
           bundleInfo.mismatch ? '*' : ' ',
           bundleInfo.bsn,
           newer.getVersion(),
-          older.getVersion()
+          older.getVersion())
 
         if (bundleInfo.mismatch) {
           failure = true
           if (bundleInfo.suggestedVersion != null) {
-            f.format ' suggests %s', bundleInfo.suggestedVersion
+            f.format(' suggests %s', bundleInfo.suggestedVersion)
           }
-          f.format '%n%#2S', baseliner.getDiff()
+          f.format('%n%#2S', baseliner.getDiff())
         }
 
-        f.format '%n===============================================================%n'
+        f.format('%n===============================================================%n')
 
         String format = '%s %-50s %-10s %-10s %-10s %-10s %-10s %s%n'
-        f.format format, ' ', 'Name', 'Type', 'Delta', 'New', 'Old', 'Suggest', 'If Prov.'
+        f.format(format, ' ', 'Name', 'Type', 'Delta', 'New', 'Old', 'Suggest', 'If Prov.')
 
         infos.each { info ->
           def packageDiff = info.packageDiff
-          f.format format,
+          f.format(format,
             info.mismatch ? '*' : ' ',
             packageDiff.getName(),
             packageDiff.getType(),
@@ -308,10 +308,10 @@ public class Baseline extends DefaultTask {
             info.newerVersion,
             info.olderVersion != null && info.olderVersion.equals(Version.LOWEST) ? '-': info.olderVersion,
             info.suggestedVersion != null && info.suggestedVersion.compareTo(info.newerVersion) <= 0 ? 'ok' : info.suggestedVersion,
-            info.suggestedIfProviders ?: '-'
+            info.suggestedIfProviders ?: '-')
           if (info.mismatch) {
             failure = true
-            f.format '%#2S%n', packageDiff
+            f.format('%#2S%n', packageDiff)
           }
         }
       }
@@ -320,7 +320,7 @@ public class Baseline extends DefaultTask {
     if (failure) {
       String msg = "Baseline problems detected. See the report in ${report}.\n${report.text}"
       if (ignoreFailures) {
-        logger.error msg
+        logger.error(msg)
       } else {
         throw new GradleException(msg)
       }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -42,14 +42,16 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.ClasspathNormalizer
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 
 public class BndPlugin implements Plugin<Project> {
   public static final String PLUGINID = 'biz.aQute.bnd'
   private Project project
   private Project workspace
-  private ProjectLayout layout
   private ObjectFactory objects
   private aQute.bnd.build.Project bndProject
 
@@ -57,483 +59,481 @@ public class BndPlugin implements Plugin<Project> {
    * Apply the {@code biz.aQute.bnd} plugin to the specified project.
    */
   @Override
-  public void apply(Project p) {
-    p.configure(p) { Project project ->
-      this.project = project
-      this.workspace = project.parent
-      this.layout = project.layout
-      this.objects = project.objects
-      if (plugins.hasPlugin(BndBuilderPlugin.PLUGINID)) {
-          throw new GradleException("Project already has '${BndBuilderPlugin.PLUGINID}' plugin applied.")
-      }
-      if (workspace == null) {
-        throw new GradleException("The '${PLUGINID}' plugin cannot be applied to the root project. Perhaps you meant to use the '${BndBuilderPlugin.PLUGINID}' plugin?")
-      }
-      if (!workspace.hasProperty('bndWorkspace')) {
-        workspace.ext.bndWorkspace = new Workspace(unwrap(workspace.layout.projectDirectory)).setOffline(gradle.startParameter.offline)
-        if (gradle.ext.has('bndWorkspaceConfigure')) {
-          gradle.bndWorkspaceConfigure(bndWorkspace)
-        }
-      }
-      this.bndProject = bndWorkspace.getProject(name)
-      if (bndProject == null) {
-        throw new GradleException("Unable to load bnd project ${name} from workspace ${workspace.layout.projectDirectory}")
-      }
-      bndProject.prepare()
-      if (!bndProject.isValid()) {
-        checkErrors(logger)
-        throw new GradleException("Project ${bndProject.getName()} is not a valid bnd project")
-      }
-      extensions.create('bnd', BndProperties, bndProject)
-      convention.plugins.bnd = new BndPluginConvention(this)
+  public void apply(Project project) {
+    this.project = project
+    Project workspace = this.workspace = project.parent
+    ProjectLayout layout = project.layout
+    ObjectFactory objects = this.objects = project.objects
+    TaskContainer tasks = project.tasks
+    if (project.plugins.hasPlugin(BndBuilderPlugin.PLUGINID)) {
+        throw new GradleException("Project already has '${BndBuilderPlugin.PLUGINID}' plugin applied.")
+    }
+    if (workspace == null) {
+      throw new GradleException("The '${PLUGINID}' plugin cannot be applied to the root project. Perhaps you meant to use the '${BndBuilderPlugin.PLUGINID}' plugin?")
+    }
+    Workspace bndWorkspace = BndWorkspacePlugin.getBndWorkspace(workspace)
+    aQute.bnd.build.Project bndProject = this.bndProject = bndWorkspace.getProject(project.name)
+    if (bndProject == null) {
+      throw new GradleException("Unable to load bnd project ${name} from workspace ${workspace.layout.projectDirectory}")
+    }
+    bndProject.prepare()
+    if (!bndProject.isValid()) {
+      checkErrors(project.logger)
+      throw new GradleException("Project ${bndProject.getName()} is not a valid bnd project")
+    }
+    project.extensions.create('bnd', BndProperties, bndProject)
+    project.convention.plugins.bnd = new BndPluginConvention(project)
 
-      layout.buildDirectory.set(bndProject.getTargetDir())
-      plugins.apply 'java'
-      libsDirName = '.'
-      testResultsDirName = bnd('test-reports', 'test-reports')
+    layout.buildDirectory.set(bndProject.getTargetDir())
+    project.plugins.apply('java')
+    project.libsDirName = '.'
+    project.testResultsDirName = project.bnd('test-reports', 'test-reports')
 
-      if (project.hasProperty('bnd_defaultTask')) {
-        defaultTasks = bnd_defaultTask.trim().split(/\s*,\s*/)
-      }
+    if (project.hasProperty('bnd_defaultTask')) {
+      project.defaultTasks = project.bnd_defaultTask.trim().split(/\s*,\s*/)
+    }
 
-      /* Set up configurations */
-      configurations {
-        runtimeOnly.artifacts.clear()
-        archives.artifacts.clear()
-      }
-      /* Set up deliverables */
-      bndProject.getDeliverables()*.getFile().each { File deliverable ->
-        artifacts {
-          runtimeOnly(deliverable) {
-             builtBy 'jar'
-          }
-          archives(deliverable) {
-             builtBy 'jar'
-          }
+    /* Set up configurations */
+    project.configurations {
+      runtimeOnly.artifacts.clear()
+      archives.artifacts.clear()
+    }
+    /* Set up deliverables */
+    bndProject.getDeliverables()*.getFile().each { File deliverable ->
+      project.artifacts {
+        runtimeOnly(deliverable) {
+           builtBy('jar')
+        }
+        archives(deliverable) {
+           builtBy('jar')
         }
       }
-      /* Set up Bnd generate support */
-      def generateInputs = bndProject.getGenerate().getInputs()
-      def generate = null
-      if (!generateInputs.isErr() && !generateInputs.unwrap().isEmpty()) {
-        generate = tasks.register('generate') { t ->
-          t.description 'Generate source code'
-          t.group 'build'
-          t.inputs.files(generateInputs.unwrap()).withPathSensitivity(RELATIVE).withPropertyName('generateInputs')
-          /* bnd can include from -dependson */
-          t.inputs.files(getBuildDependencies('jar')).withPropertyName('buildDependencies')
-          /* Workspace and project configuration changes should trigger task */
-          t.inputs.files(bndProject.getWorkspace().getPropertiesFile(),
-            bndProject.getWorkspace().getIncluded(),
-            bndProject.getPropertiesFile(),
-            bndProject.getIncluded()).withPathSensitivity(RELATIVE).withPropertyName('bndFiles')
-          t.outputs.dirs(bndProject.getGenerate().getOutputDirs()).withPropertyName('generateOutputs')
-          t.doLast('generate') { tt ->
-            try {
-              bndProject.getGenerate().generate(false)
-            } catch (Exception e) {
-              throw new GradleException("Project ${bndProject.getName()} failed to generate", e)
-            }
-            checkErrors(tt.logger)
-          }
-        }
-      }
-      /* Set up source sets */
-      sourceSets {
-        /* bnd uses the same directory for java and resources. */
-        main {
-          ConfigurableFileCollection srcDirs = objects.fileCollection().from(bndProject.getSourcePath())
-          File destinationDir = bndProject.getSrcOutput()
-          java.srcDirs = srcDirs
-          resources.srcDirs = srcDirs
-          java.outputDir = destinationDir
-          output.resourcesDir = destinationDir
-          tasks.named(compileJavaTaskName) { t ->
-            t.destinationDir = destinationDir
-            if (generate) {
-              t.inputs.files(generate).withPropertyName(generate.name)
-            }
-            jarLibraryElements(t, compileClasspathConfigurationName)
-          }
-          output.dir(destinationDir, 'builtBy': compileJavaTaskName)
-        }
-        test {
-          ConfigurableFileCollection srcDirs = objects.fileCollection().from(bndProject.getTestSrc())
-          File destinationDir = bndProject.getTestOutput()
-          java.srcDirs = srcDirs
-          resources.srcDirs = srcDirs
-          java.outputDir = destinationDir
-          output.resourcesDir = destinationDir
-          tasks.named(compileJavaTaskName) { t ->
-            t.destinationDir = destinationDir
-            jarLibraryElements(t, compileClasspathConfigurationName)
-          }
-          output.dir(destinationDir, 'builtBy': compileJavaTaskName)
-        }
-      }
-      /* Configure srcDirs for any additional languages */
-      afterEvaluate {
-        sourceSets {
-          main {
-            convention.plugins.each { lang, sourceDirSets ->
-              def sourceDirSet = sourceDirSets[lang]
-              if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
-                File destinationDir = java.outputDir
-                String compileTaskName = getCompileTaskName(lang)
-                String resourceTaskName = getProcessResourcesTaskName()
-                try {
-                  tasks.named(compileTaskName) { t ->
-                    t.destinationDir = destinationDir
-                    t.inputs.files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
-                    if (generate) {
-                      t.inputs.files(generate).withPropertyName(generate.name)
-                    }
-                  }
-                  sourceDirSet.srcDirs = java.srcDirs
-                  sourceDirSet.outputDir = destinationDir
-                  output.dir(destinationDir, 'builtBy': compileTaskName)
-                } catch (UnknownDomainObjectException e) {
-                 // no such task
-                }
-              }
-            }
-          }
-          test {
-            convention.plugins.each { lang, sourceDirSets ->
-              def sourceDirSet = sourceDirSets[lang]
-              if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
-                File destinationDir = java.outputDir
-                String compileTaskName = getCompileTaskName(lang)
-                String resourceTaskName = getProcessResourcesTaskName()
-                try {
-                  tasks.named(compileTaskName) { t ->
-                    t.destinationDir = destinationDir
-                    t.inputs.files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
-                  }
-                  sourceDirSet.srcDirs = java.srcDirs
-                  sourceDirSet.outputDir = destinationDir
-                  output.dir(destinationDir, 'builtBy': compileTaskName)
-                } catch (UnknownDomainObjectException e) {
-                 // no such task
-                }
-              }
-            }
-          }
-        }
-      }
+    }
+    FileCollection deliverables = project.configurations.archives.artifacts.files
 
-      bnd.ext.allSrcDirs = objects.fileCollection().from(bndProject.getAllsourcepath())
-      /* Set up dependencies */
-      dependencies {
-        implementation pathFiles(bndProject.getBuildpath())
-        runtimeOnly objects.fileCollection().from(bndProject.getSrcOutput())
-        testImplementation pathFiles(bndProject.getTestpath())
-        testRuntimeOnly objects.fileCollection().from(bndProject.getTestOutput())
-      }
-      /* Set up compile tasks */
-      ConfigurableFileCollection javacBootclasspath = objects.fileCollection().from(bndProject.getBootclasspath()*.getFile())
-      Property<String> javacSource = objects.property(String.class).convention(bnd('javac.source'))
-      if (javacSource.isPresent()) {
-        sourceCompatibility = javacSource.get()
-      } else {
-        javacSource.convention(provider({ -> sourceCompatibility.toString() }))
-      }
-      Property<String> javacTarget = objects.property(String.class).convention(bnd('javac.target'))
-      if (javacTarget.isPresent()) {
-        if (javacTarget.get() == 'jsr14') {
-          javacTarget.set('1.5')
-          javacBootclasspath.setFrom(bndProject.getBundle('ee.j2se', '1.5', null, ['strategy':'lowest']).getFile())
-        }
-        targetCompatibility = javacTarget.get()
-      } else {
-        javacTarget.convention(provider({ -> targetCompatibility.toString() }))
-      }
-      String javac = bnd('javac')
-      Property<String> javacProfile = objects.property(String.class)
-      if (!bnd('javac.profile', '').empty) {
-        javacProfile.convention(bnd('javac.profile'))
-      }
-      Property<String> javacRelease = objects.property(String.class)
-      if (JavaVersion.current().isJava9Compatible()) {
-        javacRelease.convention(provider({ -> 
-          if ((javacSource.get() == javacTarget.get()) && javacBootclasspath.empty && !javacProfile.isPresent()) {
-            return JavaVersion.toVersion(javacSource.get()).majorVersion
-          }
-          return null
-        }))
-      }
-      boolean javacDebug = bndis('javac.debug')
-      boolean javacDeprecation = isTrue(bnd('javac.deprecation', 'true'))
-      String javacEncoding = bnd('javac.encoding', 'UTF-8')
-      tasks.withType(JavaCompile.class).configureEach { t ->
-        t.sourceCompatibility = javacSource.get()
-        t.targetCompatibility = javacTarget.get()
-        def options = t.options
-        if (javacDebug) {
-          options.debugOptions.debugLevel = 'source,lines,vars'
-        }
-        options.verbose = t.logger.isDebugEnabled()
-        options.listFiles = t.logger.isInfoEnabled()
-        options.deprecation = javacDeprecation
-        options.encoding = javacEncoding
-        if (javac != 'javac') {
-          options.fork = true
-          options.forkOptions.executable = javac
-        }
-        if (!javacBootclasspath.empty) {
-          options.fork = true
-          options.bootstrapClasspath = javacBootclasspath
-        }
-        if (javacProfile.isPresent()) {
-          options.compilerArgs.addAll(['-profile', javacProfile.get()])
-        }
-        if (javacRelease.isPresent()) {
-          options.compilerArgs.addAll(['--release', javacRelease.get()])
-        }
-        t.doFirst('checkErrors') { tt ->
-          checkErrors(tt.logger)
-          if (tt.logger.isInfoEnabled()) {
-            tt.logger.info 'Compile to {}', tt.destinationDir
-            if (tt.options.compilerArgs.contains('--release')) {
-              tt.logger.info '{}', tt.options.compilerArgs.join(' ')
-            } else {
-              tt.logger.info '-source {} -target {} {}', tt.sourceCompatibility, tt.targetCompatibility, tt.options.compilerArgs.join(' ')
-            }
-            tt.logger.info '-classpath {}', tt.classpath.asPath
-            if (tt.options.bootstrapClasspath != null) {
-              tt.logger.info '-bootclasspath {}', tt.options.bootstrapClasspath.asPath
-            }
-          }
-        }
-      }
-
-      def jar = tasks.named('jar') { t ->
-        t.description 'Jar this project\'s bundles.'
-        t.actions.clear() /* Replace the standard task actions */
-        t.enabled !bndProject.isNoBundles()
-        FileCollection deliverables = project.configurations.archives.artifacts.files
-        /* use first deliverable as archiveFileName */
-        t.archiveFileName = provider({ -> deliverables.find()?.name ?: bndProject.getName() })
-        /* Additional excludes for projectDir inputs */
-        t.ext.projectDirInputsExcludes = Strings.split(bndMerge(Constants.BUILDERIGNORE)).collect { it.concat('/') }
-        /* all other files in the project like bnd and resources */
-        t.inputs.files(project.fileTree(layout.projectDirectory) { tree ->
-          project.sourceSets.each { sourceSet -> /* exclude sourceSet dirs */
-            tree.exclude sourceSet.allSource.sourceDirectories.collect {
-              project.relativePath(it)
-            }
-            tree.exclude sourceSet.output.collect {
-              project.relativePath(it)
-            }
-          }
-          tree.exclude project.relativePath(buildDir) /* exclude buildDir */
-          tree.exclude t.projectDirInputsExcludes /* user specified excludes */
-        }).withPathSensitivity(RELATIVE).withPropertyName('projectFolder')
-        /* bnd can include from -buildpath */
-        t.inputs.files(project.sourceSets.main.compileClasspath).withNormalizer(ClasspathNormalizer).withPropertyName('buildpath')
+    /* Set up Bnd generate support */
+    def generateInputs = bndProject.getGenerate().getInputs()
+    def generate = null
+    if (!generateInputs.isErr() && !generateInputs.unwrap().isEmpty()) {
+      generate = tasks.register('generate') { t ->
+        t.description = 'Generate source code'
+        t.group = 'build'
+        t.inputs.files(generateInputs.unwrap()).withPathSensitivity(RELATIVE).withPropertyName('generateInputs')
         /* bnd can include from -dependson */
         t.inputs.files(getBuildDependencies('jar')).withPropertyName('buildDependencies')
-        /* Workspace and project configuration changes should trigger jar task */
+        /* Workspace and project configuration changes should trigger task */
         t.inputs.files(bndProject.getWorkspace().getPropertiesFile(),
           bndProject.getWorkspace().getIncluded(),
           bndProject.getPropertiesFile(),
           bndProject.getIncluded()).withPathSensitivity(RELATIVE).withPropertyName('bndFiles')
-        t.outputs.files(deliverables).withPropertyName('artifacts')
-        t.outputs.file(layout.buildDirectory.file(Constants.BUILDFILES)).withPropertyName('buildfiles')
-        t.doLast('build') { tt ->
-          File[] built
+        t.outputs.dirs(bndProject.getGenerate().getOutputDirs()).withPropertyName('generateOutputs')
+        t.doLast('generate') { tt ->
           try {
-            built = bndProject.build()
-            long now = System.currentTimeMillis()
-            built?.each {
-              it.setLastModified(now)
+            bndProject.getGenerate().generate(false)
+          } catch (Exception e) {
+            throw new GradleException("Project ${bndProject.getName()} failed to generate", e)
+          }
+          checkErrors(tt.logger)
+        }
+      }
+    }
+    /* Set up source sets */
+    project.sourceSets {
+      /* bnd uses the same directory for java and resources. */
+      main {
+        ConfigurableFileCollection srcDirs = objects.fileCollection().from(bndProject.getSourcePath())
+        File destinationDir = bndProject.getSrcOutput()
+        java.srcDirs = srcDirs
+        resources.srcDirs = srcDirs
+        java.outputDir = destinationDir
+        output.resourcesDir = destinationDir
+        tasks.named(compileJavaTaskName) { t ->
+          t.destinationDir = destinationDir
+          if (generate) {
+            t.inputs.files(generate).withPropertyName(generate.name)
+          }
+          jarLibraryElements(t, compileClasspathConfigurationName)
+        }
+        output.dir(destinationDir, 'builtBy': compileJavaTaskName)
+      }
+      test {
+        ConfigurableFileCollection srcDirs = objects.fileCollection().from(bndProject.getTestSrc())
+        File destinationDir = bndProject.getTestOutput()
+        java.srcDirs = srcDirs
+        resources.srcDirs = srcDirs
+        java.outputDir = destinationDir
+        output.resourcesDir = destinationDir
+        tasks.named(compileJavaTaskName) { t ->
+          t.destinationDir = destinationDir
+          jarLibraryElements(t, compileClasspathConfigurationName)
+        }
+        output.dir(destinationDir, 'builtBy': compileJavaTaskName)
+      }
+    }
+    /* Configure srcDirs for any additional languages */
+    project.afterEvaluate {
+      project.sourceSets {
+        main {
+          convention.plugins.each { lang, sourceDirSets ->
+            def sourceDirSet = sourceDirSets[lang]
+            if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
+              File destinationDir = java.outputDir
+              String compileTaskName = getCompileTaskName(lang)
+              String resourceTaskName = getProcessResourcesTaskName()
+              try {
+                tasks.named(compileTaskName) { t ->
+                  t.destinationDir = destinationDir
+                  t.inputs.files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
+                  if (generate) {
+                    t.inputs.files(generate).withPropertyName(generate.name)
+                  }
+                }
+                sourceDirSet.srcDirs = java.srcDirs
+                sourceDirSet.outputDir = destinationDir
+                output.dir(destinationDir, 'builtBy': compileTaskName)
+              } catch (UnknownDomainObjectException e) {
+               // no such task
+              }
             }
-          } catch (Exception e) {
-            throw new GradleException("Project ${bndProject.getName()} failed to build", e)
-          }
-          checkErrors(tt.logger)
-          if (built != null) {
-            tt.logger.info 'Generated bundles: {}', built as Object
           }
         }
-      }
-
-      def jarDependencies = tasks.register('jarDependencies') { t ->
-        t.description 'Jar all projects this project depends on.'
-        t.dependsOn getBuildDependencies('jar')
-        t.group 'build'
-      }
-
-      def buildDependencies = tasks.register('buildDependencies') { t ->
-        t.description 'Assembles and tests all projects this project depends on.'
-        t.dependsOn getTestDependencies('buildNeeded')
-        t.group 'build'
-      }
-
-      def buildNeeded = tasks.named('buildNeeded') { t ->
-        t.dependsOn buildDependencies
-      }
-
-      def buildDependents = tasks.named('buildDependents') { t ->
-        t.dependsOn getDependents('buildDependents')
-      }
-
-      def release = tasks.register('release') { t ->
-        t.description 'Release this project to the release repository.'
-        t.group 'release'
-        t.enabled !bndProject.isNoBundles() && !bnd(Constants.RELEASEREPO, 'unset').empty
-        t.inputs.files(jar).withPropertyName(jar.name)
-        t.doLast('release') { tt ->
-          try {
-            bndProject.release()
-          } catch (Exception e) {
-            throw new GradleException("Project ${bndProject.getName()} failed to release", e)
+        test {
+          convention.plugins.each { lang, sourceDirSets ->
+            def sourceDirSet = sourceDirSets[lang]
+            if (sourceDirSet.hasProperty('srcDirs') && sourceDirSet.hasProperty('outputDir')){
+              File destinationDir = java.outputDir
+              String compileTaskName = getCompileTaskName(lang)
+              String resourceTaskName = getProcessResourcesTaskName()
+              try {
+                tasks.named(compileTaskName) { t ->
+                  t.destinationDir = destinationDir
+                  t.inputs.files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
+                }
+                sourceDirSet.srcDirs = java.srcDirs
+                sourceDirSet.outputDir = destinationDir
+                output.dir(destinationDir, 'builtBy': compileTaskName)
+              } catch (UnknownDomainObjectException e) {
+               // no such task
+              }
+            }
           }
-          checkErrors(tt.logger)
         }
       }
+    }
 
-      def releaseDependencies = tasks.register('releaseDependencies') { t ->
-        t.description 'Release all projects this project depends on.'
-        t.dependsOn getBuildDependencies('releaseNeeded')
-        t.group 'release'
+    project.bnd.ext.allSrcDirs = objects.fileCollection().from(bndProject.getAllsourcepath())
+    /* Set up dependencies */
+    project.dependencies {
+      implementation pathFiles(bndProject.getBuildpath())
+      runtimeOnly objects.fileCollection().from(bndProject.getSrcOutput())
+      testImplementation pathFiles(bndProject.getTestpath())
+      testRuntimeOnly objects.fileCollection().from(bndProject.getTestOutput())
+    }
+    /* Set up compile tasks */
+    ConfigurableFileCollection javacBootclasspath = objects.fileCollection().from(bndProject.getBootclasspath()*.getFile())
+    Property<String> javacSource = objects.property(String.class).convention(project.bnd('javac.source'))
+    if (javacSource.isPresent()) {
+      project.sourceCompatibility = javacSource.get()
+    } else {
+      javacSource.convention(provider({ -> project.sourceCompatibility.toString() }))
+    }
+    Property<String> javacTarget = objects.property(String.class).convention(project.bnd('javac.target'))
+    if (javacTarget.isPresent()) {
+      if (javacTarget.get() == 'jsr14') {
+        javacTarget.set('1.5')
+        javacBootclasspath.setFrom(bndProject.getBundle('ee.j2se', '1.5', null, ['strategy':'lowest']).getFile())
       }
-
-      def releaseNeeded = tasks.register('releaseNeeded') { t ->
-        t.description 'Release this project and all projects it depends on.'
-        t.dependsOn releaseDependencies, release
-        t.group 'release'
+      project.targetCompatibility = javacTarget.get()
+    } else {
+      javacTarget.convention(provider({ -> project.targetCompatibility.toString() }))
+    }
+    String javac = project.bnd('javac')
+    Property<String> javacProfile = objects.property(String.class)
+    if (!project.bnd('javac.profile', '').empty) {
+      javacProfile.convention(project.bnd('javac.profile'))
+    }
+    Property<String> javacRelease = objects.property(String.class)
+    if (JavaVersion.current().isJava9Compatible()) {
+      javacRelease.convention(project.provider({ -> 
+        if ((javacSource.get() == javacTarget.get()) && javacBootclasspath.empty && !javacProfile.isPresent()) {
+          return JavaVersion.toVersion(javacSource.get()).majorVersion
+        }
+        return null
+      }))
+    }
+    boolean javacDebug = project.bndis('javac.debug')
+    boolean javacDeprecation = isTrue(project.bnd('javac.deprecation', 'true'))
+    String javacEncoding = project.bnd('javac.encoding', 'UTF-8')
+    tasks.withType(JavaCompile.class).configureEach { t ->
+      t.sourceCompatibility = javacSource.get()
+      t.targetCompatibility = javacTarget.get()
+      def options = t.options
+      if (javacDebug) {
+        options.debugOptions.debugLevel = 'source,lines,vars'
       }
-
-      def test = tasks.named('test') { t ->
-        t.enabled !bndis(Constants.NOJUNIT) && !bndis('no.junit')
-        /* tests can depend upon jars from -dependson */
-        t.inputs.files(getBuildDependencies('jar')).withPropertyName('buildDependencies')
-        t.doFirst('checkErrors') { tt ->
-          checkErrors(tt.logger, tt.ignoreFailures)
+      options.verbose = t.logger.isDebugEnabled()
+      options.listFiles = t.logger.isInfoEnabled()
+      options.deprecation = javacDeprecation
+      options.encoding = javacEncoding
+      if (javac != 'javac') {
+        options.fork = true
+        options.forkOptions.executable = javac
+      }
+      if (!javacBootclasspath.empty) {
+        options.fork = true
+        options.bootstrapClasspath = javacBootclasspath
+      }
+      if (javacProfile.isPresent()) {
+        options.compilerArgs.addAll(['-profile', javacProfile.get()])
+      }
+      if (javacRelease.isPresent()) {
+        options.compilerArgs.addAll(['--release', javacRelease.get()])
+      }
+      t.doFirst('checkErrors') { tt ->
+        checkErrors(tt.logger)
+        if (tt.logger.isInfoEnabled()) {
+          tt.logger.info('Compile to {}', tt.destinationDir)
+          if (tt.options.compilerArgs.contains('--release')) {
+            tt.logger.info('{}', tt.options.compilerArgs.join(' '))
+          } else {
+            tt.logger.info('-source {} -target {} {}', tt.sourceCompatibility, tt.targetCompatibility, tt.options.compilerArgs.join(' '))
+          }
+          tt.logger.info('-classpath {}', tt.classpath.asPath)
+          if (tt.options.bootstrapClasspath != null) {
+            tt.logger.info('-bootclasspath {}', tt.options.bootstrapClasspath.asPath)
+          }
         }
       }
+    }
 
-      def testOSGi = tasks.register('testOSGi', TestOSGi.class) { t ->
-        t.description 'Runs the OSGi JUnit tests by launching a framework and running the tests in the launched framework.'
-        t.group 'verification'
-        t.enabled !bndis(Constants.NOJUNITOSGI) && !bndUnprocessed(Constants.TESTCASES, '').empty
-        t.inputs.files(jar).withPropertyName(jar.name)
-        t.bndrun = bndProject.getPropertiesFile()
-      }
-
-      def check = tasks.named('check') { t ->
-        t.dependsOn testOSGi
-      }
-
-      def checkDependencies = tasks.register('checkDependencies') { t ->
-        t.description 'Runs all checks on all projects this project depends on.'
-        t.dependsOn getTestDependencies('checkNeeded')
-        t.group 'verification'
-      }
-
-      def checkNeeded = tasks.register('checkNeeded') { t ->
-        t.description 'Runs all checks on this project and all projects it depends on.'
-        t.dependsOn checkDependencies, check
-        t.group 'verification'
-      }
-
-      def clean = tasks.named('clean') { t ->
-        t.description 'Cleans the build and compiler output directories of this project.'
-        t.delete layout.buildDirectory, project.sourceSets.main.output, project.sourceSets.test.output
-        if (generate) {
-          t.delete generate
+    def jar = tasks.named('jar') { t ->
+      t.description = 'Jar this project\'s bundles.'
+      t.actions.clear() /* Replace the standard task actions */
+      t.enabled = !bndProject.isNoBundles()
+      /* use first deliverable as archiveFileName */
+      t.archiveFileName = project.provider({ -> deliverables.find()?.name ?: bndProject.getName() })
+      /* Additional excludes for projectDir inputs */
+      t.ext.projectDirInputsExcludes = Strings.split(t.project.bndMerge(Constants.BUILDERIGNORE)).collect { it.concat('/') }
+      /* all other files in the project like bnd and resources */
+      t.inputs.files(project.fileTree(layout.projectDirectory) { tree ->
+        project.sourceSets.each { sourceSet -> /* exclude sourceSet dirs */
+          tree.exclude(sourceSet.allSource.sourceDirectories.collect {
+            project.relativePath(it)
+          })
+          tree.exclude(sourceSet.output.collect {
+            project.relativePath(it)
+          })
+        }
+        tree.exclude(project.relativePath(layout.buildDirectory)) /* exclude buildDirectory */
+        tree.exclude(t.projectDirInputsExcludes) /* user specified excludes */
+      }).withPathSensitivity(RELATIVE).withPropertyName('projectFolder')
+      /* bnd can include from -buildpath */
+      t.inputs.files(project.sourceSets.main.compileClasspath).withNormalizer(ClasspathNormalizer).withPropertyName('buildpath')
+      /* bnd can include from -dependson */
+      t.inputs.files(getBuildDependencies('jar')).withPropertyName('buildDependencies')
+      /* Workspace and project configuration changes should trigger jar task */
+      t.inputs.files(bndProject.getWorkspace().getPropertiesFile(),
+        bndProject.getWorkspace().getIncluded(),
+        bndProject.getPropertiesFile(),
+        bndProject.getIncluded()).withPathSensitivity(RELATIVE).withPropertyName('bndFiles')
+      t.outputs.files(deliverables).withPropertyName('artifacts')
+      t.outputs.file(layout.buildDirectory.file(Constants.BUILDFILES)).withPropertyName('buildfiles')
+      t.doLast('build') { tt ->
+        File[] built
+        try {
+          built = bndProject.build()
+          long now = System.currentTimeMillis()
+          built?.each {
+            it.setLastModified(now)
+          }
+        } catch (Exception e) {
+          throw new GradleException("Project ${bndProject.getName()} failed to build", e)
+        }
+        checkErrors(tt.logger)
+        if (built != null) {
+          tt.logger.info('Generated bundles: {}', built as Object)
         }
       }
+    }
 
-      def cleanDependencies = tasks.register('cleanDependencies') { t ->
-        t.description 'Cleans all projects this project depends on.'
-        t.dependsOn getTestDependencies('cleanNeeded')
-        t.group 'build'
-      }
+    def jarDependencies = tasks.register('jarDependencies') { t ->
+      t.description = 'Jar all projects this project depends on.'
+      t.group = 'build'
+      t.dependsOn(getBuildDependencies('jar'))
+    }
 
-      def cleanNeeded = tasks.register('cleanNeeded') { t ->
-        t.description 'Cleans this project and all projects it depends on.'
-        t.dependsOn cleanDependencies, clean
-        t.group 'build'
-      }
+    def buildDependencies = tasks.register('buildDependencies') { t ->
+      t.description = 'Assembles and tests all projects this project depends on.'
+      t.group = 'build'
+      t.dependsOn(getTestDependencies('buildNeeded'))
+    }
 
-      def bndruns = project.fileTree(layout.projectDirectory) {
-          include '*.bndrun'
-      }
+    def buildNeeded = tasks.named('buildNeeded') { t ->
+      t.dependsOn(buildDependencies)
+    }
 
-      def exportTasks = bndruns.collect { runFile ->
-        tasks.register("export.${runFile.name - '.bndrun'}", Export.class) { t ->
-          t.description "Export the ${runFile.name} file."
-          t.dependsOn 'assemble'
-          t.group 'export'
-          t.bndrun = runFile
-          t.exporter = EXECUTABLE_JAR
+    def buildDependents = tasks.named('buildDependents') { t ->
+      t.dependsOn(getDependents('buildDependents'))
+    }
+
+    def release = tasks.register('release') { t ->
+      t.description = 'Release this project to the release repository.'
+      t.group = 'release'
+      t.enabled = !bndProject.isNoBundles() && !project.bnd(Constants.RELEASEREPO, 'unset').empty
+      t.inputs.files(jar).withPropertyName(jar.name)
+      t.doLast('release') { tt ->
+        try {
+          bndProject.release()
+        } catch (Exception e) {
+          throw new GradleException("Project ${bndProject.getName()} failed to release", e)
         }
+        checkErrors(tt.logger)
       }
+    }
 
-      def export = tasks.register('export') { t ->
-        t.description 'Export all the bndrun files.'
-        t.group 'export'
-        t.dependsOn exportTasks
+    def releaseDependencies = tasks.register('releaseDependencies') { t ->
+      t.description = 'Release all projects this project depends on.'
+      t.group = 'release'
+      t.dependsOn(getBuildDependencies('releaseNeeded'))
+    }
+
+    def releaseNeeded = tasks.register('releaseNeeded') { t ->
+      t.description = 'Release this project and all projects it depends on.'
+      t.group = 'release'
+      t.dependsOn(releaseDependencies, release)
+    }
+
+    def test = tasks.named('test') { t ->
+      t.enabled = !project.bndis(Constants.NOJUNIT) && !project.bndis('no.junit')
+      /* tests can depend upon jars from -dependson */
+      t.inputs.files(getBuildDependencies('jar')).withPropertyName('buildDependencies')
+      t.doFirst('checkErrors') { tt ->
+        checkErrors(tt.logger, tt.ignoreFailures)
       }
+    }
 
-      def runbundlesTasks = bndruns.collect { runFile ->
-        tasks.register("runbundles.${runFile.name - '.bndrun'}", Export.class) { t ->
-          t.description "Create a distribution of the runbundles in the ${runFile.name} file."
-          t.dependsOn 'assemble'
-          t.group 'export'
-          t.bndrun = runFile
-          t.exporter = RUNBUNDLES
-        }
+    def testOSGi = tasks.register('testOSGi', TestOSGi.class) { t ->
+      t.description = 'Runs the OSGi JUnit tests by launching a framework and running the tests in the launched framework.'
+      t.group = 'verification'
+      t.enabled = !project.bndis(Constants.NOJUNITOSGI) && !project.bndUnprocessed(Constants.TESTCASES, '').empty
+      t.inputs.files(jar).withPropertyName(jar.name)
+      t.bndrun = bndProject.getPropertiesFile()
+    }
+
+    def check = tasks.named('check') { t ->
+      t.dependsOn(testOSGi)
+    }
+
+    def checkDependencies = tasks.register('checkDependencies') { t ->
+      t.description = 'Runs all checks on all projects this project depends on.'
+      t.group = 'verification'
+      t.dependsOn(getTestDependencies('checkNeeded'))
+    }
+
+    def checkNeeded = tasks.register('checkNeeded') { t ->
+      t.description = 'Runs all checks on this project and all projects it depends on.'
+      t.group = 'verification'
+      t.dependsOn(checkDependencies, check)
+    }
+
+    def clean = tasks.named('clean') { t ->
+      t.description = 'Cleans the build and compiler output directories of this project.'
+      t.delete(layout.buildDirectory, project.sourceSets.main.output, project.sourceSets.test.output)
+      if (generate) {
+        t.delete(generate)
       }
+    }
 
-      def runbundles = tasks.register('runbundles') { t ->
-        t.description 'Create a distribution of the runbundles in each of the bndrun files.'
-        t.group 'export'
-        t.dependsOn runbundlesTasks
+    def cleanDependencies = tasks.register('cleanDependencies') { t ->
+      t.description = 'Cleans all projects this project depends on.'
+      t.group = 'build'
+      t.dependsOn(getTestDependencies('cleanNeeded'))
+    }
+
+    def cleanNeeded = tasks.register('cleanNeeded') { t ->
+      t.description = 'Cleans this project and all projects it depends on.'
+      t.group = 'build'
+      t.dependsOn(cleanDependencies, clean)
+    }
+
+    def assemble = tasks.named('assemble')
+
+    def bndruns = project.fileTree(layout.projectDirectory) {
+        include('*.bndrun')
+    }
+
+    def exportTasks = bndruns.collect { File runFile ->
+      tasks.register("export.${runFile.name - '.bndrun'}", Export.class) { t ->
+        t.description = "Export the ${runFile.name} file."
+        t.group = 'export'
+        t.dependsOn(assemble)
+        t.bndrun = runFile
+        t.exporter = EXECUTABLE_JAR
       }
+    }
 
-      def resolveTasks = bndruns.collect { runFile ->
-        tasks.register("resolve.${runFile.name - '.bndrun'}", Resolve.class) { t ->
-          t.description "Resolve the runbundles required for ${runFile.name} file."
-          t.dependsOn 'assemble'
-          t.group 'export'
-          t.bndrun = runFile
-        }
+    def export = tasks.register('export') { t ->
+      t.description = 'Export all the bndrun files.'
+      t.group = 'export'
+      t.dependsOn(exportTasks)
+    }
+
+    def runbundlesTasks = bndruns.collect { File runFile ->
+      tasks.register("runbundles.${runFile.name - '.bndrun'}", Export.class) { t ->
+        t.description = "Create a distribution of the runbundles in the ${runFile.name} file."
+        t.group = 'export'
+        t.dependsOn(assemble)
+        t.bndrun = runFile
+        t.exporter = RUNBUNDLES
       }
+    }
 
-      def resolve = tasks.register('resolve') { t ->
-        t.description 'Resolve the runbundles required for each of the bndrun files.'
-        t.group 'export'
-        t.dependsOn resolveTasks
+    def runbundles = tasks.register('runbundles') { t ->
+      t.description = 'Create a distribution of the runbundles in each of the bndrun files.'
+      t.group = 'export'
+      t.dependsOn(runbundlesTasks)
+    }
+
+    def resolveTasks = bndruns.collect { File runFile ->
+      tasks.register("resolve.${runFile.name - '.bndrun'}", Resolve.class) { t ->
+        t.description = "Resolve the runbundles required for ${runFile.name} file."
+        t.group = 'export'
+        t.dependsOn(assemble)
+        t.bndrun = runFile
       }
+    }
 
-      bndruns.forEach { runFile ->
-        tasks.register("run.${runFile.name - '.bndrun'}", Bndrun.class) { t ->
-          t.description "Run the bndrun file ${runFile.name}."
-          t.dependsOn 'assemble'
-          t.group 'export'
-          t.bndrun = runFile
-        }
+    def resolve = tasks.register('resolve') { t ->
+      t.description = 'Resolve the runbundles required for each of the bndrun files.'
+      t.group = 'export'
+      t.dependsOn(resolveTasks)
+    }
+
+    bndruns.forEach { File runFile ->
+      tasks.register("run.${runFile.name - '.bndrun'}", Bndrun.class) { t ->
+        t.description = "Run the bndrun file ${runFile.name}."
+        t.group = 'export'
+        t.dependsOn(assemble)
+        t.bndrun = runFile
       }
+    }
 
-      bndruns.forEach { runFile ->
-        tasks.register("testrun.${runFile.name - '.bndrun'}", TestOSGi.class) { t ->
-          t.description "Runs the OSGi JUnit tests in the bndrun file ${runFile.name}."
-          t.dependsOn 'assemble'
-          t.group 'verification'
-          t.bndrun = runFile
-        }
+    bndruns.forEach { File runFile ->
+      tasks.register("testrun.${runFile.name - '.bndrun'}", TestOSGi.class) { t ->
+        t.description = "Runs the OSGi JUnit tests in the bndrun file ${runFile.name}."
+        t.group = 'verification'
+        t.dependsOn(assemble)
+        t.bndrun = runFile
       }
+    }
 
-      def echo = tasks.register('echo') { t ->
-        t.description 'Displays the bnd project information.'
-        t.group 'help'
-        def compileJava = tasks.getByName('compileJava')
-        def compileTestJava = tasks.getByName('compileTestJava')
-        t.doLast('echo') { tt ->
-          println """
+    def echo = tasks.register('echo') { t ->
+      t.description = 'Displays the bnd project information.'
+      t.group = 'help'
+      def compileJava = tasks.getByName('compileJava')
+      def compileTestJava = tasks.getByName('compileTestJava')
+      t.doLast('echo') { tt ->
+        println("""
 ------------------------------------------------------------
 Project ${project.name} // Bnd version ${About.CURRENT}
 ------------------------------------------------------------
@@ -543,92 +543,88 @@ project.name:           ${project.name}
 project.dir:            ${layout.projectDirectory}
 target:                 ${unwrap(layout.buildDirectory)}
 project.dependson:      ${bndProject.getDependson()*.getName()}
-project.sourcepath:     ${project.sourceSets.main.java.sourceDirectories.asPath}
+project.sourcepath:     ${project.sourceSets.main.allSource.sourceDirectories.asPath}
 project.output:         ${compileJava.destinationDir}
 project.buildpath:      ${compileJava.classpath.asPath}
-project.allsourcepath:  ${bnd.allSrcDirs.asPath}
-project.testsrc:        ${project.sourceSets.test.java.sourceDirectories.asPath}
+project.allsourcepath:  ${project.bnd.allSrcDirs.asPath}
+project.testsrc:        ${project.sourceSets.test.allSource.sourceDirectories.asPath}
 project.testoutput:     ${compileTestJava.destinationDir}
 project.testpath:       ${compileTestJava.classpath.asPath}
 project.bootclasspath:  ${compileJava.options.bootstrapClasspath?.asPath?:''}
-project.deliverables:   ${project.configurations.archives.artifacts.files*.path}
+project.deliverables:   ${deliverables*.path}
 javac:                  ${compileJava.options.forkOptions.executable?:'javac'}
 javac.source:           ${javacSource.getOrElse('')}
 javac.target:           ${javacTarget.getOrElse('')}
 javac.profile:          ${javacProfile.getOrElse('')}
-"""
-          checkErrors(tt.logger, true)
-        }
+""")
+        checkErrors(tt.logger, true)
       }
+    }
 
-      def bndproperties = tasks.register('bndproperties') { t ->
-        t.description 'Displays the bnd properties.'
-        t.group 'help'
-        t.doLast('bndproperties') { tt ->
-          println """
+    def bndproperties = tasks.register('bndproperties') { t ->
+      t.description = 'Displays the bnd properties.'
+      t.group = 'help'
+      t.doLast('bndproperties') { tt ->
+        println("""
 ------------------------------------------------------------
 Project ${project.name}
 ------------------------------------------------------------
-"""
-          bndProject.getPropertyKeys(true).sort().each {
-            println "${it}: ${bnd(it, '')}"
-          }
-          println()
-          checkErrors(tt.logger, true)
+""")
+        bndProject.getPropertyKeys(true).sort().each {
+          println("${it}: ${tt.project.bnd(it, '')}")
         }
+        println()
+        checkErrors(tt.logger, true)
       }
+    }
 
-      // Depend upon an output dir to avoid parallel task execution.
-      // This effectively claims the resource and prevents
-      // tasks claiming the same resource from executing concurrently.
-      // -noparallel: launchpad;task="test,echo"
-      def noparallel = bndProject.getMergedParameters('-noparallel')
-      noparallel.each { key, attrs ->
-        def taskNames = attrs?.'task'
-        if (taskNames) {
-          def category = removeDuplicateMarker(key)
-          def resource = workspace.project('cnf').layout.buildDirectory.dir("noparallel/${category}")
-          taskNames.trim().tokenize(',').each { taskName ->
-            tasks.named(taskName.trim()) { t ->
-              t.outputs.dir(resource).withPropertyName(category)
-            }
+    // Depend upon an output dir to avoid parallel task execution.
+    // This effectively claims the resource and prevents
+    // tasks claiming the same resource from executing concurrently.
+    // -noparallel: launchpad;task="test,echo"
+    Project noparallel = workspace.findProperty('cnf') ?: workspace
+    bndProject.getMergedParameters('-noparallel').each { key, attrs ->
+      def taskNames = attrs?.'task'
+      if (taskNames) {
+        def category = removeDuplicateMarker(key)
+        def resource = noparallel.layout.buildDirectory.dir("noparallel/${category}")
+        taskNames.trim().tokenize(',').each { taskName ->
+          tasks.named(taskName.trim()) { t ->
+            t.outputs.dir(resource).withPropertyName(category)
           }
         }
       }
     }
+  }
+
+  private Provider<List<TaskProvider<?>>> getTasks(Collection<aQute.bnd.build.Project> projects, String taskName) {
+    Project workspace = this.workspace
+    return project.provider({ ->
+      projects.collect { aQute.bnd.build.Project p ->
+        workspace.project(p.getName()).tasks.named(taskName)
+      }
+    })
   }
 
   private ConfigurableFileCollection pathFiles(Collection<Container> path) {
     return objects.fileCollection().from(path*.getFile())
-      .builtBy(path.findAll { Container c ->
-        c.getType() == TYPE.PROJECT
-      }.collect { Container c ->
-        workspace.absoluteProjectPath("${c.getProject().getName()}:jar")
-      })
+      .builtBy(getTasks(path.findAll { Container c ->
+          c.getType() == TYPE.PROJECT
+        }.collect { Container c ->
+          c.getProject()
+        }, 'jar'))
   }
 
-  private Closure getBuildDependencies(String taskName) {
-    return {
-      bndProject.getBuildDependencies().collect { dependency ->
-        workspace.project(dependency.getName()).tasks.named(taskName)
-      }
-    }
+  private Provider<List<TaskProvider<?>>> getBuildDependencies(String taskName) {
+    return getTasks(bndProject.getBuildDependencies(), taskName)
   }
 
-  private Closure getTestDependencies(String taskName) {
-    return {
-      bndProject.getTestDependencies().collect { dependency ->
-        workspace.project(dependency.getName()).tasks.named(taskName)
-      }
-    }
+  private Provider<List<TaskProvider<?>>> getTestDependencies(String taskName) {
+    return getTasks(bndProject.getTestDependencies(), taskName)
   }
 
-  private Closure getDependents(String taskName) {
-    return {
-      bndProject.getDependents().collect { dependent ->
-        workspace.project(dependent.getName()).tasks.named(taskName)
-      }
-    }
+  private Provider<List<TaskProvider<?>>> getDependents(String taskName) {
+    return getTasks(bndProject.getDependents(), taskName)
   }
 
   private void checkErrors(Logger logger, boolean ignoreFailures = false) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
@@ -12,8 +12,8 @@ import org.gradle.api.Project
 
 class BndPluginConvention {
   private final Project project
-  BndPluginConvention(BndPlugin plugin) {
-   this.project = plugin.project
+  BndPluginConvention(Project project) {
+   this.project = project
   }
   boolean bndis(String name) {
     return project.bnd.is(name)

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -27,9 +27,9 @@ class BndUtils {
       report.getWarnings().each { String msg ->
         def location = report.getLocation(msg)
         if (location && location.file) {
-          logger.warn '{}:{}: warning: {}', location.file, location.line, msg
+          logger.warn('{}:{}: warning: {}', location.file, location.line, msg)
         } else {
-          logger.warn 'warning: {}', msg
+          logger.warn('warning: {}', msg)
         }
       }
     }
@@ -37,9 +37,9 @@ class BndUtils {
       report.getErrors().each { String msg ->
         def location = report.getLocation(msg)
         if (location && location.file) {
-          logger.error '{}:{}: error: {}', location.file, location.line, msg
+          logger.error('{}:{}: error: {}', location.file, location.line, msg)
         } else {
-          logger.error 'error  : {}', msg
+          logger.error('error  : {}', msg)
         }
       }
     }
@@ -75,9 +75,9 @@ class BndUtils {
       if (attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)?.name != LibraryElements.JAR) {
         try {
           attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements.class, LibraryElements.JAR))
-          task.logger.info 'Set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)
+          task.logger.info('Set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE))
         } catch (IllegalArgumentException e) {
-          task.logger.info 'Unable to set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR, e
+          task.logger.info('Unable to set {}:{} configuration attribute {} to {}', project.path, configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR, e)
         }
       }
     }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
@@ -190,8 +190,8 @@ public class Bndrun extends DefaultTask {
    * Execute the Run object.
    */
   protected void worker(def run) {
-    logger.info 'Running {} in {}', run.getPropertiesFile(), run.getBase()
-    logger.debug 'Run properties: {}', run.getProperties()
+    logger.info('Running {} in {}', run.getPropertiesFile(), run.getBase())
+    logger.debug('Run properties: {}', run.getProperties())
     ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor()
     try {
       run.getProjectLauncher().withCloseable() { pl ->

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
@@ -148,8 +148,8 @@ public class Export extends Bndrun {
   protected void worker(def run) {
     String exporterName = unwrap(getExporter())
     File destinationDirFile = unwrap(getDestinationDirectory())
-    logger.info 'Exporting {} to {} with exporter {}', run.getPropertiesFile(), destinationDirFile, exporterName
-    logger.debug 'Run properties: {}', run.getProperties()
+    logger.info('Exporting {} to {} with exporter {}', run.getPropertiesFile(), destinationDirFile, exporterName)
+    logger.debug('Run properties: {}', run.getProperties())
     try {
       def export = run.export(exporterName, [:])
       if (exporterName == RUNBUNDLES) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
@@ -195,7 +195,7 @@ public class Index extends DefaultTask {
     File indexUncompressedFile = unwrap(getIndexUncompressed())
     new Processor().withCloseable { Processor processor ->
       def sortedBundles = getBundles().sort()
-      logger.info 'Generating index for {}.', sortedBundles
+      logger.info('Generating index for {}.', sortedBundles)
       new SimpleIndexer()
         .reporter(processor)
         .files(sortedBundles)
@@ -208,13 +208,13 @@ public class Index extends DefaultTask {
         failTask("Index ${indexUncompressedFile} has errors", indexUncompressedFile)
       }
 
-      logger.info 'Generated index {}.', indexUncompressedFile
+      logger.info('Generated index {}.', indexUncompressedFile)
       if (gzip) {
         File indexCompressedFile = unwrap(getIndexCompressed())
         indexCompressedFile.withOutputStream { out ->
           IO.copy(indexUncompressedFile, new GZIPOutputStream(out)).close()
         }
-        logger.info 'Generated index {}.', indexCompressedFile
+        logger.info('Generated index {}.', indexCompressedFile)
       }
     }
   }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/PropertiesWrapper.groovy
@@ -11,6 +11,7 @@ class PropertiesWrapper extends Properties {
   protected Properties defaults
 
   PropertiesWrapper(Properties defaults) {
+    super()
     this.defaults = defaults
   }
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
@@ -27,9 +27,9 @@
  * of the -runbundles property. The default is true.</li>
  * <li>bndrun - This is the bndrun file to be resolved.
  * This property must be set.</li>
- * <li>outputBndrun - This is an optional output file for the calculated
- * -runbundles property. This property is optional, and if not set, the
- * input bndrun file will be updated in place.</li>
+ * <li>outputBndrun - This is the output file for the calculated
+ * -runbundles property. The default is the input bndrun file
+ * which means the input bndrun file will be updated in place.</li>
  * <li>workingDirectory - This is the directory for the resolve process.
  * The default for workingDirectory is temporaryDir.</li>
  * <li>bundles - This is the collection of files to use for locating
@@ -54,7 +54,6 @@ import biz.aQute.resolve.ResolveProcess
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 
 import org.osgi.service.resolver.ResolutionException
@@ -94,7 +93,7 @@ public class Resolve extends Bndrun {
   boolean reportOptional = true
 
   /**
-   * Return the optional output file for the calculated `-runbundles`
+   * Return the output file for the calculated `-runbundles`
    * property.
    *
    * <p>
@@ -103,7 +102,6 @@ public class Resolve extends Bndrun {
    * input bndrun file.
    */
   @OutputFile
-  @Optional
   final RegularFileProperty outputBndrun
 
   /**
@@ -111,15 +109,15 @@ public class Resolve extends Bndrun {
    */
   public Resolve() {
     super()
-    outputBndrun = project.objects.fileProperty()
+    outputBndrun = project.objects.fileProperty().convention(getBndrun())
   }
 
   /**
    * Create the Bndrun object.
    */
   protected def createRun(def workspace, File bndrunFile) {
-    File outputBndrunFile = unwrap(getOutputBndrun(), true)
-    if (outputBndrunFile != null) {
+    File outputBndrunFile = unwrap(getOutputBndrun())
+    if (outputBndrunFile != bndrunFile) {
       outputBndrunFile.withWriter('UTF-8') { writer ->
         UTF8Properties props = new UTF8Properties()
         props.setProperty(Constants.INCLUDE, String.format('"%s"', IO.absolutePath(bndrunFile)))

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
@@ -133,13 +133,13 @@ public class Resolve extends Bndrun {
    * Resolve the Bndrun object.
    */
   protected void worker(def run) {
-    logger.info 'Resolving runbundles required for {}', run.getPropertiesFile()
-    logger.debug 'Run properties: {}', run.getProperties()
+    logger.info('Resolving runbundles required for {}', run.getPropertiesFile())
+    logger.debug('Run properties: {}', run.getProperties())
     try {
       def result = run.resolve(failOnChanges, writeOnChanges)
-      logger.info '{}: {}', Constants.RUNBUNDLES, result
+      logger.info('{}: {}', Constants.RUNBUNDLES, result)
     } catch (ResolutionException e) {
-      logger.error ResolveProcess.format(e, reportOptional)
+      logger.error(ResolveProcess.format(e, reportOptional))
       throw new GradleException("${run.getPropertiesFile()} resolution exception", e)
     } finally {
       logReport(run, logger)

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -106,8 +106,8 @@ public class TestOSGi extends Bndrun {
    */
   @Override
   protected void worker(def run) {
-    logger.info 'Running tests for {} in {}', run.getPropertiesFile(), run.getBase()
-    logger.debug 'Run properties: {}', run.getProperties()
+    logger.info('Running tests for {} in {}', run.getPropertiesFile(), run.getBase())
+    logger.debug('Run properties: {}', run.getProperties())
     File resultsDir = unwrap(getResultsDirectory())
     try {
       run.test(resultsDir, tests);


### PR DESCRIPTION
Refactor implementation to work with Groovy 2 and 3

When we update the build's gradlew to 7.0, we will be building the
Bnd Gradle plugins with Groovy 3 but we still need to make sure they
run on older Gradle versions which use Groovy 2.

This necessitates some restructuring of the code to avoid some
unnecessary use of closures and to avoid references to private fields
inside the remaining closures. Groovy 2 and 3 seem to handle this
in a different and incompatible way, so we just avoid trying to do it
by copying the private field into a local variable which the closure
can capture.