### PR TITLE
ant: Handle when the basedir does not represent a Bnd project

### DIFF
--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/BaseTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/BaseTask.java
@@ -8,11 +8,13 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.taskdefs.Property;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Constants;
 import aQute.lib.strings.Strings;
@@ -198,5 +200,21 @@ public class BaseTask extends Task implements Reporter {
 	@Override
 	public SetLocation warning(String s, Object... args) {
 		return reporter.warning(s, args);
+	}
+
+	protected Project getBndProject(File basedir) {
+		if ((basedir == null) || !basedir.isDirectory()) {
+			throw new BuildException("The given base dir does not exist " + basedir);
+		}
+		Project project;
+		try {
+			project = Workspace.getProject(basedir);
+		} catch (Exception e) {
+			throw new BuildException(e);
+		}
+		if (project == null) {
+			throw new BuildException("Unable to find bnd project in directory: " + basedir);
+		}
+		return project;
 	}
 }

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/BndTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/BndTask.java
@@ -119,12 +119,8 @@ public class BndTask extends BaseTask {
 
 		}
 
-		if (basedir == null)
-			throw new BuildException("No basedir set");
-
 		try {
-			Project project = Workspace.getProject(basedir);
-
+			Project project = getBndProject(basedir);
 			Workspace ws = project.getWorkspace();
 			for (Property prop : workspaceProps) {
 				ws.setProperty(prop.getName(), prop.getValue());

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/DeployTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/DeployTask.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Project;
-import aQute.bnd.build.Workspace;
 
 public class DeployTask extends BaseTask {
 	private final static Logger	logger		= LoggerFactory.getLogger(DeployTask.class);
@@ -21,7 +20,7 @@ public class DeployTask extends BaseTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			Project project = Workspace.getProject(getProject().getBaseDir());
+			Project project = getBndProject(getProject().getBaseDir());
 
 			// Deploy the files that need to be released
 			for (FileSet fileset : filesets) {

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/PackageTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/PackageTask.java
@@ -4,8 +4,6 @@ import java.io.File;
 
 import org.apache.tools.ant.BuildException;
 
-import aQute.bnd.build.Workspace;
-
 public class PackageTask extends BaseTask {
 	String	runFilePath	= null;
 	File	output		= null;
@@ -18,8 +16,7 @@ public class PackageTask extends BaseTask {
 			throw new BuildException("Output file must be specified");
 
 		try {
-			Workspace.getProject(getProject().getBaseDir())
-				.export(runFilePath, keep, output);
+			getBndProject(getProject().getBaseDir()).export(runFilePath, keep, output);
 		} catch (Exception e) {
 			throw new BuildException(e);
 		}

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/PrepareTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/PrepareTask.java
@@ -23,15 +23,9 @@ public class PrepareTask extends BaseTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			if (basedir == null || !basedir.isDirectory())
-				throw new BuildException("The given base dir does not exist " + basedir);
-
-			Workspace workspace = Workspace.getWorkspace(basedir.getParentFile());
+			Project project = getBndProject(basedir);
+			Workspace workspace = project.getWorkspace();
 			workspace.addBasicPlugin(new ConsoleProgress());
-
-			Project project = workspace.getProject(basedir.getName());
-			if (project == null)
-				throw new BuildException("Unable to find bnd project in directory: " + basedir);
 
 			project.setProperty("in.ant", "true");
 			project.setProperty("environment", "ant");

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/ProjectTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/ProjectTask.java
@@ -9,7 +9,6 @@ import java.io.File;
 import org.apache.tools.ant.BuildException;
 
 import aQute.bnd.build.Project;
-import aQute.bnd.build.Workspace;
 
 public class ProjectTask extends BaseTask {
 	File	basedir;
@@ -18,10 +17,7 @@ public class ProjectTask extends BaseTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			if (basedir == null || !basedir.isDirectory())
-				throw new BuildException("The given base dir does not exist " + basedir);
-
-			Project project = Workspace.getProject(basedir);
+			Project project = getBndProject(basedir);
 			project.build(underTest);
 			report(project);
 		} catch (Exception e) {

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/ReleaseTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/ReleaseTask.java
@@ -3,7 +3,6 @@ package aQute.bnd.ant;
 import org.apache.tools.ant.BuildException;
 
 import aQute.bnd.build.Project;
-import aQute.bnd.build.Workspace;
 
 /**
  * <p>
@@ -35,7 +34,7 @@ public class ReleaseTask extends BaseTask {
 	@Override
 	public void execute() throws BuildException {
 		try {
-			Project project = Workspace.getProject(getProject().getBaseDir());
+			Project project = getBndProject(getProject().getBaseDir());
 			if (releaseRepo == null) {
 				project.release(false);
 			} else {

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/TestTask.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/TestTask.java
@@ -10,7 +10,6 @@ import org.apache.tools.ant.BuildException;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectTester;
-import aQute.bnd.build.Workspace;
 
 public class TestTask extends BaseTask {
 
@@ -20,12 +19,11 @@ public class TestTask extends BaseTask {
 
 	@Override
 	public void execute() throws BuildException {
-
 		try {
 			// Prepare list of projects...
 			List<Project> projects;
 			File baseDir = getProject().getBaseDir();
-			Project baseProject = Workspace.getProject(baseDir);
+			Project baseProject = getBndProject(baseDir);
 			if (runFiles == null) {
 				projects = Collections.singletonList(baseProject);
 			} else {

--- a/biz.aQute.bnd.ant/src/aQute/bnd/ant/package-info.java
+++ b/biz.aQute.bnd.ant/src/aQute/bnd/ant/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package aQute.bnd.ant;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
We centralize the call to the Bnd Project object for a basedir and
check the inputs and outputs for validity.

Fixes https://github.com/bndtools/bnd/issues/4724

