### PR TITLE
unmodifiable: Reduce storage use by one third for set and map

### DIFF
--- a/aQute.libg/test/aQute/lib/unmodifiable/MapsTest.java
+++ b/aQute.libg/test/aQute/lib/unmodifiable/MapsTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.assertj.core.api.MapAssert;
 import org.junit.jupiter.api.Test;
 
 public class MapsTest {
@@ -376,6 +377,32 @@ public class MapsTest {
 			.containsEntry("polygenelubricants", "v1")
 			.containsEntry("GydZG_", "v2")
 			.containsEntry("DESIGNING WORKHOUSES", "v3");
+	}
+
+	@Test
+	public void max_entries() {
+		final int max = (1 << Short.SIZE) - 1;
+		@SuppressWarnings("unchecked")
+		Entry<String, String>[] entries = new Entry[max];
+		for (int i = 0; i < max; i++) {
+			entries[i] = Maps.entry(String.format("k%d", i + 1), String.format("v%d", i + 1));
+		}
+		Map<String, String> map = Maps.ofEntries(entries);
+		MapAssert<String, String> assertion = assertThat(map).hasSize(max);
+		for (int i = 0; i < max; i++) {
+			assertion.containsEntry(entries[i].getKey(), entries[i].getValue());
+		}
+	}
+
+	@Test
+	public void over_max_entries() {
+		final int over_max = (1 << Short.SIZE);
+		@SuppressWarnings("unchecked")
+		Entry<String, String>[] entries = new Entry[over_max];
+		for (int i = 0; i < over_max; i++) {
+			entries[i] = Maps.entry(String.format("k%d", i + 1), String.format("v%d", i + 1));
+		}
+		assertThatIllegalArgumentException().isThrownBy(() -> Maps.ofEntries(entries));
 	}
 
 }

--- a/aQute.libg/test/aQute/lib/unmodifiable/SetsTest.java
+++ b/aQute.libg/test/aQute/lib/unmodifiable/SetsTest.java
@@ -263,4 +263,29 @@ public class SetsTest {
 		assertThat(set).containsExactlyInAnyOrder("e5", "polygenelubricants", "GydZG_", "DESIGNING WORKHOUSES", "e1");
 	}
 
+	@Test
+	public void max_entries() {
+		final int max = (1 << Short.SIZE) - 1;
+		String[] entries = new String[max];
+		for (int i = 0; i < max; i++) {
+			entries[i] = String.format("e%d", i + 1);
+		}
+		Set<String> set = Sets.of(entries);
+		assertThat(set).hasSize(max);
+		for (int i = 0; i < max; i++) {
+			assertThat(set.contains(entries[i])).as("contains(%s)", entries[i])
+				.isTrue();
+		}
+	}
+
+	@Test
+	public void over_max_entries() {
+		final int over_max = (1 << Short.SIZE);
+		String[] entries = new String[over_max];
+		for (int i = 0; i < over_max; i++) {
+			entries[i] = String.format("e%d", i + 1);
+		}
+		assertThatIllegalArgumentException().isThrownBy(() -> Sets.of(entries));
+	}
+
 }


### PR DESCRIPTION
We change to use a short array instead of an int array to hold the hash
bucket. This limits the size of the set or map to 2^16-1 entries (since
we use unsigned short values) but that is plenty large.

Tests are added to verify the max size and whether an exception is
thrown if exceeded.
