### PR TITLE
[validators] Fix marker generation for validators

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -205,9 +205,9 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 						model.prepare();
 
 						Processor processor = new Processor();
+						markers.validate(model);
 						processor.getInfo(model);
 						after.accept("Decorating " + myProject, () -> {
-							markers.validate(model);
 							markers.setMarkers(processor, BndtoolsConstants.MARKER_BND_PATH_PROBLEM);
 						});
 						model.clear();


### PR DESCRIPTION
Ensure that the validators are run on the model before the processor copies them into itself.

Fixes #5006