### PR TITLE
[generate] Exception ignored

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectGenerate.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectGenerate.java
@@ -252,9 +252,13 @@ public class ProjectGenerate implements AutoCloseable {
 				@SuppressWarnings("unchecked")
 				Optional<String> error = redirect.apply(() -> p.generate(bc, spec.instance()));
 
+				project.getInfo(bc, pluginName);
 				if (error.isPresent())
 					return err(error.get() + " : " + redirect.getContent());
 
+				if (!bc.isOk()) {
+					return err("errors");
+				}
 				return ok(true);
 			});
 		return call.error()


### PR DESCRIPTION
If a plugin threw an exception it was ignored


BJ, can this still be in 6.2?

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>