### PR TITLE
repository: Fix AggregateRepository to return proper results

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/About.java
@@ -265,7 +265,7 @@ public class About {
 		bndInfo = Memoize.supplier(() -> {
 			Properties properties = new UTF8Properties();
 			try {
-				URL url = Analyzer.class.getResource("bnd.info");
+				URL url = About.class.getResource("bnd.info");
 				if (url != null) {
 					try (InputStream in = url.openStream()) {
 						properties.load(in);


### PR DESCRIPTION
If AggregateRepository was constructed with no repositories, then
findProviders would return an empty map which violated the contract
where the returned map must have each input requirement as a key.

We fix so that the returned map now follows the contact.