### PR TITLE
gradle: Use correct property name for bnd_cnf

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndWorkspacePlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndWorkspacePlugin.java
@@ -129,7 +129,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 		}
 
 		/* Add cnf project to the graph */
-		result = dynamicObject.tryGetProperty("cnf");
+		result = dynamicObject.tryGetProperty("bnd_cnf");
 		String cnf = result.isFound() ? (String) result.getValue() : Workspace.CNFDIR;
 		projectNames.add(cnf);
 


### PR DESCRIPTION
During the conversion from Groovy source code to Java, the wrong
property name was used for the name of the cnf folder.

