### PR TITLE
[quickfix test] Bump AssertJ

### DIFF
--- a/bndtools.core.test/bnd.bnd
+++ b/bndtools.core.test/bnd.bnd
@@ -46,16 +46,16 @@
 	bndtools.api;version=snapshot,\
 	bndtools.core;version=snapshot,\
 	bndtools.core.services;version=snapshot,\
-	assertj-core;version=${assertj.eclipse.version},\
+	assertj-core,\
 	javax.inject,\
 	org.apiguardian:apiguardian-api,\
 	org.opentest4j,\
 	org.apache.servicemix.bundles.junit,\
-	org.junit.platform.commons,\
-	org.junit.platform.engine,\
-	org.junit.jupiter.api,\
-	org.junit.jupiter.engine,\
-	org.junit.jupiter.params,\
+	junit-platform-commons,\
+	junit-platform-engine,\
+	junit-jupiter-api,\
+	junit-jupiter-engine,\
+	junit-jupiter-params,\
 	org.eclipse.core.jobs,\
 	org.eclipse.core.resources,\
 	org.eclipse.core.runtime,\

--- a/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
@@ -27,7 +27,7 @@
 	osgi.identity;filter:='(osgi.identity=*win32*)',\
 
 -runbundles: \
-	assertj-core;version='[3.19.0,3.19.1)',\
+	assertj-core;version='[3.20.2,3.20.3)',\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
@@ -48,6 +48,13 @@
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
 	javax.xml;version='[1.3.4,1.3.5)',\
+	junit-jupiter-api;version='[5.7.1,5.7.2)',\
+	junit-jupiter-engine;version='[5.7.1,5.7.2)',\
+	junit-jupiter-params;version='[5.7.1,5.7.2)',\
+	junit-platform-commons;version='[1.7.1,1.7.2)',\
+	junit-platform-engine;version='[1.7.1,1.7.2)',\
+	junit-platform-launcher;version='[1.7.1,1.7.2)',\
+	junit-vintage-engine;version='[5.7.1,5.7.2)',\
 	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
 	org.apache.ant;version='[1.10.8,1.10.9)',\
 	org.apache.batik.constants;version='[1.11.0,1.11.1)',\
@@ -70,7 +77,6 @@
 	org.apache.xml.resolver;version='[1.2.0,1.2.1)',\
 	org.apache.xml.serializer;version='[2.7.1,2.7.2)',\
 	org.apache.xmlgraphics;version='[2.3.0,2.3.1)',\
-	org.apiguardian;version='[1.1.0,1.1.1)',\
 	org.bndtools.headless.build.manager;version=snapshot,\
 	org.bndtools.headless.build.plugin.ant;version=snapshot,\
 	org.bndtools.headless.build.plugin.gradle;version=snapshot,\
@@ -299,13 +305,6 @@
 	org.eclipse.xsd;version='[2.17.0,2.17.1)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
 	org.junit;version='[4.13.0,4.13.1)',\
-	org.junit.jupiter.api;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.engine;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.params;version='[5.6.0,5.6.1)',\
-	org.junit.platform.commons;version='[1.6.0,1.6.1)',\
-	org.junit.platform.engine;version='[1.6.0,1.6.1)',\
-	org.junit.platform.launcher;version='[1.6.0,1.6.1)',\
-	org.junit.vintage.engine;version='[5.6.0,5.6.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.sat4j.core;version='[2.3.5,2.3.6)',\
 	org.sat4j.pb;version='[2.3.5,2.3.6)',\

--- a/bndtools.core.test/test.gtk.linux.x86_64.bndrun
+++ b/bndtools.core.test/test.gtk.linux.x86_64.bndrun
@@ -26,7 +26,7 @@
 	osgi.identity;filter:='(osgi.identity=*win32*)',\
 
 -runbundles: \
-	assertj-core;version='[3.19.0,3.19.1)',\
+	assertj-core;version='[3.20.2,3.20.3)',\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
@@ -47,6 +47,13 @@
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
 	javax.xml;version='[1.3.4,1.3.5)',\
+	junit-jupiter-api;version='[5.7.1,5.7.2)',\
+	junit-jupiter-engine;version='[5.7.1,5.7.2)',\
+	junit-jupiter-params;version='[5.7.1,5.7.2)',\
+	junit-platform-commons;version='[1.7.1,1.7.2)',\
+	junit-platform-engine;version='[1.7.1,1.7.2)',\
+	junit-platform-launcher;version='[1.7.1,1.7.2)',\
+	junit-vintage-engine;version='[5.7.1,5.7.2)',\
 	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
 	org.apache.ant;version='[1.10.8,1.10.9)',\
 	org.apache.batik.constants;version='[1.11.0,1.11.1)',\
@@ -69,7 +76,6 @@
 	org.apache.xml.resolver;version='[1.2.0,1.2.1)',\
 	org.apache.xml.serializer;version='[2.7.1,2.7.2)',\
 	org.apache.xmlgraphics;version='[2.3.0,2.3.1)',\
-	org.apiguardian;version='[1.1.0,1.1.1)',\
 	org.bndtools.headless.build.manager;version=snapshot,\
 	org.bndtools.headless.build.plugin.ant;version=snapshot,\
 	org.bndtools.headless.build.plugin.gradle;version=snapshot,\
