### PR TITLE
Improved error handler, if maven not setup properly

### DIFF
--- a/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
+++ b/bndtools.core/src/bndtools/launch/util/LaunchUtils.java
@@ -11,6 +11,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.ui.statushandlers.StatusManager;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
@@ -72,6 +73,9 @@ public final class LaunchUtils {
 				if ((run = runProvider.create(targetResource, mode)) != null) {
 					break;
 				}
+			} catch (CoreException e) {
+				StatusManager.getManager()
+					.handle(e.getStatus(), StatusManager.BLOCK);
 			} catch (Throwable t) {
 				logger.logError("Error in run listener", t);
 			}

--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -3,8 +3,8 @@
 -buildpath: \
 	osgi.annotation;version=latest;maven-scope=provided,\
 	osgi.core;version=latest;maven-scope=provided,\
-	org.osgi.service.component;version=1.3.0,\
-	org.osgi.service.component.annotations;version=1.3.0;maven-scope=provided,\
+	org.osgi.service.component;version='1.3.0',\
+	org.osgi.service.component.annotations;version='1.3.0';maven-scope=provided,\
 	aQute.libg;version=project,\
 	biz.aQute.bnd.maven;version=latest,\
 	biz.aQute.bnd.util;version=latest,\

--- a/bndtools.m2e/src/bndtools/m2e/MavenRunProvider.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenRunProvider.java
@@ -45,7 +45,9 @@ public class MavenRunProvider implements MavenRunListenerHelper, RunProvider {
 		final IMavenProjectFacade projectFacade = getMavenProjectFacade(targetResource);
 
 		Bndrun bndrun = create0(targetResource, projectFacade, mode);
-
+		if (bndrun == null) {
+			return null;
+		}
 		Workspace workspace = bndrun.getWorkspace();
 
 		final MavenImplicitProjectRepository implicitRepo = new MavenImplicitProjectRepository( //


### PR DESCRIPTION
If not resolver or test plugin has been set up properly, we internally ran into an NPE. The new error handling avoid the Exception and give a proper message to the user with a suggestion on how to fix it.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>