### PR TITLE
include: Fix documentation regarding overwriting properties

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/IncludeHeaderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/IncludeHeaderTest.java
@@ -3,16 +3,16 @@ package test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
 import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.lib.io.IO;
 
-@SuppressWarnings("resource")
 public class IncludeHeaderTest {
 
 	/**
@@ -20,14 +20,15 @@ public class IncludeHeaderTest {
 	 */
 	@Test
 	public void testUrlIncludes() throws IOException {
-		Analyzer a = new Analyzer();
-		Properties p = new Properties();
-		p.setProperty("a", "1");
-		p.setProperty("-include", "file:test/test/includeheadertest.prop");
-		a.setProperties(p);
-		assertEquals("1", a.getProperty("a"));
-		assertEquals("end", a.getProperty("last-props"));
-		assertEquals("abcd", a.getProperty("props"));
+		try (Analyzer a = new Analyzer()) {
+			Properties p = new Properties();
+			p.setProperty("a", "1");
+			p.setProperty("-include", "file:test/test/includeheadertest.prop");
+			a.setProperties(p);
+			assertEquals("1", a.getProperty("a"));
+			assertEquals("end", a.getProperty("last-props"));
+			assertEquals("abcd", a.getProperty("props"));
+		}
 	}
 
 	/**
@@ -35,13 +36,14 @@ public class IncludeHeaderTest {
 	 */
 	@Test
 	public void testUrlIncludes2() throws IOException {
-		Analyzer a = new Analyzer();
-		Properties p = new Properties();
-		p.setProperty("a", "1");
-		p.setProperty("-include", "jar:file:jar/osgi.jar/!/META-INF/MANIFEST.MF");
-		a.setProperties(p);
-		assertEquals("1", a.getProperty("a"));
-		assertEquals("osgi", a.getProperty("Bundle-SymbolicName"));
+		try (Analyzer a = new Analyzer()) {
+			Properties p = new Properties();
+			p.setProperty("a", "1");
+			p.setProperty("-include", "jar:file:jar/osgi.jar/!/META-INF/MANIFEST.MF");
+			a.setProperties(p);
+			assertEquals("1", a.getProperty("a"));
+			assertEquals("osgi", a.getProperty("Bundle-SymbolicName"));
+		}
 	}
 
 	// public void testMavenInclude() throws Exception {
@@ -68,90 +70,81 @@ public class IncludeHeaderTest {
 
 	@Test
 	public void testTopBottom() throws Exception {
-		Analyzer analyzer = new Analyzer();
-		analyzer.setProperties(IO.getFile("test/test/include.bnd/top.bnd"));
-		assertEquals("0.0.257", analyzer.getProperty("Bundle-Version"));
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setProperties(IO.getFile("test/test/include.bnd/top.bnd"));
+			assertEquals("0.0.257", analyzer.getProperty("Bundle-Version"));
+		}
 	}
 
 	@Test
-	public void testPrecedence() throws Exception {
-		File base = IO.getFile("test/test");
-		String a = "a=a.props\n";
-		String b = "a=b.props\n";
-		File aa = new File(base, "a.props");
-		File bb = new File(base, "b.props");
-		write(aa, a);
-		write(bb, b);
+	public void testPrecedence(@InjectTemporaryDirectory
+	File tmp) throws Exception {
+		IO.store("a=a.props\n", new File(tmp, "a.props"));
+		IO.store("a=b.props\n", new File(tmp, "b.props"));
 
-		Analyzer analyzer = new Analyzer();
-		analyzer.setBase(base);
-		Properties x = new Properties();
-		x.put("a", "x");
-		x.put("-include", "a.props, b.props");
-		analyzer.setProperties(x);
-		assertEquals("b.props", analyzer.getProperty("a")); // from org
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(tmp);
+			Properties x = new Properties();
+			x.put("a", "x");
+			x.put("-include", "a.props, b.props");
+			analyzer.setProperties(x);
+			assertEquals("b.props", analyzer.getProperty("a")); // from org
+		}
 
-		analyzer = new Analyzer();
-		analyzer.setBase(base);
-		x = new Properties();
-		x.put("a", "x");
-		x.put("-include", "~a.props, b.props");
-		analyzer.setProperties(x);
-		assertEquals("b.props", analyzer.getProperty("a")); // from org
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(tmp);
+			Properties x = new Properties();
+			x.put("a", "x");
+			x.put("-include", "~a.props, b.props");
+			analyzer.setProperties(x);
+			assertEquals("b.props", analyzer.getProperty("a")); // from org
+		}
 
-		analyzer = new Analyzer();
-		analyzer.setBase(base);
-		x = new Properties();
-		x.put("a", "x");
-		x.put("-include", "a.props, ~b.props");
-		analyzer.setProperties(x);
-		assertEquals("a.props", analyzer.getProperty("a")); // from org
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(tmp);
+			Properties x = new Properties();
+			x.put("a", "x");
+			x.put("-include", "a.props, ~b.props");
+			analyzer.setProperties(x);
+			assertEquals("a.props", analyzer.getProperty("a")); // from org
+		}
 
