### PR TITLE
[quickfix] Fix for unknown cast caused by missing superclass

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
@@ -111,6 +112,9 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 				return true;
 			case IProblem.HierarchyHasProblems :
 				// System.out.println("HierarchyHasProblems");
+				return true;
+			case IProblem.IllegalCast :
+				// System.out.println("IllegalCast");
 				return true;
 			case IProblem.IsClassPathCorrect :
 				// System.out.println("IsClassPathCorrect");
@@ -439,6 +443,15 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 						// add those as suggestions.
 						ASTNode node = location.getCoveredNode(context.getASTRoot());
 						visitNodeAncestry(node);
+						continue;
+					}
+					case IProblem.IllegalCast : {
+						ASTNode node = location.getCoveredNode(context.getASTRoot());
+						if (node instanceof CastExpression) {
+							CastExpression cast = (CastExpression) node;
+							visitBindingHierarchy(cast.getType()
+								.resolveBinding());
+						}
 						continue;
 					}
 					case IProblem.TypeMismatch : {

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/AbstractBuildpathQuickFixProcessorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jdt.core.compiler.IProblem.CannotThrowType;
 import static org.eclipse.jdt.core.compiler.IProblem.DiscouragedReference;
 import static org.eclipse.jdt.core.compiler.IProblem.HierarchyHasProblems;
+import static org.eclipse.jdt.core.compiler.IProblem.IllegalCast;
 import static org.eclipse.jdt.core.compiler.IProblem.ImportNotFound;
 import static org.eclipse.jdt.core.compiler.IProblem.IsClassPathCorrect;
 import static org.eclipse.jdt.core.compiler.IProblem.ParameterMismatch;
@@ -241,7 +242,7 @@ abstract class AbstractBuildpathQuickFixProcessorTest {
 	protected static final Set<Integer>	SUPPORTED		= Sets.of(ImportNotFound, UndefinedType, IsClassPathCorrect,
 		HierarchyHasProblems, ParameterMismatch, TypeMismatch, UndefinedConstructor, UndefinedField, UndefinedMethod,
 		UndefinedName, UnresolvedVariable, TypeArgumentMismatch, DiscouragedReference, CannotThrowType,
-		UnhandledException);
+		UnhandledException, IllegalCast);
 
 	protected IJavaCompletionProposal[] proposalsForStaticImport(String imp) {
 		return proposalsFor(29, 0, "package test; import static " + imp + ";");

--- a/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
+++ b/bndtools.core.test/src/bndtools/core/test/editors/quickfix/BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test.java
@@ -12,6 +12,17 @@ public class BuildpathQuickFixProcessor_WithSimpleOnBuildpath_Test extends Abstr
 	}
 
 	@Test
+	void withMissingClass_causingCantCast_suggestsBundles() {
+		String header = "package test; import simple.pkg.ClassExtendingClassFromAnotherBundle; import simple.MyClass; class "
+			+ DEFAULT_CLASS_NAME + " {" + "public void test() {" + "MyClass d = null; "
+			+ "ClassExtendingClassFromAnotherBundle c = ";
+		String source = header + "(ClassExtendingClassFromAnotherBundle)d;}}";
+
+		assertThatProposals(proposalsFor(header.length() + 1, 0, source)).haveExactly(1,
+			suggestsBundle("bndtools.core.test.fodder.iface", "1.0.0", "iface.bundle.MyForeignClass"));
+	}
+
+	@Test
 	void withMissingSuperException_causingUnhandled_suggestsBundles() {
 		String header = "package test; import simple.pkg.ClassThrowingExceptionExtendingForeignException; class "
 			+ DEFAULT_CLASS_NAME + " {" + "public void test() {"


### PR DESCRIPTION
Expressions like this:
`ClassA a = (ClassA)b;`
...that don't work because the full hierarchy of `ClassA` is not on the buildpath and the compiler cannot establish that `ClassA` is a subtype of b's class.