### PR TITLE
gradle: Add -runee inferencing to the bndrun tasks

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/changefail.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/changefail.bndrun
@@ -1,4 +1,3 @@
 -runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.eventadmin)'
 -runbundles: foo

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/create.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/create.bndrun
@@ -1,3 +1,2 @@
 -runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=${project.osgiIdentity})'

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/resolvefail.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/resolvefail.bndrun
@@ -1,3 +1,2 @@
 -runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.foo)'

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/same.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/resolvetask1/same.bndrun
@@ -1,4 +1,3 @@
 -runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.eventadmin)'
 -runbundles: org.apache.felix.eventadmin;version='[1.4.6,1.4.7)'

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/bnd.bnd
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/bnd.bnd
@@ -7,7 +7,6 @@ Test-Cases: test.simple.Test
 -includeresource: test.txt
 
 -runfw: org.eclipse.osgi;version='[3.13.0,3.14.0)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: \

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvechange.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvechange.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolveerror.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolveerror.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvenochange.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvenochange.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\


### PR DESCRIPTION
Like the maven plugins, the gradle plugins can now infer a -runee
from the compilation settings in the project. Specifically, the
release or targetCompatibility setting from the compileJava tasks is
used.

Fixes https://github.com/bndtools/bnd/issues/4142

