### PR TITLE
[quickfix] Add suggestions for "Discouraged Access"

### DIFF
--- a/bndtools.core.test/fodder.simple.bnd
+++ b/bndtools.core.test/fodder.simple.bnd
@@ -1,2 +1,4 @@
 Bundle-Version: 1.0.0
 Export-Package: simple*
+
+-includepackage: iface.embedded

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -3,6 +3,7 @@ package bndtools.core.test.editors.quickfix;
 import static bndtools.core.test.utils.TaskUtils.log;
 import static bndtools.core.test.utils.TaskUtils.synchronously;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jdt.core.compiler.IProblem.DiscouragedReference;
 import static org.eclipse.jdt.core.compiler.IProblem.HierarchyHasProblems;
 import static org.eclipse.jdt.core.compiler.IProblem.ImportNotFound;
 import static org.eclipse.jdt.core.compiler.IProblem.IsClassPathCorrect;
@@ -236,7 +237,7 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	private static final String			CLASS_FOOTER	= " var};";
 	protected static final Set<Integer>	SUPPORTED		= Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect,
 		HierarchyHasProblems, ParameterMismatch, TypeMismatch, UndefinedConstructor, UndefinedField, UndefinedMethod,
-		UndefinedName, UnresolvedVariable, TypeArgumentMismatch);
+		UndefinedName, UnresolvedVariable, TypeArgumentMismatch, DiscouragedReference);
 
 	protected IJavaCompletionProposal[] proposalsForStaticImport(String imp) {
 		return proposalsFor(29, 0, "package test; import static " + imp + ";");

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
@@ -286,4 +286,34 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyInterface"));
 	}
 
+	@Test
+	public void withEmbeddedPackageOnBuildPath_suggestsOriginalBundle() {
+		// If you have a buildpath that embeds an exported package from another
+		// bundle but doesn't export it, then it will cause a "discouraged
+		// access" warning. If it is a package that is exported by another
+		// bundle, the easy way to fix it is to add the other bundle to the
+		// build path.
+		String header = "package test; "
+			+ "import iface.embedded.*; class " + DEFAULT_CLASS_NAME + " extends ";
+		String source = header + "Embedded {}";
+
+		assertThatProposals(proposalsFor(header.length() + 2, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.embedded.Embedded"));
+
+	}
+
+	@Test
+	public void withEmbeddedImportOnBuildPath_suggestsOriginalBundle() {
+		// If you have a buildpath that embeds an exported package from another
+		// bundle but doesn't export it, then it will cause a "discouraged
+		// access" warning. If it is a package that is exported by another
+		// bundle, the easy way to fix it is to add the other bundle to the
+		// build path.
+		String header = "package test; import ";
+		String source = header + "iface.embedded.Embedded; class " + DEFAULT_CLASS_NAME + " extends Embedded {}";
+
+		assertThatProposals(proposalsFor(header.length() + 2, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.embedded.Embedded"));
+
+	}
 }

--- a/bndtools.core.test/src/iface/embedded/Embedded.java
+++ b/bndtools.core.test/src/iface/embedded/Embedded.java
@@ -1,0 +1,5 @@
+package iface.embedded;
+
+public class Embedded {
+
+}

--- a/bndtools.core.test/src/iface/embedded/package-info.java
+++ b/bndtools.core.test/src/iface/embedded/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package iface.embedded;


### PR DESCRIPTION
Sometimes you have bundles on your buildpath that embed (but don't export) classes that are part of the API of another bundle (the bndtools workspace itself does this). This results in "Discouraged Access"/non-API warnings. Adding a bundle that actually exports that API fixes the warning.