### PR TITLE
permissions: Update macro to use exportonly action

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/PermissionGeneratorTest.java
@@ -83,7 +83,7 @@ public class PermissionGeneratorTest {
 		Set<String> importedPackages = filterAndSubtract(permissions,
 			"^\\(org.osgi.framework.PackagePermission \"([^\"]+)\" \"import\"\\)$");
 		Set<String> exportedPackages = filterAndSubtract(permissions,
-			"^\\(org.osgi.framework.PackagePermission \"([^\"]+)\" \"export\"\\)$");
+			"^\\(org.osgi.framework.PackagePermission \"([^\"]+)\" \"exportonly,import\"\\)$");
 
 		/* @formatter:off */
 		assertThat(importedPackages).containsExactlyInAnyOrder(

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
@@ -69,7 +69,7 @@ public class PermissionGenerator {
 						.keySet()) {
 						sb.append("(org.osgi.framework.PackagePermission \"");
 						sb.append(exp);
-						sb.append("\" \"export\")\n");
+						sb.append("\" \"exportonly,import\")\n");
 					}
 				}
 			}


### PR DESCRIPTION
This means the generated permissions clause for exports will not work
on OSGi Core R4V4.1 or earlier.

Fixes https://github.com/bndtools/bnd/issues/4778

