### PR TITLE
Handle pseudo BSNs in BndPomRepository as in MavenBndRepository

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenCapability.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenCapability.java
@@ -5,11 +5,11 @@ import java.util.Objects;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Resource;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.resource.CapabilityBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.version.MavenVersion;
-import aQute.bnd.exceptions.Exceptions;
 
 public interface MavenCapability extends Capability {
 
@@ -23,10 +23,12 @@ public interface MavenCapability extends Capability {
 
 	String maven_classifier();
 
+	String maven_extension();
+
 	String maven_repository();
 
 	static void addMavenCapability(ResourceBuilder rb, String groupId, String artifactId, MavenVersion version,
-		String classifier, String repository) {
+		String extension, String classifier, String repository) {
 		try {
 			CapabilityBuilder c = new CapabilityBuilder(MAVEN_NAMESPACE);
 			c.addAttribute("maven-groupId", Objects.requireNonNull(groupId));
@@ -34,6 +36,9 @@ public interface MavenCapability extends Capability {
 			c.addAttribute("maven-version", Objects.requireNonNull(version));
 			if (classifier != null) {
 				c.addAttribute("maven-classifier", classifier);
+			}
+			if (extension != null) {
+				c.addAttribute("maven-extension", extension);
 			}
 			if (repository != null) {
 				c.addAttribute("maven-repository", repository);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -29,6 +29,7 @@ import org.osgi.util.promise.Promise;
 
 import aQute.bnd.annotation.plugin.BndPlugin;
 import aQute.bnd.build.Workspace;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
@@ -47,7 +48,6 @@ import aQute.bnd.service.repository.Prepare;
 import aQute.bnd.util.repository.DownloadListenerPromise;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.libg.reporter.slf4j.Slf4jReporter;
@@ -285,9 +285,9 @@ public class BndPomRepository extends BaseRepository
 				return null;
 		} else {
 
-			String name = resource.getInfo()
-				.name();
-			archive = Archive.valueOf(name);
+			String from = resource.getInfo()
+				.from();
+			archive = Archive.valueOf(from);
 		}
 
 		Promise<File> p = repoImpl.getMavenRepository()
@@ -414,9 +414,10 @@ public class BndPomRepository extends BaseRepository
 		if (resource == null)
 			return null;
 
-		return Archive.valueOf(resource.getInfo()
-			.name())
-			.getOther("jar", Archive.SOURCES_CLASSIFIER);
+		String from = resource.getInfo()
+			.from();
+		return Archive.valueOf(from)
+			.getOther(Archive.JAR_EXTENSION, Archive.SOURCES_CLASSIFIER);
 	}
 
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
@@ -1,8 +1,6 @@
 package aQute.bnd.repository.maven.pom.provider;
 
 import static aQute.bnd.osgi.repository.BridgeRepository.addInformationCapability;
-import static org.osgi.framework.namespace.IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE;
-import static org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -18,8 +16,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.osgi.framework.Version;
-import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.resource.Resource;
 import org.osgi.util.promise.Deferred;
 import org.osgi.util.promise.Promise;
@@ -30,8 +26,9 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.maven.MavenCapability;
-import aQute.bnd.osgi.resource.CapabilityBuilder;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.bnd.version.MavenVersion;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IPom.Dependency;
 import aQute.maven.api.MavenScope;
@@ -142,22 +139,18 @@ class Traverser {
 					} catch (Throwable throwable) {
 						logger.debug(" failed to parse archive {}: {}", archive, throwable);
 						ResourceBuilder rb = new ResourceBuilder();
-						String bsn = archive.revision.program.toString();
-						Version version = toFrameworkVersion(archive.revision.version.getOSGiVersion());
-						addReserveIdentity(rb, bsn, version);
-						addInformationCapability(rb, archive.toString(), parent, throwable);
+						String name = archive.getWithoutVersion();
+						MavenVersion version = archive.revision.version;
+						addInformationCapability(rb, name, version.getOSGiVersion(), archive.toString(),
+							throwable.toString());
 						MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-							archive.revision.version, archive.extension, archive.classifier, repo.getName());
+							version, archive.extension, archive.classifier, repo.getName());
 						resources.put(archive, rb.build());
 					} finally {
 						finish();
 					}
 				});
 		}
