### PR TITLE
[quickfix] Support constructor invocation throwing unhandled exceptions

### DIFF
--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
@@ -13,9 +13,9 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 
 	@Test
 	void withMissingSuperException_causingUnhandled_suggestsBundles() {
-		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingExceptionFromAnotherBundle; class "
+		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingForeignException; class "
 			+ DEFAULT_CLASS_NAME + " {" + "public void test() {"
-			+ "ClassThrowingExceptionExtendingExceptionFromAnotherBundle c; ";
+			+ "ClassThrowingExceptionExtendingForeignException c; ";
 		String source = header + "c.test();}}";
 
 		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
@@ -23,10 +23,45 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 	}
 
 	@Test
+	void withMissingSuperException_causingUnhandled_onSuperMethodInvocation_suggestsBundles() {
+		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingForeignException; class "
+			+ DEFAULT_CLASS_NAME + " extends ClassThrowingExceptionExtendingForeignException {"
+			+ "@Override public void test() {";
+		String source = header + "super.test();}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
+	void withMissingSuperException_causingUnhandled_onConstructorInvocation_suggestsBundles() {
+		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingForeignException; class "
+			+ DEFAULT_CLASS_NAME + " {" + "public void test() {"
+			+ "ClassThrowingExceptionExtendingForeignException c = ";
+		String source = header + "new ClassThrowingExceptionExtendingForeignException();}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
+	void withMissingSuperException_causingUnhandled_onSuperConstructorInvocation_suggestsBundles() {
+		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingForeignException; class "
+			+ DEFAULT_CLASS_NAME + " extends ClassThrowingExceptionExtendingForeignException {" + "public "
+			+ DEFAULT_CLASS_NAME
+			+ "() {} " + "public " + DEFAULT_CLASS_NAME
+			+ "(String param) { ";
+		String source = header + "super();}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
+	}
+
+	@Test
 	void withMissingSuperException_causingCantThrow_withSimpleReference_suggestsBundles() {
-		String header = "package test; import simple.pkg.ExceptionIndirectlyExtendingExceptionFromAnotherBundle; class "
+		String header = "package test; import simple.pkg.ExceptionIndirectlyExtendingForeignException; class "
 			+ DEFAULT_CLASS_NAME + " {" + "public void test() {" + " try { System.out.println(); } catch (";
-		String source = header + "ExceptionIndirectlyExtendingExceptionFromAnotherBundle e) {}}}";
+		String source = header + "ExceptionIndirectlyExtendingForeignException e) {}}}";
 
 		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
 			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));
@@ -36,7 +71,7 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 	void withMissingSuperException_causingCantThrow_withFullyQualifiedReference_suggestsBundles() {
 		String header = "package test; class " + DEFAULT_CLASS_NAME + " {" + "public void test() {"
 			+ " try { System.out.println(); } catch (";
-		String source = header + "simple.pkg.ExceptionIndirectlyExtendingExceptionFromAnotherBundle e) {}}}";
+		String source = header + "simple.pkg.ExceptionIndirectlyExtendingForeignException e) {}}}";
 
 		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
 			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignException"));

--- a/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingExceptionFromAnotherBundle.java
+++ b/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingExceptionFromAnotherBundle.java
@@ -1,5 +1,0 @@
-package simple.pkg;
-
-public class ClassThrowingExceptionExtendingExceptionFromAnotherBundle {
-	public void test() throws ExceptionIndirectlyExtendingExceptionFromAnotherBundle {}
-}

--- a/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingForeignException.java
+++ b/bndtools.core.test/src/simple/pkg/ClassThrowingExceptionExtendingForeignException.java
@@ -1,0 +1,9 @@
+package simple.pkg;
+
+public class ClassThrowingExceptionExtendingForeignException {
+
+	public ClassThrowingExceptionExtendingForeignException()
+		throws ExceptionIndirectlyExtendingForeignException {}
+
+	public void test() throws ExceptionIndirectlyExtendingForeignException {}
+}

--- a/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingExceptionFromAnotherBundle.java
+++ b/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingExceptionFromAnotherBundle.java
@@ -1,5 +1,0 @@
-package simple.pkg;
-
-public class ExceptionIndirectlyExtendingExceptionFromAnotherBundle extends MyLocalException {
-	private static final long serialVersionUID = 1L;
-}

--- a/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingForeignException.java
+++ b/bndtools.core.test/src/simple/pkg/ExceptionIndirectlyExtendingForeignException.java
@@ -1,0 +1,5 @@
+package simple.pkg;
+
+public class ExceptionIndirectlyExtendingForeignException extends MyLocalException {
+	private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Constructor invocation has a different grammatical structure to standard method invocation so the previous PR #4772 did not handle those cases. This PR addresses those cases too.