### PR TITLE
gradle: Don't include buildSrc or gradle folders by default

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -86,11 +86,12 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 			projectNames.add(defaultProjectName)
 		}
 
-		/* If build used but empty, add all non-private folders of rootDir */
+		/* If build used but empty, add all non-private folders of rootDir except special gradle folders */
 		if (projectNames.remove("")) {
+			Set<String> specialFolders = ["buildSrc", "gradle"]
 			rootDir.eachDir {
 				String projectName = it.getName()
-				if (!projectName.startsWith(".")) {
+				if (!projectName.startsWith(".") && !specialFolders.contains(projectName)) {
 					projectNames.add(projectName)
 				}
 			}


### PR DESCRIPTION
These folders, particularly buildSrc, have special meaning to gradle.
So when adding folders from the rootDir, do not include these folders
by default.

Fixes https://github.com/bndtools/bnd/issues/4668
