### PR TITLE
launcher: Refactor to call calculatedProperties later

### DIFF
--- a/biz.aQute.bndall.tests/order-01.bndrun
+++ b/biz.aQute.bndall.tests/order-01.bndrun
@@ -9,5 +9,5 @@
     org.apache.felix.configadmin;startlevel=5, \
     org.apache.felix.inventory
     
-    
+-runtimeout: 0 minutes
 -runtrace: true

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -926,7 +926,7 @@ public class AlsoLauncherTest {
 	@Test
 	public void testTimeoutActivator() throws Exception {
 		try (ProjectLauncher l = project.getProjectLauncher()) {
-			l.setTimeout(100, TimeUnit.MILLISECONDS);
+			l.setTimeout(100L, TimeUnit.MILLISECONDS);
 			l.setTrace(false);
 			assertThat(l.launch()).isEqualTo(ProjectLauncher.TIMEDOUT);
 		}
@@ -936,7 +936,7 @@ public class AlsoLauncherTest {
 	@Test
 	public void testTimeout() throws Exception {
 		try (ProjectLauncher l = project.getProjectLauncher()) {
-			l.setTimeout(100, TimeUnit.MILLISECONDS);
+			l.setTimeout(100L, TimeUnit.MILLISECONDS);
 			l.setTrace(false);
 			l.getRunProperties()
 				.put("test.cmd", "timeout");
@@ -981,7 +981,7 @@ public class AlsoLauncherTest {
 
 	private void assertExitCode(String cmd, int rv) throws Exception {
 		try (ProjectLauncher l = project.getProjectLauncher()) {
-			l.setTimeout(25000, TimeUnit.MILLISECONDS);
+			l.setTimeout(25000L, TimeUnit.MILLISECONDS);
 			l.setTrace(true);
 			l.getRunProperties()
 				.put("test.cmd", cmd);
@@ -998,7 +998,7 @@ public class AlsoLauncherTest {
 			runbundles + "," + new File("jar/mandatorynoversion.jar;version=file").getAbsolutePath());
 		ProjectTester tester = project.getProjectTester();
 		try (ProjectLauncher l = tester.getProjectLauncher()) {
-			l.setTimeout(25000, TimeUnit.MILLISECONDS);
+			l.setTimeout(25000L, TimeUnit.MILLISECONDS);
 			l.setTrace(true);
 			AtomicBoolean reported = new AtomicBoolean(false);
 			tester.registerForNotifications((a, b) -> {
@@ -1028,7 +1028,7 @@ public class AlsoLauncherTest {
 						error.set(notification);
 					}
 				});
-				l.setTimeout(5000, TimeUnit.MILLISECONDS);
+				l.setTimeout(5000L, TimeUnit.MILLISECONDS);
 				l.setTrace(true);
 				l.launch();
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.osgi.Constants;
-import aQute.bnd.osgi.Processor;
 import aQute.lib.io.IO;
 import aQute.libg.command.Command;
 
@@ -20,8 +19,6 @@ public class JUnitLauncher extends ProjectLauncher {
 	boolean						junit4Main;
 	private Classpath			cp;
 	private Command				java;
-	private long				timeout;
-	// private boolean trace;
 	private List<String>		fqns	= new ArrayList<>();
 
 	public JUnitLauncher(Project project) throws Exception {
@@ -46,9 +43,6 @@ public class JUnitLauncher extends ProjectLauncher {
 			return;
 		}
 
-		timeout = Processor.getDuration(getProject().getProperty(Constants.RUNTIMEOUT), 0);
-		// trace =
-		// Processor.isTrue(getProject().getProperty(Constants.RUNTRACE));
 		cp = new Classpath(getProject(), "junit");
 		addClasspath(getProject().getTestpath());
 		File output = getProject().getOutput();
@@ -68,8 +62,8 @@ public class JUnitLauncher extends ProjectLauncher {
 		java.addAll(getProject().getRunVM());
 		java.add(getMainTypeName());
 		java.addAll(fqns);
-		if (timeout != 0)
-			java.setTimeout(timeout + 1000, TimeUnit.MILLISECONDS);
+		if (getTimeout() != 0L)
+			java.setTimeout(getTimeout() + 1000L, TimeUnit.MILLISECONDS);
 
 		logger.debug("cmd line {}", java);
 		try {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2497,7 +2497,7 @@ public class Project extends Processor {
 	}
 
 	public boolean isRunTrace() {
-		return isTrue(getProperty(RUNTRACE));
+		return is(RUNTRACE);
 	}
 
 	public void runLocal() throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -30,6 +30,7 @@ import org.osgi.framework.launch.FrameworkFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
@@ -184,12 +185,11 @@ public abstract class ProjectLauncher extends Processor {
 			.forEach(this::addRunVM);
 		getProject().getRunProgramArgs()
 			.forEach(this::addRunProgramArgs);
-		runproperties = getProject().getRunProperties();
+		runproperties = null; // set in getRunProperties
 		runframeworkrestart = getProject().is(Constants.RUNFRAMEWORKRESTART);
 		storageDir = getProject().getRunStorage();
 
 		setKeep(getProject().getRunKeep());
-		calculatedProperties(runproperties);
 	}
 
 	private int getRunframework(String property) {
@@ -292,7 +292,17 @@ public abstract class ProjectLauncher extends Processor {
 	}
 
 	public Map<String, String> getRunProperties() {
-		return runproperties;
+		Map<String, String> properties = runproperties;
+		if (properties != null) {
+			return properties;
+		}
+		properties = getProject().getRunProperties();
+		try {
+			calculatedProperties(properties);
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+		return runproperties = properties;
 	}
 
 	public File getStorageDir() {
@@ -645,30 +655,6 @@ public abstract class ProjectLauncher extends Processor {
 	 */
 
 	public void calculatedProperties(Map<String, String> properties) throws Exception {
-
-		if (getTrace())
-			properties.put(Constants.LAUNCH_TRACE, "true");
-
-		boolean eager = launcherInstrs.runoptions()
-			.contains(LauncherInstructions.RunOption.eager);
-		if (eager)
-			properties.put(Constants.LAUNCH_ACTIVATION_EAGER, Boolean.toString(eager));
-
-		Collection<String> activators = getActivators();
-		if (!activators.isEmpty())
-			properties.put(Constants.LAUNCH_ACTIVATORS, join(activators, ","));
-
-		if (!keep)
-			properties.put(org.osgi.framework.Constants.FRAMEWORK_STORAGE_CLEAN,
-				org.osgi.framework.Constants.FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT);
-
-		if (!runsystemcapabilities.isEmpty())
-			properties.put(org.osgi.framework.Constants.FRAMEWORK_SYSTEMCAPABILITIES_EXTRA,
-				runsystemcapabilities.toString());
-
-		if (!runsystempackages.isEmpty())
-			properties.put(org.osgi.framework.Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, runsystempackages.toString());
-
 		setupStartlevels(properties);
 	}
 
@@ -709,7 +695,7 @@ public abstract class ProjectLauncher extends Processor {
 	 * start level to the desired level. Either the set
 	 * {@link Constants#RUNSTARTLEVEL_BEGIN} or the maximum level + 2.
 	 */
-	private void setupStartlevels(Map<String, String> properties) throws Exception, IOException {
+	private void setupStartlevels(Map<String, String> properties) throws Exception {
 		Parameters runbundles = new Parameters();
 		int maxLevel = -1;
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -62,7 +62,7 @@ public abstract class ProjectLauncher extends Processor {
 	final static Logger					logger				= LoggerFactory.getLogger(ProjectLauncher.class);
 	private final Project				project;
 	private final List<Runnable>		onUpdate			= new ArrayList<>();
-	private long						timeout				= 0;
+	private long						timeout				= 0L;
 	private final List<String>			classpath			= new ArrayList<>();
 	private List<String>				runbundles			= Create.list();
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -166,25 +166,26 @@ public abstract class ProjectLauncher extends Processor {
 					addRunBundle(IO.absolutePath(file));
 		}
 
-		Collection<Container> runpath = getProject().getRunpath();
 		runsystempackages = new Parameters(getProject().mergeProperties(Constants.RUNSYSTEMPACKAGES), getProject());
 		runsystemcapabilities = new Parameters(getProject().mergeProperties(Constants.RUNSYSTEMCAPABILITIES),
 			getProject());
-		framework = getRunframework(getProject().getProperty(Constants.RUNFRAMEWORK));
+		setRunFramework(getRunframework(getProject().getProperty(Constants.RUNFRAMEWORK)));
 
-		timeout = Processor.getDuration(getProject().getProperty(Constants.RUNTIMEOUT), 0);
-		trace = getProject().isRunTrace();
+		setTimeout(Processor.getDuration(getProject().getProperty(Constants.RUNTIMEOUT), 0L), TimeUnit.MILLISECONDS);
+		setTrace(getProject().isRunTrace());
 
+		Collection<Container> runpath = getProject().getRunpath();
 		runpath.addAll(getProject().getRunFw());
-
 		for (Container c : runpath) {
 			addClasspath(c);
 		}
 
-		runvm.addAll(getProject().getRunVM());
-		runprogramargs.addAll(getProject().getRunProgramArgs());
+		getProject().getRunVM()
+			.forEach(this::addRunVM);
+		getProject().getRunProgramArgs()
+			.forEach(this::addRunProgramArgs);
 		runproperties = getProject().getRunProperties();
-		runframeworkrestart = isTrue(getProject().getProperty(Constants.RUNFRAMEWORKRESTART));
+		runframeworkrestart = getProject().is(Constants.RUNFRAMEWORKRESTART);
 		storageDir = getProject().getRunStorage();
 
 		setKeep(getProject().getRunKeep());
@@ -194,9 +195,8 @@ public abstract class ProjectLauncher extends Processor {
 	private int getRunframework(String property) {
 		if (Constants.RUNFRAMEWORK_NONE.equalsIgnoreCase(property))
 			return NONE;
-		else if (Constants.RUNFRAMEWORK_SERVICES.equalsIgnoreCase(property))
+		if (Constants.RUNFRAMEWORK_SERVICES.equalsIgnoreCase(property))
 			return SERVICES;
-
 		return SERVICES;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -1862,16 +1863,12 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		if (tm == null)
 			return dflt;
 
-		tm = tm.toUpperCase();
-		TimeUnit unit = TimeUnit.MILLISECONDS;
-		Matcher m = DURATION_P.matcher(tm);
+		Matcher m = DURATION_P.matcher(tm.toUpperCase(Locale.ROOT));
 		if (m.matches()) {
-			long duration = Long.parseLong(tm);
+			long duration = Long.parseLong(m.group(1));
 			String u = m.group(2);
-			if (u != null)
-				unit = TimeUnit.valueOf(u);
-			duration = TimeUnit.MILLISECONDS.convert(duration, unit);
-			return duration;
+			TimeUnit unit = (u != null) ? TimeUnit.valueOf(u) : TimeUnit.MILLISECONDS;
+			return unit.toMillis(duration);
 		}
 		return dflt;
 	}

--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -1182,7 +1182,7 @@ public class Launcher implements ServiceListener, FrameworkListener {
 		if (!parms.keep && workingdir.exists()) {
 			trace("deleting working dir %s because not kept", workingdir);
 			delete(workingdir);
-			p.setProperty(Constants.FRAMEWORK_STORAGE_CLEAN, "true");
+			p.setProperty(Constants.FRAMEWORK_STORAGE_CLEAN, Constants.FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT);
 		}
 
 		IO.mkdirs(workingdir);

--- a/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
+++ b/biz.aQute.launcher/src/aQute/launcher/constants/LauncherConstants.java
@@ -81,29 +81,29 @@ public class LauncherConstants {
 	 * Translate a constants to properties.
 	 */
 	public <P extends Properties> P getProperties(P p) {
-		p.setProperty(LAUNCH_NOREFERENCES, noreferences + "");
-		p.setProperty(LAUNCH_SERVICES, services + "");
+		p.setProperty(LAUNCH_NOREFERENCES, String.valueOf(noreferences));
+		p.setProperty(LAUNCH_SERVICES, String.valueOf(services));
 		if (storageDir != null)
 			p.setProperty(LAUNCH_STORAGE_DIR, storageDir.getAbsolutePath());
-		p.setProperty(LAUNCH_KEEP, keep + "");
+		p.setProperty(LAUNCH_KEEP, String.valueOf(keep));
 
 		p.setProperty(LAUNCH_RUNBUNDLES, join(runbundles, ","));
 
 		if (systemPackages != null)
-			p.setProperty(LAUNCH_SYSTEMPACKAGES, systemPackages + "");
+			p.setProperty(LAUNCH_SYSTEMPACKAGES, systemPackages);
 		if (systemCapabilities != null)
-			p.setProperty(LAUNCH_SYSTEMCAPABILITIES, systemCapabilities + "");
-		p.setProperty(Constants.LAUNCH_TRACE, trace + "");
-		p.setProperty(LAUNCH_TIMEOUT, timeout + "");
+			p.setProperty(LAUNCH_SYSTEMCAPABILITIES, systemCapabilities);
+		p.setProperty(Constants.LAUNCH_TRACE, String.valueOf(trace));
+		p.setProperty(LAUNCH_TIMEOUT, String.valueOf(timeout));
 		p.setProperty(Constants.LAUNCH_ACTIVATORS, join(activators, ","));
-		p.setProperty(LAUNCH_EMBEDDED, embedded + "");
-		p.setProperty(LAUNCH_FRAMEWORK_RESTART, frameworkRestart + "");
+		p.setProperty(LAUNCH_EMBEDDED, String.valueOf(embedded));
+		p.setProperty(LAUNCH_FRAMEWORK_RESTART, String.valueOf(frameworkRestart));
 
 		if (name != null)
 			p.setProperty(LAUNCH_NAME, name);
 
 		p.setProperty(LAUNCH_NOTIFICATION_PORT, String.valueOf(notificationPort));
-		p.setProperty(Constants.LAUNCH_ACTIVATION_EAGER, activationEager + "");
+		p.setProperty(Constants.LAUNCH_ACTIVATION_EAGER, String.valueOf(activationEager));
 
 		for (Map.Entry<String, String> entry : runProperties.entrySet()) {
 			if (entry.getValue() == null) {
@@ -129,24 +129,24 @@ public class LauncherConstants {
 	 * @param p
 	 */
 	public LauncherConstants(Properties p) {
-		services = Boolean.valueOf(p.getProperty(LAUNCH_SERVICES));
+		services = Boolean.parseBoolean(p.getProperty(LAUNCH_SERVICES));
 		if (p.getProperty(LAUNCH_STORAGE_DIR) != null)
 			storageDir = new File(p.getProperty(LAUNCH_STORAGE_DIR));
-		noreferences = Boolean.valueOf(p.getProperty(LAUNCH_NOREFERENCES));
-		keep = Boolean.valueOf(p.getProperty(LAUNCH_KEEP));
+		noreferences = Boolean.parseBoolean(p.getProperty(LAUNCH_NOREFERENCES));
+		keep = Boolean.parseBoolean(p.getProperty(LAUNCH_KEEP));
 		runbundles.addAll(split(p.getProperty(LAUNCH_RUNBUNDLES), ","));
 
 		systemPackages = p.getProperty(LAUNCH_SYSTEMPACKAGES);
 		systemCapabilities = p.getProperty(LAUNCH_SYSTEMCAPABILITIES);
-		trace = Boolean.valueOf(p.getProperty(Constants.LAUNCH_TRACE));
+		trace = Boolean.parseBoolean(p.getProperty(Constants.LAUNCH_TRACE));
 		timeout = Long.parseLong(p.getProperty(LAUNCH_TIMEOUT));
 		activators.addAll(split(p.getProperty(Constants.LAUNCH_ACTIVATORS), " ,"));
 		String s = p.getProperty(LAUNCH_EMBEDDED);
 		embedded = s != null && Boolean.parseBoolean(s);
 		name = p.getProperty(LAUNCH_NAME);
-		notificationPort = Integer.valueOf(p.getProperty(LAUNCH_NOTIFICATION_PORT, "-1"));
-		activationEager = Boolean.valueOf(p.getProperty(Constants.LAUNCH_ACTIVATION_EAGER));
-		frameworkRestart = Boolean.valueOf(p.getProperty(LAUNCH_FRAMEWORK_RESTART));
+		notificationPort = Integer.parseInt(p.getProperty(LAUNCH_NOTIFICATION_PORT, "-1"));
+		activationEager = Boolean.parseBoolean(p.getProperty(Constants.LAUNCH_ACTIVATION_EAGER));
+		frameworkRestart = Boolean.parseBoolean(p.getProperty(LAUNCH_FRAMEWORK_RESTART));
 		@SuppressWarnings({
 			"unchecked", "rawtypes"
 		})

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -234,7 +234,7 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		lc.runbundles.addAll(runbundles);
 		lc.trace = getTrace();
 		lc.timeout = getTimeout();
-		lc.services = super.getRunFramework() == SERVICES ? true : false;
+		lc.services = getRunFramework() == SERVICES ? true : false;
 		lc.activators.addAll(getActivators());
 		lc.name = getProject().getName();
 		lc.activationEager = launcherInstrs.runoptions()
@@ -355,9 +355,9 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 
 		// Copy the bundles to the JAR
 
-		List<String> runbundles = (List<String>) getRunBundles();
 		List<String> actualPaths = new ArrayList<>();
 
+		Collection<String> runbundles = getRunBundles();
 		for (String path : runbundles) {
 			logger.debug("embedding run bundles {}", path);
 			File file = getOriginalFile(path);

--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -42,6 +42,7 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.EmbeddedResource;
 import aQute.bnd.osgi.FileResource;
+import aQute.bnd.osgi.Instruction;
 import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Jar.Compression;
@@ -398,7 +399,7 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		Resource preJar = Resource.fromURL(this.getClass()
 			.getResource("/" + PRE_JAR));
 		try (Jar pre = Jar.fromResource("pre", preJar)) {
-			jar.addAll(pre);
+			jar.addAll(pre, new Instruction("!{META-INF,OSGI-OPT}/*"));
 		}
 
 		String embeddedLauncherName = main.getValue(MAIN_CLASS);

--- a/biz.aQute.remote/bnd.bnd
+++ b/biz.aQute.remote/bnd.bnd
@@ -7,6 +7,7 @@
 aQute.agent.server.port = 29998
 
 -buildpath: \
+	osgi.annotation;version=latest;maven-scope=provided,\
 	osgi.core;version=latest;maven-scope=provided,\
     aQute.libg;version=project,\
     biz.aQute.bnd.util;version=latest,\

--- a/org.bndtools.launch/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
+++ b/org.bndtools.launch/src/bndtools/launch/OSGiJUnitLaunchDelegate.java
@@ -85,9 +85,7 @@ public class OSGiJUnitLaunchDelegate extends AbstractOSGiLaunchDelegate {
 
 	@Override
 	protected void initialiseBndLauncher(ILaunchConfiguration configuration, Project model) throws Exception {
-		synchronized (model) {
-			bndTester = model.getProjectTester();
-		}
+		bndTester = model.getProjectTester();
 
 		if (bndTester instanceof EclipseJUnitTester)
 			bndEclipseTester = (EclipseJUnitTester) bndTester;

--- a/org.bndtools.launch/src/bndtools/launch/OSGiRunLaunchDelegate.java
+++ b/org.bndtools.launch/src/bndtools/launch/OSGiRunLaunchDelegate.java
@@ -34,7 +34,6 @@ import org.osgi.service.component.annotations.ServiceScope;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectLauncher;
 import aQute.bnd.build.ProjectLauncher.NotificationType;
-import aQute.bnd.result.Result;
 
 @Component(scope = ServiceScope.PROTOTYPE, service = ILaunchConfigurationDelegate2.class)
 public class OSGiRunLaunchDelegate extends AbstractOSGiLaunchDelegate {
@@ -48,14 +47,7 @@ public class OSGiRunLaunchDelegate extends AbstractOSGiLaunchDelegate {
 
 	@Override
 	protected void initialiseBndLauncher(ILaunchConfiguration configuration, Project model) throws Exception {
-		synchronized (model) {
-			Result<ProjectLauncher> resolvingProjectLauncher = Result.of(model.getProjectLauncher(),
-				"Failed to get projectlauncher");
-
-			bndLauncher = resolvingProjectLauncher.orElseThrow(
-				e -> new IllegalStateException(String.format("Failed to obtain launcher for project %s (%s): %s",
-					model.getName(), model.getPropertiesFile(), e)));
-		}
+		bndLauncher = model.getProjectLauncher();
 		configureLauncher(configuration);
 
 		bndLauncher.registerForNotifications((type, notification) -> {


### PR DESCRIPTION
We no longer call calculatedProperties during updateFromProject since
that is too soon. We now call calculatedProperties from getRunProperties
so it is done just as it is needed.

For ProjectLauncher.calculatedProperties, we no longer set a number of
values since they are already handled in
ProjectLauncherImpl.getConstants as launcher properties which are
then set as framework properties by Launcher.createFramework. So we
then needed to modify RemoteProjectLauncherPlugin to override
calculatedProperties to set the framework properties.


Fixes #5061