### PR TITLE
[sourcelookup] Fix NPE on unknown JRE

### DIFF
--- a/bndtools.core/src/bndtools/launch/sourcelookup/containers/BndrunEESourceContainer.java
+++ b/bndtools.core/src/bndtools/launch/sourcelookup/containers/BndrunEESourceContainer.java
@@ -44,6 +44,11 @@ public class BndrunEESourceContainer extends CompositeSourceContainer {
 	}
 
 	@Override
+	public boolean isComposite() {
+		return vm != null;
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		return obj instanceof BndrunEESourceContainer;
 	}
@@ -74,6 +79,10 @@ public class BndrunEESourceContainer extends CompositeSourceContainer {
 
 	@Override
 	protected ISourceContainer[] createSourceContainers() {
+		if (vm == null) {
+			logger.logError("Couldn't find VM for " + run.getRunee(), null);
+			return EMPTY_SOURCE;
+		}
 		try {
 			LibraryLocation[] libs = vm.getLibraryLocations();
 			if (libs == null) {


### PR DESCRIPTION
The source lookup configuration GUI would NPE internally if a JRE was selected on your bndrun which couldn't be found in your
workspace. Report "no children" in this case for slightly better UX.
