### PR TITLE
bndCall after lock actions

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
@@ -3,7 +3,6 @@ package org.bndtools.builder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IDynamicReferenceProvider;
@@ -27,8 +26,7 @@ public class BndtoolsDynamicReferenceProvider implements IDynamicReferenceProvid
 			IProject project = buildConfiguration.getProject();
 			Workspace ws = Central.getWorkspace();
 			if (!ws.isDefaultWorkspace()) {
-				Callable<List<IProject>> c = () -> getDependencies(project, ws);
-				return Central.bndCall(c);
+				return Central.bndCall(after -> getDependencies(project, ws));
 			}
 			return Collections.emptyList();
 		} catch (Exception e) {

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -243,7 +243,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 			}
 
 			try {
-				Central.bndCall(this::calculateProjectClasspath);
+				Central.bndCall(after -> calculateProjectClasspath());
 			} catch (Exception e) {
 				SetLocation error = error("Unable to calculate classpath for project %s", e, project.getName());
 				logger.logError(error.location().message, e);

--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/AddBundleCompletionProposal.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/AddBundleCompletionProposal.java
@@ -99,7 +99,7 @@ class AddBundleCompletionProposal extends WorkspaceJob implements IJavaCompletio
 	@Override
 	public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 		try {
-			IStatus status = Central.bndCall(() -> {
+			IStatus status = Central.bndCall(after -> {
 
 				BndEditModel model = new BndEditModel(project);
 				model.load();

--- a/bndtools.core/src/bndtools/central/Auxiliary.java
+++ b/bndtools.core/src/bndtools/central/Auxiliary.java
@@ -120,8 +120,14 @@ class Auxiliary implements Closeable, WeavingHook {
 
 	@Override
 	public void weave(WovenClass wovenClass) {
-		if (delta == null || delta.isEmpty())
-			return;
+		List<String> extra;
+		synchronized (this) {
+			extra = delta;
+			if (extra == null || extra.isEmpty()) {
+				return;
+			}
+			delta = null;
+		}
 
 		BundleWiring wiring = wovenClass.getBundleWiring();
 		if (wiring == null)
@@ -130,11 +136,6 @@ class Auxiliary implements Closeable, WeavingHook {
 		if (wiring.getBundle() != bndlib)
 			return;
 
-		List<String> extra;
-		synchronized (this) {
-			extra = delta;
-			delta = null;
-		}
 		wovenClass.getDynamicImports()
 			.addAll(extra);
 	}

--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -156,7 +156,7 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 				}
 				// We must safely call bnd to list workspace repo
 				try {
-					Central.bndCall(() -> workspaceRepo.list(null), monitor);
+					Central.bndCall(after -> workspaceRepo.list(null), monitor);
 				} catch (TimeoutException | InterruptedException e) {
 					return new Status(IStatus.ERROR, Plugin.PLUGIN_ID,
 						"Unable to acquire lock to refresh repository " + repo.getName(), e);

--- a/bndtools.core/src/bndtools/central/RepositoryUtils.java
+++ b/bndtools.core/src/bndtools/central/RepositoryUtils.java
@@ -32,7 +32,7 @@ public class RepositoryUtils {
 
 	public static List<RepositoryPlugin> listRepositories(final Workspace localWorkspace, final boolean hideCache) {
 		try {
-			return Central.bndCall(() -> {
+			return Central.bndCall(after -> {
 				List<RepositoryPlugin> plugins = localWorkspace.getPlugins(RepositoryPlugin.class);
 				plugins.addAll(getAdditionalPlugins());
 				List<RepositoryPlugin> repos = new ArrayList<>(plugins.size() + 1);

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
@@ -85,7 +85,7 @@ public class WorkspaceSynchronizer {
 				createProject(ws.getFile(Workspace.CNFDIR), null, subMonitor.split(1));
 			}
 
-			List<String> models = Central.bndCall(() -> {
+			List<String> models = Central.bndCall(after -> {
 				ws.refreshProjects();
 				ws.refresh();
 				ws.forceRefresh();


### PR DESCRIPTION
Update bndCall to support after lock actions. bndCall will supply the operation an object to register an after lock
action. When the operation completes and the bnd lock is released,
bndCall will call each after action in order. This enables work to be
done after the bnd lock is released when that work does not need to be
done while holding the bnd lock. This can avoid deadlocks.

Making this part of bndCall makes it a common feature that callers can
use without rolling their own after lock processing.