### PR TITLE
Revert "bndtools.core.test: Re-enable in CI build"

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,6 +24,7 @@ env:
     -Dhttp.keepAlive=false
     -Dmaven.wagon.http.pool=false
     -Dmaven.wagon.http.retryHandler.count=3
+  BNDTOOLS_CORE_TEST_NOJUNITOSGI: true
 
 defaults:
   run:


### PR DESCRIPTION
This reverts commit 8bfccf54415b9f56bc74189c66c4597fc8599e24.

:bndtools.core.test:testOSGi is still intermittently failing in the CI build.