### PR TITLE
ci: Only run publish step for canonical builds

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -81,6 +81,7 @@ jobs:
         server-password: JFROG_PASSWORD
     - name: Publish
       id: publish
+      if: ${{ matrix.canonical }}
       run: |
         ./.github/scripts/ci-publish.sh
       env:


### PR DESCRIPTION
We save time in the builds for PRs. The rebuild workflow tests the
release function of the built Bnd.
