### PR TITLE
[logging] Add aQute to logging packages

### DIFF
--- a/bndtools.core.test/logback.xml
+++ b/bndtools.core.test/logback.xml
@@ -6,7 +6,7 @@
   </appender>
 
   <logger name="aQute.bnd.maven" level="WARN" />
-  <logger name="biz.aQute" level="INFO" />
+  <logger name="aQute" level="INFO" />
   <logger name="bndtools" level="DEBUG" />
   <logger name="org.bndtools" level="DEBUG" />
   <logger name="org.apache" level="DEBUG" />

--- a/bndtools.core/logback.xml
+++ b/bndtools.core/logback.xml
@@ -5,7 +5,7 @@
     </encoder>
   </appender>
 
-  <logger name="biz.aQute" level="INFO" />
+  <logger name="aQute" level="INFO" />
 
   <root level="ERROR">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
The existing logback configuration in `bndtools.core` configures logging for the package prefix `biz.aQute`. We don't actually have any packages that are `biz.aQute.*` - they are `aQute.*`. Changing logback configuration to reflect this to make the logging more useful to developers.