### PR TITLE
Workaround fix for JVM Crash Issue while refreshing 'ProblemTreeViewer'

### DIFF
--- a/bndtools.core/src/bndtools/explorer/Model.java
+++ b/bndtools.core/src/bndtools/explorer/Model.java
@@ -103,12 +103,8 @@ class Model {
 
 	void update() {
 		dirty.set(true);
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.asyncExec(this::update0);
-		} else {
-			update0();
-		}
+		Display.getDefault()
+			.asyncExec(this::update0);
 	}
 
 	private void update0() {


### PR DESCRIPTION
This workaround ensures that the action is performed on the display thread properly by rescheduling it on the display thread. Note that, previously it was also executed on the display thread, but underlying SWT/JFace didn't submit the task properly to the display thread. That's why, this MR ensures that we submit the task properly (or explicitly) to the display thread. The bug still exists in the SWT/JFace which needs to be fixed. Other plugins using `getTreeViewer().refresh()` from `PackageExplorerPart` are prone to crash the JVM as well.

Fixes #4854