### PR TITLE
[sync] Project creation

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/sync/About.java
+++ b/bndtools.core.services/src/org/bndtools/core/sync/About.java
@@ -1,8 +1,0 @@
-package org.bndtools.core.sync;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class About {
-	final static Logger logger = LoggerFactory.getLogger("bndtools.central.sync");
-}

--- a/bndtools.core/src/bndtools/central/sync/About.java
+++ b/bndtools.core/src/bndtools/central/sync/About.java
@@ -1,0 +1,8 @@
+package bndtools.central.sync;
+
+import org.slf4j.LoggerFactory;
+
+public class About {
+	static final org.slf4j.Logger logger = LoggerFactory.getLogger("bndtools.sync");
+
+}

--- a/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
+++ b/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
@@ -1,4 +1,4 @@
-package org.bndtools.core.sync;
+package bndtools.central.sync;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +32,6 @@ import aQute.lib.concurrent.serial.TriggerRepeat;
 import aQute.lib.io.IO;
 import aQute.lib.watcher.FileWatcher;
 import bndtools.central.Central;
-import bndtools.central.sync.WorkspaceSynchronizer;
 
 /**
  * Synchronizes changes in the bnd workspace with Eclipse. This will use a Java
@@ -43,7 +42,7 @@ import bndtools.central.sync.WorkspaceSynchronizer;
  * with the file system. Any deltas are processed by creating or deleting the
  * project.
  */
-@Component
+@Component(enabled = false)
 public class SynchronizeWorkspaceWithEclipse {
 	static IWorkspace			eclipse			= ResourcesPlugin.getWorkspace();
 	final static IWorkspaceRoot	root			= eclipse.getRoot();

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
@@ -9,8 +9,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.bndtools.api.ILogger;
-import org.bndtools.api.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
@@ -38,8 +36,6 @@ import bndtools.central.Central;
  * A utility class to synchronize the bnd & Eclipse workspaces as well as build.
  */
 public class WorkspaceSynchronizer {
-
-	private static final ILogger	logger	= Logger.getLogger(WorkspaceSynchronizer.class);
 	private static IWorkspace		eclipse	= ResourcesPlugin.getWorkspace();
 	private static IWorkspaceRoot	wsroot	= eclipse.getRoot();
 
@@ -56,7 +52,7 @@ public class WorkspaceSynchronizer {
 		} catch (OperationCanceledException e) {
 			return true;
 		} catch (Exception e) {
-			logger.logError("build failed", e);
+			About.logger.error("build failed {}", e, e);
 		}
 		return monitor.isCanceled();
 	}
@@ -181,7 +177,7 @@ public class WorkspaceSynchronizer {
 
 		} catch (Exception e) {
 			e.printStackTrace();
-			logger.logError("Failed to sync", e);
+			About.logger.error("Failed to sync {}", e, e);
 		} finally {
 			atend.run();
 			setAutobuild(previous);
@@ -225,7 +221,7 @@ public class WorkspaceSynchronizer {
 		try {
 			project.delete(false, true, monitor);
 		} catch (CoreException e) {
-			logger.logError("Unable to remove project " + project, e);
+			About.logger.error("Unable to remove project {} : {}", project, e, e);
 		}
 	}
 
@@ -256,7 +252,7 @@ public class WorkspaceSynchronizer {
 				project.open(subMonitor.split(1));
 				project.refreshLocal(IResource.DEPTH_INFINITE, subMonitor.split(4));
 			} catch (Exception e) {
-				logger.logError("Failed to create project " + project, e);
+				About.logger.error("Failed to create project {} : {}", project, e, e);
 			}
 		}
 

--- a/bndtools.core/src/bndtools/central/sync/package-info.java
+++ b/bndtools.core/src/bndtools/central/sync/package-info.java
@@ -1,3 +1,1 @@
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
 package bndtools.central.sync;

--- a/bndtools.core/src/org/bndtools/core/ui/OnDisplayThread.java
+++ b/bndtools.core/src/org/bndtools/core/ui/OnDisplayThread.java
@@ -1,0 +1,49 @@
+package org.bndtools.core.ui;
+
+import java.util.function.Consumer;
+
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * Simple utility to run an runnable always on the display thread.
+ */
+public class OnDisplayThread {
+
+	/**
+	 * Return a Runnable that will be executed directly if the current thread is
+	 * the Display thread and otherwise is scheduled on it async.
+	 *
+	 * @param runnable the runnable to wrap
+	 * @return a Runnable that runs the given runnable on the proper thread
+	 */
+	public static Runnable async(Runnable runnable) {
+		return () -> {
+			Display display = Display.getDefault();
+			if (display.getThread() == Thread.currentThread()) {
+				runnable.run();
+			} else {
+				display.asyncExec(runnable);
+			}
+		};
+	}
+
+	/**
+	 * Return a Consumer that will be executed directly if the current thread is
+	 * the Display thread and otherwise is scheduled on it async.
+	 *
+	 * @param consumer the runnable to wrap
+	 * @return a Runnable that runs the given runnable on the proper thread
+	 */
+	public static <T> Consumer<T> async(Consumer<T> consumer) {
+		return (T t) -> {
+			Display display = Display.getDefault();
+			if (display.getThread() == Thread.currentThread()) {
+				consumer.accept(t);
+			} else {
+				display.asyncExec(() -> {
+					consumer.accept(t);
+				});
+			}
+		};
+	}
+}


### PR DESCRIPTION
Project creation failed because bndtools code created a new Eclipse project but this interacted badly with the synchronizer.

The bndtools project creation needs
to use the synchronization facilities. This makes the whole process a lot simpler and more reliable. Bndtools should create the project in the workspace and the synchronization then automatically creates the Eclipse projects.

However, this is non-trivial since it requires a new dialog for the bndtools project creation (which can then include the template selection).

So this patch disables the auto sync feature until this is done.

This patch also moves the synchronizer back in the core. This is a core feature that other parts of the core rely on. Imho bundles should be composed of cohesive functions; grouping based on non-cohesive aspects (e.g. this is a service) leads to hard to maintains systems imho. I kept the About for the logger. I like it.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>