### PR TITLE
[quickfix] Suggestions for CannotThrowType and UnhandledException

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -2,6 +2,7 @@ package bndtools.core.test.editors.quickfix;
 
 import static bndtools.core.test.utils.TaskUtils.log;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jdt.core.compiler.IProblem.CannotThrowType;
 import static org.eclipse.jdt.core.compiler.IProblem.DiscouragedReference;
 import static org.eclipse.jdt.core.compiler.IProblem.HierarchyHasProblems;
 import static org.eclipse.jdt.core.compiler.IProblem.ImportNotFound;
@@ -14,6 +15,7 @@ import static org.eclipse.jdt.core.compiler.IProblem.UndefinedField;
 import static org.eclipse.jdt.core.compiler.IProblem.UndefinedMethod;
 import static org.eclipse.jdt.core.compiler.IProblem.UndefinedName;
 import static org.eclipse.jdt.core.compiler.IProblem.UndefinedType;
+import static org.eclipse.jdt.core.compiler.IProblem.UnhandledException;
 import static org.eclipse.jdt.core.compiler.IProblem.UnresolvedVariable;
 
 import java.nio.file.Files;
@@ -238,7 +240,8 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	private static final String			CLASS_FOOTER	= " var};";
 	protected static final Set<Integer>	SUPPORTED		= Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect,
 		HierarchyHasProblems, ParameterMismatch, TypeMismatch, UndefinedConstructor, UndefinedField, UndefinedMethod,
-		UndefinedName, UnresolvedVariable, TypeArgumentMismatch, DiscouragedReference);
+		UndefinedName, UnresolvedVariable, TypeArgumentMismatch, DiscouragedReference, CannotThrowType,
+		UnhandledException);
 
 	protected IJavaCompletionProposal[] proposalsForStaticImport(String imp) {
 		return proposalsFor(29, 0, "package test; import static " + imp + ";");
@@ -387,11 +390,12 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 			IJavaCompletionProposal[] proposals = sut.getCorrections(assistContext, locs);
 
 			// if (proposals != null) {
-			// System.err.println("Proposals: " + Stream.of(proposals).map(x ->
-			// {
+			// System.err.println("Proposals: " + Stream.of(proposals)
+			// .map(x -> {
 			// return "toString: " + x.toString() + "\ndisplaystring: " +
 			// x.getDisplayString();
-			// }).collect(Collectors.joining("\n")));
+			// })
+			// .collect(Collectors.joining("\n")));
 			// } else {
 			// System.err.println("No proposals");
 			// }

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
@@ -12,6 +12,37 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 	}
 
 	@Test
+	void withMissingSuperException_causingUnhandled_suggestsBundles() {
+		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingExceptionFromAnotherBundle; class "
+			+ DEFAULT_CLASS_NAME + " {" + "public void test() {"
+			+ "ClassThrowingExceptionExtendingExceptionFromAnotherBundle c; ";
+		String source = header + "c.test();}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
+	void withMissingSuperException_causingCantThrow_withSimpleReference_suggestsBundles() {
+		String header = "package test; import simple.pkg.ExceptionIndirectlyExtendingExceptionFromAnotherBundle; class "
+			+ DEFAULT_CLASS_NAME + " {" + "public void test() {" + " try { System.out.println(); } catch (";
+		String source = header + "ExceptionIndirectlyExtendingExceptionFromAnotherBundle e) {}}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
+	void withMissingSuperException_causingCantThrow_withFullyQualifiedReference_suggestsBundles() {
+		String header = "package test; class " + DEFAULT_CLASS_NAME + " {" + "public void test() {"
+			+ " try { System.out.println(); } catch (";
+		String source = header + "simple.pkg.ExceptionIndirectlyExtendingExceptionFromAnotherBundle e) {}}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
 	void withInconsistentHierarchy_forClassDefinition_thatImplementsAnInterfaceFromAnotherBundle_suggestsBundles() {
 		String header = "package test; class ";
 		String source = header + DEFAULT_CLASS_NAME + " extends simple.pkg.ClassWithInterfaceFromAnotherBundle {}";
@@ -220,17 +251,17 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 			+ "String myMethod() { \n" + "  field.length();" + "  method();" + "  return field;" + "}" + "}";
 
 		// HierarchyHasProblems on "Test"
-		assertThatProposals(proposalsFor(20 + 1, 0, source)).haveExactly(1, suggestsBundle(
-			"bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
+		assertThatProposals(proposalsFor(20 + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
 		// UnknownName on "field.length()"
-		assertThatProposals(proposalsFor(111 + 1, 0, source)).haveExactly(1, suggestsBundle(
-			"bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
+		assertThatProposals(proposalsFor(111 + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
 		// UnknownMethod on "method()"
-		assertThatProposals(proposalsFor(128 + 1, 0, source)).haveExactly(1, suggestsBundle(
-			"bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
+		assertThatProposals(proposalsFor(128 + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
 		// UnknownField on "return field"
-		assertThatProposals(proposalsFor(146 + 1, 0, source)).haveExactly(1, suggestsBundle(
-			"bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
+		assertThatProposals(proposalsFor(146 + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignRecursiveClass"));
 	}
 
 	@Test
@@ -293,8 +324,7 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 		// access" warning. If it is a package that is exported by another
 		// bundle, the easy way to fix it is to add the other bundle to the
 		// build path.
-		String header = "package test; "
-			+ "import iface.embedded.*; class " + DEFAULT_CLASS_NAME + " extends ";
+		String header = "package test; " + "import iface.embedded.*; class " + DEFAULT_CLASS_NAME + " extends ";
 		String source = header + "Embedded {}";
 
 		assertThatProposals(proposalsFor(header.length() + 2, 0, source)).haveExactly(1,

--- a/bndtools.core.test/src/iface/bundle/MyForeignException.java
+++ b/bndtools.core.test/src/iface/bundle/MyForeignException.java
@@ -1,0 +1,5 @@
+package iface.bundle;
+
+public class MyForeignException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+}

--- a/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingExceptionFromAnotherBundle.java
+++ b/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingExceptionFromAnotherBundle.java
@@ -1,0 +1,5 @@
+package simple.pkg;
+
+public class ClassThrowingExceptionExtendingExceptionFromAnotherBundle {
+	public void test() throws ExceptionIndirectlyExtendingExceptionFromAnotherBundle {}
+}

--- a/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingExceptionFromAnotherBundle.java
+++ b/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingExceptionFromAnotherBundle.java
@@ -1,0 +1,5 @@
+package simple.pkg;
+
+public class ExceptionIndirectlyExtendingExceptionFromAnotherBundle extends MyLocalException {
+	private static final long serialVersionUID = 1L;
+}

--- a/bndtools.core.test/src/simple/pkg/MyLocalException.java
+++ b/bndtools.core.test/src/simple/pkg/MyLocalException.java
@@ -1,0 +1,14 @@
+package simple.pkg;
+
+import iface.bundle.MyForeignException;
+import iface.bundle.MyInterface;
+
+// Add the MyInterface interface to check that we don't add suggestions for it
+// when it's a missing exception; the missing interface isn't relevant to an
+// error caused by a missing exception.
+public class MyLocalException extends MyForeignException implements MyInterface {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void myInterfaceMethod() {}
+}


### PR DESCRIPTION
This error can cause if one of the exception's superclasses is not on the classpath and so the compiler cannot tell that it is an exception.