### PR TITLE
workspace: Utilize workspace ReentrantReadWriteLock for locking

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceLock.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceLock.java
@@ -1,0 +1,139 @@
+package aQute.bnd.build;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import aQute.lib.strings.Strings;
+
+/**
+ * ReentrantReadWriteLock lock for serializing access to the Workspace.
+ */
+final class WorkspaceLock extends ReentrantReadWriteLock {
+	private static final long	serialVersionUID	= 1L;
+	private static final Logger	logger				= LoggerFactory.getLogger(WorkspaceLock.class);
+	private final AtomicInteger	progress			= new AtomicInteger();
+
+	WorkspaceLock(boolean fair) {
+		super(fair);
+	}
+
+	private String type(Lock lock) {
+		if (lock == readLock()) {
+			return "read";
+		}
+		if (lock == writeLock()) {
+			return "write";
+		}
+		return "unknown_lock";
+	}
+
+	private void trace(String name, Lock lock) {
+		if (logger.isDebugEnabled()) {
+			String trace = Arrays.stream(new Exception().getStackTrace())
+				.skip(3L)
+				.limit(5L)
+				.map(Object::toString)
+				.collect(Strings.joining("\n\tat ", "\n\tat ", "", ""));
+			logger.debug("{} {} @{}[Write locks = {}, Read locks = {}]; owner {}; waiting {}{}", name, type(lock),
+				Integer.toHexString(hashCode()), getWriteHoldCount(), getReadLockCount(), getOwner(),
+				getQueuedThreads(), trace);
+		}
+	}
+
+	private Throwable getOwnerCause() {
+		final Thread owner = getOwner();
+		if (owner == null) {
+			return null;
+		}
+		final Throwable cause = new Throwable(
+			owner + " owns the WorkspaceLock\n\nFull thread dump:\n" + dumpAllThreads() + "Owner stacktrace:");
+		cause.setStackTrace(owner.getStackTrace());
+		return cause;
+	}
+
+	private String dumpAllThreads() {
+		ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+		return Arrays
+			.stream(threadMXBean.dumpAllThreads(threadMXBean.isObjectMonitorUsageSupported(),
+				threadMXBean.isSynchronizerUsageSupported()))
+			.map(Object::toString)
+			.collect(Collectors.joining());
+	}
+
+	private CancellationException canceled(Lock lock) {
+		CancellationException e = new CancellationException(
+			String.format("Canceled waiting to %s acquire %s; owner %s; waiting %s", type(lock), this, getOwner(),
+				getQueuedThreads()));
+		e.initCause(getOwnerCause());
+		return e;
+	}
+
+	private TimeoutException timeout(Lock lock) {
+		TimeoutException e = new TimeoutException(
+			String.format("Timeout waiting to %s acquire %s; owner %s; waiting %s", type(lock), this, getOwner(),
+				getQueuedThreads()));
+		e.initCause(getOwnerCause());
+		return e;
+	}
+
+	<T> T locked(final Lock lock, final long timeoutInMs, final Callable<T> callable, final BooleanSupplier canceled)
+		throws Exception {
+		boolean interrupted = Thread.interrupted();
+		trace("Enter", lock);
+		try {
+			int startingProgress = progress.get();
+			long remaining = timeoutInMs;
+			do {
+				if (canceled.getAsBoolean()) {
+					throw canceled(lock);
+				}
+				long wait = Math.min(remaining, 1_000L); // max is 1s
+				long start = System.nanoTime();
+				boolean locked;
+				try {
+					locked = lock.tryLock(wait, TimeUnit.MILLISECONDS);
+				} catch (InterruptedException e) {
+					interrupted = true;
+					throw e;
+				}
+				if (locked) {
+					try {
+						return callable.call();
+					} finally {
+						progress.incrementAndGet();
+						lock.unlock();
+					}
+				}
+				int currentProgress = progress.get();
+				if (startingProgress == currentProgress) {
+					long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+					remaining -= elapsed;
+					trace("Busy with no progress", lock);
+				} else {
+					startingProgress = currentProgress;
+					trace("Busy but progressing", lock);
+				}
+			} while (remaining > 0L);
+			throw timeout(lock);
+		} finally {
+			trace("Exit", lock);
+			if (interrupted) {
+				Thread.currentThread()
+					.interrupt();
+			}
+		}
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("4.1.0")
+@Version("4.2.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/remoteworkspace/server/RemoteWorkspaceServer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/remoteworkspace/server/RemoteWorkspaceServer.java
@@ -76,13 +76,7 @@ public class RemoteWorkspaceServer implements Closeable {
 		ServerSocket server = new ServerSocket(0, 10, InetAddress.getLoopbackAddress());
 
 		RemoteWorkspace workspaceLocker = Aspects.intercept(RemoteWorkspace.class, new Instance())
-			.around((inv, c) -> workspace.readLocked(() -> {
-				try {
-					return c.call();
-				} catch (Throwable e) {
-					throw Exceptions.duck(e);
-				}
-			}))
+			.around((inv, c) -> workspace.readLocked(c))
 			.build();
 
 		this.server = Link.server("remotews", RemoteWorkspaceClient.class, server, l -> workspaceLocker, true,

--- a/bndtools.builder/src/org/bndtools/builder/BndSourceGenerateCompilationParticipant.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndSourceGenerateCompilationParticipant.java
@@ -55,7 +55,7 @@ public class BndSourceGenerateCompilationParticipant extends CompilationParticip
 
 			Processor processor = new Processor();
 
-			Central.bndCall(after -> {
+			Central.bndCall(workspace::readLocked, after -> {
 				Project model = workspace.getProject(project.getName());
 				if (model != null) {
 
@@ -89,7 +89,7 @@ public class BndSourceGenerateCompilationParticipant extends CompilationParticip
 					});
 				}
 				return null;
-			});
+			}, null);
 		} catch (Exception e) {
 			logger.logError("generating phase, aboutToBuild", e);
 		}

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -161,8 +161,8 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 
 			try {
 				markers.deleteMarkers(BndtoolsConstants.MARKER_BND_BLOCKER);
-
-				Central.bndCall(after -> {
+				Workspace ws = model.getWorkspace();
+				Central.bndCall(ws::readLocked, after -> {
 					if (!model.isValid()) {
 						after.accept("Not a valid project" + model, () -> {
 							markers.createMarker(null, IMarker.SEVERITY_ERROR, "Not a valid bnd project",
@@ -355,10 +355,11 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 				return;
 
 			try {
-				Central.bndCall(after -> {
+				Workspace ws = model.getWorkspace();
+				ws.readLocked(() -> {
 					model.clean();
 					return null;
-				}, monitor);
+				}, monitor::isCanceled);
 			} catch (TimeoutException | InterruptedException e) {
 				logger.logWarning("Unable to clean project " + myProject.getName(), e);
 				return;

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
@@ -26,7 +26,7 @@ public class BndtoolsDynamicReferenceProvider implements IDynamicReferenceProvid
 			IProject project = buildConfiguration.getProject();
 			Workspace ws = Central.getWorkspace();
 			if (!ws.isDefaultWorkspace()) {
-				return Central.bndCall(after -> getDependencies(project, ws));
+				return ws.readLocked(() -> getDependencies(project, ws));
 			}
 			return Collections.emptyList();
 		} catch (Exception e) {

--- a/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
+++ b/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
@@ -70,24 +70,24 @@ public class CnfWatcher implements IResourceChangeListener {
 				.next();
 			DeltaWrapper dw = new DeltaWrapper(p, delta, new BuildLogger(BuildLogger.LOG_NONE, "", 0));
 			if (dw.hasCnfChanged()) {
-				workspace.clear();
-				workspace.forceRefresh();
-				workspace.getPlugins();
-
-				BndtoolsBuilder.dirty.addAll(allProjects);
-
-				WorkspaceJob j = new WorkspaceJob("Update errors on workspace") {
+				WorkspaceJob j = new WorkspaceJob("Refreshing workspace for cnf change") {
 					@Override
 					public IStatus runInWorkspace(IProgressMonitor arg0) throws CoreException {
 						try {
+							workspace.clear();
+							workspace.refresh();
+							workspace.getPlugins();
+
+							BndtoolsBuilder.dirty.addAll(allProjects);
 							MarkerSupport ms = new MarkerSupport(cnfProject);
 							ms.deleteMarkers("*");
 							ms.setMarkers(workspace, BndtoolsConstants.MARKER_BND_WORKSPACE_PROBLEM);
-							return Status.OK_STATUS;
 						} catch (Exception e) {
-							return new Status(IStatus.ERROR, BndtoolsBuilder.PLUGIN_ID, "updating errors for workspace",
+							return new Status(IStatus.ERROR, BndtoolsBuilder.PLUGIN_ID,
+								"error during workspace refresh",
 								e);
 						}
+						return Status.OK_STATUS;
 					}
 				};
 				j.schedule();

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -243,7 +243,8 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 			}
 
 			try {
-				Central.bndCall(after -> calculateProjectClasspath());
+				model.getWorkspace()
+					.readLocked(this::calculateProjectClasspath);
 			} catch (Exception e) {
 				SetLocation error = error("Unable to calculate classpath for project %s", e, project.getName());
 				logger.logError(error.location().message, e);

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerSourceManager.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerSourceManager.java
@@ -93,10 +93,10 @@ public class BndContainerSourceManager {
 			return classPathEntries;
 		}
 
+		final List<RepositoryPlugin> repositories = RepositoryUtils.listRepositories(true);
 		final Properties props = loadSourceAttachmentProperties(project);
 
 		final List<IClasspathEntry> configuredClassPathEntries = new ArrayList<>(classPathEntries.size());
-
 		for (final IClasspathEntry entry : classPathEntries) {
 			if (entry.getEntryKind() != IClasspathEntry.CPE_LIBRARY || entry.getSourceAttachmentPath() != null) {
 				configuredClassPathEntries.add(entry);
@@ -124,7 +124,7 @@ public class BndContainerSourceManager {
 					extraProps.put(attr.getName(), attr.getValue());
 				}
 
-				File sourceBundle = getSourceBundle(entry.getPath(), extraProps);
+				File sourceBundle = getSourceBundle(entry.getPath(), extraProps, repositories);
 				if (sourceBundle != null) {
 					srcPath = new Path(sourceBundle.getAbsolutePath());
 				}
@@ -141,7 +141,7 @@ public class BndContainerSourceManager {
 		return configuredClassPathEntries;
 	}
 
-	private static File getSourceBundle(IPath path, Map<String, String> props) {
+	private static File getSourceBundle(IPath path, Map<String, String> props, List<RepositoryPlugin> repositories) {
 		if (Central.getWorkspaceIfPresent() == null) {
 			return null;
 		}
@@ -172,7 +172,7 @@ public class BndContainerSourceManager {
 				version = props.get("version");
 			}
 
-			for (RepositoryPlugin repo : RepositoryUtils.listRepositories(true)) {
+			for (RepositoryPlugin repo : repositories) {
 				if (repo == null) {
 					continue;
 				}

--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/AddBundleCompletionProposal.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/AddBundleCompletionProposal.java
@@ -20,6 +20,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 
 import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.osgi.BundleId;
@@ -99,7 +100,8 @@ class AddBundleCompletionProposal extends WorkspaceJob implements IJavaCompletio
 	@Override
 	public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 		try {
-			IStatus status = Central.bndCall(after -> {
+			Workspace ws = project.getWorkspace();
+			IStatus status = ws.readLocked(() -> {
 
 				BndEditModel model = new BndEditModel(project);
 				model.load();
@@ -120,7 +122,7 @@ class AddBundleCompletionProposal extends WorkspaceJob implements IJavaCompletio
 				Central.refreshFile(project.getPropertiesFile());
 				return Status.OK_STATUS;
 
-			}, monitor);
+			}, monitor::isCanceled);
 
 			classes.entrySet()
 				.stream()

--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -143,7 +143,7 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 				}
 				// We must safely call bnd to list workspace repo
 				try {
-					Central.bndCall(after -> workspaceRepo.list(null), monitor);
+					ws.readLocked(() -> workspaceRepo.list(null), monitor::isCanceled);
 				} catch (TimeoutException | InterruptedException e) {
 					return new Status(IStatus.ERROR, Plugin.PLUGIN_ID,
 						"Unable to acquire lock to refresh repository " + repo.getName(), e);

--- a/bndtools.core/src/bndtools/central/RepositoryUtils.java
+++ b/bndtools.core/src/bndtools/central/RepositoryUtils.java
@@ -47,7 +47,7 @@ public class RepositoryUtils {
 
 	public static List<RepositoryPlugin> listRepositories(final Workspace localWorkspace, final boolean hideCache) {
 		try {
-			return Central.bndCall(after -> {
+			return localWorkspace.readLocked(() -> {
 				List<RepositoryPlugin> plugins = localWorkspace.getPlugins(RepositoryPlugin.class);
 				plugins.addAll(getAdditionalPlugins());
 				List<RepositoryPlugin> repos = new ArrayList<>(plugins.size() + 1);

--- a/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
+++ b/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
@@ -109,7 +109,7 @@ public class SynchronizeWorkspaceWithEclipse {
 					List<Project> createProjects = new ArrayList<>(100);
 					List<IProject> removeProjects = new ArrayList<>(100);
 
-					Central.bndCall(after -> {
+					workspace.writeLocked(() -> {
 						Collection<Project> allProjects = workspace.getAllProjects();
 						// Step 2: look for projects to add/update
 						SubMonitor loopMonitor = subMonitor.split(1)
@@ -141,7 +141,7 @@ public class SynchronizeWorkspaceWithEclipse {
 							removeProjects.add(project);
 						}
 						return null;
-					});
+					}, subMonitor::isCanceled);
 
 					// Step 4: add/refresh projects that were found
 					SubMonitor loopMonitor = subMonitor.split(1)

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
@@ -104,7 +104,7 @@ public class WorkspaceSynchronizer {
 				createProject(ws.getFile(Workspace.CNFDIR), null, subMonitor.split(1));
 			}
 
-			List<String> models = Central.bndCall(after -> {
+			List<String> models = ws.writeLocked(() -> {
 				ws.refreshProjects();
 				ws.forceRefresh();
 				return ws.getBuildOrder()
@@ -112,8 +112,7 @@ public class WorkspaceSynchronizer {
 					.filter(Project::isValid)
 					.map(Project::getName)
 					.collect(Collectors.toList());
-
-			}, monitor);
+			}, monitor::isCanceled);
 
 			projects.remove(Workspace.CNFDIR);
 			models.remove(Workspace.CNFDIR);


### PR DESCRIPTION
We replace the use of Bndtools' bndLock with the Workspace's
ReentrantReadWriteLock. This allows us to use read locking in most
places and write locking only when necessary.
