### PR TITLE
repository: Avoid collection mutation if possible

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -744,8 +744,10 @@ public class ResourceUtils {
 
 	public static <CAPABILITY extends Capability, COLLECTION extends Collection<CAPABILITY>> COLLECTION capabilitiesCombiner(
 		COLLECTION leftCollection, COLLECTION rightCollection) {
-		rightCollection.removeAll(leftCollection);
-		leftCollection.addAll(rightCollection);
+		if (leftCollection.isEmpty()) {
+			return rightCollection;
+		}
+		rightCollection.forEach(capability -> capabilitiesAccumulator(leftCollection, capability));
 		return leftCollection;
 	}
 


### PR DESCRIPTION
Empty left collection is common in reduce with identity. We also avoid
mutating the right collection.

