### PR TITLE
Gradle plugin updates

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -673,10 +673,8 @@ If you do need to write a `build.gradle` file for a Bnd project, there are some 
 * The `bnd.project` property of the project contains the [Project][9] object.
 
 Bnd properties for a project can be accessed in several ways.
-Given the example property name `foo`, you can use the [`bnd` function][15], `bnd('foo', 'defaultValue')`, or directly from the [bnd extension][16], `bnd.foo`.
-To access Bnd properties without any macro processing you can use the [`bndUnprocessed` function][15], `bndUnprocessed('foo', 'defaultValue')`.
-
-You can also use the `Index` task type described above to generate an index.
+Given the example Bnd property name `foo`, you can use the [bnd extension][16], `bnd.get('foo', 'defaultValue')`, or directly `bnd.foo`.
+To access Bnd properties without any macro processing you can use the [`unprocessed` function][16], `bnd.unprocessed('foo', 'defaultValue')`.
 
 ## Using other JVM languages with the Bnd Gradle Plugins for Bnd Workspace builds
 
@@ -751,8 +749,7 @@ For full details on what the Bnd Gradle Plugins do, check out the [source code][
 [11]: https://github.com/bndtools/bnd/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/filter/root/gradle.properties
 [12]: https://github.com/bndtools/bnd/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/settings.gradle
 [13]: https://github.com/bndtools/bnd/blob/master/org.bndtools.headless.build.plugin.gradle/resources/templates/unprocessed/root/build.gradle
-[15]: src/aQute/bnd/gradle/BndPluginConvention.groovy
-[16]: src/aQute/bnd/gradle/BndProperties.groovy
+[16]: src/aQute/bnd/gradle/BndPluginExtension.groovy
 [18]: https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html
 [19]: https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportingExtension.html#org.gradle.api.reporting.ReportingExtension:baseDir
 [20]: #gradle-plugins-for-bnd-workspace-builds

--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -5,8 +5,7 @@ A typical Gradle build is a non-Bnd workspace build.
 A Bnd Workspace build uses the information specified in the Bnd Workspace's `cnf/build.bnd` file and each project's `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins requires at least Gradle 5.3 for Java 8 to Java 12,
-at least Gradle 6.0 for Java 13,
+These plugins requires at least Gradle 6.1 for Java 8 to Java 13,
 at least Gradle 6.3 for Java 14,
 at least Gradle 6.7 for Java 15,
 and at least Gradle 7.0 for Java 16.
@@ -377,7 +376,6 @@ This property must be set.
 ### destinationDirectory
 
 The directory for the output.
-The default for destinationDirectory is _${project.distsDirectory}_/executable if the exporter is `bnd.executablejar`, _${project.distsDirectory}_/runbundles/_${bndrun.name - '.bndrun'}_ if the exporter is `bnd.runbundles`, and _${project.distsDirectory}_/_${task.name}_ for all other exporters.
 
 ### workingDirectory
 
@@ -437,7 +435,7 @@ Use a colon (`:`) to specify a test method to run on the specified test class.
 ### resultsDirectory
 
 The directory for the test results.
-The default is _${project.buildDir}/${project.testResultsDirName}/${task.name}_.
+The default is _${project.java.testResultsDir}/${task.name}_.
 
 ## Create a task of the `Index` type
 

--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -46,7 +46,7 @@ tasks.named('test') {
 	def target = layout.buildDirectory.dir('testresources')
 	inputs.files(tasks.named('jar')).withPropertyName('jar')
 	inputs.dir(testresources).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName('testresources')
-	systemProperty 'bnd_version', bnd('bnd_version')
+	systemProperty 'bnd_version', bnd.get('bnd_version')
 	systemProperty 'org.gradle.warning.mode', gradle.startParameter.warningMode.name().toLowerCase()
 	def injected = objects.newInstance(Injected)
 	doFirst('copy') { t ->

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -16,6 +16,7 @@ package aQute.bnd.gradle
 
 import static aQute.bnd.exporter.executable.ExecutableJarExporter.EXECUTABLE_JAR
 import static aQute.bnd.exporter.runbundles.RunbundlesExporter.RUNBUNDLES
+import static aQute.bnd.gradle.BndUtils.isGradleCompatible
 import static aQute.bnd.gradle.BndUtils.jarLibraryElements
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.gradle.BndUtils.unwrap
@@ -38,8 +39,10 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -89,8 +92,13 @@ public class BndPlugin implements Plugin<Project> {
 
 		layout.getBuildDirectory().set(bndProject.getTargetDir())
 		project.getPlugins().apply("java")
-		project.libsDirName = "."
-		project.testResultsDirName = bndProject.getProperty("test-reports", "test-reports")
+		if (isGradleCompatible("7.1")) {
+			project.base.getLibsDirectory().value(layout.getBuildDirectory())
+			project.java.getTestResultsDir().value(layout.getBuildDirectory().dir(bndProject.getProperty("test-reports", "test-reports")))
+		} else {
+			project.libsDirName = "."
+			project.testResultsDirName = bndProject.getProperty("test-reports", "test-reports")
+		}
 
 		if (project.hasProperty("bnd_defaultTask")) {
 			project.setDefaultTasks(Strings.split(project.bnd_defaultTask))
@@ -146,10 +154,10 @@ public class BndPlugin implements Plugin<Project> {
 				String compileTaskName = getCompileJavaTaskName()
 				getJava().srcDirs = srcDirs
 				getResources().srcDirs = srcDirs
-				getJava().outputDir = destinationDir
+				getJava().getDestinationDirectory().fileValue(destinationDir)
 				getOutput().resourcesDir = destinationDir
 				tasks.named(compileTaskName, t -> {
-					t.destinationDir = destinationDir
+					t.getDestinationDirectory().fileValue(destinationDir)
 					if (generate) {
 						t.getInputs().files(generate).withPropertyName(generate.getName())
 					}
@@ -163,10 +171,10 @@ public class BndPlugin implements Plugin<Project> {
 				String compileTaskName = getCompileJavaTaskName()
 				getJava().srcDirs = srcDirs
 				getResources().srcDirs = srcDirs
-				getJava().outputDir = destinationDir
+				getJava().getDestinationDirectory().fileValue(destinationDir)
 				getOutput().resourcesDir = destinationDir
 				tasks.named(compileTaskName, t -> {
-					t.destinationDir = destinationDir
+					t.getDestinationDirectory().fileValue(destinationDir)
 					jarLibraryElements(t, getCompileClasspathConfigurationName())
 				})
 				getOutput().dir(destinationDir, "builtBy": compileTaskName)
@@ -176,47 +184,83 @@ public class BndPlugin implements Plugin<Project> {
 		project.afterEvaluate {
 			project.sourceSets {
 				main {
-					convention.getPlugins().forEach((lang, sourceDirSets) -> {
-						var sourceDirSet = sourceDirSets[lang]
-						if (sourceDirSet.hasProperty("srcDirs") && sourceDirSet.hasProperty("outputDir")){
-							File destinationDir = getJava().getOutputDir()
-							String compileTaskName = getCompileTaskName(lang)
-							String resourceTaskName = getProcessResourcesTaskName()
-							try {
-								tasks.named(compileTaskName, t -> {
-									t.destinationDir = destinationDir
-									t.getInputs().files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
-									if (generate) {
-										t.getInputs().files(generate).withPropertyName(generate.getName())
-									}
-								})
-								sourceDirSet.srcDirs = getJava().getSrcDirs()
-								sourceDirSet.outputDir = destinationDir
-								getOutput().dir(destinationDir, "builtBy": compileTaskName)
-							} catch (UnknownDomainObjectException e) {
-								// no such task
+					Map<String,Object> sourceDirectorySets = new LinkedHashMap<>();
+					extensions.getExtensionsSchema().forEach(schema -> {
+						String name = schema.getName()
+						var sourceDirectorySet = extensions.getByName(name)
+						if (sourceDirectorySet instanceof SourceDirectorySet) {
+							sourceDirectorySets.put(name, sourceDirectorySet)
+						}
+					})
+					convention.getPlugins().forEach((name, plugin) -> {
+						if (!sourceDirectorySets.containsKey(name)) {
+							var sourceDirectorySet = plugin[name]
+							if ((sourceDirectorySet instanceof SourceDirectorySet) ||
+								(sourceDirectorySet.hasProperty("srcDirs") && sourceDirectorySet.hasProperty("outputDir"))) {
+								sourceDirectorySets.put(name, sourceDirectorySet)
 							}
+						}
+					})
+					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
+						Provider<Directory> destinationDir = getJava().getClassesDirectory()
+						String compileTaskName = getCompileTaskName(name)
+						String resourceTaskName = getProcessResourcesTaskName()
+						try {
+							tasks.named(compileTaskName, t -> {
+								t.getDestinationDirectory().value(destinationDir)
+								t.getInputs().files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
+								if (generate) {
+									t.getInputs().files(generate).withPropertyName(generate.getName())
+								}
+							})
+							sourceDirectorySet.srcDirs = getJava().getSrcDirs()
+							if (sourceDirectorySet instanceof SourceDirectorySet) {
+								sourceDirectorySet.getDestinationDirectory().value(destinationDir)
+							} else {
+								sourceDirectorySet.outputDir = bndProject.getSrcOutput()
+							}
+							getOutput().dir(destinationDir, "builtBy": compileTaskName)
+						} catch (UnknownDomainObjectException e) {
+							// no such task
 						}
 					})
 				}
 				test {
-					convention.getPlugins().forEach((lang, sourceDirSets) -> {
-						var sourceDirSet = sourceDirSets[lang]
-						if (sourceDirSet.hasProperty("srcDirs") && sourceDirSet.hasProperty("outputDir")){
-							File destinationDir = getJava().getOutputDir()
-							String compileTaskName = getCompileTaskName(lang)
-							String resourceTaskName = getProcessResourcesTaskName()
-							try {
-								tasks.named(compileTaskName, t -> {
-									t.destinationDir = destinationDir
-									t.getInputs().files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
-								})
-								sourceDirSet.srcDirs = getJava().getSrcDirs()
-								sourceDirSet.outputDir = destinationDir
-								getOutput().dir(destinationDir, "builtBy": compileTaskName)
-							} catch (UnknownDomainObjectException e) {
-								// no such task
+					Map<String,Object> sourceDirectorySets = new LinkedHashMap<>();
+					extensions.getExtensionsSchema().forEach(schema -> {
+						String name = schema.getName()
+						var sourceDirectorySet = extensions.getByName(name)
+						if (sourceDirectorySet instanceof SourceDirectorySet) {
+							sourceDirectorySets.put(name, sourceDirectorySet)
+						}
+					})
+					convention.getPlugins().forEach((name, plugin) -> {
+						if (!sourceDirectorySets.containsKey(name)) {
+							var sourceDirectorySet = plugin[name]
+							if ((sourceDirectorySet instanceof SourceDirectorySet) ||
+								(sourceDirectorySet.hasProperty("srcDirs") && sourceDirectorySet.hasProperty("outputDir"))) {
+								sourceDirectorySets.put(name, sourceDirectorySet)
 							}
+						}
+					})
+					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
+						Provider<Directory> destinationDir = getJava().getClassesDirectory()
+						String compileTaskName = getCompileTaskName(name)
+						String resourceTaskName = getProcessResourcesTaskName()
+						try {
+							tasks.named(compileTaskName, t -> {
+								t.getDestinationDirectory().value(destinationDir)
+								t.getInputs().files(tasks.named(resourceTaskName)).withPropertyName(resourceTaskName)
+							})
+							sourceDirectorySet.srcDirs = getJava().getSrcDirs()
+							if (sourceDirectorySet instanceof SourceDirectorySet) {
+								sourceDirectorySet.getDestinationDirectory().value(destinationDir)
+							} else {
+								sourceDirectorySet.outputDir = bndProject.getSrcOutput()
+							}
+							getOutput().dir(destinationDir, "builtBy": compileTaskName)
+						} catch (UnknownDomainObjectException e) {
+							// no such task
 						}
 					})
 				}
@@ -233,17 +277,17 @@ public class BndPlugin implements Plugin<Project> {
 		}
 		/* Set up compile tasks */
 		ConfigurableFileCollection javacBootclasspath = objects.fileCollection().from(decontainer(bndProject.getBootclasspath()))
-		Property<String> javacSource = objects.property(String.class).convention(bndProject.getProperty("javac.source"))
+		Property<JavaVersion> javacSource = objects.property(JavaVersion.class).convention(JavaVersion.toVersion(bndProject.getProperty("javac.source")))
 		if (javacSource.isPresent()) {
-			project.sourceCompatibility = javacSource.get()
+			project.java.sourceCompatibility = javacSource.get()
 		} else {
-			javacSource.convention(project.provider(() -> project.sourceCompatibility.toString()))
+			javacSource.convention(project.provider(() -> project.java.sourceCompatibility))
 		}
-		Property<String> javacTarget = objects.property(String.class).convention(bndProject.getProperty("javac.target"))
+		Property<JavaVersion> javacTarget = objects.property(JavaVersion.class).convention(JavaVersion.toVersion(bndProject.getProperty("javac.target")))
 		if (javacTarget.isPresent()) {
-			project.targetCompatibility = javacTarget.get()
+			project.java.targetCompatibility = javacTarget.get()
 		} else {
-			javacTarget.convention(project.provider(() -> project.targetCompatibility.toString()))
+			javacTarget.convention(project.provider(() -> project.java.targetCompatibility))
 		}
 		String javac = bndProject.getProperty("javac")
 		Property<String> javacProfile = objects.property(String.class)
@@ -254,8 +298,8 @@ public class BndPlugin implements Plugin<Project> {
 		boolean javacDeprecation = isTrue(bndProject.getProperty("javac.deprecation", "true"))
 		String javacEncoding = bndProject.getProperty("javac.encoding", "UTF-8")
 		tasks.withType(JavaCompile.class).configureEach(t -> {
-			t.setSourceCompatibility(javacSource.get())
-			t.setTargetCompatibility(javacTarget.get())
+			t.setSourceCompatibility(javacSource.get().toString())
+			t.setTargetCompatibility(javacTarget.get().toString())
 			Property<Boolean> supportsRelease = objects.property(Boolean.class)
 			if (t.hasProperty("javaCompiler")) {
 				// Gradle 6.7
@@ -264,7 +308,7 @@ public class BndPlugin implements Plugin<Project> {
 			Property<Integer> javacRelease = objects.property(Integer.class).convention(project.provider(() -> {
 				if (supportsRelease.getOrElse(Boolean.valueOf(JavaVersion.current().isJava9Compatible())).booleanValue()) {
 					if (Objects.equals(javacSource.get(), javacTarget.get()) && javacBootclasspath.isEmpty() && !javacProfile.isPresent()) {
-						return Integer.valueOf(JavaVersion.toVersion(javacSource.get()).getMajorVersion())
+						return Integer.valueOf(javacSource.get().getMajorVersion())
 					}
 				}
 				return null
@@ -296,7 +340,7 @@ public class BndPlugin implements Plugin<Project> {
 				Logger logger = tt.getLogger()
 				checkErrors(logger)
 				if (logger.isInfoEnabled()) {
-					logger.info("Compile to {}", tt.getDestinationDir())
+					logger.info("Compile to {}", unwrap(tt.getDestinationDirectory()))
 					List<String> allCompilerArgs = tt.getOptions().getAllCompilerArgs()
 					if (tt.getOptions().hasProperty("release") && tt.getOptions().getRelease().isPresent()) {
 						// Gradle 6.6
@@ -550,11 +594,11 @@ project.dir:            ${layout.getProjectDirectory()}
 target:                 ${unwrap(layout.getBuildDirectory())}
 project.dependson:      ${bndProject.getDependson()}
 project.sourcepath:     ${project.sourceSets.main.getAllSource().getSourceDirectories().getAsPath()}
-project.output:         ${compileJava.getDestinationDir()}
+project.output:         ${unwrap(compileJava.getDestinationDirectory())}
 project.buildpath:      ${compileJava.getClasspath().getAsPath()}
 project.allsourcepath:  ${project.bnd.allSrcDirs.getAsPath()}
 project.testsrc:        ${project.sourceSets.test.getAllSource().getSourceDirectories().getAsPath()}
-project.testoutput:     ${compileTestJava.getDestinationDir()}
+project.testoutput:     ${unwrap(compileTestJava.getDestinationDirectory())}
 project.testpath:       ${compileTestJava.getClasspath().getAsPath()}
 project.bootclasspath:  ${compileJava.getOptions().getBootstrapClasspath()?.getAsPath()?:""}
 project.deliverables:   ${deliverables.getFiles()}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -84,8 +84,8 @@ public class BndPlugin implements Plugin<Project> {
 			checkErrors(project.getLogger())
 			throw new GradleException("Project ${bndProject.getName()} is not a valid bnd project")
 		}
-		project.getExtensions().create("bnd", BndProperties.class, bndProject)
-		project.getConvention().getPlugins().put("bnd", new BndPluginConvention(project))
+		BndPluginExtension extension = project.getExtensions().create("bnd", BndPluginExtension.class, bndProject)
+		project.getConvention().getPlugins().put("bnd", new BndPluginConvention(extension))
 
 		layout.getBuildDirectory().set(bndProject.getTargetDir())
 		project.getPlugins().apply("java")

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPlugin.groovy
@@ -241,10 +241,6 @@ public class BndPlugin implements Plugin<Project> {
 		}
 		Property<String> javacTarget = objects.property(String.class).convention(project.bnd("javac.target"))
 		if (javacTarget.isPresent()) {
-			if (Objects.equals(javacTarget.get(), "jsr14")) {
-				javacTarget.set("1.5")
-				javacBootclasspath.setFrom(bndProject.getBundle("ee.j2se", "1.5", null, ["strategy":"lowest"]).getFile())
-			}
 			project.targetCompatibility = javacTarget.get()
 		} else {
 			javacTarget.convention(project.provider(() -> project.targetCompatibility.toString()))

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginConvention.groovy
@@ -1,43 +1,33 @@
 /**
  * BndPluginConvention for Gradle.
- *
- * <p>
- * Adds bnd and bndUnprocessed methods to projects that apply
- * the {@code biz.aQute.bnd} plugin.
  */
 
 package aQute.bnd.gradle
 
 import org.gradle.api.Project
 
+@Deprecated
 class BndPluginConvention {
-	private final Project project
-	BndPluginConvention(Project project) {
-		this.project = project
+	private final BndPluginExtension extension
+	BndPluginConvention(BndPluginExtension extension) {
+		this.extension = extension
 	}
 	boolean bndis(String name) {
-		return project.bnd.is(name)
+		return extension.is(name)
 	}
 	String bnd(String name) {
-		return project.bnd.get(name)
+		return extension.get(name)
 	}
 	String bndMerge(String name) {
-		return project.bnd.merge(name)
+		return extension.merge(name)
 	}
 	Object bnd(String name, Object defaultValue) {
-		return project.bnd.get(name, defaultValue)
+		return extension.get(name, defaultValue)
 	}
 	String bndProcess(String line) {
-		return project.bnd.process(line)
+		return extension.process(line)
 	}
 	Object bndUnprocessed(String name, Object defaultValue) {
-		var value = project.bnd.project.getUnprocessedProperty(name, null)
-		if (Objects.isNull(value)) {
-			value = defaultValue
-		}
-		if (value instanceof String) {
-			value = value.trim()
-		}
-		return value
+		return extension.unprocessed(name, defaultValue)
 	}
 }

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginExtension.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndPluginExtension.groovy
@@ -1,5 +1,5 @@
 /**
- * BndProperties for Gradle.
+ * BndPluginExtension for Gradle.
  *
  * <p>
  * Add property access for bnd properties to projects that apply
@@ -10,9 +10,9 @@ package aQute.bnd.gradle
 
 import aQute.bnd.build.Project
 
-class BndProperties {
+class BndPluginExtension {
 	final Project project
-	BndProperties(Project bndProject) {
+	BndPluginExtension(Project bndProject) {
 		this.project = bndProject
 	}
 
@@ -40,6 +40,17 @@ class BndProperties {
 		return project.getReplacer().process(line)
 	}
 
+	Object unprocessed(String name, Object defaultValue) {
+		var value = project.getUnprocessedProperty(name, null)
+		if (Objects.isNull(value)) {
+			value = defaultValue
+		}
+		if (value instanceof String) {
+			value = value.trim()
+		}
+		return value
+	}
+	
 	Object propertyMissing(String name) {
 		if (Objects.equals(name, "ext") || extensions.extraProperties.has(name) || extensions.findByName(name)) {
 			throw new MissingPropertyException(name, String)

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/BndUtils.groovy
@@ -20,7 +20,9 @@ import org.gradle.util.GradleVersion
 class BndUtils {
 	private BndUtils() { }
 
-	private static final boolean IS_GRADLE_COMPATIBLE_5_6 = GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0
+	public static boolean isGradleCompatible(String requestedVersion) {
+		return GradleVersion.current().compareTo(GradleVersion.version(requestedVersion)) >= 0
+	}
 
 	public static void logReport(var report, Logger logger) {
 		if (logger.isWarnEnabled()) {
@@ -69,16 +71,14 @@ class BndUtils {
 	}
 
 	public static void jarLibraryElements(Task task, String configurationName) {
-		if (IS_GRADLE_COMPATIBLE_5_6) {
-			Project project = task.getProject()
-			var attributes = project.configurations[configurationName].attributes
-			if (!Objects.equals(attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)?.getName(), LibraryElements.JAR)) {
-				try {
-					attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.getObjects().named(LibraryElements.class, LibraryElements.JAR))
-					task.getLogger().info("Set {}:{} configuration attribute {} to {}", project.getPath(), configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE))
-				} catch (IllegalArgumentException e) {
-					task.getLogger().info("Unable to set {}:{} configuration attribute {} to {}", project.getPath(), configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR, e)
-				}
+		Project project = task.getProject()
+		var attributes = project.configurations[configurationName].attributes
+		if (!Objects.equals(attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)?.getName(), LibraryElements.JAR)) {
+			try {
+				attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.getObjects().named(LibraryElements.class, LibraryElements.JAR))
+				task.getLogger().info("Set {}:{} configuration attribute {} to {}", project.getPath(), configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, attributes.getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE))
+			} catch (IllegalArgumentException e) {
+				task.getLogger().info("Unable to set {}:{} configuration attribute {} to {}", project.getPath(), configurationName, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR, e)
 			}
 		}
 	}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
@@ -30,9 +30,9 @@
  * <li>bndrun - This is the bndrun file to be exported.
  * This property must be set.</li>
  * <li>destinationDirectory - This is the directory for the output.
- * The default for destinationDirectory is project.distsDirectory.dir("executable")
- * if the exporter is "bnd.executablejar", project.distsDirectory.dir("runbundles"/bndrun)
- * if the exporter is "bnd.runbundles", and project.distsDirectory.dir(task.name)
+ * The default for destinationDirectory is project.base.distsDirectory.dir("executable")
+ * if the exporter is "bnd.executablejar", project.base.distsDirectory.dir("runbundles"/bndrun)
+ * if the exporter is "bnd.runbundles", and project.base.distsDirectory.dir(task.name)
  * for all other exporters.</li>
  * <li>workingDirectory - This is the directory for the export operation.
  * The default for workingDirectory is temporaryDir.</li>
@@ -47,6 +47,7 @@ package aQute.bnd.gradle
 
 import static aQute.bnd.exporter.executable.ExecutableJarExporter.EXECUTABLE_JAR
 import static aQute.bnd.exporter.runbundles.RunbundlesExporter.RUNBUNDLES
+import static aQute.bnd.gradle.BndUtils.isGradleCompatible
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.gradle.BndUtils.unwrap
 
@@ -93,9 +94,9 @@ public class Export extends Bndrun {
 	 * The destination directory for the export.
 	 *
 	 * <p>
-	 * The default for destinationDirectory is project.distsDirectory.dir("executable")
-	 * if the exporter is "bnd.executablejar", project.distsDirectory.dir("runbundles"/bndrun)
-	 * if the exporter is "bnd.runbundles", and project.distsDirectory.dir(task.name)
+	 * The default for destinationDirectory is project.base.distsDirectory.dir("executable")
+	 * if the exporter is "bnd.executablejar", project.base.distsDirectory.dir("runbundles"/bndrun)
+	 * if the exporter is "bnd.runbundles", and project.base.distsDirectory.dir(task.name)
 	 * for all other exporters.
 	 */
 	@OutputDirectory
@@ -109,8 +110,8 @@ public class Export extends Bndrun {
 		super()
 		ObjectFactory objects = getProject().getObjects()
 		exporter = objects.property(String.class).convention(getProject().provider(() -> getBundlesOnly() ? RUNBUNDLES : EXECUTABLE_JAR))
-		Provider<Directory> distsDirectory = getProject().hasProperty("distsDirectory") ? getProject().distsDirectory : // Gradle 6.0
-		getProject().getLayout().getBuildDirectory().dir(getProject().provider(() -> getProject().distsDirName))
+		Provider<Directory> distsDirectory = isGradleCompatible("7.1") ? getProject().base.getDistsDirectory()
+		: getProject().distsDirectory
 		destinationDirectory = objects.directoryProperty().convention(distsDirectory.flatMap(distsDir -> {
 			return distsDir.dir(getExporter().map(exporterName -> {
 				switch(exporterName) {

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -29,7 +29,7 @@
  * "configurations.archives.artifacts.files".</li>
  * <li>resultsDirectory - This is the directory
  * where the test case results are placed.
- * The default is project.testResultsDir/name.</li>
+ * The default is project.java.testResultsDir/name.</li>
  * <li>tests - The test class names to be run.
  * If not set, all test classes are run.
  * Use a colon (:) to specify a test method to run on the specified test class.</li>
@@ -38,6 +38,7 @@
 
 package aQute.bnd.gradle
 
+import static aQute.bnd.gradle.BndUtils.isGradleCompatible
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.gradle.BndUtils.unwrap
 
@@ -65,7 +66,7 @@ public class TestOSGi extends Bndrun {
 	 *
 	 * <p>
 	 * The default for resultsDirectory is
-	 * "${buildDir}/${testResultsDirName}/${task.name}"
+	 * "${project.java.testResultsDir}/${task.name}"
 	 */
 	@OutputDirectory
 	final DirectoryProperty resultsDirectory
@@ -76,9 +77,10 @@ public class TestOSGi extends Bndrun {
 	 */
 	public TestOSGi() {
 		super()
-		Provider<Directory> testResultsDirectory = getProject().getLayout().getBuildDirectory().dir(getProject().provider(() -> getProject().testResultsDirName))
+		Provider<Directory> testResultsDir = isGradleCompatible("7.1") ? getProject().java.getTestResultsDir()
+		: getProject().getLayout().getBuildDirectory().dir(getProject().provider(() -> getProject().testResultsDirName))
 		String taskName = getName()
-		resultsDirectory = getProject().getObjects().directoryProperty().convention(testResultsDirectory.map(d -> d.dir(taskName)))
+		resultsDirectory = getProject().getObjects().directoryProperty().convention(testResultsDir.map(d -> d.dir(taskName)))
 	}
 
 	@Deprecated

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -39,9 +39,6 @@ class TestHelper {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
       return '6.3'
     }
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_13)) {
-      return '6.0'
-    }
-    return '5.3'
+    return '6.1'
   }
 }

--- a/bndtools.core.test/build.gradle
+++ b/bndtools.core.test/build.gradle
@@ -4,15 +4,15 @@ import aQute.bnd.osgi.Constants
 tasks.named('testOSGi') {
 	description = 'Bndtools Core Integration tests'
 	if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-		enabled = !bndis(Constants.NOJUNITOSGI)
+		enabled = !bnd.is(Constants.NOJUNITOSGI)
 		bndrun = file('test.win32.x86_64.bndrun')
 	} else if (Os.isFamily(Os.FAMILY_MAC)) {
 		// This has to come before the check for Unix as MacOS also
 		// returns true for Unix
-		enabled = !bndis(Constants.NOJUNITOSGI)
+		enabled = !bnd.is(Constants.NOJUNITOSGI)
 		bndrun = file('test.cocoa.macosx.x86_64.bndrun')
 	} else if (Os.isFamily(Os.FAMILY_UNIX)) {
-		enabled = !bndis(Constants.NOJUNITOSGI)
+		enabled = !bnd.is(Constants.NOJUNITOSGI)
 		bndrun = file('test.gtk.linux.x86_64.bndrun')
 	} else {
 		enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
 /* Configure the subprojects */
 subprojects {
 	if (plugins.hasPlugin('biz.aQute.bnd')) {
-		group = bnd('-groupid')
-		version = bnd('base.version')
+		group = bnd.get('-groupid')
+		version = bnd.get('base.version')
 		tasks.withType(JavaCompile).configureEach {
 			options.compilerArgs.add('-Xlint:unchecked')
 		}

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -29,6 +29,6 @@ tasks.named('releaseDependencies') {
 }
 
 tasks.named('clean') {
-	File releaserepo = file(bnd('releaserepo', 'bundles')) /* Release repository. */
+	File releaserepo = file(bnd.get('releaserepo', 'bundles')) /* Release repository. */
 	delete releaserepo
 }

--- a/maven/build.gradle
+++ b/maven/build.gradle
@@ -11,7 +11,7 @@ def windows = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('w
 def mvnw = rootProject.file(windows ? 'mvnw.cmd' : 'mvnw')
 
 def deploy = tasks.register('deploy', Exec.class) {
-	def releaserepo = uri(bnd('releaserepo', dist.file('bundles'))) /* Release repository. */
+	def releaserepo = uri(bnd.get('releaserepo', dist.file('bundles'))) /* Release repository. */
 	dependsOn dist.tasks.named('releaseDependencies')
 	if (windows) {
 		executable 'cmd'
@@ -33,7 +33,7 @@ def deploy = tasks.register('deploy', Exec.class) {
 }
 
 def deployJFrog = tasks.register('deployJFrog', Exec.class) {
-	enabled = !bnd('-releaserepo.jfrog', '').empty
+	enabled = !bnd.get('-releaserepo.jfrog', '').empty
 	def settings = cnf.file('ext/jfrog-settings.xml')
 	def deployState = deploy.map { it.state }
 	onlyIf {

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -12,13 +12,13 @@ interface Injected {
 
 /* Configure this project */
 String masterVersion = String.format('%s-%s-g%.7s',
-		bnd('gittag'),
-		bnd('timestamp'),
-		bnd('Git-SHA'))
+		bnd.get('gittag'),
+		bnd.get('timestamp'),
+		bnd.get('Git-SHA'))
 
 def p2Plugins = tasks.register('p2Plugins', Sync.class) {
 	dependsOn 'jarDependencies'
-	from bnd('plugins').tokenize(',')
+	from bnd.get('plugins').tokenize(',')
 	into layout.buildDirectory.dir('plugins')
 }
 

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -105,7 +105,7 @@ def p2 = tasks.register('p2') {
 	doLast('exec') { t ->
 		injected.exec.javaexec {
 			classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
-			main = 'org.eclipse.equinox.launcher.Main'
+			mainClass = 'org.eclipse.equinox.launcher.Main'
 			if (logger.isDebugEnabled()) {
 				args '-consoleLog'
 			}
@@ -125,7 +125,7 @@ def p2 = tasks.register('p2') {
 
 		injected.exec.javaexec {
 			classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
-			main = 'org.eclipse.equinox.launcher.Main'
+			mainClass = 'org.eclipse.equinox.launcher.Main'
 			if (logger.isDebugEnabled()) {
 				args '-consoleLog'
 			}


### PR DESCRIPTION
Gradle 7.1 is deprecating things including conventions and so we must react.

This is the first part which covers BndPlugin.

As a consequence, the minimum supported Gradle version is now 6.1 (from 5.3).

See #4699.