### PR TITLE
gradle: Use the configured java toolchain to decide to use --release

### DIFF
--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin1/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin1/test.simple/build.gradle
@@ -1,0 +1,8 @@
+tasks.withType(JavaCompile).configureEach { t ->
+	if (t.hasProperty('javaCompiler')) { // Gradle 6.7
+		println "### Task ${name} has javaCompiler property"
+		javaCompiler = javaToolchains.compilerFor {
+			languageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
+		}
+	}
+}


### PR DESCRIPTION
Since gradle can support compiling with different versions of java than
the version running gradle, we need to check the java toolchain, if one
is configured, to decide if it is safe to pass the --release flag to
javac.