-	}
-
-	private Version toFrameworkVersion(aQute.bnd.version.Version v) {
-		return new Version(v.getMajor(), v.getMinor(), v.getMicro(), v.getQualifier());
 	}
 
 	/*
@@ -206,38 +199,23 @@ class Traverser {
 	private void parseResource(Archive archive, String parent) throws Exception {
 		ResourceBuilder rb = new ResourceBuilder();
 
-		Version frameworkVersion = toFrameworkVersion(archive.revision.version.getOSGiVersion());
-		String bsn = archive.revision.program.toString();
+		String name = archive.getWithoutVersion();
+		MavenVersion version = archive.revision.version;
 
 		try {
 			File binary = repo.get(archive)
 				.getValue();
 
-			if (!rb.addFile(binary, binary.toURI())) {
-				// no identity
-				addReserveIdentity(rb, bsn, frameworkVersion);
-			}
-			addInformationCapability(rb, archive.toString(), parent);
+			boolean hasIdentity = rb.addFile(binary, binary.toURI());
+			addInformationCapability(rb, name, version.getOSGiVersion(), archive.toString(),
+				hasIdentity ? null : Constants.NOT_A_BUNDLE_S);
 		} catch (Exception e) {
 			Throwable theException = Exceptions.unrollCause(e, InvocationTargetException.class);
-			addReserveIdentity(rb, bsn, frameworkVersion);
-			addInformationCapability(rb, archive.toString(), parent, theException);
+			addInformationCapability(rb, name, version.getOSGiVersion(), archive.toString(), theException.toString());
 		}
 		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-			archive.revision.version, archive.extension, archive.classifier, repo.getName());
+			version, archive.extension, archive.classifier, repo.getName());
 		resources.put(archive, rb.build());
-	}
-
-	private void addReserveIdentity(ResourceBuilder rb, String bsn, Version version) {
-		try {
-			CapabilityBuilder c = new CapabilityBuilder(IDENTITY_NAMESPACE);
-			c.addAttribute(IDENTITY_NAMESPACE, bsn);
-			c.addAttribute(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE, version);
-			c.addAttribute(CAPABILITY_TYPE_ATTRIBUTE, IdentityNamespace.TYPE_UNKNOWN);
-			rb.addCapability(c);
-		} catch (Exception ee) {
-			ee.printStackTrace();
-		}
 	}
 
 	public Traverser revision(Revision revision) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
@@ -27,11 +27,11 @@ import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.maven.MavenCapability;
 import aQute.bnd.osgi.resource.CapabilityBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IPom.Dependency;
 import aQute.maven.api.MavenScope;
@@ -147,7 +147,7 @@ class Traverser {
 						addReserveIdentity(rb, bsn, version);
 						addInformationCapability(rb, archive.toString(), parent, throwable);
 						MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-							archive.revision.version, archive.classifier, parent);
+							archive.revision.version, archive.extension, archive.classifier, repo.getName());
 						resources.put(archive, rb.build());
 					} finally {
 						finish();
@@ -218,15 +218,13 @@ class Traverser {
 				addReserveIdentity(rb, bsn, frameworkVersion);
 			}
 			addInformationCapability(rb, archive.toString(), parent);
-			MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-				archive.revision.version, archive.classifier, parent);
 		} catch (Exception e) {
 			Throwable theException = Exceptions.unrollCause(e, InvocationTargetException.class);
 			addReserveIdentity(rb, bsn, frameworkVersion);
 			addInformationCapability(rb, archive.toString(), parent, theException);
-			MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-				archive.revision.version, archive.classifier, parent);
 		}
+		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
+			archive.revision.version, archive.extension, archive.classifier, repo.getName());
 		resources.put(archive, rb.build());
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -29,7 +29,10 @@ import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.exceptions.SupplierWithException;
 import aQute.bnd.maven.MavenCapability;
+import aQute.bnd.memoize.Memoize;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Macro;
@@ -44,10 +47,7 @@ import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
-import aQute.bnd.exceptions.Exceptions;
-import aQute.bnd.exceptions.SupplierWithException;
 import aQute.lib.io.IO;
-import aQute.bnd.memoize.Memoize;
 import aQute.lib.strings.Strings;
 import aQute.maven.api.Archive;
 import aQute.maven.api.IMavenRepo;
@@ -333,7 +333,7 @@ class IndexFile {
 				Constants.NOT_A_BUNDLE_S);
 		}
 		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-			archive.revision.version, archive.classifier, repo.toString());
+			archive.revision.version, archive.extension, archive.classifier, repo.getName());
 		Resource resource = rb.build();
 		return Collections.singletonMap(archive, resource);
 	}
@@ -483,7 +483,7 @@ class IndexFile {
 		MavenVersion version = archive.revision.version;
 		BridgeRepository.addInformationCapability(rb, bsn, version.getOSGiVersion(), repo.toString(), msg);
 		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-			archive.revision.version, archive.classifier, repo.toString());
+			archive.revision.version, archive.extension, archive.classifier, repo.getName());
 		return rb.build();
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -324,16 +324,15 @@ class IndexFile {
 
 	private Map<Archive, Resource> parseSingle(Archive archive, File single) throws Exception {
 		ResourceBuilder rb = new ResourceBuilder();
+		MavenVersion version = archive.revision.version;
 		boolean hasIdentity = rb.addFile(single, single.toURI());
 		if (!hasIdentity) {
 			String name = archive.getWithoutVersion();
-			MavenVersion version = archive.revision.version;
-
-			BridgeRepository.addInformationCapability(rb, name, version.getOSGiVersion(), repo.toString(),
+			BridgeRepository.addInformationCapability(rb, name, version.getOSGiVersion(), archive.toString(),
 				Constants.NOT_A_BUNDLE_S);
 		}
 		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-			archive.revision.version, archive.extension, archive.classifier, repo.getName());
+			version, archive.extension, archive.classifier, repo.getName());
 		Resource resource = rb.build();
 		return Collections.singletonMap(archive, resource);
 	}
@@ -481,9 +480,9 @@ class IndexFile {
 		ResourceBuilder rb = new ResourceBuilder();
 		String bsn = archive.getWithoutVersion();
 		MavenVersion version = archive.revision.version;
-		BridgeRepository.addInformationCapability(rb, bsn, version.getOSGiVersion(), repo.toString(), msg);
+		BridgeRepository.addInformationCapability(rb, bsn, version.getOSGiVersion(), archive.toString(), msg);
 		MavenCapability.addMavenCapability(rb, archive.revision.group, archive.revision.artifact,
-			archive.revision.version, archive.extension, archive.classifier, repo.getName());
+			version, archive.extension, archive.classifier, repo.getName());
 		return rb.build();
 	}
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -694,6 +694,7 @@ public class PomRepositoryTest extends TestCase {
 				"biz.aQute.bnd:biz.aQute.junit:3.3.0", "biz.aQute.bnd:biz.aQute.launcher:3.3.0",
 				"biz.aQute.bnd:biz.aQute.remote.launcher:3.3.0", "biz.aQute.bnd:biz.aQute.tester:3.3.0",
 				"org.jacoco:org.jacoco.agent:jar:runtime:0.8.6",
+				"org.jacoco:org.jacoco.agent:0.8.6",
 				"org.apache.felix:org.apache.felix.framework:bin:zip:1.4.0"
 			});
 
@@ -715,10 +716,19 @@ public class PomRepositoryTest extends TestCase {
 
 			assertThat(mcsr.list("*")).contains("biz.aQute.remote.launcher",
 				"biz.aQute.launcher", "biz.aQute.junit", "biz.aQute.tester", //
-				"org.jacoco:org.jacoco.agent", // with classifier
+				"org.jacoco.agent", // has bsn
+				"org.jacoco:org.jacoco.agent:jar:runtime", // with classifier
 				"org.apache.felix:org.osgi.foundation",// from zip
-				"org.apache.felix:org.apache.felix.framework" // from zip
+				"org.apache.felix:org.apache.felix.framework:bin:zip" // zip
 				);
+
+				SortedSet<Version> versions = mcsr.versions("org.jacoco.agent");
+				assertThat(versions).hasSize(1);
+				assertThat(mcsr.get("org.jacoco.agent", versions.first(), null)).isFile();
+
+				versions = mcsr.versions("org.jacoco:org.jacoco.agent:jar:runtime");
+				assertThat(versions).hasSize(1);
+				assertThat(mcsr.get("org.jacoco:org.jacoco.agent:jar:runtime", versions.first(), null)).isFile();
 		}
 	}
 
@@ -845,7 +855,7 @@ public class PomRepositoryTest extends TestCase {
 			capabilities = resource.getCapabilities("bnd.info");
 			Capability c = capabilities.get(0);
 			String a = (String) c.getAttributes()
-				.get("name");
+				.get("from");
 			Archive archive = Archive.valueOf(a);
 			assertNotNull(archive);
 		}

--- a/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
@@ -44,6 +44,7 @@ import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.maven.MavenCapability;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
@@ -60,7 +61,6 @@ import aQute.bnd.service.Actionable;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.libg.glob.Glob;
 import bndtools.central.Central;
 
@@ -323,7 +323,7 @@ public class MavenWorkspaceRepository extends AbstractIndexingRepository<IProjec
 				}
 
 				MavenCapability.addMavenCapability(rb, artifact.getGroupId(), artifact.getArtifactId(), mavenVersion,
-					artifact.getClassifier(), from);
+					artifact.getExtension(), artifact.getClassifier(), from);
 
 				if (logger.isDebugEnabled()) {
 					logger.debug("{}: Project {} indexing artifact {} as {}", getName(), project.getName(), artifact,


### PR DESCRIPTION
Replacement for and closes #4674.

When an artifact has an extension (other than `jar`) and/or a classifier, the pseudo BSN must include these.