### PR TITLE
makes maven project properties available to the bndrun

### DIFF
--- a/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
+++ b/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
@@ -194,7 +194,7 @@ public class BndrunContainer {
 		File cnf = new File(temporaryDir, Workspace.CNFDIR);
 		aQute.lib.io.IO.mkdirs(cnf);
 
-		Bndrun run = Bndrun.createBndrun(null, runFile);
+		Bndrun run = Bndrun.createBndrun(runFile, project.getProperties());
 		run.setBase(temporaryDir);
 		Workspace workspace = run.getWorkspace();
 		workspace.setBase(temporaryDir);

--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Properties;
 
 import org.osgi.resource.Requirement;
 import org.osgi.service.resolver.ResolutionException;
@@ -39,6 +40,20 @@ public class Bndrun extends Run {
 	final ResolutionInstructions												resolutionInstructions;
 	private static final Converter<String, Collection<? extends HeaderClause>>	runbundlesListFormatter	= new CollectionFormatter<>(
 		",", new HeaderClauseFormatter(), null, "", "");
+
+	/**
+	 * Create a Bndrun that will be stand alone if it contains -standalone. In
+	 * that case the given workspace is ignored. Otherwise, the workspace must
+	 * be a valid workspace.
+	 */
+	public static Bndrun createBndrun(File file, Properties additionProperties) throws Exception {
+		Processor processor = new Processor();
+		processor.setProperties(file);
+
+		Workspace standaloneWorkspace = Workspace.createStandaloneWorkspace(processor, file.toURI());
+		standaloneWorkspace.addProperties(additionProperties);
+		return createBndrun(standaloneWorkspace, file);
+	}
 
 	/**
 	 * Create a Bndrun that will be stand alone if it contains -standalone. In

--- a/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
@@ -1,4 +1,4 @@
-@Version("7.0.0")
+@Version("7.1.0")
 package biz.aQute.resolve;
 
 import org.osgi.annotation.versioning.Version;

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -21,6 +21,7 @@
 		<module>resolve-from-inputbundles</module>
 		<module>enroute</module>
 		<module>resolve-infer-with-custom-bsn</module>
+		<module>resolve-with-project-props</module>
 	</modules>
 
 	<build>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/error.properties
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/error.properties
@@ -1,0 +1,1 @@
+-runrequires.error: ${error;'property test.prop not set'}

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/include.properties
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/include.properties
@@ -1,0 +1,1 @@
+-runrequires.success: bnd.identity;id=org.apache.felix.eventadmin

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>resolver-test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<artifactId>resolve-with-project-props</artifactId>
+	<version>0.0.1</version>
+
+	<properties>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<test.prop>false</test.prop>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.eventadmin</artifactId>
+			<version>1.4.8</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.framework</artifactId>
+			<version>5.4.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-resolver-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<target>${maven.compiler.target}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/test.bndrun
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/test.bndrun
@@ -1,0 +1,3 @@
+-runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
+#test.prop must be set to false
+-include: ${if;${test.prop}; ${.}/error.properties; ${.}/include.properties}


### PR DESCRIPTION
Currently bndrun files in maven have no access to any properties of the maven project. We have a Project with a couple of of tests that are housed in bndrun files. They all have a couple of duplicate properties (`-tester`, `-runproperties` etc.). We wanted to put this in a centralized file and include them from each file as we already do in the `bnd.bnd ` files. Long story short: it did not work, because we have a mojo that calculates the root folder and we need to access this property.

This is now fixed with this commit. It unfortunately does not work when the bndrun has a `-standalone` but I couldn't say why.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>