### PR TITLE
remoteinstall: The feature was incomplete and could not install

### DIFF
--- a/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
@@ -31,7 +31,6 @@
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	biz.aQute.tester.junit-platform;version=snapshot,\

--- a/bndtools.core.test/test.gtk.linux.x86_64.bndrun
+++ b/bndtools.core.test/test.gtk.linux.x86_64.bndrun
@@ -30,7 +30,6 @@
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	biz.aQute.tester.junit-platform;version=snapshot,\

--- a/bndtools.core.test/test.win32.x86_64.bndrun
+++ b/bndtools.core.test/test.win32.x86_64.bndrun
@@ -29,7 +29,6 @@
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	biz.aQute.tester.junit-platform;version=snapshot,\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -31,7 +31,6 @@
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	bndtools.api;version=snapshot,\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -30,7 +30,6 @@
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	bndtools.api;version=snapshot,\

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -29,7 +29,6 @@
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.remote.api;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot,\
 	bndtools.api;version=snapshot,\

--- a/org.bndtools.remoteinstall/bnd.bnd
+++ b/org.bndtools.remoteinstall/bnd.bnd
@@ -7,7 +7,9 @@ Import-Package: \
 -privatepackage: ${p}.*
 -conditionalpackage: \
     aQute.lib.*,\
-    aQute.libg.*
+    aQute.libg.*,\
+    aQute.remote.*
+
 -buildpath: \
 	osgi.annotation;version=latest;maven-scope=provided,\
 	osgi.core;version=latest;maven-scope=provided,\


### PR DESCRIPTION
The remoteinstall bundle depended upon the remote.api bundle which
is not part of the main feature. So p2 cannot install the feature.
The remote.api bundle is not really well formed in that it duplicates
exports from bndlib which is already part of the main feature.

Since the remoteinstall bundle needed very little of the remote.api
code, we now just conditional package it into the remoteinstall bundle
to avoid another dependency.
