### PR TITLE
Multiple identical plugins in plugins list

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
@@ -236,7 +236,8 @@ public class PluginsContainer extends AbstractSet<Object> implements Set<Object>
 					return ((PluginProvider) plugin).provide(type);
 				}
 				return Stream.empty();
-			});
+			})
+			.distinct();
 	}
 
 	/**

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -56,8 +56,8 @@ org.apache.felix:org.apache.felix.scr:2.1.12
 org.apache.felix:org.apache.felix.inventory:1.0.6
 org.apache.felix:org.apache.felix.logback:1.0.6
 
-ch.qos.logback:logback-classic:1.2.8
-ch.qos.logback:logback-core:1.2.8
+ch.qos.logback:logback-classic:1.2.9
+ch.qos.logback:logback-core:1.2.9
 
 org.apache.geronimo.specs:geronimo-atinject_1.0_spec:1.1
 org.apache.geronimo.specs:geronimo-interceptor_1.2_spec:1.1


### PR DESCRIPTION
In a sub bundle project, the XML files for components
were generated multiple times. After debugging, I found
that the PluginContainer returned multiple instances
of the same plugin.

This seems to have been caused by using the PluginProvider
mechanism to get the plugins from the parent. Although
this could be fixed, the easiest (and seemingly safest)
solution was to just make the stream that returns the
plugins distinct.

@BJ you might want to take a further look to see if
the logic is causing the traversal of the parent
hierarchy multiple times?

Signed-off-by: Peter Kriens Peter.Kriens@aqute.biz