### PR TITLE
bndrun: Force refresh after setting parent

### DIFF
--- a/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
+++ b/biz.aQute.bnd.maven/src/aQute/bnd/maven/lib/resolve/BndrunContainer.java
@@ -34,6 +34,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.repository.fileset.FileSetRepository;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.unmodifiable.Sets;
+import aQute.lib.io.IO;
 import biz.aQute.resolve.Bndrun;
 
 @ProviderType
@@ -192,16 +193,18 @@ public class BndrunContainer {
 			.resolve(bndrun)
 			.toFile();
 		File cnf = new File(temporaryDir, Workspace.CNFDIR);
-		aQute.lib.io.IO.mkdirs(cnf);
+		IO.mkdirs(cnf);
 
 		Bndrun run = Bndrun.createBndrun(null, runFile);
-		run.setBase(temporaryDir);
 		Workspace workspace = run.getWorkspace();
 		workspace.setBase(temporaryDir);
 		workspace.setBuildDir(cnf);
 		workspace.setOffline(session.getSettings()
 			.isOffline());
 		run.setParent(getProcessor(workspace));
+		run.clear();
+		run.forceRefresh(); // setBase must be called after forceRefresh
+		run.setBase(temporaryDir);
 		run.getInfo(workspace);
 		setRunrequiresFromProjectArtifact(run);
 		setEEfromBuild(run);

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
@@ -242,16 +242,19 @@ public abstract class AbstractBndrun<WORKER extends aQute.bnd.build.Project, RUN
 				gradleProperties.put("task", this);
 				gradleProperties.put("project", getProject());
 				run.setParent(new Processor(runWorkspace, gradleProperties, false));
+				run.clear();
+				run.forceRefresh(); // setBase must be called after forceRefresh
 			}
 			run.setBase(workingDirFile);
 			if (run.isStandalone()) {
+				runWorkspace.setBase(workingDirFile);
+				File cnf = new File(workingDirFile, Workspace.CNFDIR);
+				IO.mkdirs(cnf);
+				runWorkspace.setBuildDir(cnf);
 				runWorkspace.setOffline(Objects.nonNull(workspace) ? workspace.isOffline()
 					: getProject().getGradle()
 						.getStartParameter()
 						.isOffline());
-				File cnf = new File(workingDirFile, Workspace.CNFDIR);
-				IO.mkdirs(cnf);
-				runWorkspace.setBuildDir(cnf);
 				if (Objects.isNull(workspace)) {
 					FileSetRepository fileSetRepository = new FileSetRepository(getName(), getBundles().getFiles());
 					runWorkspace.addBasicPlugin(fileSetRepository);

--- a/maven/bnd-plugin-parent/pom.xml
+++ b/maven/bnd-plugin-parent/pom.xml
@@ -321,6 +321,7 @@
 						<scriptVariables>
 							<bndVersion>${project.version}</bndVersion>
 						</scriptVariables>
+						<showErrors>true</showErrors>
 						<mavenOpts>${mavenOpts}</mavenOpts>
 						<goals>
 							<goal>--no-transfer-progress</goal>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/pom.xml
@@ -21,6 +21,7 @@
 		<module>resolve-from-inputbundles</module>
 		<module>enroute</module>
 		<module>resolve-infer-with-custom-bsn</module>
+		<module>resolve-with-project-props</module>
 	</modules>
 
 	<build>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/error.properties
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/error.properties
@@ -1,0 +1,1 @@
+-runrequires.error: ${error;'property test.prop not set'}

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/include.properties
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/include.properties
@@ -1,0 +1,1 @@
+-runrequires.success: bnd.identity;id=org.apache.felix.eventadmin

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>resolver-test</artifactId>
+		<version>0.0.1</version>
+	</parent>
+
+	<artifactId>resolve-with-project-props</artifactId>
+	<version>0.0.1</version>
+
+	<properties>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<test.prop>false</test.prop>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.eventadmin</artifactId>
+			<version>1.4.8</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.framework</artifactId>
+			<version>5.4.0</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-resolver-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<target>${maven.compiler.target}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/test.bndrun
+++ b/maven/bnd-resolver-maven-plugin/src/test/resources/integration-test/test/resolve-with-project-props/test.bndrun
@@ -1,0 +1,3 @@
+-runfw: org.apache.felix.framework;version='[5.4.0,5.4.0]'
+#test.prop must be set to false
+-include: ${if;${test.prop}; ${.}/error.properties; ${.}/include.properties}


### PR DESCRIPTION
After setting the parent of the bndrun so the bndrun has access to the maven/gradle project properties, we clear any errors and force a refresh of the bndrun. The will enable the -include processing access to the maven/gradle project properties.

Closes #4881 