### PR TITLE
[generate] Problems with generate

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -1770,7 +1770,6 @@ public class Workspace extends Processor {
 
 			List<RepositoryPlugin> plugins = getPlugins(RepositoryPlugin.class);
 			for (RepositoryPlugin rp : plugins) {
-				SortedSet<Version> versions = rp.versions(bsn);
 				File file = rp.get(bsn, version, attrs);
 				if (file != null)
 					return Result.ok(file);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -54,13 +54,13 @@ import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.header.Attrs;
+import aQute.bnd.memoize.Memoize;
 import aQute.bnd.osgi.BundleId;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Macro;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
-import aQute.bnd.memoize.Memoize;
 import aQute.lib.strings.Strings;
 
 public class ResourceUtils {
@@ -132,7 +132,7 @@ public class ResourceUtils {
 
 			private String s;
 
-			private Type(String s) {
+			Type(String s) {
 				this.s = s;
 			}
 
@@ -240,8 +240,7 @@ public class ResourceUtils {
 		Capability cap = capabilities.get(0);
 		String bsn = (String) cap.getAttributes()
 			.get("name");
-		Version version = (Version) cap.getAttributes()
-			.get("version");
+		Version version = getVersion(cap);
 		if (version == null)
 			version = Version.LOWEST;
 		if (bsn == null)
@@ -327,6 +326,8 @@ public class ResourceUtils {
 
 	public static String getVersionAttributeForNamespace(String namespace) {
 		switch (namespace) {
+			case "bnd.info" :
+				return "version";
 			case IdentityNamespace.IDENTITY_NAMESPACE :
 				return IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE;
 			case BundleNamespace.BUNDLE_NAMESPACE :


### PR DESCRIPTION
- Multiple clauses using the same output conflicted.
  Changed to prepare the steps so directory clean happens
  before all steps. 

- Using plain maven JARs had a cast problem with versions.
  Now supports bnd.info namespace for versions and
  properly coerces the version to a bnd version.

- A JAR without a main class in the manifest can now be used.
  If the JAR had no Main-Class, an error was reported. Now
  the `classpath` option is first passed. If there is no
  Main-Class in the manifest but the `classpath` is set
  then we try the command anyway.



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>