### PR TITLE
ds: Improve error message for Reference annotation on method parms

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -1060,7 +1060,9 @@ public class DSAnnotationReader extends ClassDataCollector {
 			}
 			case PARAMETER : {
 				if (!"<init>".equals(member.getName())) {
-					analyzer.error("In component '%s', @Reference cannot be used for method parameters", className)
+					analyzer.error(
+						"In component '%s', @Reference can be used on parameters only for constructors; method '%s' is not a constructor",
+						className, member)
 						.details(getDetails(def, ErrorType.REFERENCE));
 					return;
 				}


### PR DESCRIPTION
We now name the method. It appears that some code instrumentation may
be "converting" a constructor to a method and then Bnd is upset. So
we name the member to provide evidence of the conversion.

