### PR TITLE
[baseline] Change in builder cased baseline errors no longer properly…

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BaselineErrorHandler.java
+++ b/bndtools.builder/src/org/bndtools/builder/handlers/baseline/BaselineErrorHandler.java
@@ -42,8 +42,8 @@ import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.IMarkerResolution;
 
-import aQute.bnd.build.Project;
 import aQute.bnd.differ.Baseline.Info;
+import aQute.bnd.osgi.Processor;
 import aQute.bnd.properties.IRegion;
 import aQute.bnd.properties.LineType;
 import aQute.bnd.properties.PropertiesLineReader;
@@ -71,7 +71,7 @@ public class BaselineErrorHandler extends AbstractBuildErrorDetailsHandler {
 	private static final ILogger	logger						= Logger.getLogger(BaselineErrorHandler.class);
 
 	@Override
-	public List<MarkerData> generateMarkerData(IProject project, Project model, Location location) throws Exception {
+	public List<MarkerData> generateMarkerData(IProject project, Processor model, Location location) throws Exception {
 		List<MarkerData> result = new LinkedList<>();
 
 		Info baselineInfo = (Info) location.details;

--- a/bndtools.core/src/org/bndtools/build/api/AbstractBuildErrorDetailsHandler.java
+++ b/bndtools.core/src/org/bndtools/build/api/AbstractBuildErrorDetailsHandler.java
@@ -34,6 +34,8 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.IMarkerResolution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Project;
 import aQute.bnd.osgi.Processor;
@@ -41,7 +43,8 @@ import aQute.bnd.unmodifiable.Maps;
 import aQute.service.reporter.Report.Location;
 
 public abstract class AbstractBuildErrorDetailsHandler implements BuildErrorDetailsHandler {
-
+	final static Logger						logger						= LoggerFactory
+		.getLogger(AbstractBuildErrorDetailsHandler.class);
 	private static final Map<Code, String> PRIMITIVES_TO_SIGNATURES = Maps.of(PrimitiveType.VOID, "V",
 		PrimitiveType.BOOLEAN, "Z", PrimitiveType.BYTE, "B", PrimitiveType.SHORT, "S", PrimitiveType.CHAR, "C",
 		PrimitiveType.INT, "I", PrimitiveType.FLOAT, "F", PrimitiveType.LONG, "J", PrimitiveType.DOUBLE, "D");
@@ -375,16 +378,16 @@ public abstract class AbstractBuildErrorDetailsHandler implements BuildErrorDeta
 	 * can have Builder, Workspace, Project. etc. If it is a project, we defer
 	 * to the old method. Otherwise we allow others to override this method.
 	 */
+	@SuppressWarnings("deprecation")
 	@Override
 	public List<MarkerData> generateMarkerData(IProject project, Processor model, Location location) throws Exception {
-		if (model instanceof Project)
+		if (model instanceof Project) {
+			logger.warn(
+				"error details handler implements a deprecated method, please replace with generateMarkerData(...Processor...)");
 			return generateMarkerData(project, (Project) model, location);
+		}
 
-		return Collections.emptyList();
-	}
-
-	@Override
-	public List<MarkerData> generateMarkerData(IProject project, Project model, Location location) throws Exception {
+		logger.info("generateMarkerData: why not overridden?");
 		return Collections.emptyList();
 	}
 

--- a/bndtools.core/src/org/bndtools/build/api/BuildErrorDetailsHandler.java
+++ b/bndtools.core/src/org/bndtools/build/api/BuildErrorDetailsHandler.java
@@ -20,10 +20,7 @@ import aQute.service.reporter.Report.Location;
  */
 @ProviderType
 public interface BuildErrorDetailsHandler {
-
 	String PROP_HAS_RESOLUTIONS = "bndHasResolutions";
-
-	List<MarkerData> generateMarkerData(IProject project, Project model, Location location) throws Exception;
 
 	/**
 	 * Bridge method to convert a Processor model to a Project model. This is
@@ -43,5 +40,16 @@ public interface BuildErrorDetailsHandler {
 	List<IMarkerResolution> getResolutions(IMarker marker);
 
 	List<ICompletionProposal> getProposals(IMarker marker);
+
+	/**
+	 * Replaced by {@link #generateMarkerData(IProject, Processor, Location)},
+	 * in many cases details are on other processors than Project.
+	 */
+	@Deprecated
+	default List<MarkerData> generateMarkerData(IProject project, Project model, Location location) throws Exception {
+		// this is impossible to happen since old code overrides this method.
+		throw new UnsupportedOperationException(
+			"error details handler implements a deprecated method, please replace with generateMarkerData(...Processor...)");
+	}
 
 }


### PR DESCRIPTION
… reported

The recent builder changes passed a Processor to the marker handling instead
of a Project. This was the proper current API. However, the base class
had a bridge method to the original method that took a Project. 

The BaselineErrorHandler therefore implemented the Project method although
it did not require a Project. The bridge method therefore failed silently.

I've deprecated the old method and added a warning to the log if the
old method is still used. The only implementation of it is in the
BaselineErrorDetailsHandler and it has been properly updated.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>