### PR TITLE
startlevel: Correctly populate installed bundles

### DIFF
--- a/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
+++ b/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
@@ -185,6 +185,17 @@ public class StartLevelRuntimeHandler implements Closeable {
 
 				this.systemBundle = systemBundle;
 
+				for (Bundle bundle : systemBundle.getBundleContext()
+					.getBundles()) {
+					if (bundle.getBundleId() == 0) {
+						continue;
+					}
+					if (bundle.getSymbolicName() == null) {
+						continue;
+					}
+					installed.put(bundle, new BundleIdentity(bundle));
+				}
+
 				updateConfiguration(outerConfiguration);
 
 				setDefaultStartlevel(this.systemBundle, defaultStartlevel);


### PR DESCRIPTION
When -runkeep=true is used, there may already be installed bundles and
then there well be no installed bundle event to trigger setting the
start level. So we must initialize the installed bundles before we
start processing start levels.

