### PR TITLE
PluginsContainer ordering

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
@@ -250,8 +250,7 @@ public class PluginsContainer extends AbstractSet<Object> implements Set<Object>
 
 	@Override
 	public <T> T getPlugin(Class<T> type) {
-		Optional<T> first = stream(type).distinct()
-			.findFirst();
+		Optional<T> first = stream(type).findFirst();
 		return first.orElse(null);
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
@@ -1,4 +1,4 @@
-@Version("5.2.0")
+@Version("5.3.0")
 package aQute.bnd.osgi;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
ParentPluginProvider led to an ordering problem where a plugin from the
parent would be selected over a plugin from the child. This issue
had been present before but ParentPluginProvider did not help.

So we remove ParentPluginProvider and define a PluginsSpliterator
which defines an ordering where the child's plugins are before the
parent's plugins. This also allows us to simplify the stream code
and avoid using flatMaps over a single item stream and using concat
to combine two streams. This is all handled in the spliterator
implementation by walking multiple spliterators in an order.