### PR TITLE
Support resolution of bundles with directory layout.

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
@@ -477,6 +477,25 @@ public abstract class Domain implements Iterable<String> {
 	}
 
 	public static Domain domain(File file) throws IOException {
+		// also support directories
+		if (file.isDirectory()) {
+			File manifestFile = new File(file, "META-INF/MANIFEST.MF");
+			if (manifestFile.exists()) {
+				Manifest m = new Manifest();
+				try (InputStream in = IO.stream(manifestFile)) {
+					m.read(in);
+				}
+				Domain domain = domain(m);
+				File localization = new File(file, domain.getLocalization());
+				if (localization.exists()) {
+					try (InputStream in = IO.stream(manifestFile)) {
+						domain.translation.load(in);
+					}
+				}
+				return domain;
+			}
+		}
+
 		if (file.getName()
 			.endsWith(".mf")) {
 			try (InputStream in = IO.stream(file)) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -712,11 +712,12 @@ public class ResourceBuilder {
 		if (manifest != null) {
 			hasIdentity = addManifest(manifest);
 		}
-		String mime = hasIdentity ? MIME_TYPE_BUNDLE : MIME_TYPE_JAR;
-		String sha256 = SHA256.digest(file)
-			.asHex();
-		addContentCapability(uri, sha256, file.length(), mime);
-
+		if (! file.isDirectory()) {
+			String mime = hasIdentity ? MIME_TYPE_BUNDLE : MIME_TYPE_JAR;
+			String sha256 = SHA256.digest(file)
+				.asHex();
+			addContentCapability(uri, sha256, file.length(), mime);
+		}
 		if (hasIdentity) {
 			addHashes(file);
 		}

--- a/biz.aQute.repository/src/aQute/bnd/repository/fileset/FileSetRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/fileset/FileSetRepository.java
@@ -91,9 +91,6 @@ public class FileSetRepository extends BaseRepository implements Plugin, Reposit
 
 	private Promise<Resource> parseFile(File file) {
 		Promise<Resource> resource = promiseFactory.submit(() -> {
-			if (!file.isFile()) {
-				return null;
-			}
 			ResourceBuilder rb = new ResourceBuilder();
 			try {
 				boolean hasIdentity = rb.addFile(file, null);


### PR DESCRIPTION
This is a first attempt to also support the resolution of bundles with directory layout.
The change may be useful to run an OSGi framework with the contents of the `target/classes` folder of a Maven project.
This is already supported by https://github.com/BestSolution-at/maven-osgi-plugin/tree/master/maven-osgi-exec-plugin and saves us from rebuilding jars for (multi-module) Maven projects.
