### PR TITLE
build: Update build to support using RC builds in next branch

### DIFF
--- a/.github/scripts/rebuild-test.sh
+++ b/.github/scripts/rebuild-test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ev
 ./gradlew --no-daemon --version
-./gradlew --no-daemon -Dmaven.repo.local=dist/m2 -Pbnd_repourl=./dist/bundles --warning-mode=fail :buildscriptDependencies :build :publish "$@"
+./gradlew --no-daemon -Dmaven.repo.local=dist/m2 -Pbnd_snapshots=./dist/bundles --warning-mode=fail :buildscriptDependencies :build :publish "$@"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 /*
  * Master Gradle build script
- *
- * Depends on bndPlugin property set by settings.gradle.
- * and bnd_* values from gradle.properties.
  */
 
 import aQute.lib.io.IO
@@ -123,10 +120,11 @@ subprojects {
 
 tasks.register("buildscriptDependencies") {
 	doLast {
-		println "Java version: ${JavaVersion.current()}"
-		println "Bnd version:  ${About.getBndVersion()}"
-		println "bnd_plugin:   ${bnd_plugin}"
-		println "bnd_repourl:  ${bnd_repourl}"
+		println "Java version:  ${JavaVersion.current()}"
+		println "Bnd version:   ${About.getBndVersion()}"
+		println "bnd_version:   ${bnd_version}"
+		println "bnd_snapshots: ${bnd_snapshots}"
+		println "bnd_releases:  ${bnd_releases}"
 		println buildscript.configurations.classpath.asPath
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,14 @@ org.gradle.jvmargs=-Xms1024m -Xmx2048m
 # cnf project name
 bnd_cnf=cnf
 
-# bnd_plugin is the dependency declaration for the bnd gradle plugin
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:+
+# bnd_version is the version of the Bnd Gradle plugin
+# We use `+` for the master branch to use the latest snapshot.
+# We use a range, e.g. `[6.1.0-RC,6.2)` for the next branch.
+bnd_version=+
 
-# The URL to the repo to load the bnd gradle plugin
-bnd_repourl=https://bndtools.jfrog.io/bndtools/libs-snapshot-local
+# The URLs to the repos for the Bnd Gradle plugin
+bnd_snapshots=https://bndtools.jfrog.io/bndtools/libs-snapshot-local
+bnd_releases=https://bndtools.jfrog.io/bndtools/libs-release-local
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=dist

--- a/rebuild-with-local-plugin
+++ b/rebuild-with-local-plugin
@@ -16,4 +16,4 @@ if [ -z "$ARGS" ]; then
 fi
 set -ev
 
-$REPO/gradlew --no-daemon -Pbnd_repourl=$REPO/dist/bundles $ARGS
+$REPO/gradlew --no-daemon -Pbnd_snapshots=$REPO/dist/bundles $ARGS

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,10 +7,15 @@ import aQute.bnd.osgi.Constants
 /* Add bnd gradle plugin as a script dependency */
 buildscript {
 	repositories {
-		mavenCentral()
 		maven {
-			url = uri(bnd_repourl)
+			name = "Bnd Snapshots"
+			url = uri(bnd_snapshots)
 		}
+		maven {
+			name = "Bnd Releases"
+			url = uri(bnd_releases)
+		}
+		mavenCentral()
 	}
 	var bndConfiguration = configurations.create("bnd") {
 		/* Since the files in the repository change with each build, we need to recheck for changes */
@@ -21,7 +26,13 @@ buildscript {
 	}
 	configurations.classpath.extendsFrom(bndConfiguration)
 	dependencies {
-		bnd(bnd_plugin)
+		bnd("biz.aQute.bnd:biz.aQute.bnd.gradle") {
+			version {
+				require bnd_version
+				// Prefer RC over SNAPSHOT for next branch
+				prefer "latest.release" 
+			}
+		}
 		components {
 			all { ComponentMetadataDetails details ->
 				if ((details.id.group == "biz.aQute.bnd") || (details.id.group == "biz.aQute.bnd.workspace")) {


### PR DESCRIPTION
Previously, the next branch just uses the final snapshot before RC
builds start.