@@ -296,13 +302,6 @@
 	org.eclipse.xsd;version='[2.17.0,2.17.1)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
 	org.junit;version='[4.13.0,4.13.1)',\
-	org.junit.jupiter.api;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.engine;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.params;version='[5.6.0,5.6.1)',\
-	org.junit.platform.commons;version='[1.6.0,1.6.1)',\
-	org.junit.platform.engine;version='[1.6.0,1.6.1)',\
-	org.junit.platform.launcher;version='[1.6.0,1.6.1)',\
-	org.junit.vintage.engine;version='[5.6.0,5.6.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.sat4j.core;version='[2.3.5,2.3.6)',\
 	org.sat4j.pb;version='[2.3.5,2.3.6)',\

--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -73,9 +73,9 @@
 	bnd.identity;id='org.eclipse.ui.console',\
 	bnd.identity;id='org.eclipse.ui.ide',\
 	bnd.identity;id='org.eclipse.ui.ide.application',\
-	bnd.identity;id='org.junit.jupiter.engine',\
-	bnd.identity;id='org.junit.platform.launcher',\
-	bnd.identity;id='org.junit.vintage.engine',\
+	bnd.identity;id='junit-jupiter-engine',\
+	bnd.identity;id='junit-platform-launcher',\
+	bnd.identity;id='junit-vintage-engine',\
 	bnd.identity;id='org.slf4j.jcl'
 
 -runfw: org.eclipse.osgi;version='[3.15.300.v20200520-1959,3.15.300.v20200520-1959]'
@@ -150,7 +150,5 @@
 	bnd.identity;id='biz.aQute.junit',\
 	bnd.identity;id='org.apache.felix.scr';version='[0,2.1.16)',\
 	bnd.identity;id='org.osgi.*',\
-	bnd.identity;id='junit-jupiter-*',\
-	bnd.identity;id='junit-platform-*',\
-	bnd.identity;id='junit-vintage-*'
+	bnd.identity;id='org.junit.*'
 

--- a/bndtools.core.test/test.win32.x86_64.bndrun
+++ b/bndtools.core.test/test.win32.x86_64.bndrun
@@ -46,6 +46,13 @@
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
 	javax.xml;version='[1.3.4,1.3.5)',\
+	junit-jupiter-api;version='[5.7.1,5.7.2)',\
+	junit-jupiter-engine;version='[5.7.1,5.7.2)',\
+	junit-jupiter-params;version='[5.7.1,5.7.2)',\
+	junit-platform-commons;version='[1.7.1,1.7.2)',\
+	junit-platform-engine;version='[1.7.1,1.7.2)',\
+	junit-platform-launcher;version='[1.7.1,1.7.2)',\
+	junit-vintage-engine;version='[5.7.1,5.7.2)',\
 	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
 	org.apache.ant;version='[1.10.8,1.10.9)',\
 	org.apache.batik.constants;version='[1.11.0,1.11.1)',\
@@ -68,7 +75,6 @@
 	org.apache.xml.resolver;version='[1.2.0,1.2.1)',\
 	org.apache.xml.serializer;version='[2.7.1,2.7.2)',\
 	org.apache.xmlgraphics;version='[2.3.0,2.3.1)',\
-	org.apiguardian;version='[1.1.0,1.1.1)',\
 	org.bndtools.headless.build.manager;version=snapshot,\
 	org.bndtools.headless.build.plugin.ant;version=snapshot,\
 	org.bndtools.headless.build.plugin.gradle;version=snapshot,\
@@ -298,13 +304,6 @@
 	org.eclipse.xsd;version='[2.17.0,2.17.1)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
 	org.junit;version='[4.13.0,4.13.1)',\
-	org.junit.jupiter.api;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.engine;version='[5.6.0,5.6.1)',\
-	org.junit.jupiter.params;version='[5.6.0,5.6.1)',\
-	org.junit.platform.commons;version='[1.6.0,1.6.1)',\
-	org.junit.platform.engine;version='[1.6.0,1.6.1)',\
-	org.junit.platform.launcher;version='[1.6.0,1.6.1)',\
-	org.junit.vintage.engine;version='[5.6.0,5.6.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.sat4j.core;version='[2.3.5,2.3.6)',\
 	org.sat4j.pb;version='[2.3.5,2.3.6)',\

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -83,7 +83,6 @@ org.junit.platform:junit-platform-launcher:${junit.platform.version}
 org.opentest4j:opentest4j:${opentest4j.tester.version}
 org.opentest4j:opentest4j:1.2.0
 org.apiguardian:apiguardian-api:1.1.0
-org.assertj:assertj-core:${assertj.eclipse.version}
 org.assertj:assertj-core:${assertj.version}
 org.xmlunit:xmlunit-core:2.6.3
 org.xmlunit:xmlunit-assertj:2.6.3

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -12,7 +12,6 @@ junit.platform.eclipse.version=1.6.0
 junit.jupiter.version=5.7.1
 junit.platform.version=1.7.1
 hamcrest.version=1.3
-assertj.eclipse.version=3.19.0
 assertj.version=3.20.2
 
 junit: \


### PR DESCRIPTION
This also requires us to bump the version of JUnit Platform and friends so it's not the same version as Eclipse. That's ok because we're not testing Eclipse's testing functionality, so it doesn't matter if our test instance is not using the same version of JUnit that Eclipse 2020-06 is using.

Fixes #4766.