-		analyzer = new Analyzer();
-		analyzer.setBase(base);
-		x = new Properties();
-		x.put("a", "x");
-		x.put("-include", "~a.props, ~b.props");
-		analyzer.setProperties(x);
-		assertEquals("x", analyzer.getProperty("a")); // from org
-
-		aa.delete();
-		bb.delete();
-	}
-
-	private static void write(File file, String b) throws Exception {
-		FileOutputStream out = new FileOutputStream(file);
-		out.write(b.getBytes());
-		out.close();
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(tmp);
+			Properties x = new Properties();
+			x.put("a", "x");
+			x.put("-include", "~a.props, ~b.props");
+			analyzer.setProperties(x);
+			assertEquals("x", analyzer.getProperty("a")); // from org
+		}
 	}
 
 	@Test
 	public void testAbsentIncludes() throws IOException {
-		Analyzer analyzer = new Analyzer();
-		analyzer.setBase(IO.getFile("test/test"));
-		Properties p = new Properties();
-		p.put("-include", "-iamnotthere.txt");
-		analyzer.setProperties(p);
-		System.err.println(analyzer.getErrors());
-		assertEquals(0, analyzer.getErrors()
-			.size());
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(IO.getFile("test/test"));
+			Properties p = new Properties();
+			p.put("-include", "-iamnotthere.txt");
+			analyzer.setProperties(p);
+			System.err.println(analyzer.getErrors());
+			assertEquals(0, analyzer.getErrors()
+				.size());
+		}
 	}
 
 	@Test
