### PR TITLE
[PomRepository] respect classifier when using artifact-gav as pseudo-bsn

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -29,6 +29,7 @@ import org.osgi.util.promise.Promise;
 
 import aQute.bnd.annotation.plugin.BndPlugin;
 import aQute.bnd.build.Workspace;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
@@ -47,7 +48,6 @@ import aQute.bnd.service.repository.Prepare;
 import aQute.bnd.util.repository.DownloadListenerPromise;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.libg.reporter.slf4j.Slf4jReporter;
@@ -286,7 +286,8 @@ public class BndPomRepository extends BaseRepository
 		} else {
 
 			String name = resource.getInfo()
-				.name();
+				.name() + ":" + version;
+
 			archive = Archive.valueOf(name);
 		}
 
@@ -415,7 +416,7 @@ public class BndPomRepository extends BaseRepository
 			return null;
 
 		return Archive.valueOf(resource.getInfo()
-			.name())
+			.name() + ":" + version)
 			.getOther("jar", Archive.SOURCES_CLASSIFIER);
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
@@ -27,11 +27,11 @@ import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.maven.MavenCapability;
 import aQute.bnd.osgi.resource.CapabilityBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IPom.Dependency;
 import aQute.maven.api.MavenScope;
@@ -207,7 +207,9 @@ class Traverser {
 		ResourceBuilder rb = new ResourceBuilder();
 
 		Version frameworkVersion = toFrameworkVersion(archive.revision.version.getOSGiVersion());
-		String bsn = archive.revision.program.toString();
+
+		// g:a:jar and g:a:jar:all are different artifacts respect classifier
+		String bsn = archive.getWithoutVersion();
 
 		try {
 			File binary = repo.get(archive)

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -851,7 +851,9 @@ public class PomRepositoryTest extends TestCase {
 			Capability c = capabilities.get(0);
 			String a = (String) c.getAttributes()
 				.get("name");
-			Archive archive = Archive.valueOf(a);
+			org.osgi.framework.Version version = (org.osgi.framework.Version) c.getAttributes()
+				.get("version");
+			Archive archive = Archive.valueOf(a + ":" + version);
 			assertNotNull(archive);
 		}
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -693,7 +693,7 @@ public class PomRepositoryTest extends TestCase {
 			String revisions = Strings.join(new String[] {
 				"biz.aQute.bnd:biz.aQute.junit:3.3.0", "biz.aQute.bnd:biz.aQute.launcher:3.3.0",
 				"biz.aQute.bnd:biz.aQute.remote.launcher:3.3.0", "biz.aQute.bnd:biz.aQute.tester:3.3.0",
-				"org.jacoco:org.jacoco.agent:jar:runtime:0.8.6",
+				"org.jacoco:org.jacoco.agent:jar:runtime:0.8.6", "org.jacoco:org.jacoco.agent:0.8.6",
 				"org.apache.felix:org.apache.felix.framework:bin:zip:1.4.0"
 			});
 
@@ -714,12 +714,17 @@ public class PomRepositoryTest extends TestCase {
 			assertFalse(resources.isEmpty());
 
 			assertThat(mcsr.list("*")).contains("biz.aQute.remote.launcher",
-				"biz.aQute.launcher", "biz.aQute.junit", "biz.aQute.tester", //
-				"org.jacoco:org.jacoco.agent", // with classifier
+				"biz.aQute.launcher", "biz.aQute.junit", "biz.aQute.tester",
+				// "org.jacoco:org.jacoco.agent:0.8.6"
+				// a bundle so normal bsn
+				"org.jacoco.agent",
+				// "org.jacoco:org.jacoco.agent:jar:runtime:0.8.6"
+				// with classifier & not a bundle
+				"org.jacoco:org.jacoco.agent:jar:runtime",
 				"org.apache.felix:org.osgi.foundation",// from zip
-				"org.apache.felix:org.apache.felix.framework" // from zip
+				"org.apache.felix:org.apache.felix.framework:bin:zip" // zip
 				);
-		}
+			}
 	}
 
 	public void testMultiplePomFiles() throws Exception {


### PR DESCRIPTION
`g:a:jar` and `g:a:jar:all` are different artifacts. We should respect the classifier when using artifact-gav as pseudo-bsn.