### PR TITLE
PluginsContainer

### DIFF
--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndWorkspacePlugin.groovy
@@ -118,10 +118,6 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 			gradle.bndWorkspaceConfigure(workspace)
 		}
 
-		/* Make sure all workspace plugins are loaded before preparing
-		 * projects.
-		 */
-		workspace.getPlugins()
 		/* Prepare each project in the workspace to establish complete 
 		 * dependencies and dependents information.
 		 */

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/CloseableMemoize.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/CloseableMemoize.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
- * Closable memoizing supplier.
+ * Closeable memoizing supplier.
  * <p>
  * This type extends {@link Memoize} and {@code AutoCloseable}.
  *
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
  */
 public interface CloseableMemoize<S extends AutoCloseable> extends Memoize<S>, AutoCloseable {
 	/**
-	 * Creates an AutoClosable supplier which memoizes the AutoCloseable value
+	 * Creates an AutoCloseable supplier which memoizes the AutoCloseable value
 	 * returned by the specified supplier.
 	 * <p>
 	 * When the returned supplier is called to get a value, it will call the
@@ -21,15 +21,16 @@ public interface CloseableMemoize<S extends AutoCloseable> extends Memoize<S>, A
 	 * When {@code close()} is called on the returned supplier, it will call
 	 * {@code close()} on the memoized value, if present, and dereference the
 	 * value. After {@code close()} is called on the returned supplier, the
-	 * {@code get()} method of the returned supplier will throw an
-	 * {@code IllegalStateException}.
+	 * {@link #get()} and {@link #accept(Consumer)} methods of the returned
+	 * supplier will throw an {@code IllegalStateException}.
 	 *
 	 * @param <T> Type of the value returned by the supplier.
 	 * @param supplier The source supplier. Must not be {@code null}. The
 	 *            supplier should not return a {@code null} value. If the
 	 *            supplier does return a {@code null} value, the returned
-	 *            supplier will be marked closed and its {@code get()} method
-	 *            will throw an {@code IllegalStateException}.
+	 *            supplier will be marked closed and its {@link #get()} and
+	 *            {@link #accept(Consumer)} methods will throw an
+	 *            {@code IllegalStateException}.
 	 * @return A memoized supplier wrapping the specified supplier.
 	 */
 	static <T extends AutoCloseable> CloseableMemoize<T> closeableSupplier(Supplier<? extends T> supplier) {
@@ -50,15 +51,42 @@ public interface CloseableMemoize<S extends AutoCloseable> extends Memoize<S>, A
 	boolean isClosed();
 
 	/**
-	 * Call the consumer with the value of this memoized supplier.
+	 * Get the memoized AutoCloseable value.
+	 *
+	 * @return The memoized AutoCloseable value.
+	 * @throws IllegalStateException If this memoizing supplier
+	 *             {@link #isClosed() is closed}.
+	 */
+	@Override
+	S get();
+
+	/**
+	 * Call the consumer with the value of this memoizing supplier.
 	 * <p>
-	 * This method will block closing this memoized supplier while this method
+	 * This method will block closing this memoizing supplier while the consumer
 	 * is executing.
 	 *
-	 * @param consumer The consumer to accept the value of this memoized
+	 * @param consumer The consumer to accept the value of this memoizing
 	 *            supplier. Must not be {@code null}.
-	 * @return This memoized supplier.
+	 * @return This memoizing supplier.
+	 * @throws IllegalStateException If this memoizing supplier
+	 *             {@link #isClosed() is closed}.
 	 */
 	@Override
 	CloseableMemoize<S> accept(Consumer<? super S> consumer);
+
+	/**
+	 * If a value is memoized, call the consumer with the value of this
+	 * memoizing supplier. Otherwise do nothing.
+	 * <p>
+	 * This method will block closing this memoizing supplier while the consumer
+	 * is executing.
+	 *
+	 * @param consumer The consumer to accept the value of this memoizing
+	 *            supplier if a value is memoized. Must not be {@code null} if a
+	 *            value is memoized.
+	 * @return This memoizing supplier.
+	 */
+	@Override
+	CloseableMemoize<S> ifPresent(Consumer<? super S> consumer);
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/CloseableMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/CloseableMemoizingSupplier.java
@@ -2,6 +2,7 @@ package aQute.bnd.memoize;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -156,5 +157,11 @@ class CloseableMemoizingSupplier<T extends AutoCloseable> implements CloseableMe
 			}
 		}
 		return this;
