### PR TITLE
Parent plugin provider

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -3199,7 +3199,7 @@ public class bnd extends Processor {
 			filter = new Glob("*");
 		List<Actionable> actionables = project.getPlugins(Actionable.class);
 		if (actionables.isEmpty()) {
-			error("No actionables in [%s]", project.getPlugins());
+			error("No actionables in [%s]", project.getPlugins(Object.class));
 			return;
 		}
 		for (Actionable o : actionables) {
@@ -3600,7 +3600,7 @@ public class bnd extends Processor {
 		}
 
 		int n = 0;
-		for (Object o : ws.getPlugins()) {
+		for (Object o : ws.getPlugins(Object.class)) {
 			String s = o.toString();
 			if (s.trim()
 				.length() == 0)

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -459,9 +459,9 @@ public class Verifier extends Processor {
 					+ " %s is being imported into the bundle rather than being contained inside it. This is usually a bundle packaging error",
 					bactivator), bactivator, ActivatorErrorType.IS_IMPORTED);
 			}
-		} else if (parent != null) {
+		} else if (getParent() != null) {
 			// If we have access to the parent we can do deeper checking
-			String raw = parent.getUnprocessedProperty(BUNDLE_ACTIVATOR, null);
+			String raw = getParent().getUnprocessedProperty(BUNDLE_ACTIVATOR, null);
 			if (raw != null) {
 				// The activator was specified, but nothing showed up.
 				if (raw.isEmpty()) {


### PR DESCRIPTION
Use PluginProvider to access plugins of parent

Instead of copying the parent's plugins into the child's plugins
container, we now use a PluginProvider to access the parent's plugins.
This better handles the case where the parent (e.g. Workspace) is
refreshed but the child is not. Any closeable plugins (like maven
repos) in the parent would linger in the child's plugins container.

Since the child no longer contains the parent's plugin objects,
it always has the correct view onto the parent's plugins.
