### PR TITLE
ds 1.5: Mark component as 1.5 if it used satisfying condition target

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -797,7 +797,10 @@ public class DSAnnotationReader extends ClassDataCollector {
 						key = identifierToPropertyName(key);
 					}
 					if (prefix != null) {
-						key = prefix + key;
+						key = prefix.concat(key);
+					}
+					if (key.equals("osgi.ds.satisfying.condition.target")) {
+						component.updateVersion(V1_5, "use of osgi.ds.satisfying.condition.target property");
 					}
 					return key;
 				}));


### PR DESCRIPTION
This is to make sure SCR properly handles target property precedence
for DS 1.5.

