### PR TITLE
[quickfix test] Use logging progress monitor

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -1,7 +1,6 @@
 package bndtools.core.test.editors.quickfix;
 
 import static bndtools.core.test.utils.TaskUtils.log;
-import static bndtools.core.test.utils.TaskUtils.synchronously;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jdt.core.compiler.IProblem.HierarchyHasProblems;
 import static org.eclipse.jdt.core.compiler.IProblem.ImportNotFound;
@@ -70,6 +69,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.unmodifiable.Sets;
 import aQute.lib.io.IO;
 import bndtools.central.Central;
+import bndtools.core.test.utils.LoggingProgressMonitor;
 import bndtools.core.test.utils.TaskUtils;
 import bndtools.core.test.utils.WorkbenchTest;
 
@@ -158,16 +158,17 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			TaskUtils.dumpWorkspace();
 			throw new IllegalStateException("Could not get bndProject from the current workspace");
 		}
-		synchronously("open project", eclipseProject::open);
+		eclipseProject.open(new LoggingProgressMonitor("open()ing project"));
 		IJavaProject javaProject = JavaCore.create(eclipseProject);
 
 		IFolder sourceFolder = eclipseProject.getFolder("src");
 		if (!sourceFolder.exists()) {
-			synchronously("create src", monitor -> sourceFolder.create(true, true, monitor));
+			sourceFolder.create(true, true, new LoggingProgressMonitor("create()ing source folder"));
 		}
 
 		IPackageFragmentRoot root = javaProject.getPackageFragmentRoot(sourceFolder);
-		synchronously("createPackageFragment", monitor -> pack = root.createPackageFragment("test", false, monitor));
+		pack = root.createPackageFragment("test", false,
+			new LoggingProgressMonitor("createPackageFragment() \"test\""));
 
 		// Wait for build to finish - attempted fix for #4553.
 		TaskUtils.waitForBuild("beforeAllBase()");

--- a/bndtools.core.test/src/bndtools/core/test/utils/LoggingProgressMonitor.java
+++ b/bndtools.core.test/src/bndtools/core/test/utils/LoggingProgressMonitor.java
@@ -1,0 +1,86 @@
+package bndtools.core.test.utils;
+
+import java.util.function.Supplier;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+public class LoggingProgressMonitor implements IProgressMonitor {
+
+	int						totalWork	= -1;
+	String					task;
+	String					subTask;
+	int						wip;
+	boolean					canceled;
+	final Supplier<String>	context;
+
+	public LoggingProgressMonitor(String context) {
+		this.context = () -> context;
+	}
+
+	public LoggingProgressMonitor(Supplier<String> context) {
+		this.context = context;
+	}
+
+	private String getTaskProgress() {
+		return task == null ? "<unnamed task>"
+			: (subTask == null ? task : task + "/" + subTask) + ", " + wip + "/" + totalWork;
+	}
+
+	private void log(String msg) {
+		TaskUtils.log(() -> context.get() + ": " + getTaskProgress() + ": " + msg);
+	}
+
+	private void log(Supplier<String> msg) {
+		TaskUtils.log(() -> context.get() + ": " + getTaskProgress() + ": " + msg.get());
+	}
+
+	@Override
+	public void beginTask(String name, int totalWork) {
+		task = name;
+		subTask = null;
+		this.totalWork = totalWork;
+		wip = 0;
+		canceled = false;
+		log("beginTask");
+	}
+
+	@Override
+	public void done() {
+		log("done");
+	}
+
+	@Override
+	public void internalWorked(double work) {
+		log(() -> "internalWorked(" + work + ")");
+	}
+
+	@Override
+	public boolean isCanceled() {
+		return canceled;
+	}
+
+	@Override
+	public void setCanceled(boolean value) {
+		canceled = value;
+		log(() -> "setCanceled(" + value + ")");
+	}
+
+	@Override
+	public void setTaskName(String name) {
+		subTask = null;
+		task = name;
+		log(() -> "setTaskName(" + name + ")");
+	}
+
+	@Override
+	public void subTask(String name) {
+		subTask = name;
+		log(() -> "subTask(" + name + ")");
+	}
+
+	@Override
+	public void worked(int work) {
+		wip += work;
+		log(() -> "worked(" + work + ")");
+	}
+}

--- a/bndtools.core.test/src/bndtools/core/test/utils/WorkspaceImporter.java
+++ b/bndtools.core.test/src/bndtools/core/test/utils/WorkspaceImporter.java
@@ -9,6 +9,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.ui.dialogs.IOverwriteQuery;
 import org.eclipse.ui.wizards.datatransfer.FileSystemStructureProvider;
 import org.eclipse.ui.wizards.datatransfer.ImportOperation;
@@ -62,12 +63,13 @@ public class WorkspaceImporter {
 			ws.run(monitor -> {
 				// Clean the workspace
 				IProject[] existingProjects = wsr.getProjects();
+				SubMonitor loopMonitor = SubMonitor.convert(monitor, existingProjects.length * 2);
 				for (IProject project : existingProjects) {
-					project.delete(true, true, monitor);
+					project.delete(true, true, loopMonitor.split(1));
 				}
 
-				projects.forEach(path -> importProject(path, monitor));
-			}, null);
+				projects.forEach(path -> importProject(path, loopMonitor.split(1)));
+			}, new LoggingProgressMonitor("importAllProjects()"));
 
 			TaskUtils.updateWorkspace("importAllProjects()");
 			TaskUtils.requestClasspathUpdate("importAllProjects()");


### PR DESCRIPTION
Introduces an IProgressMonitor implementation that logs output. Replaces the misguided synchronously() method and provides
more detailed diagnostics.
