### PR TITLE
Adds support to consider dependencyManagement

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -168,13 +168,17 @@ public class BndPomRepository extends BaseRepository
 				.executor(), reporter);
 
 			boolean transitive = configuration.transitive(true);
+			boolean dependencyManagement = configuration.dependencyManagement(false);
 
 			if (pomFiles != null) {
-				repoImpl = new PomRepository(repository, client, location, transitive).uris(pomFiles);
+				repoImpl = new PomRepository(repository, client, location, transitive, dependencyManagement)
+					.uris(pomFiles);
 			} else if (archives != null) {
-				repoImpl = new PomRepository(repository, client, location, transitive).archives(archives);
+				repoImpl = new PomRepository(repository, client, location, transitive, dependencyManagement)
+					.archives(archives);
 			} else if (query != null) {
-				repoImpl = new SearchRepository(repository, location, query, queryUrl, workspace, client, transitive);
+				repoImpl = new SearchRepository(repository, location, query, queryUrl, workspace, client, transitive,
+					dependencyManagement);
 			} else {
 				repository.close();
 				return false;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
@@ -87,4 +87,10 @@ public interface PomConfiguration {
 	// default: 5 Minutes
 	int poll_time(int pollTimeInSecs);
 
+	/**
+	 * Also considers the dependency management section of a pom. Default is
+	 * false.
+	 */
+	boolean dependencyManagement(boolean deflt);
+
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
@@ -35,10 +35,13 @@ class PomRepository extends InnerRepository {
 	private final HttpClient		client;
 	private final PromiseFactory	promiseFactory;
 	final boolean					transitive;
+	final boolean					dependencyManagement;
 
-	PomRepository(MavenRepository repo, HttpClient client, File location, boolean transitive) {
+	PomRepository(MavenRepository repo, HttpClient client, File location, boolean transitive,
+		boolean dependencyManagement) {
 		super(repo, location);
 		this.transitive = transitive;
+		this.dependencyManagement = dependencyManagement;
 		this.archives = new ArrayList<>();
 		this.uris = new ArrayList<>();
 		this.client = client;
@@ -46,7 +49,7 @@ class PomRepository extends InnerRepository {
 	}
 
 	public PomRepository(MavenRepository repo, HttpClient client, File location) {
-		this(repo, client, location, true);
+		this(repo, client, location, true, false);
 	}
 
 	PomRepository revisions(Collection<Revision> revisions) throws Exception {
@@ -77,11 +80,11 @@ class PomRepository extends InnerRepository {
 	}
 
 	void readUris() throws Exception {
-		save(new Traverser(getMavenRepository(), client, transitive).uris(uris));
+		save(new Traverser(getMavenRepository(), client, transitive, dependencyManagement).uris(uris));
 	}
 
 	void readArchives() throws Exception {
-		save(new Traverser(getMavenRepository(), client, transitive).archives(archives));
+		save(new Traverser(getMavenRepository(), client, transitive, dependencyManagement).archives(archives));
 	}
 
 	void save(Traverser traverser) throws Exception {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/SearchRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/SearchRepository.java
@@ -35,15 +35,17 @@ class SearchRepository extends InnerRepository {
 	final HttpClient			client;
 	final File					cacheFile;
 	final boolean				transitive;
+	final boolean				dependencyManagement;
 
 	SearchRepository(MavenRepository repo, File location, String query, String queryUrl, Reporter reporter,
-		HttpClient client, boolean transitive) throws Exception {
+		HttpClient client, boolean transitive, boolean dependencyManagement) throws Exception {
 		super(repo, location);
 		this.query = query;
 		this.queryUrl = queryUrl;
 		this.reporter = reporter;
 		this.client = client;
 		this.transitive = transitive;
+		this.dependencyManagement = dependencyManagement;
 		cacheFile = new File(location.getParentFile(), "pom-" + repo.getName() + ".query");
 		read();
 	}
@@ -51,7 +53,7 @@ class SearchRepository extends InnerRepository {
 	@Override
 	void refresh() throws Exception {
 		SearchResult result = query();
-		Traverser traverser = new Traverser(getMavenRepository(), client, transitive)
+		Traverser traverser = new Traverser(getMavenRepository(), client, transitive, dependencyManagement)
 			.revisions(result.response.docsToRevisions());
 		Promise<Map<Archive, Resource>> p = traverser.getResources();
 		Collection<Resource> resources = p.getValue()

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/Traverser.java
@@ -50,10 +50,12 @@ class Traverser {
 	final MavenRepository					repo;
 	final HttpClient						client;
 	final boolean							transitive;
+	final boolean							dependencyManagement;
 
-	Traverser(MavenRepository repo, HttpClient client, boolean transitive) {
+	Traverser(MavenRepository repo, HttpClient client, boolean transitive, boolean dependencyManagement) {
 		this.repo = repo;
 		this.client = client;
+		this.dependencyManagement = dependencyManagement;
 		this.promiseFactory = client.promiseFactory();
 		this.deferred = promiseFactory.deferred();
 		this.transitive = transitive;
@@ -184,7 +186,7 @@ class Traverser {
 	private void parsePom(POM pom, String parent) throws Exception {
 
 		Map<Program, Dependency> dependencies = pom.getDependencies(EnumSet.of(MavenScope.compile, MavenScope.runtime),
-			false);
+			transitive, dependencyManagement);
 		for (Dependency d : dependencies.values()) {
 
 			d.bindToVersion(repo);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.2")
+@Version("2.1.0")
 package aQute.bnd.repository.maven.pom.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/maven/api/IPom.java
+++ b/biz.aQute.repository/src/aQute/maven/api/IPom.java
@@ -70,4 +70,7 @@ public interface IPom {
 	Map<Program, Dependency> getDependencies(MavenScope scope, boolean transitive) throws Exception;
 
 	boolean hasValidGAV();
+
+	Map<Program, Dependency> getDependencies(MavenScope scope, boolean transitive, boolean dependencyManagement)
+		throws Exception;
 }

--- a/biz.aQute.repository/src/aQute/maven/api/MavenScope.java
+++ b/biz.aQute.repository/src/aQute/maven/api/MavenScope.java
@@ -35,7 +35,7 @@ public enum MavenScope {
 	/**
 	 *
 	 */
-	import_(false),;
+	import_(true);
 
 	private boolean transitive;
 

--- a/biz.aQute.repository/src/aQute/maven/api/package-info.java
+++ b/biz.aQute.repository/src/aQute/maven/api/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.7.0")
+@Version("1.8.0")
 package aQute.maven.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/maven/provider/packageinfo
+++ b/biz.aQute.repository/src/aQute/maven/provider/packageinfo
@@ -1,1 +1,1 @@
-version 2.4
+version 2.5

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -75,7 +75,7 @@ public class PomRepositoryTest extends TestCase {
 			.version("1.0.8");
 
 		HttpClient client = new HttpClient();
-		Traverser t = new Traverser(mr, client, true).revision(revision);
+		Traverser t = new Traverser(mr, client, true, false).revision(revision);
 		Map<Archive, Resource> value = t.getResources()
 			.getValue();
 		assertEquals(8, value.size());
@@ -89,7 +89,7 @@ public class PomRepositoryTest extends TestCase {
 			.version("1.0.8");
 
 		HttpClient client = new HttpClient();
-		Traverser t = new Traverser(mr, client, false).revision(revision);
+		Traverser t = new Traverser(mr, client, false, false).revision(revision);
 		Map<Archive, Resource> value = t.getResources()
 			.getValue();
 		assertEquals(1, value.size());
@@ -772,6 +772,81 @@ public class PomRepositoryTest extends TestCase {
 			providers = mcsr.findProviders(builder.buildExpression());
 			resources = providers.getValue();
 			assertFalse(resources.isEmpty());
+		}
+	}
+
+	public void testPomFilesWithDependencyManagement() throws Exception {
+		try (BndPomRepository bpr = new BndPomRepository()) {
+			Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			w.setBase(tmp);
+			bpr.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("pom", "testdata/pomrepo/simpleDepManagement.xml");
+			config.put("snapshotUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("releaseUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("name", "test");
+			bpr.setProperties(config);
+
+			List<String> list = bpr.list(null);
+			assertNotNull(list);
+			assertEquals(1, list.size());
+		}
+		try (BndPomRepository bpr = new BndPomRepository()) {
+			Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			w.setBase(tmp);
+			bpr.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("pom", "testdata/pomrepo/simpleDepManagement.xml");
+			config.put("snapshotUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("releaseUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("dependencyManagement", "true");
+			config.put("name", "test");
+			bpr.setProperties(config);
+
+			List<String> list = bpr.list(null);
+			assertNotNull(list);
+			assertEquals(2, list.size());
+		}
+	}
+
+	public void testPomFilesWithDependencyManagementImport() throws Exception {
+		try (BndPomRepository bpr = new BndPomRepository()) {
+			Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			w.setBase(tmp);
+			bpr.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("pom", "testdata/pomrepo/depManagementImport.xml");
+			config.put("snapshotUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("releaseUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("dependencyManagement", "true");
+			config.put("transitive", "false");
+			config.put("name", "test");
+			bpr.setProperties(config);
+
+			List<String> list = bpr.list(null);
+			assertNotNull(list);
+			assertEquals(2, list.size());
+		}
+		try (BndPomRepository bpr = new BndPomRepository()) {
+			Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			w.setBase(tmp);
+			bpr.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("pom", "testdata/pomrepo/depManagementImport.xml");
+			config.put("snapshotUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("releaseUrls", "https://repo.maven.apache.org/maven2/");
+			config.put("dependencyManagement", "true");
+			config.put("transitive", "true");
+			config.put("name", "test");
+			bpr.setProperties(config);
+
+			List<String> list = bpr.list(null);
+			assertNotNull(list);
+			assertEquals(14, list.size());
 		}
 	}
 

--- a/biz.aQute.repository/testdata/pomrepo/depManagementImport.xml
+++ b/biz.aQute.repository/testdata/pomrepo/depManagementImport.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.core</artifactId>
+				<version>6.0.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.osgi</groupId>
+				<artifactId>osgi.cmpn</artifactId>
+				<version>6.0.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-parent</artifactId>
+				<version>1.7.5</version>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/biz.aQute.repository/testdata/pomrepo/simpleDepManagement.xml
+++ b/biz.aQute.repository/testdata/pomrepo/simpleDepManagement.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+    <dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+    </dependencies>
+    </dependencyManagement>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+	</dependencies>
+	
+ </project>

--- a/docs/_plugins/pomrepo.md
+++ b/docs/_plugins/pomrepo.md
@@ -58,7 +58,7 @@ The query must return a JSON response.
 
 | Property         | Type  | Default | Description |
 |------------------|-------|---------|-------------|
-| `releaseUrl`    | `URI...` |      | Comma separated list of URLs to the repositories of released artifacts.| 
+| `releaseUrl`    | `URI...` |      | Comma separated list of URLs to the repositories of released artifacts.|
 | `snapshotUrl`   | `URI...` |      | Comma separated list of URLs to the repositories of snapshot artifacts.|
 |                  |       |         | If this is not specified, it falls back to the release repository or just `local` if that is also not specified.|
 | `local`          | `PATH`| `~/.m2/repository` | The file path to the local Maven repository.  |
@@ -72,6 +72,7 @@ The query must return a JSON response.
 | `name`           | `STRING`|       | Required name of the repo.|
 | `transitive`     | `true|false` | `true` | If set to _truthy_ then dependencies are transitive.|
 | `poll.time`      | `integer`| 5 minutes | Number of seconds between checks for changes to POM files referenced by `pom` or `revision`. If the value is negative or the workspace is in batch/CI mode, then no polling takes place.|
+| `dependencyManagement` | `boolean`| false | If set to `true`, dependencies in the `dependencyManagement` section will be handled as actual dependencies.|
 
 
 One, and only one, of the `pom`, `revision`, or `query` configurations can be set. If multiple are set then the first in `[pom, revision, query]` is used and the remainders are ignored.


### PR DESCRIPTION
When using bnd to Work on top of maven Projects it is often useful to use the parant pom of the Project as BndPomRepository to get the necessary dependencies. Unfortunately they are then in the depencyManagement section and will not be seen by the Repo. 
This PR adds an addtional attribute to the repo to enable consideration of these dependencies. The default is `false` so the default behavior does not change.

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>