+	}
+
+	@Override
+	public String toString() {
+		// read initial _before_ read memoized
+		return initial ? "<empty>" : Objects.toString(memoized, "<closed>");
 	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/Memoize.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/Memoize.java
@@ -125,13 +125,32 @@ public interface Memoize<S> extends Supplier<S> {
 	}
 
 	/**
+	 * Get the memoized value.
+	 *
+	 * @return The memoized value.
+	 */
+	@Override
+	S get();
+
+	/**
 	 * Peek the memoized value, if any.
 	 * <p>
 	 * This method will not result in a call to the source supplier.
 	 *
-	 * @return The value if a value is memoized; otherwise {@code null}.
+	 * @return The memoized value if a value is memoized; otherwise
+	 *         {@code null}.
 	 */
 	S peek();
+
+	/**
+	 * If a value is memoized, return {@code true}. Otherwise return
+	 * {@code false}.
+	 * <p>
+	 * This method will not result in a call to the source supplier.
+	 *
+	 * @return {@code true} if a value is memoized; otherwise {@code false}.
+	 */
+	boolean isPresent();
 
 	/**
 	 * Map this memoizing supplier to a new memoizing supplier.
@@ -190,6 +209,22 @@ public interface Memoize<S> extends Supplier<S> {
 	default Memoize<S> accept(Consumer<? super S> consumer) {
 		requireNonNull(consumer);
 		consumer.accept(get());
+		return this;
+	}
+
+	/**
+	 * If a value is memoized, call the consumer with the value of this
+	 * memoizing supplier. Otherwise do nothing.
+	 *
+	 * @param consumer The consumer to accept the value of this memoizing
+	 *            supplier if a value is memoized. Must not be {@code null} if a
+	 *            value is memoized.
+	 * @return This memoizing supplier.
+	 */
+	default Memoize<S> ifPresent(Consumer<? super S> consumer) {
+		if (isPresent()) {
+			return accept(consumer);
+		}
 		return this;
 	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/MemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/MemoizingSupplier.java
@@ -53,4 +53,9 @@ class MemoizingSupplier<T> implements Memoize<T> {
 		}
 		return (T) memoized;
 	}
+
+	@Override
+	public boolean isPresent() {
+		return !initial;
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/MemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/MemoizingSupplier.java
@@ -58,4 +58,10 @@ class MemoizingSupplier<T> implements Memoize<T> {
 	public boolean isPresent() {
 		return !initial;
 	}
+
+	@Override
+	public String toString() {
+		// read initial _before_ read memoized
+		return initial ? "<empty>" : String.valueOf(memoized);
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/PredicateMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/PredicateMemoizingSupplier.java
@@ -67,4 +67,10 @@ class PredicateMemoizingSupplier<T> implements Memoize<T> {
 	public boolean isPresent() {
 		return !initial;
 	}
+
+	@Override
+	public String toString() {
+		// read initial _before_ read memoized
+		return initial ? "<empty>" : String.valueOf(memoized);
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/PredicateMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/PredicateMemoizingSupplier.java
@@ -62,4 +62,9 @@ class PredicateMemoizingSupplier<T> implements Memoize<T> {
 		}
 		return (T) memoized;
 	}
+
+	@Override
+	public boolean isPresent() {
+		return !initial;
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/ReferenceMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/ReferenceMemoizingSupplier.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -53,5 +54,10 @@ class ReferenceMemoizingSupplier<T> implements Memoize<T> {
 	@Override
 	public boolean isPresent() {
 		return peek() != null;
+	}
+
+	@Override
+	public String toString() {
+		return Objects.toString(peek(), "<empty>");
 	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/ReferenceMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/ReferenceMemoizingSupplier.java
@@ -49,4 +49,9 @@ class ReferenceMemoizingSupplier<T> implements Memoize<T> {
 		T referent = memoized.get();
 		return referent;
 	}
+
+	@Override
+	public boolean isPresent() {
+		return peek() != null;
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/RefreshingMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/RefreshingMemoizingSupplier.java
@@ -83,4 +83,11 @@ class RefreshingMemoizingSupplier<T> implements Memoize<T> {
 		}
 		return true;
 	}
+
+	@Override
+	public String toString() {
+		// read timebound _before_ read memoized
+		long endtime = timebound;
+		return (System.nanoTime() - endtime >= 0L) ? "<empty>" : String.valueOf(memoized);
+	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/memoize/RefreshingMemoizingSupplier.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/memoize/RefreshingMemoizingSupplier.java
@@ -65,4 +65,22 @@ class RefreshingMemoizingSupplier<T> implements Memoize<T> {
 		}
 		return memoized;
 	}
+
+	@Override
+	public boolean isPresent() {
+		long endtime = timebound;
+		while (System.nanoTime() - endtime >= 0L) { // timebound has passed
+			// critical section: only one at a time
+			synchronized (this) {
+				if (endtime == timebound) {
+					memoized = null; // release to GC
+					// write timebound _after_ write memoized
+					timebound = System.nanoTime(); // mark ttl expired
+					return false;
+				}
+			}
+			endtime = timebound; // recheck
+		}
+		return true;
+	}
 }

--- a/biz.aQute.bndlib.tests/test/test/ExtensionsTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ExtensionsTest.java
@@ -3,6 +3,7 @@ package test;
 import java.io.File;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.util.home.Home;
 import aQute.lib.io.IO;
 import junit.framework.TestCase;
 
@@ -15,6 +16,9 @@ public class ExtensionsTest extends TestCase {
 	public void setUp() throws Exception {
 		tmp = IO.getFile("tmp");
 		ws = new Workspace(IO.getFile("testresources/ws-extensions"));
+		File cacheDir = IO.getFile(ws.getProperty(Workspace.CACHEDIR, Home.getUserHomeBnd() + "/caches/shas"));
+		File dir = IO.getFile(cacheDir, "2D96DA7F7A81443130072C718CB40CE5182DA362");
+		IO.delete(dir);
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.7.0")
+@org.osgi.annotation.versioning.Version("2.0.0")
 package aQute.bnd.junit;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("1.11.0")
+@Version("2.0.0")
 package aQute.bnd.maven;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -163,9 +163,9 @@ public class Analyzer extends Processor {
 	public Analyzer() {}
 
 	@Override
-	protected void setTypeSpecificPlugins(Set<Object> list) {
-		super.setTypeSpecificPlugins(list);
-		list.add(new ClassIndexerAnalyzer());
+	protected void setTypeSpecificPlugins(PluginsContainer pluginsContainer) {
+		super.setTypeSpecificPlugins(pluginsContainer);
+		pluginsContainer.add(new ClassIndexerAnalyzer());
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -1702,17 +1702,17 @@ public class Builder extends Analyzer {
 	static SPIDescriptorGenerator	spiDescriptorGenerator	= new SPIDescriptorGenerator();
 
 	@Override
-	protected void setTypeSpecificPlugins(Set<Object> list) {
-		list.add(makeBnd);
-		list.add(makeCopy);
-		list.add(serviceComponent);
-		list.add(cdiAnnotations);
-		list.add(dsAnnotations);
-		list.add(metatypeAnnotations);
-		list.add(moduleAnnotations);
-		list.add(moduleInfoPlugin);
-		list.add(spiDescriptorGenerator);
-		super.setTypeSpecificPlugins(list);
+	protected void setTypeSpecificPlugins(PluginsContainer pluginsContainer) {
+		pluginsContainer.add(makeBnd);
+		pluginsContainer.add(makeCopy);
+		pluginsContainer.add(serviceComponent);
+		pluginsContainer.add(cdiAnnotations);
+		pluginsContainer.add(dsAnnotations);
+		pluginsContainer.add(metatypeAnnotations);
+		pluginsContainer.add(moduleAnnotations);
+		pluginsContainer.add(moduleInfoPlugin);
+		pluginsContainer.add(spiDescriptorGenerator);
+		super.setTypeSpecificPlugins(pluginsContainer);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("1.12.0")
+@Version("2.0.0")
 package aQute.bnd.osgi.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.1.0")
+@Version("2.0.0")
 package aQute.bnd.print;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("2.0.0")
 package aQute.bnd.service.generate;

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ subprojects {
 			}
 			testLogging {
 				exceptionFormat = 'full'
+				info {
+					events "STANDARD_OUT", "STANDARD_ERROR", "STARTED", "FAILED", "PASSED", "SKIPPED"
+				}
 			}
 			if (!logger.isInfoEnabled()) {
 				def stdOut = [:]


### PR DESCRIPTION
Refactor plugin support into the PluginsContainer class

The prior logic, in its attempt to avoid deadlocks, could expose a
child processor to zero parent plugins. So this meant that
creating or refreshing a workspace also required the caller to force the
workspace to load its plugins right away. Otherwise, when each
project initialized its plugins, they could attempt to access their
parent's plugins across multiple threads (e.g. gradle parallel build)
and all but one project could see the workspace as having zero plugins.
This has occurred in the OSGi build since it builds bnd plugins in cnf
and then refreshes the workspace to include the just built plugins.

This refactoring addresses this issue at the cost of some breaking API
changes to rarely overridden protected methods due to the
use of the new PluginsContainer type. The new PluginsContainer type
implements both Set<Object> and Registry. Since PluginsContainer
implements Registry, we can pass it to RegistryPlugins at their
customization rather than Processor. This lets us break the cycle
between initializing plugins in the Processor and using the Processor
as a Registry for initializing plugins.

Since we are at a major version boundary, this is a good time to fix
this.