### PR TITLE
mvn - respect pre-set Bundle-SymbolicName Fragment-Host

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenTestsPlugin.java
@@ -112,11 +112,13 @@ public class BndMavenTestsPlugin extends AbstractBndMavenPlugin {
 	@Override
 	protected void processBuilder(Builder builder) throws MojoFailureException {
 		String defaultBsn = project.getArtifactId();
+		String bsn = builder.getProperty(Constants.BUNDLE_SYMBOLICNAME, defaultBsn + "-tests");
+
+		builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, bsn);
+
 		if (artifactFragment) {
-			builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, defaultBsn + "-tests");
-			builder.setProperty(Constants.FRAGMENT_HOST, defaultBsn);
-		} else if (builder.getProperty(Constants.BUNDLE_SYMBOLICNAME) == null) {
-			builder.setProperty(Constants.BUNDLE_SYMBOLICNAME, defaultBsn + "-tests");
+			String fragmentHost = builder.getProperty(Constants.FRAGMENT_HOST, defaultBsn);
+			builder.setProperty(Constants.FRAGMENT_HOST, fragmentHost);
 		}
 
 		if (testCases != TestCases.useTestCasesHeader) {


### PR DESCRIPTION
@rotty3000 could you have a look on this?

If you customize the `Bundle-SymbolicName` of the main bundle to 
`Bundle-SymbolicName: ${groupId}.${artifactId}` you need a way to manually customize the tests-bundle
```
Bundle-SymbolicName: ${groupId}.${artifactId}-tests
Fragment-Host: ${groupId}.${artifactId}
```