### PR TITLE
Feature/UI to add bundles

### DIFF
--- a/aQute.libg/src/aQute/libg/dtos/DTOsImpl.java
+++ b/aQute.libg/src/aQute/libg/dtos/DTOsImpl.java
@@ -67,7 +67,7 @@ public class DTOsImpl implements DTOs {
 
 		void verifyCycle(Object o) {
 			if (isCycle(o)) {
-				throw new IllegalArgumentException("Cycle in DTO " + getPath(0));
+				throw new IllegalArgumentException("Cycle in DTO " + Arrays.toString(getPath(0)));
 			}
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceExternalPluginHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceExternalPluginHandler.java
@@ -88,9 +88,10 @@ public class WorkspaceExternalPluginHandler implements AutoCloseable {
 				}
 			}
 		} catch (ClassNotFoundException e) {
-			return Result.err("no such class %s in %s for plugin %s", e.getMessage(), pluginName);
+			return Result.err("no such class %s in %s for plugin %s", c.getName(), e.getMessage(), pluginName);
 		} catch (Exception e) {
-			return Result.err("could not instantiate class %s in %s for plugin %s: %s", e.getMessage(), pluginName,
+			return Result.err("could not instantiate class %s in %s for plugin %s: %s", c.getName(), e.getMessage(),
+				pluginName,
 				Exceptions.causes(e));
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/api/OnWorkspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/api/OnWorkspace.java
@@ -32,7 +32,7 @@ public interface OnWorkspace extends AutoCloseable {
 	/**
 	 * The set of projects has changed for some reason
 	 *
-	 * @param cb the callback, will get the current set of projects
+	 * @param projects the callback, will get the current set of projects
 	 */
 	OnWorkspace projects(Consumer<? super Collection<Project>> projects);
 

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceSynchronizer.java
@@ -1,7 +1,6 @@
 package bndtools.central.sync;
 
 import java.io.File;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -117,8 +116,6 @@ public class WorkspaceSynchronizer {
 			projects.remove(Workspace.CNFDIR);
 			models.remove(Workspace.CNFDIR);
 
-			Set<String> changed = new HashSet<>();
-
 			System.out.println("Projects    " + projects.keySet());
 			System.out.println("Models      " + new TreeSet<>(models));
 			System.out.println("To create   " + new TreeSet<>(Logic.remove(models, projects.keySet())));
@@ -132,7 +129,6 @@ public class WorkspaceSynchronizer {
 
 				File dir = ws.getFile(mm);
 				project = createProject(dir, null, subMonitor);
-				changed.add(mm);
 			}
 
 			projects.values()
@@ -162,7 +158,6 @@ public class WorkspaceSynchronizer {
 				IProject project = toBeDeleted.getValue();
 				System.out.println("deleting " + toBeDeleted);
 				project.delete(true, subMonitor);
-				changed.add(toBeDeleted.getKey());
 			}
 
 			if (refresh && monitor != null) {


### PR DESCRIPTION
If you searched for a bundle in the bndeditor/build tab
then it would not list any matches that were already
added to the build path. This could give the false
impression that the bundle was not in the list,
this confusion caused #4858

This patch will always list any matching bundles.
However, it will filter any bundles that are already
part of the selected bundles. The addButton is
also only enabled if there is at least 1 bundle
selected in the available list that is not in the
selected list.

Was https://github.com/bndtools/bnd/commit/62926c53990f7f5c976acb45bb3b473e59ccec6e on 
[#4929]

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>