### PR TITLE
ci: Use settings created by setup-java action

### DIFF
--- a/cnf/ext/jfrog-settings.xml
+++ b/cnf/ext/jfrog-settings.xml
@@ -1,9 +1,0 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-	<servers>
-		<server>
-			<id>https://bndtools.jfrog.io</id>
-			<username>${env.JFROG_USERNAME}</username>
-			<password>${env.JFROG_PASSWORD}</password>
-		</server>
-	</servers>
-</settings>

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -41,6 +41,4 @@ ossrh:                  https://oss.sonatype.org/content/repositories/snapshots
 -releaserepo: Release
 -releaserepo.jfrog: ${if;${env;CANONICAL};JFrog}
 
--connection-settings.jfrog: ${if;${-releaserepo.jfrog};${.}/jfrog-settings.xml}
-
 -baselinerepo: Baseline


### PR DESCRIPTION
We rely upon the new simple glob support in ConnectionSettings to match
the URLs to the server id in the settings.

