### PR TITLE
github action: Replace 'adopt' with 'temurin'

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build
       id: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Initialize CodeQL Analysis
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
'adopt' has been superseded by 'temurin'.
