### PR TITLE
Build p2 java8

### DIFF
--- a/biz.aQute.bnd.gradle/build.gradle
+++ b/biz.aQute.bnd.gradle/build.gradle
@@ -24,10 +24,10 @@ if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_1_9)) {
 	}
 }
 
-def pluginUnderTestResources = layout.buildDirectory.dir('plugin-under-test')
+var pluginUnderTestResources = layout.buildDirectory.dir('plugin-under-test')
 
-def pluginUnderTestMetadata = tasks.register('pluginUnderTestMetadata', WriteProperties.class) {
-	def pluginClasspath = objects.fileCollection().from(configurations.runtimeClasspath.allArtifacts.files, configurations.runtimeClasspath)
+var pluginUnderTestMetadata = tasks.register('pluginUnderTestMetadata', WriteProperties.class) {
+	var pluginClasspath = objects.fileCollection().from(configurations.runtimeClasspath.allArtifacts.files, configurations.runtimeClasspath)
 	inputs.files(pluginClasspath).withNormalizer(ClasspathNormalizer).withPropertyName('pluginClasspath')
 	outputFile = pluginUnderTestResources.map { it.file('plugin-under-test-metadata.properties') }
 	doFirst('implementation-classpath') { t->
@@ -42,13 +42,13 @@ sourceSets {
 }
 
 tasks.named('test') {
-	def testresources = file('testresources')
-	def target = layout.buildDirectory.dir('testresources')
+	var testresources = file('testresources')
+	var target = layout.buildDirectory.dir('testresources')
 	inputs.files(tasks.named('jar')).withPropertyName('jar')
 	inputs.dir(testresources).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName('testresources')
 	systemProperty 'bnd_version', bnd.get('bnd_version')
 	systemProperty 'org.gradle.warning.mode', gradle.startParameter.warningMode.name().toLowerCase()
-	def injected = objects.newInstance(Injected)
+	var injected = objects.newInstance(Injected)
 	doFirst('copy') { t ->
 		// copy test resources into build dir
 		injected.fs.delete {

--- a/biz.aQute.bnd.gradle/publish.gradle
+++ b/biz.aQute.bnd.gradle/publish.gradle
@@ -66,9 +66,9 @@ tasks.create('displayArtifacts') {
 	}
 }
 
-def pomFile = file("$buildDir/pom.xml")
+var pomFile = file("$buildDir/pom.xml")
 
-def copyPublishedPom = tasks.create('copyPublishedPom') {
+var copyPublishedPom = tasks.create('copyPublishedPom') {
 	inputs.files(configurations.pom).withPathSensitivity(PathSensitivity.NONE)
 	outputs.file(pomFile)
 	doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ subprojects {
 				}
 			}
 			if (!logger.isInfoEnabled()) {
-				def stdOut = [:]
-				def stdErr = [:]
+				var stdOut = [:]
+				var stdErr = [:]
 				onOutput { descriptor, event ->
 					if (event.destination == TestOutputEvent.Destination.StdErr) {
 						stdErr.get(descriptor, []).add(event)
@@ -70,8 +70,8 @@ subprojects {
 					}
 				}
 				afterTest { descriptor, result ->
-					def stdErrEvents = stdErr.remove(descriptor)
-					def stdOutEvents = stdOut.remove(descriptor)
+					var stdErrEvents = stdErr.remove(descriptor)
+					var stdOutEvents = stdOut.remove(descriptor)
 					if (result.resultType == TestResult.ResultType.FAILURE) {
 						if (stdErrEvents && !stdErrEvents.empty) {
 							logger.lifecycle('\n{} > {} STANDARD_ERROR', descriptor.className, descriptor.name)
@@ -98,7 +98,7 @@ subprojects {
 			inputs.files(fileTree(layout.projectDirectory) {
 				include 'testresources/', 'testdata/'
 				exclude {
-					def f = it.file
+					var f = it.file
 					if (f.directory && f.list().length == 0) {
 						return true
 					}

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -2,13 +2,13 @@
  * dist Gradle build script
  */
 
-def buildProject = project
+var buildProject = project
 
 /* Configure the workspace project */
 configure(parent) {
 	layout.buildDirectory.set(buildProject.layout.buildDirectory)
 
-	def build = tasks.register(bnd_defaultTask) {
+	var build = tasks.register(bnd_defaultTask) {
 		dependsOn buildProject.absoluteProjectPath('jarDependencies')
 		dependsOn buildProject.absoluteProjectPath('checkDependencies')
 		dependsOn buildProject.absoluteProjectPath('releaseNeeded')

--- a/maven/build.gradle
+++ b/maven/build.gradle
@@ -2,16 +2,16 @@
  * maven Gradle build script
  */
 
-def localrepo = System.getProperty('maven.repo.local')
+var localrepo = System.getProperty('maven.repo.local')
 if (localrepo) {
 	localrepo = relativePath(uri(gradle.startParameter.currentDir).resolve(localrepo))
 }
-def dist = parent.project(bnd_build)
-def windows = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')
-def mvnw = rootProject.file(windows ? 'mvnw.cmd' : 'mvnw')
+var dist = parent.project(bnd_build)
+var windows = System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')
+var mvnw = rootProject.file(windows ? 'mvnw.cmd' : 'mvnw')
 
-def deploy = tasks.register('deploy', Exec.class) {
-	def releaserepo = uri(bnd.get('releaserepo', dist.file('bundles'))) /* Release repository. */
+var deploy = tasks.register('deploy', Exec.class) {
+	var releaserepo = uri(bnd.get('releaserepo', dist.file('bundles'))) /* Release repository. */
 	dependsOn dist.tasks.named('releaseDependencies')
 	if (windows) {
 		executable 'cmd'
@@ -32,12 +32,12 @@ def deploy = tasks.register('deploy', Exec.class) {
 	args 'deploy'
 }
 
-def deployJFrog = tasks.register('deployJFrog', Exec.class) {
+var deployJFrog = tasks.register('deployJFrog', Exec.class) {
 	enabled = !bnd.get('-releaserepo.jfrog', '').empty
-	def settings = cnf.file('ext/jfrog-settings.xml')
-	def deployState = deploy.map { it.state }
+	var settings = cnf.file('ext/jfrog-settings.xml')
+	var deployState = deploy.map { it.state }
 	onlyIf {
-		def state = deployState.get()
+		var state = deployState.get()
 		state.didWork && (state.failure == null)
 	}
 	dependsOn deploy
@@ -64,7 +64,7 @@ deploy.configure {
 	finalizedBy deployJFrog
 }
 
-def mvnClean = tasks.register('mvnClean', Exec.class) {
+var mvnClean = tasks.register('mvnClean', Exec.class) {
 	if (windows) {
 		executable 'cmd'
 		args '/c', mvnw
@@ -86,7 +86,7 @@ tasks.named('clean') {
 	dependsOn mvnClean
 }
 
-def mvnTestCompile = tasks.register('test-compile', Exec.class) {
+var mvnTestCompile = tasks.register('test-compile', Exec.class) {
 	dependsOn dist.tasks.named('releaseDependencies')
 	if (windows) {
 		executable 'cmd'

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -89,7 +89,9 @@ var p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
 var p2 = tasks.register('p2') {
 	description = 'Publish the p2 repositories.'
 	group = 'release'
-	enabled = JavaVersion.current().isJava8()
+	var javaLauncher = javaToolchains.launcherFor {
+		languageVersion = JavaLanguageVersion.of(8)
+	}
 	inputs.files(p2Plugins).withPropertyName('p2Plugins')
 	inputs.files(p2FeatureMain).withPropertyName('p2FeatureMain')
 	inputs.files(p2FeatureM2e).withPropertyName('p2FeatureM2e')
@@ -104,6 +106,7 @@ var p2 = tasks.register('p2') {
 	var categoryURI = uri('features/category.xml')
 	doLast('exec') { t ->
 		injected.exec.javaexec {
+			executable = javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath()
 			classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
 			mainClass = 'org.eclipse.equinox.launcher.Main'
 			if (logger.isDebugEnabled()) {
@@ -124,6 +127,7 @@ var p2 = tasks.register('p2') {
 		}.assertNormalExitValue()
 
 		injected.exec.javaexec {
+			executable = javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath()
 			classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"
 			mainClass = 'org.eclipse.equinox.launcher.Main'
 			if (logger.isDebugEnabled()) {
@@ -152,10 +156,4 @@ var p2 = tasks.register('p2') {
 
 tasks.named('jar') {
 	inputs.files(p2).withPropertyName('p2')
-}
-
-tasks.named('release') {
-	onlyIf {
-		JavaVersion.current().isJava8()
-	}
 }

--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -16,16 +16,16 @@ String masterVersion = String.format('%s-%s-g%.7s',
 		bnd.get('timestamp'),
 		bnd.get('Git-SHA'))
 
-def p2Plugins = tasks.register('p2Plugins', Sync.class) {
+var p2Plugins = tasks.register('p2Plugins', Sync.class) {
 	dependsOn 'jarDependencies'
 	from bnd.get('plugins').tokenize(',')
 	into layout.buildDirectory.dir('plugins')
 }
 
-def p2FeatureProperties = tasks.register('p2FeatureProperties', WriteProperties.class) {
+var p2FeatureProperties = tasks.register('p2FeatureProperties', WriteProperties.class) {
 	inputs.files(p2Plugins).withPropertyName('p2Plugins')
 	outputFile = layout.buildDirectory.file('feature.properties')
-	def plugins = objects.fileTree().from(p2Plugins.map { it.destinationDir })
+	var plugins = objects.fileTree().from(p2Plugins.map { it.destinationDir })
 	doFirst('collect') { t ->
 		plugins.each {
 			new Jar(it).withCloseable { jar ->
@@ -35,13 +35,13 @@ def p2FeatureProperties = tasks.register('p2FeatureProperties', WriteProperties.
 	}
 }
 
-def p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
+var p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
 	inputs.files(p2FeatureProperties).withPropertyName('p2FeatureProperties')
 	destinationDirectory = layout.buildDirectory.dir('features')
 	archiveFileName = 'bndtools.main.feature.jar'
 	from 'features/bndtools.main'
 	include 'feature.xml'
-	def propertiesFile = p2FeatureProperties.map { it.outputFile }
+	var propertiesFile = p2FeatureProperties.map { it.outputFile }
 	doFirst('filter') { t ->
 		Properties properties = new Properties()
 		propertiesFile.get().withInputStream {
@@ -52,13 +52,13 @@ def p2FeatureMain = tasks.register('p2FeatureMain', Zip.class) {
 	}
 }
 
-def p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
+var p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
 	inputs.files(p2FeatureProperties).withPropertyName('p2FeatureProperties')
 	destinationDirectory = layout.buildDirectory.dir('features')
 	archiveFileName = 'bndtools.m2e.feature.jar'
 	from 'features/bndtools.m2e'
 	include 'feature.xml'
-	def propertiesFile = p2FeatureProperties.map { it.outputFile }
+	var propertiesFile = p2FeatureProperties.map { it.outputFile }
 	doFirst('filter') { t ->
 		Properties properties = new Properties()
 		propertiesFile.get().withInputStream {
@@ -69,13 +69,13 @@ def p2FeatureM2e = tasks.register('p2FeatureM2e', Zip.class) {
 	}
 }
 
-def p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
+var p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
 	inputs.files(p2FeatureProperties).withPropertyName('p2FeatureProperties')
 	destinationDirectory = layout.buildDirectory.dir('features')
 	archiveFileName = 'bndtools.pde.feature.jar'
 	from 'features/bndtools.pde'
 	include 'feature.xml'
-	def propertiesFile = p2FeatureProperties.map { it.outputFile }
+	var propertiesFile = p2FeatureProperties.map { it.outputFile }
 	doFirst('filter') { t ->
 		Properties properties = new Properties()
 		propertiesFile.get().withInputStream {
@@ -86,7 +86,7 @@ def p2FeaturePde = tasks.register('p2FeaturePde', Zip.class) {
 	}
 }
 
-def p2 = tasks.register('p2') {
+var p2 = tasks.register('p2') {
 	description = 'Publish the p2 repositories.'
 	group = 'release'
 	enabled = JavaVersion.current().isJava8()
@@ -96,12 +96,12 @@ def p2 = tasks.register('p2') {
 	inputs.files(p2FeaturePde).withPropertyName('p2FeaturePde')
 	inputs.file('p2.xml').withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName('p2.xml')
 	inputs.file('features/category.xml').withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName('category.xml')
-	def injected = objects.newInstance(Injected)
-	def buildDirectoryProperty = layout.buildDirectory
+	var injected = objects.newInstance(Injected)
+	var buildDirectoryProperty = layout.buildDirectory
 	ext.destinationDirectory = buildDirectoryProperty.dir('p2')
 	outputs.dir(destinationDirectory).withPropertyName('destinationDirectory')
-	def eclipseDir = file('eclipse-3.5.2')
-	def categoryURI = uri('features/category.xml')
+	var eclipseDir = file('eclipse-3.5.2')
+	var categoryURI = uri('features/category.xml')
 	doLast('exec') { t ->
 		injected.exec.javaexec {
 			classpath "${eclipseDir}/plugins/org.eclipse.equinox.launcher_1.0.201.R35x_v20090715.jar"

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ buildscript {
 		}
 	}
 	/* Add bnd gradle plugin to buildscript classpath of rootProject */
-	def bndPlugin = files(configurations.classpath.files)
+	var bndPlugin = files(configurations.classpath.files)
 	gradle.rootProject {
 		buildscript {
 			dependencies {


### PR DESCRIPTION
We use the JavaLauncher from Gradle 6.7 to always use Java 8 to
run the p2 code for our update site build. This means these tasks
can now run on any java for the gradle build as long as gradle can
find a Java 8 runtime.