### PR TITLE
build: We change the build to allow using -snapshot to specify a Maven version qualifier

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -23,16 +23,18 @@ Git-SHA:                ${system-allow-fail;git rev-list -1 --no-abbrev-commit H
 baseline.version:       5.3.0
 # biz.aQute.bndlib:aQute.bnd.osgi.About.CURRENT needs to be kept in sync with the base.version.
 base.version:           6.0.0
-# Uncomment the following line to build the non-snapshot version.
-#-snapshot:
 Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
 # Don't baseline Bundle-Version
 -diffignore:            Bundle-Version
 
 # Maven info. The maven artifactId defaults to Bundle-SymbolicName
 -groupid:               biz.aQute.bnd
--pom:                   version=${versionmask;===s;${@version}}
+-pom:                   version=${if;${def;-snapshot};${versionmask;===;${@version}}-${-snapshot};${versionmask;===s;${@version}}}
 -maven-release:         pom;path=JAR,javadoc;-classpath="${project.buildpath}"
+# -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
+# -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
+# -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)
+#-snapshot:
 
 Automatic-Module-Name:  ${def;bsn}
 Bundle-Vendor:          Bndtools https://bndtools.org/


### PR DESCRIPTION
* -snapshot unset (commented out) is a snapshot build.
 (e.g. 6.0.0-SNAPSHOT)
* -snapshot set to a value (e.g. RC1) is a release build with the
 value as the Maven version qualifier. (e.g. 6.0.0-RC1)
* -snapshot set to the empty string is a release build with no
 Maven version qualifier. (e.g. 6.0.0)
