### PR TITLE
bndtools: Fix project refreshing causing performance issues

### DIFF
--- a/bndtools.core/src/bndtools/Activator.java
+++ b/bndtools.core/src/bndtools/Activator.java
@@ -143,11 +143,10 @@ public class Activator extends AbstractUIPlugin {
 	}
 
 	static void async(Runnable run) {
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.asyncExec(run);
-		} else
-			run.run();
+		Display display = Display.getCurrent();
+		if (display == null)
+			display = Display.getDefault();
+		display.asyncExec(run);
 	}
 
 	public static boolean getReportDone() {

--- a/bndtools.core/src/bndtools/Plugin.java
+++ b/bndtools.core/src/bndtools/Plugin.java
@@ -197,11 +197,10 @@ public class Plugin extends AbstractUIPlugin {
 	}
 
 	static void async(Runnable run) {
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.asyncExec(run);
-		} else
-			run.run();
+		Display display = Display.getCurrent();
+		if (display == null)
+			display = Display.getDefault();
+		display.asyncExec(run);
 	}
 
 	public static void error(List<String> errors) {

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -582,23 +582,15 @@ public class Central implements IStartupParticipant {
 		//
 
 		if (changed) {
-			try {
-
-				for (File file : refreshedFiles) {
-					refreshFile(file);
-				}
-
-				refreshProjects();
-
-				if (repoChanged) {
-					repositoriesViewRefresher.repositoriesRefreshed();
-				}
-			} catch (Exception e) {
-				e.printStackTrace();
-				throw new RuntimeException(e);
+			for (File file : refreshedFiles) {
+				refreshFile(file);
 			}
-		}
 
+			if (repoChanged) {
+				repositoriesViewRefresher.repositoriesRefreshed();
+			}
+			refreshProjects();
+		}
 	}
 
 	public static void refreshPlugin(Refreshable plugin) throws Exception {
@@ -611,11 +603,8 @@ public class Central implements IStartupParticipant {
 			refreshFile(plugin.getRoot());
 			if (plugin instanceof RepositoryPlugin) {
 				repositoriesViewRefresher.repositoryRefreshed((RepositoryPlugin) plugin);
-			} else {
-				// If the Plugin was a RepositoryPlugin, the ViewRefresher will
-				// trigger the Project update. If not, we have to do it ourself
-				refreshProjects();
 			}
+			refreshProjects();
 		}
 	}
 

--- a/bndtools.core/src/bndtools/central/Central.java
+++ b/bndtools.core/src/bndtools/central/Central.java
@@ -462,12 +462,13 @@ public class Central implements IStartupParticipant {
 
 	public void changed(Project model) {
 		model.setChanged();
-		for (ModelListener m : listeners)
+		for (ModelListener m : listeners) {
 			try {
 				m.modelChanged(model);
 			} catch (Exception e) {
-				e.printStackTrace();
+				logger.error("While notifying ModelListener {} of change to project {}", m, model, e);
 			}
+		}
 	}
 
 	public void addModelListener(ModelListener m) {
@@ -619,11 +620,21 @@ public class Central implements IStartupParticipant {
 	}
 
 	public static void refreshProjects() throws Exception {
-		for (Project p : Central.getWorkspace()
-			.getAllProjects()) {
+		Collection<Project> allProjects = getWorkspace().getAllProjects();
+		// Mark all projects changed before we notify model listeners
+		// since the listeners can take actions on project's other than
+		// the specified project.
+		for (Project p : allProjects) {
 			p.setChanged();
-			for (ModelListener l : getInstance().listeners)
-				l.modelChanged(p);
+		}
+		for (Project p : allProjects) {
+			for (ModelListener m : getInstance().listeners) {
+				try {
+					m.modelChanged(p);
+				} catch (Exception e) {
+					logger.error("While notifying ModelListener {} of change to project {}", m, p, e);
+				}
+			}
 		}
 	}
 

--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizard.java
@@ -482,12 +482,10 @@ public class ImportBndWorkspaceWizard extends Wizard implements IImportWizard {
 		// build the error message and include the current stack trace
 		final MultiStatus status = createMultiStatus(t);
 		Runnable run = () -> ErrorDialog.openError(null, "Error", message, status);
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.asyncExec(run);
-		} else {
-			run.run();
-		}
+		Display display = Display.getCurrent();
+		if (display == null)
+			display = Display.getDefault();
+		display.asyncExec(run);
 	}
 
 	/*

--- a/bndtools.core/src/bndtools/wizards/workspace/AddFilesToRepositoryWizard.java
+++ b/bndtools.core/src/bndtools/wizards/workspace/AddFilesToRepositoryWizard.java
@@ -20,9 +20,11 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jface.wizard.Wizard;
 
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.lib.io.IO;
 import bndtools.Plugin;
+import bndtools.central.Central;
 import bndtools.central.RefreshFileJob;
 import bndtools.types.Pair;
 
@@ -84,6 +86,9 @@ public class AddFilesToRepositoryWizard extends Wizard {
 						if ((artifact != null) && artifact.getScheme()
 							.equalsIgnoreCase("file")) {
 							refresh.add(new File(artifact));
+						}
+						if (repository instanceof Refreshable) {
+							Central.refreshPlugin((Refreshable) repository, true);
 						}
 					} catch (Exception e) {
 						status.add(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,

--- a/bndtools.release/src/bndtools/release/Activator.java
+++ b/bndtools.release/src/bndtools/release/Activator.java
@@ -100,19 +100,17 @@ public class Activator extends AbstractUIPlugin implements BundleActivator {
 	}
 
 	static void async(Runnable run) {
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.asyncExec(run);
-		} else
-			run.run();
+		Display display = Display.getCurrent();
+		if (display == null)
+			display = Display.getDefault();
+		display.asyncExec(run);
 	}
 
 	static void sync(Runnable run) {
-		if (Display.getCurrent() == null) {
-			Display.getDefault()
-				.syncExec(run);
-		} else
-			run.run();
+		Display display = Display.getCurrent();
+		if (display == null)
+			display = Display.getDefault();
+		display.syncExec(run);
 	}
 
 	public static void message(final String msg) {

--- a/bndtools.release/src/bndtools/release/ReleaseDialogJob.java
+++ b/bndtools.release/src/bndtools/release/ReleaseDialogJob.java
@@ -93,12 +93,10 @@ public class ReleaseDialogJob extends Job {
 				}
 			};
 
-			if (Display.getCurrent() == null) {
-				Display.getDefault()
-					.asyncExec(runnable);
-			} else {
-				runnable.run();
-			}
+			Display display = Display.getCurrent();
+			if (display == null)
+				display = Display.getDefault();
+			display.asyncExec(runnable);
 
 			monitor.worked(33);
 			return Status.OK_STATUS;

--- a/bndtools.release/src/bndtools/release/ReleaseHelper.java
+++ b/bndtools.release/src/bndtools/release/ReleaseHelper.java
@@ -120,11 +120,10 @@ public class ReleaseHelper {
 					throw new RuntimeException(e);
 				}
 			};
-			if (Display.getCurrent() == null) {
-				Display.getDefault()
-					.syncExec(run);
-			} else
-				run.run();
+			Display display = Display.getCurrent();
+			if (display == null)
+				display = Display.getDefault();
+			display.syncExec(run);
 		}
 	}
 
@@ -258,13 +257,10 @@ public class ReleaseHelper {
 				error.open();
 			};
 
-			if (Display.getCurrent() == null) {
-				Display.getDefault()
-					.asyncExec(runnable);
-			} else {
-				runnable.run();
-			}
-
+			Display display = Display.getCurrent();
+			if (display == null)
+				display = Display.getDefault();
+			display.asyncExec(runnable);
 		}
 
 	}

--- a/bndtools.release/src/bndtools/release/WorkspaceAnalyserJob.java
+++ b/bndtools.release/src/bndtools/release/WorkspaceAnalyserJob.java
@@ -102,12 +102,10 @@ public class WorkspaceAnalyserJob extends Job {
 			if (projectDiffs.isEmpty()) {
 				Runnable runnable = () -> MessageDialog.openInformation(shell, Messages.releaseWorkspaceBundles,
 					Messages.noBundlesRequireRelease);
-				if (Display.getCurrent() == null) {
-					Display.getDefault()
-						.syncExec(runnable);
-				} else {
-					runnable.run();
-				}
+				Display display = Display.getCurrent();
+				if (display == null)
+					display = Display.getDefault();
+				display.syncExec(runnable);
 				return Status.OK_STATUS;
 			}
 
@@ -135,13 +133,10 @@ public class WorkspaceAnalyserJob extends Job {
 				}
 			};
 
-			if (Display.getCurrent() == null) {
-				Display.getDefault()
-					.asyncExec(runnable);
-			} else {
-				runnable.run();
-			}
-
+			Display display = Display.getCurrent();
+			if (display == null)
+				display = Display.getDefault();
+			display.asyncExec(runnable);
 		} catch (Exception e) {
 			return new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage(), e);
 		}


### PR DESCRIPTION
f0928dab068431590c0a0c1abbbc454588e098f1 causes performance issues and possibly #4861. The way all projects were refreshed and the refreshing of project from a view refresher caused repetitive project refreshing.

This PR fixes Central.refreshProjects() to mark all projects changed before advising model listeners of the changes. It also removes refreshing projects from the view refresher. Projects should be refreshed only when some action is taken not in a UI view refresher which is itself responding to some taken action. I saw a stack trace where the view refresher refreshed the projects which ended back up in the view refresher refreshing the projects again!

Also, we should not be refreshing projects on the UI thread as that causes responsiveness issues.

So far this PR seems to address recent performance issues I have had using the latest Bndtools.