### PR TITLE
build: Bump logback-classic

### DIFF
--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -56,8 +56,8 @@ org.apache.felix:org.apache.felix.scr:2.1.12
 org.apache.felix:org.apache.felix.inventory:1.0.6
 org.apache.felix:org.apache.felix.logback:1.0.6
 
-ch.qos.logback:logback-classic:1.2.8
-ch.qos.logback:logback-core:1.2.8
+ch.qos.logback:logback-classic:1.2.9
+ch.qos.logback:logback-core:1.2.9
 
 org.apache.geronimo.specs:geronimo-atinject_1.0_spec:1.1
 org.apache.geronimo.specs:geronimo-interceptor_1.2_spec:1.1


### PR DESCRIPTION
Bumps logback-classic from 1.2.8 to 1.2.9.

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic
  dependency-type: direct:development
  update-type: version-update:semver-patch
...