### PR TITLE
[issue] Plugins container returned duplicates

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
@@ -236,7 +236,8 @@ public class PluginsContainer extends AbstractSet<Object> implements Set<Object>
 					return ((PluginProvider) plugin).provide(type);
 				}
 				return Stream.empty();
-			});
+			})
+			.distinct();
 	}
 
 	/**


### PR DESCRIPTION
In a sub bundle project, the XML files for components
were generated multiple times. After debugging, I found
that the PluginContainer returned multiple instances
of the same plugin. 

This seems to have been caused by using the PluginProvider
mechanism to get the plugins from the parent. Although
this could be fixed, the easiest (and seemingly safest) 
solution was to just make the stream that returns the 
plugins distinct.

@BJ you might want to take a further look to see if
the logic is causing the traversal of the parent
hierarchy multiple times?



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>