### PR TITLE
gradle: Remove conditional code for older Gradle version

### DIFF
--- a/biz.aQute.bnd.gradle/testresources/workspaceplugin1/test.simple/build.gradle
+++ b/biz.aQute.bnd.gradle/testresources/workspaceplugin1/test.simple/build.gradle
@@ -1,8 +1,6 @@
 tasks.withType(JavaCompile).configureEach { t ->
-	if (t.hasProperty('javaCompiler')) { // Gradle 6.7
-		println "### Task ${name} has javaCompiler property"
-		javaCompiler = javaToolchains.compilerFor {
-			languageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
-		}
+	println "### Task ${name} has javaCompiler property"
+	javaCompiler = javaToolchains.compilerFor {
+		languageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
 	}
 }


### PR DESCRIPTION
Since we moved the minimum supported Gradle version to 6.7, we can
remove conditional code for older versions.

