### PR TITLE
gradle: Use correct XmlSlurper class

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -5,6 +5,7 @@ import static org.gradle.testkit.runner.TaskOutcome.*
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 
+import groovy.xml.XmlSlurper
 import spock.lang.Specification
 
 class TestBundlePlugin extends Specification {

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestIndexTask.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestIndexTask.groovy
@@ -6,6 +6,7 @@ import java.util.jar.Attributes
 import java.util.jar.JarFile
 import java.util.zip.GZIPInputStream
 
+import groovy.xml.XmlSlurper
 import spock.lang.Specification
 
 class TestIndexTask extends Specification {

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestTestOSGiTask.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestTestOSGiTask.groovy
@@ -5,6 +5,7 @@ import static org.gradle.testkit.runner.TaskOutcome.*
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 
+import groovy.xml.XmlSlurper
 import spock.lang.Specification
 
 class TestTestOSGiTask extends Specification {


### PR DESCRIPTION
Groovy 3.0 relocated XmlSlurper to groovy.xml and deprecated the
copy in groovy.util.