-	public void testIncludeWithProperty() throws IOException {
-		File home = new File(System.getProperty("user.home"));
-		File include = new File(home, "includeheadertest.txt");
-		try {
-			FileOutputStream fw = new FileOutputStream(include);
-			fw.write("IncludeHeaderTest: yes\n\r".getBytes());
-			fw.write("a: 2\n\r".getBytes());
-			fw.write("b: ${a}\n\r".getBytes());
-			fw.close();
-			Analyzer analyzer = new Analyzer();
-			analyzer.setBase(IO.getFile("test/test"));
+	public void testIncludeWithProperty(@InjectTemporaryDirectory
+		File tmp) throws IOException {
+		IO.store("IncludeHeaderTest: yes\n\r" + //
+			"a: 2\n\r" + //
+			"b: ${a}\n\r", new File(tmp, "includeheadertest.txt"));
+		try (Processor parent = new Processor();
+			Analyzer analyzer = new Analyzer(parent)) {
+			parent.setProperty("home", tmp.getAbsolutePath());
+			analyzer.setBase(tmp);
 			Properties p = new Properties();
 			p.put("a", "1");
-			p.put("-include", "-iamnotthere.txt, ${user.home}/includeheadertest.txt");
+			p.put("-include", "-iamnotthere.txt, ${home}/includeheadertest.txt");
 			analyzer.setProperties(p);
 			String value = analyzer.getProperty("IncludeHeaderTest");
 			assertEquals("yes", value);
@@ -159,26 +152,25 @@ public class IncludeHeaderTest {
 			assertEquals("2", analyzer.getProperty("b"));
 			assertEquals(0, analyzer.getErrors()
 				.size());
-		} finally {
-			include.delete();
 		}
 	}
 
 	@Test
 	public void testIncludeHeader() throws IOException {
-		Analyzer analyzer = new Analyzer();
-		analyzer.setBase(IO.getFile("test/test"));
-		Properties p = new Properties();
-		p.put("a", "1");
-		p.put("-include", "includeheadertest.mf, includeheadertest.prop");
-		analyzer.setProperties(p);
-		System.err.println(analyzer.getProperties());
-		assertEquals("1", analyzer.getProperty("a"));
-		assertEquals("end", analyzer.getProperty("last-props"));
-		assertEquals("end", analyzer.getProperty("last-manifest"));
-		assertEquals("abcd", analyzer.getProperty("manifest"));
-		assertEquals("abcd", analyzer.getProperty("props"));
-		assertEquals("1", analyzer.getProperty("test"));
+		try (Analyzer analyzer = new Analyzer()) {
+			analyzer.setBase(IO.getFile("test/test"));
+			Properties p = new Properties();
+			p.put("a", "1");
+			p.put("-include", "includeheadertest.mf, includeheadertest.prop");
+			analyzer.setProperties(p);
+			System.err.println(analyzer.getProperties());
+			assertEquals("1", analyzer.getProperty("a"));
+			assertEquals("end", analyzer.getProperty("last-props"));
+			assertEquals("end", analyzer.getProperty("last-manifest"));
+			assertEquals("abcd", analyzer.getProperty("manifest"));
+			assertEquals("abcd", analyzer.getProperty("props"));
+			assertEquals("1", analyzer.getProperty("test"));
+		}
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -794,11 +794,11 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		return getProperties().getProperty(key);
 	}
 
-	public void mergeProperties(File file, boolean override) {
+	public void mergeProperties(File file, boolean overwrite) {
 		if (file.isFile()) {
 			try {
 				Properties properties = loadProperties(file);
-				mergeProperties(properties, override);
+				mergeProperties(properties, overwrite);
 			} catch (Exception e) {
 				error("Error loading properties file: %s", file);
 			}
@@ -810,10 +810,10 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		}
 	}
 
-	public void mergeProperties(Properties properties, boolean override) {
+	public void mergeProperties(Properties properties, boolean overwrite) {
 		for (String key : Iterables.iterable(properties.propertyNames(), String.class::cast)) {
 			String value = properties.getProperty(key);
-			if (override || !getProperties().containsKey(key))
+			if (overwrite || !getProperties().containsKey(key))
 				setProperty(key, value);
 		}
 	}
@@ -879,7 +879,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 						value = value.substring(1)
 							.trim();
 					} else if (value.startsWith("~")) {
-						// Overwrite properties!
+						// Don't overwrite properties!
 						overwrite = false;
 						value = value.substring(1)
 							.trim();
@@ -958,7 +958,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			sub = loadProperties(file);
 
 		doIncludes(file.getParentFile(), sub);
-		// make sure we do not override properties
+		// take care regarding overwriting properties
 		for (Map.Entry<?, ?> entry : sub.entrySet()) {
 			String key = (String) entry.getKey();
 			String value = (String) entry.getValue();
@@ -1382,7 +1382,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	/**
-	 * Add or override a new property.
+	 * Add or overwrite a new property.
 	 *
 	 * @param key
 	 * @param value
@@ -2231,7 +2231,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 				return fl;
 
 			// Get the includes (actually should parse the header
-			// to see if they override or only provide defaults?
+			// to see if they overwrite or only provide defaults?
 
 			for (Iterator<File> iter = new ArrayDeque<>(getIncluded()).descendingIterator(); iter.hasNext();) {
 				File file = iter.next();

--- a/docs/_instructions/include.md
+++ b/docs/_instructions/include.md
@@ -11,20 +11,32 @@ You can use `-include` as follows:
 
 This will read the path or url as a properties or manifest file (if it ends in `.MF`). 
 
-It is important to realize that the include is not handled by the parser. That is, it is not a normal text include. The properties parser will read all properties in one go and then the Properties object is inspected for the `-include` instruction. The paths or URLs in the `-include` instruction one by one in order. By default, the read properties do not override the properties that were set in the same file as the `-include` instruction. If a property is already defined and not set to be overwritten (see below), the property will get a namespace assigned. The namespace will be derived from the filename or the last segment of the URL.
+It is important to realize that the include is not handled by the parser.
+That is, it is not a normal text include.
+The properties parser will read all properties in one go and then the Properties object is inspected for the `-include` instruction.
+The paths or URLs in the `-include` instruction are processed one by one in order.
+By default, the properties in the included file overwrite the properties that were set in the same file as the `-include` instruction.
+If a property is already defined and not set to be overwritten (see below), the property will get a namespace assigned.
+The namespace will be derived from the filename or the last segment of the URL.
 
-The `-include` instruction is processed before anything else in the properties. This means the `-include` instruction cannot use any properties defined in the same properties file to define the include paths. It can use properties already defined by a parent. So a Project's `bnd.bnd` file can have an `-include` instruction use properties defined in the Workspace (`cnf/build.bnd` and `cnf/ext/*.bnd`). For the Workspace, `cnf/build.bnd`, `-include` instruction can only use the default properties of Bnd. The Workspace `cnf/ext/*.bnd` files are processed _after_ `cnf/build.bnd`. So `cnf/ext/*.bnd` files can have `-include` instructions which use properties set in `cnf/build.bnd`.
+The `-include` instruction is processed before anything else in the properties.
+This means the `-include` instruction cannot use any properties defined in the same properties file to define the include paths.
+It can use properties already defined by a parent.
+So a Project's `bnd.bnd` file can have an `-include` instruction use properties defined in the Workspace (`cnf/build.bnd` and `cnf/ext/*.bnd`).
+For the Workspace, `cnf/build.bnd`, `-include` instruction can only use the default properties of Bnd.
+The Workspace `cnf/ext/*.bnd` files are processed _after_ `cnf/build.bnd`.
+So `cnf/ext/*.bnd` files can have `-include` instructions which use properties set in `cnf/build.bnd`.
 
 There are two possible options. The path/URL starts with a:
 
-* `~` – The included properties override the locally set properties.
+* `~` – Included properties do not overwrite any existing properties having the same property names.
 * `-` – If file or URL or path does not exist then do not report an error.
 
 
 ## Examples
 
 	# Read an optional file in the user's home directory
-	-include ${java.home}/.xyz/base.bnd
+	-include ${user.home}/.xyz/base.bnd
 
 	# Read a manifest
 	-include META-INF/MANIFEST.MF
@@ -33,6 +45,8 @@ There are two possible options. The path/URL starts with a:
 	-include http://example.com/foo/bar/setup.bnd
 
 	# Read several
-	
-	-include first.bnd, second.properties, ~third.override
+	-include first.bnd, second.properties
+
+	# Don't overwrite any existing properties
+	-include ~no.overwrite
 


### PR DESCRIPTION
The code has, since at least 2010, defaulted to overwriting properties
in included files. That is, included files, by default, overwrite
properties in the including properties. A test case expects this
behavior.

The documentation however says the default is not to overwrite. Since
the code's behavior dates back at least 12 years, it would not be safe
to change the code to match the documentation as it would be a breaking
behavioral change. So we update the documentation to document the
actual behavior of the code.

