### PR TITLE
[markers] Markers lost their position

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -687,10 +687,6 @@ public class Project extends Processor {
 							if (isPedantic())
 								warning("Multiple bundles with the same final URL: %s, dropped duplicate", cc);
 						} else {
-							if (cc.getError() != null) {
-								error("Cannot find %s", cc).context(bsn)
-									.header(source);
-							}
 							result.add(cc);
 						}
 					}

--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsBuilder.java
@@ -204,7 +204,7 @@ public class BndtoolsBuilder extends IncrementalProjectBuilder {
 						model.setDelayRunDependencies(true);
 						model.prepare();
 
-						Processor processor = new Processor();
+						Processor processor = new Processor(model);
 						markers.validate(model);
 						processor.getInfo(model);
 						after.accept("Decorating " + myProject, () -> {


### PR DESCRIPTION
Originally the error/warning Location was set on the place where
the problem was detected. However, we switched to just
set the header & clause. The Default Error Handler then 
would lookup the header and clause and set the line, start, and
and end attributes.

However, since we delayed the reporting, we gave a processor.
This was a bare processor, so the findHeader had neither
the proper file, nor an inheritance chain, to find the
header clause combination. So all errors ended up at the
top line.

This patch makes the temporary processor that holds
the messages inherit from project.

It also removes an error on a low level routine that reported a missing dependency, this was handled in two places.
Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>