### PR TITLE
transitive=false will now look in the first level of pom revisions

### DIFF
--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -92,6 +92,21 @@ public class PomRepositoryTest {
 	}
 
 	@Test
+	public void testPomIndexNoTransitive() throws Exception {
+		MavenRepository mr = getRepo();
+
+		Revision revision = Program.valueOf("org.osgi.enroute", "enterprise-api")
+			.version("7.0.0");
+
+		HttpClient client = new HttpClient();
+		Traverser t = new Traverser(mr, client, false, false).revision(revision);
+		Map<Archive, Resource> value = t.getResources()
+			.getValue();
+		assertEquals(3, value.size());
+		assertAllBndCap(value);
+	}
+
+	@Test
 	public void testPomNotTransitive() throws Exception {
 		MavenRepository mr = getRepo();
 


### PR DESCRIPTION
If e.g. a revision points to a pom file and transitive was false, the repo
didn't even acknowledge dependencies in this pom file, which beats the
purpose of the PomRepository all together. It will now use this
dependencies but will not go further.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>