### PR TITLE
better naming for archives as part of a multi zip

### DIFF
--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -244,7 +244,8 @@ public class MavenBndRepoTest {
 		File file2 = repo.get("name.njbartlett.eclipse.macbadge", new Version("1.0.0.201110100042"), null);
 		assertNotNull(file2);
 
-		File file3 = repo.get("group:artifact:jar:1003", Version.parseVersion(multi_version), null);
+		File file3 = repo.get("group:artifact:jar:name_njbartlett_eclipse_macbadge_1_0_0_201110100042",
+			Version.parseVersion(multi_version), null);
 		assertNotNull(file3);
 		assertTrue(file3.isFile());
 


### PR DESCRIPTION
The Maven repo can be configured to download an archive containing jars. These jars will then be added to the repos index. Currently they land in the local m2 repo with generically numbered names like: "groupid-artifactid-1.0.0-bin123.jar" 

When we export a bndrun, we add them with exactly that name. This makes it hard to identify what really is in there and also "looks bad".

Thus we now modify the classierfier to reflect the original jar name instead of the bin123.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>