### PR TITLE
repository: Define util methods for building findProviders maps

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceRepositoryDynamic.java
@@ -1,8 +1,6 @@
 package aQute.bnd.build;
 
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,9 +32,8 @@ class WorkspaceRepositoryDynamic extends BaseRepository implements Repository, W
 			.flatMap(Collection::stream)
 			.collect(toList());
 
-		Map<Requirement, Collection<Capability>> result = requirements.stream()
-			.collect(toMap(identity(), requirement -> findProvider(resources, requirement),
-				ResourceUtils::capabilitiesCombiner));
+		Map<Requirement, Collection<Capability>> result = ResourceUtils.findProviders(requirements,
+			requirement -> findProvider(resources, requirement));
 		return result;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/AggregateRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/AggregateRepository.java
@@ -1,8 +1,6 @@
 package aQute.bnd.osgi.repository;
 
 import static java.util.Collections.singleton;
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,8 +28,8 @@ public class AggregateRepository extends BaseRepository {
 
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-		Map<Requirement, Collection<Capability>> result = requirements.stream()
-			.collect(toMap(identity(), this::findProviders));
+		Map<Requirement, Collection<Capability>> result = ResourceUtils.findProviders(requirements,
+			this::findProviders);
 		return result;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/ResourcesRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/ResourcesRepository.java
@@ -1,8 +1,5 @@
 package aQute.bnd.osgi.repository;
 
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -40,8 +37,7 @@ public class ResourcesRepository extends BaseRepository {
 
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-		return requirements.stream()
-			.collect(toMap(identity(), this::findProvider, ResourceUtils::capabilitiesCombiner));
+		return ResourceUtils.findProviders(requirements, this::findProvider);
 	}
 
 	public List<Capability> findProvider(Requirement requirement) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -4,6 +4,7 @@ import static java.lang.invoke.MethodHandles.publicLookup;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
@@ -746,5 +747,19 @@ public class ResourceUtils {
 		rightCollection.removeAll(leftCollection);
 		leftCollection.addAll(rightCollection);
 		return leftCollection;
+	}
+
+	public static <CAPABILITY extends Capability, COLLECTION extends Collection<CAPABILITY>> Map<Requirement, Collection<Capability>> findProviders(
+		Collection<? extends Requirement> requirements, Function<? super Requirement, COLLECTION> provider) {
+		@SuppressWarnings("unchecked")
+		Map<Requirement, Collection<Capability>> result = (Map<Requirement, Collection<Capability>>) requirements
+			.stream()
+			.collect(toMap(Function.identity(), provider, ResourceUtils::capabilitiesCombiner));
+		return result;
+	}
+
+	public static Map<Requirement, Collection<Capability>> emptyProviders(
+		Collection<? extends Requirement> requirements) {
+		return findProviders(requirements, requirement -> new ArrayList<>());
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/package-info.java
@@ -1,4 +1,4 @@
-@Version("4.0.0")
+@Version("4.1.0")
 package aQute.bnd.osgi.resource;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/AbstractIndexedRepo.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/AbstractIndexedRepo.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,6 +44,7 @@ import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.service.IndexProvider;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.Refreshable;
@@ -423,13 +423,11 @@ public abstract class AbstractIndexedRepo extends BaseRepository
 			throw new RuntimeException(e);
 		}
 
-		Map<Requirement, Collection<Capability>> result = new HashMap<>();
-		for (Requirement requirement : requirements) {
-			List<Capability> matches = new LinkedList<>();
-			result.put(requirement, matches);
-
+		Map<Requirement, Collection<Capability>> result = ResourceUtils.findProviders(requirements, requirement -> {
+			List<Capability> matches = new ArrayList<>();
 			capabilityIndex.appendMatchingCapabilities(requirement, matches);
-		}
+			return matches;
+		});
 		return result;
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/CapabilityIndex.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/CapabilityIndex.java
@@ -44,7 +44,7 @@ public class CapabilityIndex {
 		}
 	}
 
-	public void appendMatchingCapabilities(Requirement requirement, Collection<? super Capability> capabilities) {
+	public void appendMatchingCapabilities(Requirement requirement, Collection<Capability> capabilities) {
 		List<Capability> caps;
 
 		synchronized (this) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -1,17 +1,14 @@
 package aQute.bnd.repository.maven.pom.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +33,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.osgi.repository.BridgeRepository;
 import aQute.bnd.osgi.repository.BridgeRepository.ResourceInfo;
+import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.service.Actionable;
 import aQute.bnd.service.Plugin;
 import aQute.bnd.service.Refreshable;
@@ -252,8 +250,7 @@ public class BndPomRepository extends BaseRepository
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
 		if (!init()) {
-			return requirements.stream()
-				.collect(toMap(identity(), requirement -> new ArrayList<>()));
+			return ResourceUtils.emptyProviders(requirements);
 		}
 		return repoImpl.findProviders(requirements);
 	}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -1,9 +1,7 @@
 package aQute.bnd.repository.maven.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import java.io.Closeable;
@@ -15,7 +13,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,6 +55,7 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Resource;
 import aQute.bnd.osgi.repository.BaseRepository;
+import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.repository.maven.provider.ReleaseDTO.JavadocPackages;
 import aQute.bnd.repository.maven.provider.ReleaseDTO.ReleaseType;
 import aQute.bnd.service.Actionable;
@@ -897,8 +895,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
 		if (!init()) {
-			return requirements.stream()
-				.collect(toMap(identity(), requirement -> new ArrayList<>()));
+			return ResourceUtils.emptyProviders(requirements);
 		}
 
 		return index.getBridge()

--- a/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
@@ -23,11 +23,12 @@ import org.osgi.resource.Requirement;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.build.Run;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.maven.lib.resolve.BndrunContainer;
+import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.repository.fileset.FileSetRepository;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.version.Version;
-import aQute.bnd.exceptions.Exceptions;
 import bndtools.central.Central;
 
 public class MavenImplicitProjectRepository extends AbstractMavenRepository
@@ -50,7 +51,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
 		if (fileSetRepository == null) {
-			return Collections.emptyMap();
+			return ResourceUtils.emptyProviders(requirements);
 		}
 		return fileSetRepository.findProviders(requirements);
 	}


### PR DESCRIPTION
Since this is a common action in repository implementations, we add
2 methods to generate a result Map for findProviders. One is a valid
result Map when there are no present capabilities.

It is incorrect to return an empty Map. We fixed one occurrence of this
in MavenImplicitProjectRepository.
