### PR TITLE
builder: Handle updates to classpath container elements

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
+++ b/bndtools.builder/src/org/bndtools/builder/DeltaWrapper.java
@@ -222,10 +222,10 @@ class DeltaWrapper {
 	}
 
 	/**
-	 * Check if the target JARs have gone. We look for the buildfiles and the
-	 * listed jars. If anything is odd, we rebuild.
+	 * Check if the target JARs have gone or out-of-date. We look for the
+	 * buildfiles and the listed jars. If anything is odd, we rebuild.
 	 */
-	public boolean hasNoTarget(Project model) throws Exception {
+	public boolean hasOutOfDateTarget(Project model, long lastModified) throws Exception {
 
 		//
 		// $/buildfiles must exists
@@ -236,7 +236,7 @@ class DeltaWrapper {
 			return true;
 
 		File file = IO.getFile(model.getTarget(), Constants.BUILDFILES);
-		if (!file.isFile())
+		if (!file.isFile() || (file.lastModified() < lastModified))
 			return true;
 
 		//
@@ -257,7 +257,7 @@ class DeltaWrapper {
 					continue;
 
 				File f = IO.getFile(model.getTarget(), line);
-				if (!f.isFile())
+				if (!f.isFile() || (f.lastModified() < lastModified))
 					return true;
 			}
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainer.java
@@ -64,7 +64,7 @@ public class BndContainer implements IClasspathContainer, Serializable {
 		return getDescription();
 	}
 
-	long lastModified() {
+	public long lastModified() {
 		return lastModified;
 	}
 

--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -141,7 +141,7 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 	 * @param javaProject The java project of interest. Must not be null.
 	 * @return The BndContainer for the java project.
 	 */
-	static IClasspathContainer getClasspathContainer(IJavaProject javaProject) {
+	public static IClasspathContainer getClasspathContainer(IJavaProject javaProject) {
 		return JavaModelManager.getJavaModelManager()
 			.containerGet(javaProject, BndtoolsConstants.BND_CLASSPATH_ID);
 	}


### PR DESCRIPTION
If an upstream classpath container element is updated, the builder
must rebuild the project.

Fixes https://github.com/bndtools/bnd/issues/5025

