### PR TITLE
[quickfix test] Bump AssertJ properly

### DIFF
--- a/bndtools.core.test/test.win32.x86_64.bndrun
+++ b/bndtools.core.test/test.win32.x86_64.bndrun
@@ -25,7 +25,7 @@
 	osgi.identity;filter:='(osgi.identity=*linux*)',\
 
 -runbundles: \
-	assertj-core;version='[3.19.0,3.19.1)',\
+	assertj-core;version='[3.20.2,3.20.3)',\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\


### PR DESCRIPTION
Forgot to bump the AssertJ version in the win32 resolved file.

Signed-off-by: Fr Jeremy Krieg <fr.jkrieg@greekwelfaresa.org.au>