### PR TITLE
ds 1.5: Mark component as 1.5 if it used satisfying condition target

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/ComponentDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/ComponentDef.java
@@ -5,6 +5,7 @@ import static aQute.bnd.component.DSAnnotationReader.V1_1;
 import static aQute.bnd.component.DSAnnotationReader.V1_2;
 import static aQute.bnd.component.DSAnnotationReader.V1_3;
 import static aQute.bnd.component.DSAnnotationReader.V1_4;
+import static aQute.bnd.component.DSAnnotationReader.V1_5;
 import static java.util.stream.Collectors.joining;
 
 import java.util.ArrayList;
@@ -153,6 +154,11 @@ class ComponentDef extends ExtensionDef {
 		}
 		if (!factoryProperties.isEmpty()) {
 			updateVersion(V1_4, "factoryProperties");
+		}
+		if (propertyDefs.values()
+			.stream()
+			.anyMatch(p -> p.containsKey("osgi.ds.satisfying.condition.target"))) {
+			updateVersion(V1_5, "use of osgi.ds.satisfying.condition.target property");
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -799,9 +799,6 @@ public class DSAnnotationReader extends ClassDataCollector {
 					if (prefix != null) {
 						key = prefix.concat(key);
 					}
-					if (key.equals("osgi.ds.satisfying.condition.target")) {
-						component.updateVersion(V1_5, "use of osgi.ds.satisfying.condition.target property");
-					}
 					return key;
 				}));
 			}


### PR DESCRIPTION
This is to make sure SCR properly handles target property precedence
for DS 1.5. We move the check to a higher level to handle other places
the target property can be set.
