### PR TITLE
Add Gradle Enterprise plugin to make --scan work

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,9 +11,11 @@ buildscript {
 		maven {
 			url = uri(bnd_repourl)
 		}
+		gradlePluginPortal()
 	}
 	dependencies {
 		classpath(bnd_plugin)
+		classpath("com.gradle:gradle-enterprise-gradle-plugin:3.6.3")
 	}
 	/* Since the files in the repository change with each build, we need to recheck for changes */
 	configurations.classpath {
@@ -56,3 +58,4 @@ gradle.ext.bndWorkspaceConfigure = { workspace ->
 }
 
 apply plugin: "biz.aQute.bnd.workspace"
+apply plugin: "com.gradle.enterprise"


### PR DESCRIPTION
Due to how settings.gradle is written, using `--scan` does not work out
of the box. While reviewing #4746, I found build scans to be immensely
helpful and hence applied the Gradle Enterprise plugin manually. Since I
think this might help others working on the build, this commit persists
that configuration.