### PR TITLE
gradle: Add -runrequires inferencing to the bndrun tasks

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
@@ -23,10 +23,6 @@ dependencies {
 	runtimeOnly 'org.eclipse.platform:org.eclipse.osgi:3.13.0'
 }
 
-ext {
-	osgiIdentity = 'testosgitask1'
-}
-
 def resolveTask = tasks.register('resolve', Resolve) {
 	description = 'Resolve testosgi.bndrun'
 	group = 'test'

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/testosgi.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/testosgi.bndrun
@@ -1,10 +1,8 @@
 -include: ${.}/included.bnd
 
 -runfw: ${runfw}
--runee: JavaSE-1.8
 
--runrequires: osgi.identity;filter:='(osgi.identity=${junit})',\
- osgi.identity;filter:='(osgi.identity=${project.osgiIdentity})'
+-runrequires.junit: osgi.identity;filter:='(osgi.identity=${junit})'
 
 -runproperties:
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/bnd.bnd
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/bnd.bnd
@@ -7,7 +7,6 @@ Test-Cases: test.simple.Test
 -includeresource: test.txt
 
 -runfw: org.eclipse.osgi;version='[3.13.0,3.14.0)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: \
 	osgi.enroute.junit.wrapper

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolve2.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvechange.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvechange.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolveerror.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolveerror.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper
 	

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvenochange.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin6/test.simple/resolvenochange.bndrun
@@ -1,5 +1,4 @@
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
--runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'
 
 -runbundles: osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
     test.simple;version=snapshot


### PR DESCRIPTION
Like the maven plugins, the gradle plugins can now infer a -runrequires
from the archives configuration of the project. Each file in the
archives configuration is examined for its Bundle-SymbolicName header
in the manifest. If not found, the project's name is used.

Fixes https://github.com/bndtools/bnd/issues/4143
