### PR TITLE
[sync] Remove rebuild from workspace sync

### DIFF
--- a/bndtools.core.services/bnd.bnd
+++ b/bndtools.core.services/bnd.bnd
@@ -12,7 +12,8 @@ Import-Package: \
 # Bundle Content
 
 -includepackage: \
-	org.bndtools.core.editors.quickfix
+	org.bndtools.core.editors.quickfix,\
+	org.bndtools.core.sync
 
 -conditionalpackage: \
     aQute.lib.*,\
@@ -35,5 +36,6 @@ Import-Package: \
 	org.eclipse.swt,\
 	org.eclipse.swt.cocoa.macosx.x86_64,\
 	org.eclipse.jface.text,\
-	org.osgi.service.component.annotations;version=1.3.0
+	org.osgi.service.component.annotations;version='1.3.0',\
+	slf4j.api
 	

--- a/bndtools.core.services/src/org/bndtools/core/sync/About.java
+++ b/bndtools.core.services/src/org/bndtools/core/sync/About.java
@@ -1,4 +1,4 @@
-package bndtools.central.sync;
+package org.bndtools.core.sync;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
@@ -232,6 +232,7 @@ public class WorkspaceSynchronizer {
 	public static IProject createProject(File directory, Project model, IProgressMonitor monitor) throws CoreException {
 		IPath location = new Path(directory.getAbsolutePath());
 
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 7);
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IProject project = workspace.getRoot()
 			.getProject(directory.getName());
@@ -248,10 +249,12 @@ public class WorkspaceSynchronizer {
 						EclipseUtil.createClasspath(model);
 					}
 				}
+				subMonitor.setWorkRemaining(6);
 				IProjectDescription description = workspace.newProjectDescription(directory.getName());
 				description.setLocation(location);
-				project.create(description, monitor);
-				project.open(monitor);
+				project.create(description, subMonitor.split(1));
+				project.open(subMonitor.split(1));
+				project.refreshLocal(IResource.DEPTH_INFINITE, subMonitor.split(4));
 			} catch (Exception e) {
 				logger.logError("Failed to create project " + project, e);
 			}

--- a/bndtools.core/src/bndtools/central/sync/package-info.java
+++ b/bndtools.core/src/bndtools/central/sync/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("1.0.0")
+package bndtools.central.sync;


### PR DESCRIPTION
Fixes #4695.

Does the following:

* Moved the sync component into `bndtools.core.services`. Doesn't change the functionality, but makes it more convenient to do live coding/debugging as the `bndtools.core.services` bundle can be restarted while Eclipse is still running.
* Made sure that the event listener callback is de-registered in `@Deactivate` (only important because of the previous point).
* Removed code that disables the autobuild.
* Removed code that does the refresh and build.
* Added cancellation checks to the bndCall `after` callbacks` and short-circuit their execution if it has been cancelled..

There still seems to be an issue on  newly-loaded workspace. as you get a "resource out of sync" problem if (eg) you try delete a project before refreshing it. It is possible I might need to put the refresh back in.

Seems to work and the autobuild takes care of rebuilding (i necessary).