### PR TITLE
fixes Project refresh after mavenBndRepo Update in View

### DIFF
--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -28,6 +28,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.RepositoryPlugin;
@@ -127,6 +128,12 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 								busy = false;
 								if (redo) {
 									refreshRepositories(null);
+								} else {
+									try {
+										Central.refreshProjects();
+									} catch (Exception e) {
+										Exceptions.duck(e);
+									}
 								}
 							}
 						});

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -93,13 +93,13 @@ import org.eclipse.ui.part.ViewPart;
 import org.osgi.resource.Requirement;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.service.Actionable;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RemoteRepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.lib.converter.Converter;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import bndtools.Plugin;
 import bndtools.central.Central;
@@ -821,7 +821,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 													e1.getValue()
 														.run();
 													if (rp != null && rp instanceof Refreshable)
-														Central.refreshPlugin((Refreshable) rp);
+														Central.refreshPlugin((Refreshable) rp, true);
 												} catch (final Exception e) {
 													IStatus status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID,
 														"Error executing: " + getName(), e);


### PR DESCRIPTION
- fixes #4320

The issue was caused by the periodic file synchronizer that listens to changes on the index file. Its refresh kicked in during the action that updates the artifact und was not communicating any changes back to the Eclipse projects. 

This is not the most elegant fix. It would be better, if all Projects would register there `BndContainerInitializer`s as `RepositoryListenerPlugin` Services. Unfortunately, Registering wouldn't have been a problem, but I wasn't able to find a point to unregister the service again, if e.g. somebody removes the nature. 

Good thing now is: the `Bnd Bundle Path` will be updated if any of the actions in the maven repo context menu will be triggered and when the index file is edited (which wasn't the case before).

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>