### PR TITLE
FileTree reproducible result

### DIFF
--- a/aQute.libg/src/aQute/lib/io/IO.java
+++ b/aQute.libg/src/aQute/lib/io/IO.java
@@ -140,8 +140,8 @@ public class IO {
 			String[] names = dir.list();
 			if (names != null) {
 				Stream<String> result = StreamSupport
-					.stream(Spliterators.<String> spliterator(names, Spliterator.IMMUTABLE | Spliterator.DISTINCT),
-						false)
+					.stream(Spliterators.<String> spliterator(names,
+						Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.DISTINCT), false)
 					.filter(name -> filter.test(dir, name))
 					.map(fileCollator()::getCollationKey)
 					.sorted()


### PR DESCRIPTION
The FileTree results were sorted using simple Path.compareTo over the complete
Path. This updates the sorting to sort file names using the
IO.fileCollator like we use for sorting in the other IO list methods.
This will remove some file system dependency in the sort order while
providing a depth first traversal like Files.walk.