### PR TITLE
fixed build loop in eclipse

### DIFF
--- a/bndtools.m2e/lifecycle-mapping-metadata.xml
+++ b/bndtools.m2e/lifecycle-mapping-metadata.xml
@@ -8,6 +8,7 @@
 				<versionRange>[3.0.0,)</versionRange>
 				<goals>
 					<goal>bnd-process</goal>
+					<goal>bnd-process-tests</goal>
 				</goals>
 			</pluginExecutionFilter>
 			<action>


### PR DESCRIPTION
We ran into the problem, that in certain situations a single project was build over and over again in eclipse when using the bndtools m2e connector.

it turned out, that a few things went wrong here. 
1. The bnd-maven-plugin supports two goals: bnd-process and bnd-process-tests. The `BndConfigurator`  however was only called for `bnd-process` and build the artifact and the test artifact. This is now separated.
2. We call the `maven-jar-plugin` after we updated all the decorators. This is something that m2e normally does not do and wasn't expecting. Thus the resulting jar comes as a surprise to eclipse, which causes the incremental builder to be called again and finally dribbles down to us. We never checked the delta that causes the build and blindly rebuild the jars. Thus the loops starts. In addition to that, we get a Delta in some cases, when e.g. the jar is opened or sometimes simply when the target folder becomes visible for the first time in the Explorer. It now checks if the delta only contains the suspicious content changes on our jars and will only build when other deltas are found. With this we may miss, if someone editors the jars somehow, but I would see this cases as negligible. It seems to work reliably for all the other cases.  

This should also improve the build performance for larger projects, as the build jar was triggered far to often during a full build.

Signed-off-by: Jürgen Albert <j.albert@data-in-motion.biz>