### PR TITLE
Add javaLauncher property to Gradle Bndrun and TestOSGi tasks

### DIFF
--- a/biz.aQute.bnd.gradle/README.md
+++ b/biz.aQute.bnd.gradle/README.md
@@ -5,9 +5,7 @@ A typical Gradle build is a non-Bnd workspace build.
 A Bnd Workspace build uses the information specified in the Bnd Workspace's `cnf/build.bnd` file and each project's `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins requires at least Gradle 6.1 for Java 8 to Java 13,
-at least Gradle 6.3 for Java 14,
-at least Gradle 6.7 for Java 15,
+These plugins requires at least Gradle 6.7 for Java 8 to Java 15,
 and at least Gradle 7.0 for Java 16.
 
 This README represents the capabilities and features of the Bnd Gradle Plugins in the branch containing this README.
@@ -448,6 +446,11 @@ Use a colon (`:`) to specify a test method to run on the specified test class.
 The directory for the test results.
 The default is _${project.java.testResultsDir}/${task.name}_.
 
+### javaLauncher
+
+Specify the default java executable to be used for execution.
+This java launcher is used if the bndrun does not specify the `java` property or specifies it with the default value `java`. 
+
 ## Create a task of the `Index` type
 
 The `Index` task type will generate an index for a set of bundles.
@@ -549,6 +552,11 @@ The default is _${temporaryDir}_.
 The collection of files to use for locating bundles during the bndrun execution.
 The default is _${project.sourceSets.main.runtimeClasspath}_ plus _${project.configurations.archives.artifacts.files}_.
 This property must not be used for and is ignored in Bnd Workspace builds.
+
+### javaLauncher
+
+Specify the default java executable to be used for execution.
+This java launcher is used if the bndrun does not specify the `java` property or specifies it with the default value `java`. 
 
 # Gradle Plugins for Bnd Workspace Builds
 

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/AbstractBndrun.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/AbstractBndrun.groovy
@@ -1,0 +1,189 @@
+package aQute.bnd.gradle
+
+import static aQute.bnd.gradle.BndUtils.builtBy
+import static aQute.bnd.gradle.BndUtils.logReport
+import static aQute.bnd.gradle.BndUtils.unwrap
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE
+
+import aQute.bnd.build.Workspace
+import aQute.bnd.osgi.Processor
+import aQute.bnd.repository.fileset.FileSetRepository
+import aQute.lib.io.IO
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Asbtract Bndrun task type for Gradle.
+ *
+ * <p>
+ * This abstract task type is the super type of the bndrun based task types.
+ *
+ * <p>
+ * Properties:
+ * <ul>
+ * <li>bndrun - This is the bndrun file to be run.
+ * This property must be set.</li>
+ * <li>bundles - The bundles to added to a FileSetRepository for non-Bnd Workspace builds. The default is
+ * "sourceSets.main.runtimeClasspath" plus
+ * "configurations.archives.artifacts.files".
+ * This must not be used for Bnd Workspace builds.</li>
+ * <li>ignoreFailures - If true the task will not fail if the execution
+ * fails. The default is false.</li>
+ * <li>workingDirectory - This is the directory for the execution.
+ * The default for workingDirectory is temporaryDir.</li>
+ * </ul>
+ */
+public abstract class AbstractBndrun extends DefaultTask {
+	/**
+	 * The bndrun file for the execution.
+	 *
+	 */
+	@InputFile
+	@PathSensitive(RELATIVE)
+	final RegularFileProperty bndrun
+	
+	/**
+	 * The bundles to added to a FileSetRepository for non-Bnd Workspace builds.
+	 * <p>
+	 * This must not be used for Bnd Workspace builds.
+	 */
+	@InputFiles
+	@PathSensitive(RELATIVE)
+	final ConfigurableFileCollection bundles
+	
+	/**
+	 * Whether execution failures should be ignored.
+	 *
+	 * <p>
+	 * If <code>true</code>, then execution failures will not fail the task.
+	 * Otherwise, a execution failure will fail the task. The default is
+	 * <code>false</code>.
+	 */
+	@Input
+	boolean ignoreFailures = false
+
+	/**
+	 * The working directory for the execution.
+	 *
+	 */
+	@Internal
+	final DirectoryProperty workingDirectory
+
+	/**
+	 * Create a Bndrun task.
+	 *
+	 */
+	public AbstractBndrun() {
+		super()
+		Project project = getProject()
+		ObjectFactory objects = project.getObjects()
+		bndrun = objects.fileProperty()
+		DirectoryProperty temporaryDirProperty = objects.directoryProperty()
+		temporaryDirProperty.set(getTemporaryDir())
+		workingDirectory = objects.directoryProperty().convention(temporaryDirProperty)
+		bundles = objects.fileCollection()
+		if (project.hasProperty("bndWorkspace")) {
+			bundles.disallowChanges() // bundles must not be used for Bnd workspace builds
+		} else {
+			bundles(project.sourceSets.main.getRuntimeClasspath())
+			bundles(project.getConfigurations().archives.getArtifacts().getFiles())
+			// We add this in case someone actually looks for this convention
+			getConvention().getPlugins().put("bundles", new FileSetRepositoryConvention(this))
+		}
+	}
+
+	/**
+	 * Add files to use when locating bundles.
+	 *
+	 * <p>
+	 * The arguments will be handled using
+	 * ConfigurableFileCollection.from().
+	 */
+	public ConfigurableFileCollection bundles(Object... paths) {
+		return builtBy(getBundles().from(paths), paths)
+	}
+
+	/**
+	 * Set the files to use when locating bundles.
+	 *
+	 * <p>
+	 * The argument will be handled using
+	 * ConfigurableFileCollection.from().
+	 */
+	public void setBundles(Object path) {
+		getBundles().setFrom(Collections.emptyList())
+		getBundles().setBuiltBy(Collections.emptyList())
+		bundles(path)
+	}
+
+	/**
+	 * Setup the Run object and call worker on it.
+	 */
+	@TaskAction
+	void bndrunAction() {
+		var workspace = getProject().findProperty("bndWorkspace")
+		File bndrunFile = unwrap(getBndrun())
+		File workingDirFile = unwrap(getWorkingDirectory())
+		if (Objects.nonNull(workspace) && getProject().getPlugins().hasPlugin(BndPlugin.PLUGINID) && Objects.equals(bndrunFile, getProject().bnd.project.getPropertiesFile())) {
+			worker(getProject().bnd.project)
+			return
+		}
+		try (var run = createRun(workspace, bndrunFile)) {
+			var runWorkspace = run.getWorkspace()
+			IO.mkdirs(workingDirFile)
+			if (Objects.isNull(workspace)) {
+				Properties gradleProperties = new PropertiesWrapper(runWorkspace.getProperties())
+				gradleProperties.put("task", this)
+				gradleProperties.put("project", getProject())
+				run.setParent(new Processor(runWorkspace, gradleProperties, false))
+			}
+			run.setBase(workingDirFile)
+			if (run.isStandalone()) {
+				runWorkspace.setOffline(Objects.nonNull(workspace) ? workspace.isOffline() : getProject().getGradle().getStartParameter().isOffline())
+				File cnf = new File(workingDirFile, Workspace.CNFDIR)
+				IO.mkdirs(cnf)
+				runWorkspace.setBuildDir(cnf)
+				if (Objects.isNull(workspace)) {
+					FileSetRepository fileSetRepository = new FileSetRepository(name, getBundles().getFiles())
+					runWorkspace.addBasicPlugin(fileSetRepository)
+					runWorkspace.getRepositories().forEach(repo -> repo.list(null))
+				}
+			}
+			run.getInfo(runWorkspace)
+			logReport(run, getLogger())
+			if (!run.isOk()) {
+				throw new GradleException("${run.getPropertiesFile()} workspace errors")
+			}
+
+			worker(run)
+		}
+	}
+
+	/**
+	 * Create the Run object.
+	 */
+	protected Object createRun(var workspace, File bndrunFile) {
+		Class runClass = workspace ? Class.forName(aQute.bnd.build.Run.class.getName(), true, workspace.getClass().getClassLoader()) : aQute.bnd.build.Run.class
+		return runClass.createRun(workspace, bndrunFile)
+	}
+
+	/**
+	 * Execute the Run object.
+	 */
+	abstract protected void worker(var run)
+}

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Baseline.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -244,12 +243,6 @@ public class Baseline extends DefaultTask {
 			}
 			t instanceof Task && t.getExtensions().findByName("bundle") ? t : null
 		}
-	}
-
-	@Deprecated
-	@ReplacedBy("reportFile")
-	public File getDestination() {
-		return unwrap(getReportFile())
 	}
 
 	/**

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Bndrun.groovy
@@ -1,37 +1,14 @@
 package aQute.bnd.gradle
 
-import static aQute.bnd.gradle.BndUtils.builtBy
 import static aQute.bnd.gradle.BndUtils.logReport
-import static aQute.bnd.gradle.BndUtils.unwrap
-import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 
 import java.util.concurrent.Executors
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.ScheduledExecutorService
 
 import aQute.bnd.build.ProjectLauncher
-import aQute.bnd.build.Workspace
-import aQute.bnd.osgi.Processor
-import aQute.bnd.repository.fileset.FileSetRepository
-import aQute.lib.io.IO
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.Project
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.ProjectLayout
-import org.gradle.api.file.RegularFile
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.model.ReplacedBy
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.TaskAction
 
 /**
  * OSGi Bndrun task type for Gradle.
@@ -63,176 +40,19 @@ import org.gradle.api.tasks.TaskAction
  * This must not be used for Bnd Workspace builds.</li>
  * </ul>
  */
-public class Bndrun extends DefaultTask {
-	/**
-	 * Whether execution failures should be ignored.
-	 *
-	 * <p>
-	 * If <code>true</code>, then execution failures will not fail the task.
-	 * Otherwise, a execution failure will fail the task. The default is
-	 * <code>false</code>.
-	 */
-	@Input
-	boolean ignoreFailures = false
-
-	/**
-	 * The bndrun file for the execution.
-	 *
-	 */
-	@InputFile
-	@PathSensitive(RELATIVE)
-	final RegularFileProperty bndrun
-
-	/**
-	 * The working directory for the execution.
-	 *
-	 */
-	@Internal
-	final DirectoryProperty workingDirectory
-
-	/**
-	 * The bundles to added to a FileSetRepository for non-Bnd Workspace builds.
-	 * <p>
-	 * This must not be used for Bnd Workspace builds.
-	 */
-	@InputFiles
-	@PathSensitive(RELATIVE)
-	final ConfigurableFileCollection bundles
-
+public class Bndrun extends AbstractBndrun {
 	/**
 	 * Create a Bndrun task.
 	 *
 	 */
 	public Bndrun() {
 		super()
-		Project project = getProject()
-		ObjectFactory objects = project.getObjects()
-		bndrun = objects.fileProperty()
-		DirectoryProperty temporaryDirProperty = objects.directoryProperty()
-		temporaryDirProperty.set(getTemporaryDir())
-		workingDirectory = objects.directoryProperty().convention(temporaryDirProperty)
-		bundles = objects.fileCollection()
-		if (project.hasProperty("bndWorkspace")) {
-			bundles.disallowChanges() // bundles must not be used for Bnd workspace builds
-		} else {
-			bundles(project.sourceSets.main.getRuntimeClasspath())
-			bundles(project.getConfigurations().archives.getArtifacts().getFiles())
-			// We add this in case someone actually looks for this convention
-			getConvention().getPlugins().put("bundles", new FileSetRepositoryConvention(this))
-		}
-	}
-
-	/**
-	 * Set the bndfile for the execution.
-	 *
-	 * <p>
-	 * The argument will be handled using
-	 * project.layout.projectDirectory.file().
-	 */
-	public void setBndrun(String file) {
-		getBndrun().value(getProject().getLayout().getProjectDirectory().file(file))
-	}
-
-	/**
-	 * Set the bndfile for the execution.
-	 *
-	 * <p>
-	 * The argument will be handled using
-	 * Project.file().
-	 */
-	public void setBndrun(Object file) {
-		getBndrun().set(getProject().file(file))
-	}
-
-	/**
-	 * Add files to use when locating bundles.
-	 *
-	 * <p>
-	 * The arguments will be handled using
-	 * ConfigurableFileCollection.from().
-	 */
-	public ConfigurableFileCollection bundles(Object... paths) {
-		return builtBy(getBundles().from(paths), paths)
-	}
-
-	/**
-	 * Set the files to use when locating bundles.
-	 *
-	 * <p>
-	 * The argument will be handled using
-	 * ConfigurableFileCollection.from().
-	 */
-	public void setBundles(Object path) {
-		getBundles().setFrom(Collections.emptyList())
-		getBundles().setBuiltBy(Collections.emptyList())
-		bundles(path)
-	}
-
-	@Deprecated
-	@ReplacedBy("workingDirectory")
-	public File getWorkingDir() {
-		return unwrap(getWorkingDirectory())
-	}
-
-	@Deprecated
-	public void setWorkingDir(Object dir) {
-		getWorkingDirectory().set(getProject().file(dir))
-	}
-
-	/**
-	 * Setup the Run object and call worker on it.
-	 */
-	@TaskAction
-	void bndrunAction() {
-		var workspace = getProject().findProperty("bndWorkspace")
-		File bndrunFile = unwrap(getBndrun())
-		File workingDirFile = unwrap(getWorkingDirectory())
-		if (Objects.nonNull(workspace) && getProject().getPlugins().hasPlugin(BndPlugin.PLUGINID) && Objects.equals(bndrunFile, getProject().bnd.project.getPropertiesFile())) {
-			worker(getProject().bnd.project)
-			return
-		}
-		try (var run = createRun(workspace, bndrunFile)) {
-			var runWorkspace = run.getWorkspace()
-			IO.mkdirs(workingDirFile)
-			if (Objects.isNull(workspace)) {
-				Properties gradleProperties = new PropertiesWrapper(runWorkspace.getProperties())
-				gradleProperties.put("task", this)
-				gradleProperties.put("project", getProject())
-				run.setParent(new Processor(runWorkspace, gradleProperties, false))
-			}
-			run.setBase(workingDirFile)
-			if (run.isStandalone()) {
-				runWorkspace.setOffline(Objects.nonNull(workspace) ? workspace.isOffline() : getProject().getGradle().getStartParameter().isOffline())
-				File cnf = new File(workingDirFile, Workspace.CNFDIR)
-				IO.mkdirs(cnf)
-				runWorkspace.setBuildDir(cnf)
-				if (Objects.isNull(workspace)) {
-					FileSetRepository fileSetRepository = new FileSetRepository(name, getBundles().getFiles())
-					runWorkspace.addBasicPlugin(fileSetRepository)
-					runWorkspace.getRepositories().forEach(repo -> repo.list(null))
-				}
-			}
-			run.getInfo(runWorkspace)
-			logReport(run, getLogger())
-			if (!run.isOk()) {
-				throw new GradleException("${run.getPropertiesFile()} workspace errors")
-			}
-
-			worker(run)
-		}
-	}
-
-	/**
-	 * Create the Run object.
-	 */
-	protected Object createRun(var workspace, File bndrunFile) {
-		Class runClass = workspace ? Class.forName(aQute.bnd.build.Run.class.getName(), true, workspace.getClass().getClassLoader()) : aQute.bnd.build.Run.class
-		return runClass.createRun(workspace, bndrunFile)
 	}
 
 	/**
 	 * Execute the Run object.
 	 */
+	@Override
 	protected void worker(var run) {
 		getLogger().info("Running {} in {}", run.getPropertiesFile(), run.getBase())
 		getLogger().debug("Run properties: {}", run.getProperties())

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Export.groovy
@@ -41,53 +41,34 @@ import org.gradle.api.tasks.OutputDirectory
  * <p>
  * Properties:
  * <ul>
- * <li>ignoreFailures - If true the task will not fail if the export
- * fails. The default is false.</li>
- * <li>exporter - The name of the exporter plugin to use.
- * Bnd has two built-in exporter plugins. "bnd.executablejar"
- * exports an executable jar and "bnd.runbundles" exports the
- * -runbundles files. The default is "bnd.executablejar".</li>
  * <li>bndrun - This is the bndrun file to be exported.
  * This property must be set.</li>
+ * <li>bundles - The bundles to added to a FileSetRepository for non-Bnd Workspace builds. The default is
+ * "sourceSets.main.runtimeClasspath" plus
+ * "configurations.archives.artifacts.files".
+ * This must not be used for Bnd Workspace builds.</li>
+ * <li>ignoreFailures - If true the task will not fail if the export
+ * fails. The default is false.</li>
+ * <li>workingDirectory - This is the directory for the export operation.
+ * The default for workingDirectory is temporaryDir.</li>
  * <li>destinationDirectory - This is the directory for the output.
  * The default for destinationDirectory is project.base.distsDirectory.dir("executable")
  * if the exporter is "bnd.executablejar", project.base.distsDirectory.dir("runbundles"/bndrun)
  * if the exporter is "bnd.runbundles", and project.base.distsDirectory.dir(task.name)
  * for all other exporters.</li>
- * <li>workingDirectory - This is the directory for the export operation.
- * The default for workingDirectory is temporaryDir.</li>
- * <li>bundles - The bundles to added to a FileSetRepository for non-Bnd Workspace builds. The default is
- * "sourceSets.main.runtimeClasspath" plus
- * "configurations.archives.artifacts.files".
- * This must not be used for Bnd Workspace builds.</li>
+ * <li>exporter - The name of the exporter plugin to use.
+ * Bnd has two built-in exporter plugins. "bnd.executablejar"
+ * exports an executable jar and "bnd.runbundles" exports the
+ * -runbundles files. The default is "bnd.executablejar".</li>
  * </ul>
  */
-public class Export extends Bndrun {
+public class Export extends AbstractBndrun {
 	/**
-	 * This property is replaced by exporter.
-	 * This property is only used when the exporter
-	 * property is not specified.
-	 *
-	 * <p>
-	 * If <code>true</code>, then the exporter defaults to
-	 * "bnd.runbundles". Otherwise the exporter defaults to
-	 * "bnd.executablejar". The default is <code>false</code>.
+	 * @deprecated Replaced by exporter.
 	 */
 	@ReplacedBy("exporter")
 	@Deprecated
 	boolean bundlesOnly = false
-
-	/**
-	 * The name of the exporter for this task.
-	 *
-	 * <p>
-	 * Bnd has two built-in exporter plugins. "bnd.executablejar"
-	 * exports an executable jar and "bnd.runbundles" exports the
-	 * -runbundles files. The default is "bnd.executablejar" unless
-	 * bundlesOnly is false when the default is "bnd.runbundles".
-	 */
-	@Input
-	final Property<String> exporter
 
 	/**
 	 * The destination directory for the export.
@@ -100,6 +81,18 @@ public class Export extends Bndrun {
 	 */
 	@OutputDirectory
 	final DirectoryProperty destinationDirectory
+
+	/**
+	 * The name of the exporter for this task.
+	 *
+	 * <p>
+	 * Bnd has two built-in exporter plugins. "bnd.executablejar"
+	 * exports an executable jar and "bnd.runbundles" exports the
+	 * -runbundles files. The default is "bnd.executablejar" unless
+	 * bundlesOnly is false when the default is "bnd.runbundles".
+	 */
+	@Input
+	final Property<String> exporter
 
 	/**
 	 * Create a Export task.
@@ -115,27 +108,16 @@ public class Export extends Bndrun {
 			return distsDir.dir(getExporter().map(exporterName -> {
 				switch(exporterName) {
 					case EXECUTABLE_JAR:
-					return "executable"
+						return "executable"
 					case RUNBUNDLES:
-					File bndrunFile = unwrap(getBndrun())
-					String bndrunName = bndrunFile.getName() - ".bndrun"
-					return "runbundles/${bndrunName}"
+						File bndrunFile = unwrap(getBndrun())
+						String bndrunName = bndrunFile.getName() - ".bndrun"
+						return "runbundles/${bndrunName}"
 					default:
-					return exporterName
+						return exporterName
 				}
 			}))
 		}))
-	}
-
-	@Deprecated
-	@ReplacedBy("destinationDirectory")
-	public File getDestinationDir() {
-		return unwrap(getDestinationDirectory())
-	}
-
-	@Deprecated
-	public void setDestinationDir(Object dir) {
-		getDestinationDirectory().set(getProject().file(dir))
 	}
 
 	/**

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/FileSetRepositoryConvention.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/FileSetRepositoryConvention.groovy
@@ -9,12 +9,12 @@ import org.gradle.api.file.ConfigurableFileCollection
  * Task convention to make a FileSetRepository from
  * a bundles property.
  * 
- * @deprecated Function moved into Bndrun task type.
+ * @deprecated Function moved into AbstractBndrun type.
  */
 
 @Deprecated
 class FileSetRepositoryConvention {
-	private final Bndrun bndrunTask
+	private final AbstractBndrun bndrunTask
 
 	FileSetRepositoryConvention(Task task) {
 		this.bndrunTask = task

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Index.groovy
@@ -17,7 +17,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -51,6 +50,13 @@ import org.gradle.api.tasks.TaskAction
  * <p>
  * Properties:
  * <ul>
+ * <li>base - The base URI for the generated index. The default is
+ * the file: URI of the destinationDirectory.</li>
+ * The default value is buildDir.</li>
+ * <li>bundles - This is the bundles to be indexed. This property
+ * must be set.</li>
+ * <li>destinationDirectory - The destination directory for the index.
+ * This is used as the URI base of the generated index.
  * <li>gzip - If <code>true</code>, then a gzip'd copy of the index will be made.
  * Otherwise, only the uncompressed index will be made. The default is
  * <code>false</code>.</li>
@@ -58,16 +64,33 @@ import org.gradle.api.tasks.TaskAction
  * <code>index.xml</code>.</li>
  * <li>repositoryName - The name attribute in the generated index. The default is
  * the name of the task.</li>
- * <li>destinationDirectory - The destination directory for the index.
- * This is used as the URI base of the generated index.
- * <li>base - The base URI for the generated index. The default is
- * the file: URI of the destinationDirectory.</li>
- * The default value is buildDir.</li>
- * <li>bundles - This is the bundles to be indexed. This property
- * must be set.</li>
  * </ul>
  */
 public class Index extends DefaultTask {
+	/**
+	 * The URI base of the generated index.
+	 *
+	 * <p>
+	 * The default is the file: URI of the destinationDir.
+	 */
+	@Input
+	final Property<URI> base
+	
+	/**
+	 * The bundles to be indexed.
+	 */
+	@InputFiles
+	final ConfigurableFileCollection bundles
+
+	/**
+	 * The destination directory for the index.
+	 *
+	 * <p>
+	 * The default value is project.layout.buildDirectory.
+	 */
+	@Internal("Represented by indexUncompressed and indexCompressed")
+	final DirectoryProperty destinationDirectory
+
 	/**
 	 * Whether a gzip'd index should be made.
 	 *
@@ -80,24 +103,6 @@ public class Index extends DefaultTask {
 	boolean gzip = false
 
 	/**
-	 * The URI base of the generated index.
-	 *
-	 * <p>
-	 * The default is the file: URI of the destinationDir.
-	 */
-	@Input
-	final Property<URI> base
-
-	/**
-	 * The name attribute in the generated index.
-	 *
-	 * <p>
-	 * The default is the name of the task.
-	 */
-	@Input
-	final Property<String> repositoryName
-
-	/**
 	 * The name of the index file.
 	 *
 	 * <p>
@@ -107,13 +112,13 @@ public class Index extends DefaultTask {
 	final Property<String> indexName
 
 	/**
-	 * The destination directory for the index.
+	 * The name attribute in the generated index.
 	 *
 	 * <p>
-	 * The default value is project.layout.buildDirectory.
+	 * The default is the name of the task.
 	 */
-	@Internal("Represented by indexUncompressed and indexCompressed")
-	final DirectoryProperty destinationDirectory
+	@Input
+	final Property<String> repositoryName
 
 	/**
 	 * The uncompressed index file.
@@ -134,12 +139,6 @@ public class Index extends DefaultTask {
 	final RegularFileProperty indexCompressed
 
 	/**
-	 * The bundles to be indexed.
-	 */
-	@InputFiles
-	final ConfigurableFileCollection bundles
-
-	/**
 	 * Create an Index task.
 	 *
 	 */
@@ -153,17 +152,6 @@ public class Index extends DefaultTask {
 		base = objects.property(URI.class).convention(destinationDirectory.map(d -> d.getAsFile().toURI()))
 		indexUncompressed = objects.fileProperty().convention(destinationDirectory.file(indexName))
 		indexCompressed = objects.fileProperty().convention(destinationDirectory.file(indexName.map(n -> n.concat(".gz"))))
-	}
-
-	@Deprecated
-	@ReplacedBy("destinationDirectory")
-	public File getDestinationDir() {
-		return unwrap(getDestinationDirectory())
-	}
-
-	@Deprecated
-	public void setDestinationDir(Object dir) {
-		getDestinationDirectory().set(getProject().file(dir))
 	}
 
 	/**

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/Resolve.groovy
@@ -35,29 +35,29 @@ import org.osgi.service.resolver.ResolutionException
  * <p>
  * Properties:
  * <ul>
- * <li>ignoreFailures - If true the task will not fail if the execution
- * fails. The default is false.</li>
- * <li>failOnChanges - If true the task will fail if the resolve process
- * results in a different value for -runbundles than the current value.
- * The default is false.</li>
- * <li>writeOnChanges - If true the task will write changes to the value
- * of the -runbundles property. The default is true.</li>
  * <li>bndrun - This is the bndrun file to be resolved.
  * This property must be set.</li>
- * <li>outputBndrun - This is the output file for the calculated
- * -runbundles property. The default is the input bndrun file
- * which means the input bndrun file will be updated in place.</li>
- * <li>workingDirectory - This is the directory for the resolve process.
- * The default for workingDirectory is temporaryDir.</li>
  * <li>bundles - The bundles to added to a FileSetRepository for non-Bnd Workspace builds. The default is
  * "sourceSets.main.runtimeClasspath" plus
  * "configurations.archives.artifacts.files".
  * This must not be used for Bnd Workspace builds.</li>
+ * <li>ignoreFailures - If true the task will not fail if the execution
+ * fails. The default is false.</li>
+ * <li>workingDirectory - This is the directory for the resolve process.
+ * The default for workingDirectory is temporaryDir.</li>
+ * <li>failOnChanges - If true the task will fail if the resolve process
+ * results in a different value for -runbundles than the current value.
+ * The default is false.</li>
+ * <li>outputBndrun - This is the output file for the calculated
+ * -runbundles property. The default is the input bndrun file
+ * which means the input bndrun file will be updated in place.</li>
  * <li>reportOptional - If true failure reports will include
  * optional requirements. The default is true.</li>
+ * <li>writeOnChanges - If true the task will write changes to the value
+ * of the -runbundles property. The default is true.</li>
  * </ul>
  */
-public class Resolve extends Bndrun {
+public class Resolve extends AbstractBndrun {
 	/**
 	 * Whether resolve changes should fail the task.
 	 *
@@ -70,28 +70,6 @@ public class Resolve extends Bndrun {
 	boolean failOnChanges = false
 
 	/**
-	 * Whether resolve changes should be writen back.
-	 *
-	 * <p>
-	 * If <code>true</code>, then a change to the current -runbundles
-	 * value will be writen back into the bndrun file. The default is
-	 * <code>true</code>.
-	 */
-	@Input
-	boolean writeOnChanges = true
-
-	/**
-	 * Whether to report optional requirements.
-	 *
-	 * <p>
-	 * If <code>true</code>, optional requirements will be reported. The
-	 * default is <code>true</code>.
-	 *
-	 */
-	@Input
-	boolean reportOptional = true
-
-	/**
 	 * Return the output file for the calculated `-runbundles`
 	 * property.
 	 *
@@ -102,6 +80,28 @@ public class Resolve extends Bndrun {
 	 */
 	@OutputFile
 	final RegularFileProperty outputBndrun
+	
+	/**
+	 * Whether to report optional requirements.
+	 *
+	 * <p>
+	 * If <code>true</code>, optional requirements will be reported. The
+	 * default is <code>true</code>.
+	 *
+	 */
+	@Input
+	boolean reportOptional = true
+	
+	/**
+	 * Whether resolve changes should be writen back.
+	 *
+	 * <p>
+	 * If <code>true</code>, then a change to the current -runbundles
+	 * value will be writen back into the bndrun file. The default is
+	 * <code>true</code>.
+	 */
+	@Input
+	boolean writeOnChanges = true
 
 	/**
 	 * Create a Resolve task.
@@ -114,6 +114,7 @@ public class Resolve extends Bndrun {
 	/**
 	 * Create the Bndrun object.
 	 */
+	@Override
 	protected Object createRun(var workspace, File bndrunFile) {
 		File outputBndrunFile = unwrap(getOutputBndrun())
 		if (!Objects.equals(outputBndrunFile, bndrunFile)) {
@@ -131,6 +132,7 @@ public class Resolve extends Bndrun {
 	/**
 	 * Resolve the Bndrun object.
 	 */
+	@Override
 	protected void worker(var run) {
 		getLogger().info("Resolving runbundles required for {}", run.getPropertiesFile())
 		getLogger().debug("Run properties: {}", run.getProperties())

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -4,6 +4,8 @@ import static aQute.bnd.gradle.BndUtils.isGradleCompatible
 import static aQute.bnd.gradle.BndUtils.logReport
 import static aQute.bnd.gradle.BndUtils.unwrap
 
+import aQute.lib.io.IO
+
 import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -42,6 +44,7 @@ import org.gradle.api.tasks.options.Option
  * fails. The default is false.</li>
  * <li>workingDirectory - This is the directory for the test case execution.
  * The default for workingDir is temporaryDir.</li>
+ * <li>javaLauncher - Configures the default java executable to be used for execution.</li>
  * <li>resultsDirectory - This is the directory
  * where the test case results are placed.
  * The default is project.java.testResultsDir/name.</li>
@@ -86,6 +89,9 @@ public class TestOSGi extends Bndrun {
 	 */
 	@Override
 	protected void worker(var run) {
+		if (getJavaLauncher().isPresent() && Objects.equals(run.getProperty("java", "java"), "java")) {
+			run.setProperty("java", IO.absolutePath(getJavaLauncher().get().getExecutablePath().getAsFile()))
+		}
 		getLogger().info("Running tests for {} in {}", run.getPropertiesFile(), run.getBase())
 		getLogger().debug("Run properties: {}", run.getProperties())
 		File resultsDir = unwrap(getResultsDirectory())

--- a/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
+++ b/biz.aQute.bnd.gradle/src/aQute/bnd/gradle/TestOSGi.groovy
@@ -7,7 +7,6 @@ import static aQute.bnd.gradle.BndUtils.unwrap
 import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.model.ReplacedBy
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
@@ -32,17 +31,17 @@ import org.gradle.api.tasks.options.Option
  * <p>
  * Properties:
  * <ul>
- * <li>ignoreFailures - If true the task will not fail if the any
- * test cases fail. Otherwise, the task will fail if any test case
- * fails. The default is false.</li>
  * <li>bndrun - This is the bndrun file to be tested.
  * This property must be set.</li>
- * <li>workingDirectory - This is the directory for the test case execution.
- * The default for workingDir is temporaryDir.</li>
  * <li>bundles - The bundles to added to a FileSetRepository for non-Bnd Workspace builds. The default is
  * "sourceSets.main.runtimeClasspath" plus
  * "configurations.archives.artifacts.files".
  * This must not be used for Bnd Workspace builds.</li>
+ * <li>ignoreFailures - If true the task will not fail if the any
+ * test cases fail. Otherwise, the task will fail if any test case
+ * fails. The default is false.</li>
+ * <li>workingDirectory - This is the directory for the test case execution.
+ * The default for workingDir is temporaryDir.</li>
  * <li>resultsDirectory - This is the directory
  * where the test case results are placed.
  * The default is project.java.testResultsDir/name.</li>
@@ -53,14 +52,6 @@ import org.gradle.api.tasks.options.Option
  */
 public class TestOSGi extends Bndrun {
 	/**
-	 * Configures the test class names to be run.
-	 */
-	@Input
-	@Optional
-	@Option(description = "Configures the test class names to be run.")
-	List<String> tests
-
-	/**
 	 * The directory where the test case results are placed.
 	 *
 	 * <p>
@@ -69,6 +60,14 @@ public class TestOSGi extends Bndrun {
 	 */
 	@OutputDirectory
 	final DirectoryProperty resultsDirectory
+	
+	/**
+	 * Configures the test class names to be run.
+	 */
+	@Input
+	@Optional
+	@Option(description = "Configures the test class names to be run.")
+	List<String> tests
 
 	/**
 	 * Create a TestOSGi task.
@@ -80,12 +79,6 @@ public class TestOSGi extends Bndrun {
 		: getProject().getLayout().getBuildDirectory().dir(getProject().provider(() -> getProject().testResultsDirName))
 		String taskName = getName()
 		resultsDirectory = getProject().getObjects().directoryProperty().convention(testResultsDir.map(d -> d.dir(taskName)))
-	}
-
-	@Deprecated
-	@ReplacedBy("resultsDirectory")
-	public File getResultsDir() {
-		return unwrap(getResultsDirectory())
 	}
 
 	/**

--- a/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
+++ b/biz.aQute.bnd.gradle/test/aQute/bnd/gradle/TestHelper.groovy
@@ -33,12 +33,6 @@ class TestHelper {
     if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
       return '7.0'
     }
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
-      return '6.7'
-    }
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
-      return '6.3'
-    }
-    return '6.1'
+    return '6.7'
   }
 }

--- a/biz.aQute.bnd.gradle/testresources/exporttask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/exporttask1/build.gradle
@@ -44,6 +44,6 @@ task runbundles(type: Export) {
 	description = "Export ${name}.bndrun"
 	group = 'export'
 	bndrun = file("${name}.bndrun")
-	bundlesOnly = true
+	exporter = 'bnd.runbundles'
 	bundles = configurations.bundles
 }

--- a/biz.aQute.bnd.gradle/testresources/resolvetask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/resolvetask1/build.gradle
@@ -28,7 +28,7 @@ ext {
 task create(type: Resolve) {
 	description = "Resolve ${name}.bndrun"
 	group = 'export'
-	bndrun "${name}.bndrun"
+	bndrun = file("${name}.bndrun")
 	outputBndrun = file("${buildDir}/${name}.bndrun")
 	bundles = configurations.bundles
 }
@@ -36,7 +36,7 @@ task create(type: Resolve) {
 task same(type: Resolve) {
 	description = "Resolve ${name}.bndrun"
 	group = 'export'
-	bndrun file("${name}.bndrun")
+	bndrun = file("${name}.bndrun")
 	failOnChanges = true
 	bundles = configurations.bundles
 }
@@ -52,6 +52,6 @@ task changefail(type: Resolve) {
 task resolvefail(type: Resolve) {
 	description = "Resolve ${name}.bndrun"
 	group = 'export'
-	bndrun = "${name}.bndrun"
+	bndrun = file("${name}.bndrun")
 	bundles = configurations.bundles
 }

--- a/biz.aQute.bnd.gradle/testresources/runtask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/runtask1/build.gradle
@@ -24,4 +24,7 @@ task run(type: Bndrun) {
 	group = 'export'
 	inputs.files jar
 	bndrun = file("${name}.bndrun")
+	javaLauncher = javaToolchains.launcherFor {
+		languageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
+	}
 }

--- a/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
@@ -39,6 +39,9 @@ def testosgiTask = tasks.register('testosgi', TestOSGi) {
 	description = 'OSGi Test testosgi.bndrun'
 	group = 'test'
 	bndrun = resolveTask.flatMap { it.outputBndrun }
+	javaLauncher = javaToolchains.launcherFor {
+		languageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
+	}
 }
 
 def checkTask = tasks.named('check') {

--- a/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/testosgitask2/build.gradle
@@ -30,7 +30,7 @@ task testosgi(type: TestOSGi) {
 	inputs.files jar
 	bndrun = file("${name}.bndrun")
 	bundles configurations.framework
-	workingDir = new File(temporaryDir, 'temptemp')
+	workingDirectory = new File(temporaryDir, 'temptemp')
 }
 
 check {


### PR DESCRIPTION
This raises the minimum Gradle version to 6.7.

Previously deprecated methods and some obsolete setters are removed.