### PR TITLE
org.bndtools.launch: Fix break in the p2 installation

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -8,6 +8,7 @@ javac.source:           1.8
 javac.target:           1.8
 javac.compliance:       1.8
 javac.debug:            on
+-noimportjava: true
 
 # This build requires newer Bnd features
 -require-bnd: "(version>=5.1.0)"

--- a/org.bndtools.launch/bnd.bnd
+++ b/org.bndtools.launch/bnd.bnd
@@ -11,7 +11,7 @@ Import-Package: \
 # Bundle Content
 
 -privatepackage: \
-	bndtools.launch.*
+	bndtools.launch.*;from:=${p}
 
 -conditionalpackage: \
     aQute.lib.*,\
@@ -19,14 +19,16 @@ Import-Package: \
     org.bndtools.utils.*
 
 -buildpath: \
+	osgi.annotation;version=latest;maven-scope=provided,\
+	osgi.core;version=latest;maven-scope=provided,\
+	org.osgi.service.component.annotations;version='1.3.0';maven-scope=provided,\
 	aQute.libg;version=project,\
-	biz.aQute.bnd.util;version=snapshot,\
-	biz.aQute.bndlib;version=snapshot,\
+	biz.aQute.bnd.util;version=latest,\
+	biz.aQute.bndlib;version=latest,\
 	biz.aQute.resolve;version=latest,\
-	bndtools.utils;version=project,\
-	bndtools.api;version=snapshot,\
-	bndtools.core;version=snapshot,\
-	org.osgi.service.component.annotations;version='1.3.0',\
+	bndtools.utils;version=project;packages='*',\
+	bndtools.api;version=latest,\
+	bndtools.core;version=latest,\
 	slf4j.api,\
 	org.apiguardian,\
 	org.eclipse.core.runtime,\
@@ -56,7 +58,6 @@ Import-Package: \
 	org.eclipse.equinox.preferences,\
 	org.eclipse.swt,\
 	org.eclipse.swt.cocoa.macosx.x86_64,\
-	osgi.annotation,\
 	org.eclipse.core.expressions,\
 	org.eclipse.jdt.debug.ui,\
 	org.eclipse.e4.core.services,\


### PR DESCRIPTION
We disable importing of java.* packages which upsets the p2 packaging
code. This occurred because the bnd.bnd file for the new
org.bndtools.launch project did not put osgi.core on the buildpath.

As a safety measure, we also now use -noimportjava=true.

Also: fixed compile warning in Eclipse for references to code in the
bndtools.utils project, and removed the improper inclusion and exporting
of the bndtools.launch.util package from bndtools.core.

