### PR TITLE
Use extension name as suffix on include of bnd file

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/WorkspaceTest.java
+++ b/biz.aQute.bndlib.tests/test/test/WorkspaceTest.java
@@ -267,7 +267,9 @@ public class WorkspaceTest {
 		IO.copy(new File("testresources/w o r k s p a c e"), wsdir);
 		try (Workspace ws = Workspace.getWorkspace(wsdir)) {
 			assertEquals("parent", ws.getProperty("override"));
-			assertEquals("ExtPlugin,ParentPlugin", ws.getProperty("-plugin"));
+			assertEquals("ParentPlugin", ws.getProperty("-plugin"));
+			assertEquals("ParentPlugin,ExtPlugin", ws.getMergedParameters("-plugin")
+				.toString());
 			assertEquals("true", ws.getProperty("ext"));
 			assertEquals("abcdef", ws.getProperty("test"));
 		}

--- a/biz.aQute.bndlib.tests/testresources/w o r k s p a c e/cnf/build.bnd
+++ b/biz.aQute.bndlib.tests/testresources/w o r k s p a c e/cnf/build.bnd
@@ -1,3 +1,3 @@
 test=abcdef
 override=parent
--plugin: ${ext.extension.-plugin},ParentPlugin
+-plugin: ParentPlugin

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -966,7 +966,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			if (overwrite || !target.containsKey(key)) {
 				target.setProperty(key, value);
 			} else if (extensionName != null) {
-				String extensionKey = extensionName + "." + key;
+				String extensionKey = key + "." + extensionName;
 				if (!target.containsKey(extensionKey))
 					target.setProperty(extensionKey, value);
 			}


### PR DESCRIPTION
There was a test, that looked exactly for what I want to change. This suggests, that it was intended behaviour and might break things. 

@njbartlett as the Test seems to have originated from you, can you comment on it?

Fixes #4667