### PR TITLE
IncludeResouce handles extras in jars paths

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -3387,6 +3387,59 @@ public class BuilderTest {
 	}
 
 	@Test
+	public void testIncludeResourceFromZipRecurseDirectoryFlatten() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.put("Import-Package", "!*");
+			p.put("-includeresource", "new.package/=@jar/cxf-rt-rs-sse-3.2.5.jar!/META-INF/services/*;flatten:=true");
+			bmaker.setProperties(p);
+			Jar jar = bmaker.build();
+			assertTrue(bmaker.check());
+			assertThat(jar.getResources().keySet())
+					.containsExactlyInAnyOrder("new.package/javax.ws.rs.sse.SseEventSource$Builder",
+						"new.package/org.apache.cxf.jaxrs.ext.JAXRSServerFactoryCustomizationExtension");
+		}
+
+	}
+
+	@Test
+	public void testIncludeResourceFromZipRecurseDirectoryRename2() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.put("Import-Package", "!*");
+			p.put("-includeresource", "new.package/=@jar/cxf-rt-rs-sse-3.2.5.jar!/META-INF/services/(*);rename:=$1");
+			bmaker.setProperties(p);
+			Jar jar = bmaker.build();
+			assertTrue(bmaker.check());
+			System.out.println(jar.getResources());
+			assertThat(jar.getResources()
+				.keySet()).containsExactlyInAnyOrder("new.package/javax.ws.rs.sse.SseEventSource$Builder",
+					"new.package/org.apache.cxf.jaxrs.ext.JAXRSServerFactoryCustomizationExtension");
+		}
+
+	}
+
+	@Test
+	public void testIncludeResourceFromZipRecurseDirectoryRename3() throws Exception {
+		try (Builder bmaker = new Builder()) {
+			Properties p = new Properties();
+			p.put("Import-Package", "!*");
+			p.put("-includeresource",
+				"new.package/=@jar/cxf-rt-rs-sse-3.2.5.jar!/(META-INF)/(cxf|services)/(*);rename:=$2/$1/$3.copy");
+			bmaker.setProperties(p);
+			Jar jar = bmaker.build();
+			assertTrue(bmaker.check());
+			System.out.println(jar.getResources());
+			assertThat(jar.getResources()
+				.keySet()).containsExactlyInAnyOrder(
+					"new.package/services/META-INF/javax.ws.rs.sse.SseEventSource$Builder.copy",
+					"new.package/services/META-INF/org.apache.cxf.jaxrs.ext.JAXRSServerFactoryCustomizationExtension.copy",
+					"new.package/cxf/META-INF/bus-extensions.txt.copy");
+		}
+
+	}
+
+	@Test
 	public void testIncludeLicenseFromZip() throws Exception {
 		Builder bmaker = new Builder();
 		try {

--- a/docs/_instructions/includeresource.md
+++ b/docs/_instructions/includeresource.md
@@ -70,6 +70,16 @@ Wrapping often requires access to a JAR from the repository. It is therefore com
 
     -includeresource    @${repo;biz.aQute.bndlib}!/about.html
 
+### Unrolling options
+
+`flatten:=BOOLEAN` - puts all files in the file-tree into one folder
+
+    -includeresource new.package/=@jar/file.jar!/META-INF/services/*;flatten:=true
+
+`rename:=RENAME` - maps the path using a given renaming instruction. Paths are filtered by the given instruction-SELECTOR. The instruction-Selector is compiled to a regex-pattern. This pattern is used to generate a matcher by using the filtered path and the matcher is used to replaceAll using the given extra value.
+
+    -includeresource new.package=@jar/cxf-rt-rs-sse-3.2.5.jar!/(META-INF)/(c*f)/(*);rename:=$2/$1/$3.copy
+
 ## Literals
 
 For testing purposes it is often necessary to have tiny resources in the bundle. These could of course be placed on the file system but bnd can also generate these on the fly. Since these are defined in the bnd files, the content has full access to the macros. This is done by specifying a `literal` attribute on the clause.
@@ -87,7 +97,7 @@ The recursion and the hierarchy can be controlled with directives.
 
     -includeresource    target/=hierarchy/
 
-The `recursive:` directive can be used ot indicate that the source should not be recursively traversed by specifying `false`:
+The `recursive:` directive can be used to indicate that the source should not be recursively traversed by specifying `false`:
 
     -includeresource    target/=hierarchy/;recursive:=false
 


### PR DESCRIPTION
When using `-includeresource` Instructions to process files inside a jar, no extras Attributes had been processed.

Now it should handle:
`flatten:=BOOLEAN` - puts all files in the file-tree into one folder

`rename:=RENAME`  - maps the Path using a given recipe , Regex groups allowed on Folders and Files

@juergen-albert 

For your need: `-includeresource: newFoldername=@fromFolder/zipFile.zip!/InnerFolder1/InnerFolder2/*;rebase:=/");`