### PR TITLE
Support replacement of enum types in osgi.annotation

### DIFF
--- a/aQute.libg/src/aQute/lib/converter/Converter.java
+++ b/aQute.libg/src/aQute/lib/converter/Converter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Stack;
@@ -280,7 +281,7 @@ public class Converter {
 				try {
 					return Enum.valueOf((Class<Enum>) resultType, input);
 				} catch (Exception e) {
-					input = input.toUpperCase();
+					input = input.toUpperCase(Locale.ROOT);
 					return Enum.valueOf((Class<Enum>) resultType, input);
 				}
 			}

--- a/aQute.libg/src/aQute/lib/getopt/CommandLine.java
+++ b/aQute.libg/src/aQute/lib/getopt/CommandLine.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -627,7 +628,7 @@ public class CommandLine {
 			return ""; // Is a flag
 
 		return "<" + lastPart(clazz.getName()
-			.toLowerCase()) + ">";
+			.toLowerCase(Locale.ROOT)) + ">";
 	}
 
 	public Object getResult() {

--- a/aQute.libg/src/aQute/lib/xpath/XPathParser.java
+++ b/aQute.libg/src/aQute/lib/xpath/XPathParser.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Locale;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
@@ -73,7 +74,7 @@ public class XPathParser {
 
 			if (f.getType()
 				.isAnnotation())
-				value = value.toUpperCase();
+				value = value.toUpperCase(Locale.ROOT);
 
 			Object o = Converter.cnv(f.getGenericType(), value);
 			try {

--- a/aQute.libg/src/aQute/libg/classdump/ClassDumper.java
+++ b/aQute.libg/src/aQute/libg/classdump/ClassDumper.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Modifier;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import aQute.lib.io.IO;
 
@@ -381,7 +382,7 @@ public class ClassDumper {
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < 16 && index < code.length; i++) {
 				String s = Integer.toHexString((0xFF & code[index++]))
-					.toUpperCase();
+					.toUpperCase(Locale.ROOT);
 				if (s.length() == 1)
 					sb.append("0");
 				sb.append(s);

--- a/aQute.libg/src/aQute/libg/shacache/ShaCache.java
+++ b/aQute.libg/src/aQute/libg/shacache/ShaCache.java
@@ -3,6 +3,7 @@ package aQute.libg.shacache;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import aQute.lib.io.IO;
@@ -81,7 +82,7 @@ public class ShaCache {
 					// and copy it.
 					//
 
-					File tmp = IO.createTempFile(root, sha.toLowerCase(), ".shacache");
+					File tmp = IO.createTempFile(root, sha.toLowerCase(Locale.ROOT), ".shacache");
 					IO.copy(in, tmp);
 					String digest = SHA1.digest(tmp)
 						.asHex();
@@ -141,7 +142,7 @@ public class ShaCache {
 			try {
 				InputStream in = s.get(sha);
 				if (in != null) {
-					File tmp = IO.createTempFile(root, sha.toLowerCase(), ".shacache");
+					File tmp = IO.createTempFile(root, sha.toLowerCase(Locale.ROOT), ".shacache");
 					IO.copy(in, tmp);
 					String digest = SHA1.digest(tmp)
 						.asHex();

--- a/aQute.libg/test/aQute/lib/hex/HexTest.java
+++ b/aQute.libg/test/aQute/lib/hex/HexTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +51,7 @@ public class HexTest {
 	public void testHex() {
 		byte[] bytes = Hex.toByteArray("b10a8db164e0754105b7a99be72e3fe5");
 		String s = Hex.toHexString(bytes);
-		assertEquals("b10a8db164e0754105b7a99be72e3fe5", s.toLowerCase());
+		assertEquals("b10a8db164e0754105b7a99be72e3fe5", s.toLowerCase(Locale.ROOT));
 	}
 
 	@Test

--- a/biz.aQute.bnd.exporters/src/aQute/bnd/exporter/subsystem/ContainerType.java
+++ b/biz.aQute.bnd.exporters/src/aQute/bnd/exporter/subsystem/ContainerType.java
@@ -1,7 +1,8 @@
 package aQute.bnd.exporter.subsystem;
 
 import java.io.File;
-import java.util.stream.Stream;
+import java.util.Arrays;
+import java.util.Locale;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.subsystem.SubsystemConstants;;
@@ -111,9 +112,10 @@ public enum ContainerType {
 			return null;
 		}
 		String filename = file.getName()
-			.toLowerCase();
-		return Stream.of(ContainerType.values())
-			.filter(c -> filename.endsWith("." + c.getExtension()))
+			.toLowerCase(Locale.ROOT);
+		return Arrays.stream(ContainerType.values())
+			.filter(c -> filename.endsWith(".".concat(c.getExtension()
+				.toLowerCase(Locale.ROOT))))
 			.findFirst()
 			.orElse(null);
 	}

--- a/biz.aQute.bnd.exporters/src/aQute/bnd/exporter/subsystem/EsaArchiveType.java
+++ b/biz.aQute.bnd.exporters/src/aQute/bnd/exporter/subsystem/EsaArchiveType.java
@@ -1,5 +1,7 @@
 package aQute.bnd.exporter.subsystem;
 
+import java.util.Locale;
+
 public enum EsaArchiveType {
 	NONE,
 	CONTENT,
@@ -10,7 +12,7 @@ public enum EsaArchiveType {
 			return CONTENT; // default
 		}
 		try {
-			return valueOf(archiveContent.toUpperCase());
+			return valueOf(archiveContent.toUpperCase(Locale.ROOT));
 		} catch (IllegalArgumentException e) {
 			return null;
 		}

--- a/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/gogo/Log.java
+++ b/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/gogo/Log.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.WeakHashMap;
 
 import org.apache.felix.service.command.CommandSession;
@@ -118,7 +119,7 @@ public class Log implements Closeable {
 	}
 
 	private List<LogEntry> log0(String level, int number) {
-		Level l = Level.valueOf(level.toUpperCase());
+		Level l = Level.valueOf(level.toUpperCase(Locale.ROOT));
 		List<LogEntry> result = new ArrayList<>();
 		for (int i = entries.size() - 1; i >= 0 && result.size() <= number; i--) {
 			LogEntry entry = entries.get(i);

--- a/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/snapshot/Snapshot.java
+++ b/biz.aQute.bnd.runtime/src/aQute/bnd/runtime/snapshot/Snapshot.java
@@ -10,6 +10,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -156,7 +157,7 @@ public class Snapshot implements BundleActivator {
 				if (className != null) {
 					int x = className.lastIndexOf('.');
 					className = className.substring(x + 1);
-					name = className.toLowerCase() + "-" + name;
+					name = className.toLowerCase(Locale.ROOT) + "-" + name;
 				}
 				name += ".json";
 			} else

--- a/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/BaselineCommands.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -47,6 +48,7 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.diff.Delta;
 import aQute.bnd.service.diff.Diff;
 import aQute.bnd.service.diff.Tree;
+import aQute.bnd.unmodifiable.Lists;
 import aQute.bnd.version.Version;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.collections.SortedList;
@@ -55,7 +57,6 @@ import aQute.lib.getopt.Description;
 import aQute.lib.getopt.Options;
 import aQute.lib.io.IO;
 import aQute.lib.tag.Tag;
-import aQute.bnd.unmodifiable.Lists;
 import aQute.lib.xml.XML;
 
 /**
@@ -245,7 +246,8 @@ public class BaselineCommands {
 	protected void doDiff(Diff diff, StringBuilder sb) {
 		String type = String.valueOf(diff.getType());
 
-		String output = String.format("%s%-5s %-10s %s", sb, getShortDelta(diff.getDelta()), type.toLowerCase(),
+		String output = String.format("%s%-5s %-10s %s", sb, getShortDelta(diff.getDelta()),
+			type.toLowerCase(Locale.ROOT),
 			diff.getName());
 
 		bnd.out.println(output);

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -690,7 +691,7 @@ public class bnd extends Processor {
 			for (String path : selected) {
 				if (opts.verbose())
 					err.printf("%8s: %s\n", compression.toString()
-						.toLowerCase(), path);
+						.toLowerCase(Locale.ROOT), path);
 
 				File f = getFile(store, path);
 				File pf = f.getParentFile();
@@ -3746,7 +3747,7 @@ public class bnd extends Processor {
 						.entrySet()) {
 						String header = e.getKey()
 							.toString()
-							.toLowerCase();
+							.toLowerCase(Locale.ROOT);
 						if (header.startsWith("bundle-"))
 							continue;
 

--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.net.Proxy.Type;
 import java.net.URL;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -118,7 +119,7 @@ public class SettingsParserTest {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("http-proxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.HTTP.name(), p.protocol.toUpperCase());
+		assertEquals(Type.HTTP.name(), p.protocol.toUpperCase(Locale.ROOT));
 		assertEquals("localhost", p.host);
 		assertEquals(80, p.port);
 		assertEquals(null, p.nonProxyHosts);
@@ -128,7 +129,7 @@ public class SettingsParserTest {
 		p = settings.proxies.get(1);
 		assertEquals("https-proxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals("HTTPS", p.protocol.toUpperCase());
+		assertEquals("HTTPS", p.protocol.toUpperCase(Locale.ROOT));
 		assertEquals("localhost", p.host);
 		assertEquals(443, p.port);
 		assertEquals(null, p.nonProxyHosts);
@@ -143,7 +144,7 @@ public class SettingsParserTest {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase(Locale.ROOT));
 		assertEquals(1080, p.port);
 		assertEquals(null, p.nonProxyHosts);
 		assertEquals("proxyuser", p.username);
@@ -157,7 +158,7 @@ public class SettingsParserTest {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase(Locale.ROOT));
 		assertEquals(1080, p.port);
 		assertEquals(null, p.nonProxyHosts);
 		assertEquals(null, p.username);
@@ -171,7 +172,7 @@ public class SettingsParserTest {
 		ProxyDTO p = settings.proxies.get(0);
 		assertEquals("myproxy", p.id);
 		assertEquals(true, p.active);
-		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase());
+		assertEquals(Type.SOCKS.name(), p.protocol.toUpperCase(Locale.ROOT));
 		assertEquals(1080, p.port);
 		assertEquals("*.google.com|ibiblio.org", p.nonProxyHosts);
 		assertEquals(null, p.username);

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/a/ResolutionDirectiveOverride.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/a/ResolutionDirectiveOverride.java
@@ -3,9 +3,9 @@ package test.annotationheaders.attrs.std.a;
 import org.osgi.annotation.bundle.Attribute;
 import org.osgi.annotation.bundle.Directive;
 import org.osgi.annotation.bundle.Requirement;
-import org.osgi.annotation.bundle.Requirement.Resolution;
+import org.osgi.resource.Namespace;
 
-@Custom(name = "bar", resolution = Resolution.OPTIONAL)
+@Custom(name = "bar", resolution = Namespace.RESOLUTION_OPTIONAL)
 public class ResolutionDirectiveOverride {}
 
 @Requirement(namespace = "foo")
@@ -14,5 +14,5 @@ public class ResolutionDirectiveOverride {}
 	String name();
 
 	@Directive
-	Resolution resolution() default Resolution.MANDATORY;
+	String resolution() default Namespace.RESOLUTION_MANDATORY;
 }

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/b/CardinalityDirectiveOverride.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/attrs/std/b/CardinalityDirectiveOverride.java
@@ -3,9 +3,9 @@ package test.annotationheaders.attrs.std.b;
 import org.osgi.annotation.bundle.Attribute;
 import org.osgi.annotation.bundle.Directive;
 import org.osgi.annotation.bundle.Requirement;
-import org.osgi.annotation.bundle.Requirement.Cardinality;
+import org.osgi.resource.Namespace;
 
-@Custom(name = "bar", cardinality = Cardinality.MULTIPLE)
+@Custom(name = "bar", cardinality = Namespace.CARDINALITY_MULTIPLE)
 public class CardinalityDirectiveOverride {}
 
 @Requirement(namespace = "foo")
@@ -14,5 +14,5 @@ public class CardinalityDirectiveOverride {}
 	String name();
 
 	@Directive
-	Cardinality cardinality() default Cardinality.SINGLE;
+	String cardinality() default Namespace.CARDINALITY_SINGLE;
 }

--- a/biz.aQute.bndlib.tests/test/test/lib/NanoHTTPD.java
+++ b/biz.aQute.bndlib.tests/test/test/lib/NanoHTTPD.java
@@ -239,7 +239,7 @@ public class NanoHTTPD {
 				port = Integer.parseInt(args[i + 1]);
 			else if (args[i].equalsIgnoreCase("-d"))
 				wwwroot = new File(args[i + 1]).getAbsoluteFile();
-			else if (args[i].toLowerCase()
+			else if (args[i].toLowerCase(Locale.ROOT)
 				.endsWith("licence")) {
 				myOut.println(LICENCE + "\n");
 				break;
@@ -460,7 +460,7 @@ public class NanoHTTPD {
 						if (p >= 0)
 							header.put(line.substring(0, p)
 								.trim()
-								.toLowerCase(),
+								.toLowerCase(Locale.ROOT),
 								line.substring(p + 1)
 									.trim());
 						line = in.readLine();
@@ -496,7 +496,7 @@ public class NanoHTTPD {
 						if (p != -1)
 							item.put(mpline.substring(0, p)
 								.trim()
-								.toLowerCase(),
+								.toLowerCase(Locale.ROOT),
 								mpline.substring(p + 1)
 									.trim());
 						mpline = in.readLine();
@@ -515,7 +515,7 @@ public class NanoHTTPD {
 							if (p != -1)
 								disposition.put(token.substring(0, p)
 									.trim()
-									.toLowerCase(),
+									.toLowerCase(Locale.ROOT),
 									token.substring(p + 1)
 										.trim());
 						}
@@ -869,7 +869,7 @@ public class NanoHTTPD {
 				if (dot >= 0)
 					mime = theMimeTypes.get(f.getCanonicalPath()
 						.substring(dot + 1)
-						.toLowerCase());
+						.toLowerCase(Locale.ROOT));
 				if (mime == null)
 					mime = MIME_DEFAULT_BINARY;
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -980,7 +981,7 @@ public class Project extends Processor {
 		String runBuildsStr = getProperty(Constants.RUNBUILDS);
 		if (runBuildsStr == null)
 			result = !getPropertiesFile().getName()
-				.toLowerCase()
+				.toLowerCase(Locale.ROOT)
 				.endsWith(Constants.DEFAULT_BNDRUN_EXTENSION);
 		else
 			result = Boolean.parseBoolean(runBuildsStr);

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -1232,7 +1232,7 @@ public class Workspace extends Processor {
 				alias = ann.name();
 			else {
 				alias = Strings.getLastSegment(plugin.getName())
-					.toLowerCase();
+					.toLowerCase(Locale.ROOT);
 				if (alias.endsWith("plugin")) {
 					alias = alias.substring(0, alias.length() - "plugin".length());
 				}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -1007,9 +1008,9 @@ public class BndEditModel {
 	}
 
 	public void setRunFramework(String clause) {
-		assert (Constants.RUNFRAMEWORK_SERVICES.equals(clause.toLowerCase()
+		assert (Constants.RUNFRAMEWORK_SERVICES.equals(clause.toLowerCase(Locale.ROOT)
 			.trim()) || Constants.RUNFRAMEWORK_NONE.equals(
-				clause.toLowerCase()
+				clause.toLowerCase(Locale.ROOT)
 					.trim()));
 		String oldValue = getRunFramework();
 		doSetObject(Constants.RUNFRAMEWORK, oldValue, clause, newlineEscapeFormatter);

--- a/biz.aQute.bndlib/src/aQute/bnd/bundle/annotations/Export.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/bundle/annotations/Export.java
@@ -22,8 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.osgi.annotation.versioning.ConsumerType;
-import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.annotation.versioning.Version;
 
 /**
@@ -76,40 +74,8 @@ public @interface Export {
 	 * bundles are willing to import exported packages; these imports will allow
 	 * a framework to substitute exports for imports.
 	 * <p>
-	 * If not specified, the {@link Substitution#CALCULATED} substitution policy
-	 * is used for this package.
+	 * If not specified, the {@code CALCULATED} substitution policy is used for
+	 * this package.
 	 */
-	Substitution substitution() default Substitution.CALCULATED;
-
-	/**
-	 * Substitution policy for this package.
-	 */
-	public enum Substitution {
-		/**
-		 * Use a consumer type version range for the import package clause when
-		 * substitutably importing a package.
-		 *
-		 * @see ConsumerType
-		 */
-		CONSUMER,
-
-		/**
-		 * Use a provider type version range for the import package clause when
-		 * substitutably importing a package.
-		 *
-		 * @see ProviderType
-		 */
-		PROVIDER,
-
-		/**
-		 * The package must not be substitutably imported.
-		 */
-		NOIMPORT,
-
-		/**
-		 * The policy value is calculated by inspection of the classes in the
-		 * package.
-		 */
-		CALCULATED
-	}
+	String substitution() default "CALCULATED";
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/bundle/annotations/Requirement.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/bundle/annotations/Requirement.java
@@ -117,33 +117,7 @@ public @interface Requirement {
 	 * If not specified, the {@code cardinality} directive is omitted from the
 	 * requirement clause.
 	 */
-	Cardinality cardinality() default Cardinality.SINGLE;
-
-	/**
-	 * Cardinality for this requirement.
-	 */
-	public enum Cardinality {
-		/**
-		 * Indicates if the requirement can only be wired a single time.
-		 */
-		SINGLE("single"), // Namespace.CARDINALITY_SINGLE
-
-		/**
-		 * Indicates if the requirement can be wired multiple times.
-		 */
-		MULTIPLE("multiple"); // Namespace.CARDINALITY_MULTIPLE
-
-		private final String value;
-
-		Cardinality(String value) {
-			this.value = value;
-		}
-
-		@Override
-		public String toString() {
-			return value;
-		}
-	}
+	String cardinality() default "SINGLE";
 
 	/**
 	 * The resolution policy of this requirement.
@@ -155,33 +129,5 @@ public @interface Requirement {
 	 * If not specified, the {@code resolution} directive is omitted from the
 	 * requirement clause.
 	 */
-	Resolution resolution() default Resolution.MANDATORY;
-
-	/**
-	 * Resolution for this requirement.
-	 */
-	public enum Resolution {
-		/**
-		 * A mandatory requirement forbids the bundle to resolve when the
-		 * requirement is not satisfied.
-		 */
-		MANDATORY("mandatory"), // Namespace.RESOLUTION_MANDATORY
-
-		/**
-		 * An optional requirement allows a bundle to resolve even if the
-		 * requirement is not satisfied.
-		 */
-		OPTIONAL("optional"); // Namespace.RESOLUTION_OPTIONAL
-
-		private final String value;
-
-		Resolution(String value) {
-			this.value = value;
-		}
-
-		@Override
-		public String toString() {
-			return value;
-		}
-	}
+	String resolution() default "MANDATORY";
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/compatibility/Access.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/compatibility/Access.java
@@ -1,6 +1,7 @@
 package aQute.bnd.compatibility;
 
 import java.lang.reflect.Modifier;
+import java.util.Locale;
 
 /**
  * Access modifier
@@ -25,6 +26,6 @@ public enum Access {
 
 	@Override
 	public String toString() {
-		return super.toString().toLowerCase();
+		return super.toString().toLowerCase(Locale.ROOT);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/compatibility/Kind.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/compatibility/Kind.java
@@ -1,5 +1,7 @@
 package aQute.bnd.compatibility;
 
+import java.util.Locale;
+
 /**
  * The kind of thing we scope
  */
@@ -13,6 +15,6 @@ public enum Kind {
 
 	@Override
 	public String toString() {
-		return super.toString().toLowerCase();
+		return super.toString().toLowerCase(Locale.ROOT);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/component/HeaderReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/HeaderReader.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -29,9 +30,9 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Descriptors.TypeRef;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Verifier;
+import aQute.bnd.unmodifiable.Sets;
 import aQute.bnd.version.Version;
 import aQute.lib.tag.Tag;
-import aQute.bnd.unmodifiable.Sets;
 
 public class HeaderReader extends Processor {
 	private final static Pattern		PROPERTY_PATTERN	= Pattern
@@ -64,7 +65,7 @@ public class HeaderReader extends Processor {
 			cd.immediate = Boolean.valueOf(info.get(COMPONENT_IMMEDIATE));
 		if (info.get(COMPONENT_CONFIGURATION_POLICY) != null)
 			cd.configurationPolicy = ConfigurationPolicy.valueOf(info.get(COMPONENT_CONFIGURATION_POLICY)
-				.toUpperCase());
+				.toUpperCase(Locale.ROOT));
 		cd.activate = checkIdentifier(COMPONENT_ACTIVATE, info.get(COMPONENT_ACTIVATE));
 		cd.deactivate = checkIdentifier(COMPONENT_DEACTIVATE, info.get(COMPONENT_DEACTIVATE));
 		cd.modified = checkIdentifier(COMPONENT_MODIFIED, info.get(COMPONENT_MODIFIED));

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -232,7 +233,7 @@ public class ConnectionSettings {
 		}
 
 		String scheme = m.group(1)
-			.toLowerCase();
+			.toLowerCase(Locale.ROOT);
 		String host = m.group(2);
 		String port = m.group(3);
 
@@ -365,7 +366,7 @@ public class ConnectionSettings {
 		public ProxySetup forURL(URL url) throws Exception {
 			Proxy.Type type;
 
-			switch (proxyDTO.protocol.toUpperCase()) {
+			switch (proxyDTO.protocol.toUpperCase(Locale.ROOT)) {
 
 				case "DIRECT" :
 					type = Type.DIRECT;

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.connection.settings.ConnectionSettings;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.URLCache.Info;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.Registry;
@@ -62,7 +63,6 @@ import aQute.bnd.service.url.URLConnector;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.util.home.Home;
 import aQute.lib.date.Dates;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.io.IO;
 import aQute.lib.json.JSONCodec;
 import aQute.libg.reporter.ReporterAdapter;
@@ -895,7 +895,7 @@ public class HttpClient implements Closeable, URLConnector {
 		if (scheme == null) {
 			return "Invalid uri, no scheme: " + u;
 		}
-		switch (scheme.toLowerCase()) {
+		switch (scheme.toLowerCase(Locale.ROOT)) {
 			case "http" :
 			case "https" :
 			case "file" :

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
@@ -6,6 +6,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -83,7 +84,7 @@ public class HttpRequest<T> {
 
 	public HttpRequest<T> verb(String verb) {
 		this.verb = verb;
-		switch (verb.toUpperCase()) {
+		switch (verb.toUpperCase(Locale.ROOT)) {
 			case "GET" :
 			case "HEAD" :
 			case "PUT" :

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDependencyGraph.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/MavenDependencyGraph.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -63,7 +64,7 @@ public class MavenDependencyGraph {
 				optional = (Boolean) xpath.evaluate("optinal", node, XPathConstants.BOOLEAN);
 				String scope = xpath.evaluate("scope", node);
 				if (scope != null && scope.length() > 0) {
-					this.scope = Scope.valueOf(scope.toUpperCase());
+					this.scope = Scope.valueOf(scope.toUpperCase(Locale.ROOT));
 				}
 				NodeList evaluate = (NodeList) xpath.evaluate("//dependencies/dependency", doc, XPathConstants.NODESET);
 

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/support/MavenEntry.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/support/MavenEntry.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.FutureTask;
@@ -305,9 +306,9 @@ public class MavenEntry implements Closeable {
 			IO.copy(actualFile, md);
 			byte[] digest = md.digest();
 			String source = IO.collect(digestFile)
-				.toUpperCase();
+				.toUpperCase(Locale.ROOT);
 			String hex = Hex.toHexString(digest)
-				.toUpperCase();
+				.toUpperCase(Locale.ROOT);
 			if (source.startsWith(hex)) {
 				System.err.println("Verified ok " + actualFile + " digest " + algorithm);
 				return true;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2841,7 +2841,7 @@ public class Analyzer extends Processor {
 
 		Set<Clazz> matched = new HashSet<>(classspace.values());
 		for (int i = 1; i < args.length; i++) {
-			String typeName = args[i].toUpperCase();
+			String typeName = args[i].toUpperCase(Locale.ROOT);
 			Clazz.QUERY type;
 			switch (typeName) {
 				case "EXTENDING" :
@@ -2894,7 +2894,7 @@ public class Analyzer extends Processor {
 			queryType = null;
 			instr = null;
 		} else if (args.length >= 2) {
-			queryType = Packages.QUERY.valueOf(args[1].toUpperCase());
+			queryType = Packages.QUERY.valueOf(args[1].toUpperCase(Locale.ROOT));
 			if (args.length > 2)
 				instr = new Instruction(args[2]);
 			else
@@ -3612,7 +3612,7 @@ public class Analyzer extends Processor {
 						break;
 					}
 
-					Check c = Check.valueOf(k.toUpperCase()
+					Check c = Check.valueOf(k.toUpperCase(Locale.ROOT)
 						.replace('-', '_'));
 					checks.add(c);
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -841,7 +842,8 @@ public class Analyzer extends Processor {
 
 						Object substitution = a.get("substitution");
 						if (substitution != null) {
-							switch (substitution.toString()) {
+							switch (substitution.toString()
+								.toUpperCase(Locale.ROOT)) {
 								case "CONSUMER" :
 									info.put(PROVIDE_DIRECTIVE, "false");
 									break;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -467,8 +467,8 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 							.getFQN()
 							.equals(STD_REQUIREMENT_RESOLUTION)) {
 
-						o = String.valueOf(o)
-							.toLowerCase();
+						o = o.toString()
+							.toLowerCase(Locale.ROOT);
 					}
 
 					attributesAndDirectives.putTyped(attributeName, o);
@@ -518,14 +518,14 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 				object = current.getClassName();
 			}
 
-			String returnFQN = method.getType()
-				.getFQN();
-
-			if ((object != null) && (returnFQN.equals(CARDINALITY) || returnFQN.equals(RESOLUTION)
-				|| returnFQN.equals(STD_REQUIREMENT_CARDINALITY) || returnFQN.equals(STD_REQUIREMENT_RESOLUTION))) {
-
-				object = String.valueOf(object)
-					.toLowerCase();
+			if (object != null) {
+				String returnFQN = method.getType()
+					.getFQN();
+				if ((returnFQN.equals(CARDINALITY) || returnFQN.equals(RESOLUTION)
+					|| returnFQN.equals(STD_REQUIREMENT_CARDINALITY) || returnFQN.equals(STD_REQUIREMENT_RESOLUTION))) {
+					object = object.toString()
+						.toLowerCase(Locale.ROOT);
+				}
 			}
 
 			return object;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -1938,7 +1939,7 @@ public class Builder extends Analyzer {
 			}
 		}
 		return content.trim()
-			.toUpperCase();
+			.toUpperCase(Locale.ROOT);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Domain.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -34,13 +35,13 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.maven.PomParser;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.io.ByteBufferInputStream;
 import aQute.lib.io.IO;
 import aQute.lib.utf8properties.UTF8Properties;
@@ -518,7 +519,7 @@ public abstract class Domain implements Iterable<String> {
 			}
 		} catch (ZipException e) {
 			if (file.getName()
-				.toLowerCase()
+				.toLowerCase(Locale.ROOT)
 				.endsWith(".jar"))
 				throw new ZipException("invalid jar format: " + file);
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1972,7 +1972,7 @@ public class Macro {
 	public String _toupper(String[] args) throws Exception {
 		verifyCommand(args, _tolowerHelp, null, 2, 2);
 
-		return args[1].toUpperCase();
+		return args[1].toUpperCase(Locale.ROOT);
 	}
 
 	static final String _tolowerHelp = "${tolower;<target>}";
@@ -1980,7 +1980,7 @@ public class Macro {
 	public String _tolower(String[] args) throws Exception {
 		verifyCommand(args, _tolowerHelp, null, 2, 2);
 
-		return args[1].toLowerCase();
+		return args[1].toLowerCase(Locale.ROOT);
 	}
 
 	static final String _compareHelp = "${compare;<astring>;<bstring>}";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/OSInformation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/OSInformation.java
@@ -355,7 +355,7 @@ public class OSInformation {
 			nc.osversion = convertUnixKernelVersion(sysPropOsVersion);
 			nc.osnames = "MacOSX,Mac OS X";
 			return nc;
-		} else if (sysPropOsName.toLowerCase()
+		} else if (sysPropOsName.toLowerCase(Locale.ROOT)
 			.startsWith("linux")) {
 			nc.osversion = convertUnixKernelVersion(sysPropOsVersion);
 			nc.osnames = "Linux";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PermissionGenerator.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toCollection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -186,7 +187,7 @@ public class PermissionGenerator {
 		EnumSet<Parameter> parameters = EnumSet.noneOf(Parameter.class);
 		// Skip the key name, so start at index 1
 		for (int ix = 1; ix < args.length; ix++) {
-			String name = args[ix].toUpperCase();
+			String name = args[ix].toUpperCase(Locale.ROOT);
 			try {
 				parameters.add(Parameter.valueOf(name));
 			} catch (IllegalArgumentException ex) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -951,7 +951,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		updateModified(file.lastModified(), file.toString());
 		Properties sub;
 		if (file.getName()
-			.toLowerCase()
+			.toLowerCase(Locale.ROOT)
 			.endsWith(".mf")) {
 			try (InputStream in = IO.stream(file)) {
 				sub = getManifestAsProperties(in);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -7,6 +7,7 @@ import java.util.Formatter;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -307,7 +308,7 @@ public class Verifier extends Processor {
 						if (del == '=')
 							value = qt.nextToken();
 
-						String key = name.toLowerCase();
+						String key = name.toLowerCase(Locale.ROOT);
 						if (key.equals("osname")) {
 							// ...
 						} else if (key.equals("osversion")) {

--- a/biz.aQute.bndlib/src/aQute/bnd/resource/repository/ResourceRepositoryImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/resource/repository/ResourceRepositoryImpl.java
@@ -19,6 +19,7 @@ import java.util.Formatter;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -30,6 +31,7 @@ import java.util.zip.InflaterInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin.DownloadListener;
 import aQute.bnd.service.repository.ResourceRepository;
@@ -38,7 +40,6 @@ import aQute.bnd.service.url.URLConnectionHandler;
 import aQute.bnd.url.DefaultURLConnectionHandler;
 import aQute.bnd.version.VersionRange;
 import aQute.lib.collections.MultiMap;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.hex.Hex;
 import aQute.lib.io.IO;
 import aQute.lib.json.JSONCodec;
@@ -429,7 +430,7 @@ public class ResourceRepositoryImpl implements ResourceRepository {
 
 			String deflate = http.getHeaderField("Content-Encoding");
 			in = http.getInputStream();
-			if (deflate != null && deflate.toLowerCase()
+			if (deflate != null && deflate.toLowerCase(Locale.ROOT)
 				.contains("deflate")) {
 				in = new InflaterInputStream(in);
 				logger.debug("inflate");

--- a/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
+++ b/biz.aQute.launcher/src/aQute/launcher/SimplePermissionPolicy.java
@@ -104,7 +104,7 @@ public class SimplePermissionPolicy implements SynchronousBundleListener {
 	public PermissionInfo[] getPermissions(Bundle bundle) {
 		URL url = bundle.getEntry("/OSGI-INF/permissions.perm");
 		if (url == null)
-			url = bundle.getEntry("/OSGI-INF/permissions.perm".toUpperCase());
+			url = bundle.getEntry("/OSGI-INF/PERMISSIONS.PERM");
 
 		PermissionInfo[] info = null;
 		if (url != null)

--- a/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
+++ b/biz.aQute.repository/src/aQute/bnd/deployer/repository/LocalIndexedRepo.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -252,7 +253,7 @@ public class LocalIndexedRepo extends AbstractIndexedRepo implements Refreshable
 			MessageDigest md = MessageDigest.getInstance(SHA256.ALGORITHM);
 			md.update(data);
 			IO.store(Hex.toHexString(md.digest())
-				.toLowerCase(), shaFile);
+				.toLowerCase(Locale.ROOT), shaFile);
 		}
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -13,6 +13,7 @@ import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -321,7 +322,7 @@ class IndexFile {
 		if (multi.isEmpty())
 			return false;
 
-		String[] extension = Strings.extension(name.toLowerCase());
+		String[] extension = Strings.extension(name.toLowerCase(Locale.ROOT));
 		return extension.length == 2 && multi.contains(extension[1]);
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -954,7 +954,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 	}
 
 	public File getIndexFile() {
-		return IO.getFile(base, configuration.index(name.toLowerCase() + ".mvn"));
+		return IO.getFile(base, configuration.index(name.toLowerCase(Locale.ROOT) + ".mvn"));
 	}
 
 	public Set<Archive> getArchives() {

--- a/biz.aQute.repository/src/aQute/maven/api/MavenScope.java
+++ b/biz.aQute.repository/src/aQute/maven/api/MavenScope.java
@@ -1,5 +1,7 @@
 package aQute.maven.api;
 
+import java.util.Locale;
+
 public enum MavenScope {
 	/**
 	 * compile - this is the default scope, used if none is specified. Compile
@@ -48,7 +50,7 @@ public enum MavenScope {
 	}
 
 	public static MavenScope getScope(String scope) {
-		switch (scope.toLowerCase()) {
+		switch (scope.toLowerCase(Locale.ROOT)) {
 			case "import" :
 				return MavenScope.import_;
 

--- a/biz.aQute.repository/src/aQute/maven/provider/POM.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/POM.java
@@ -11,6 +11,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -112,7 +113,8 @@ public class POM implements IPom {
 				for (int j = i + 1; j < jlimit; j++) {
 					c = (char) array[j];
 					if (c == ';') {
-						String entity = new String(array, i + 1, j - (i + 1), StandardCharsets.US_ASCII).toLowerCase();
+						String entity = new String(array, i + 1, j - (i + 1), StandardCharsets.US_ASCII)
+							.toLowerCase(Locale.ROOT);
 						switch (entity) {
 							case "lt" :
 							case "gt" :

--- a/biz.aQute.repository/test/aQute/bnd/deployer/repository/CachingUriResourceHandlerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/deployer/repository/CachingUriResourceHandlerTest.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ import test.lib.NanoHTTPD;
 public class CachingUriResourceHandlerTest {
 
 	private static final String	EXPECTED_SHA	= "d0002141a722ef03ecd8fd2e0d3e4d3bc680ba91483cb4962f68a41a12dd01ab"
-		.toUpperCase();
+		.toUpperCase(Locale.ROOT);
 
 	static File					currentDir		= new File(System.getProperty("user.dir"));
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerTest.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -89,7 +90,7 @@ public class P2IndexerTest {
 					.getRepository();
 				RequirementBuilder rb = new RequirementBuilder("osgi.content");
 
-				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
+				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase(Locale.ROOT) + ")");
 
 				Requirement req = rb.synthetic();
 				Collection<Capability> collection = repository.findProviders(Collections.singleton(req))
@@ -204,7 +205,7 @@ public class P2IndexerTest {
 					.getRepository();
 				RequirementBuilder rb = new RequirementBuilder("osgi.content");
 
-				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase() + ")");
+				rb.addDirective("filter", "(osgi.content~=" + sha256.toLowerCase(Locale.ROOT) + ")");
 
 				Requirement req = rb.synthetic();
 				Collection<Capability> collection = repository.findProviders(Collections.singleton(req))

--- a/biz.aQute.repository/test/aQute/maven/provider/RemoteRepoTest.java
+++ b/biz.aQute.repository/test/aQute/maven/provider/RemoteRepoTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -162,7 +163,7 @@ public class RemoteRepoTest {
 		remoteFoobar.getParentFile()
 			.mkdirs();
 		IO.store("bla", remoteFoobar);
-		IO.store(" FFA6706FF2127A749973072756F83C532E43ED02\r\n".toLowerCase(), remoteFoobarSha1);
+		IO.store(" FFA6706FF2127A749973072756F83C532E43ED02\r\n".toLowerCase(Locale.ROOT), remoteFoobarSha1);
 
 		assertEquals(State.UPDATED, repo.fetch("foo/bar", localFoobar)
 			.getState());

--- a/biz.aQute.repository/test/test/lib/NanoHTTPD.java
+++ b/biz.aQute.repository/test/test/lib/NanoHTTPD.java
@@ -306,7 +306,7 @@ public class NanoHTTPD {
 				keyStoreFile = new File(args[i + 1]).getAbsoluteFile();
 			else if (args[i].equalsIgnoreCase("--keyStorePass"))
 				keyStorePass = args[i + 1];
-			else if (args[i].toLowerCase()
+			else if (args[i].toLowerCase(Locale.ROOT)
 				.endsWith("licence")) {
 				myOut.println(LICENCE + "\n");
 				break;
@@ -540,7 +540,7 @@ public class NanoHTTPD {
 						if (p >= 0)
 							header.put(line.substring(0, p)
 								.trim()
-								.toLowerCase(),
+								.toLowerCase(Locale.ROOT),
 								line.substring(p + 1)
 									.trim());
 						line = in.readLine();
@@ -576,7 +576,7 @@ public class NanoHTTPD {
 						if (p != -1)
 							item.put(mpline.substring(0, p)
 								.trim()
-								.toLowerCase(),
+								.toLowerCase(Locale.ROOT),
 								mpline.substring(p + 1)
 									.trim());
 						mpline = in.readLine();
@@ -595,7 +595,7 @@ public class NanoHTTPD {
 							if (p != -1)
 								disposition.put(token.substring(0, p)
 									.trim()
-									.toLowerCase(),
+									.toLowerCase(Locale.ROOT),
 									token.substring(p + 1)
 										.trim());
 						}
@@ -950,7 +950,7 @@ public class NanoHTTPD {
 				if (dot >= 0)
 					mime = theMimeTypes.get(f.getCanonicalPath()
 						.substring(dot + 1)
-						.toLowerCase());
+						.toLowerCase(Locale.ROOT));
 				if (mime == null)
 					mime = MIME_DEFAULT_BINARY;
 

--- a/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
+++ b/bndtools.core/src/bndtools/editor/contents/GeneralInfoPart.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.bndtools.api.ILogger;
@@ -297,8 +298,8 @@ public class GeneralInfoPart extends SectionPart implements PropertyChangeListen
 							ITypeHierarchy hierarchy = activatorType.newTypeHierarchy(javaProject, monitor);
 							for (IType subType : hierarchy.getAllSubtypes(activatorType)) {
 								if (!Flags.isAbstract(subType.getFlags()) && subType.getElementName()
-									.toLowerCase()
-									.contains(prefix.toLowerCase())) {
+									.toLowerCase(Locale.ROOT)
+									.contains(prefix.toLowerCase(Locale.ROOT))) {
 									result.add(new JavaTypeContentProposal(subType));
 								}
 							}
@@ -327,8 +328,8 @@ public class GeneralInfoPart extends SectionPart implements PropertyChangeListen
 		protected boolean match(String contents, int position, IContentProposal proposal) {
 			String prefix = contents.substring(0, position);
 			return ((JavaTypeContentProposal) proposal).getTypeName()
-				.toLowerCase()
-				.startsWith(prefix.toLowerCase());
+				.toLowerCase(Locale.ROOT)
+				.startsWith(prefix.toLowerCase(Locale.ROOT));
 		}
 	}
 }

--- a/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsProposalProvider.java
+++ b/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsProposalProvider.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.TreeSet;
 
 import org.bndtools.api.ILogger;
@@ -114,8 +115,8 @@ public class PkgPatternsProposalProvider extends CachingContentProposalProvider 
 		final String prefix = contents.substring(0, position);
 		return ((PkgPatternProposal) proposal).getPackageFragment()
 			.getElementName()
-			.toLowerCase()
-			.indexOf(prefix.toLowerCase()) > -1;
+			.toLowerCase(Locale.ROOT)
+			.indexOf(prefix.toLowerCase(Locale.ROOT)) > -1;
 	}
 
 }

--- a/bndtools.core/src/bndtools/refactor/PkgRenameParticipant.java
+++ b/bndtools.core/src/bndtools/refactor/PkgRenameParticipant.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -103,7 +104,7 @@ public class PkgRenameParticipant extends RenameParticipant implements ISharable
 			}
 
 			if (!((proxy.getType() == IResource.FILE) && proxy.getName()
-				.toLowerCase()
+				.toLowerCase(Locale.ROOT)
 				.endsWith(".bnd"))) {
 				return false;
 			}

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -151,11 +152,11 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 	private CapReqLoader getLoaderForFile(File file) {
 		CapReqLoader loader;
 		if (file.getName()
-			.toLowerCase()
+			.toLowerCase(Locale.ROOT)
 			.endsWith(".bnd")) {
 			loader = new BndFileCapReqLoader(file);
 		} else if (file.getName()
-			.toLowerCase()
+			.toLowerCase(Locale.ROOT)
 			.endsWith(".jar")) {
 			loader = new JarFileCapReqLoader(file);
 		} else {

--- a/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
+++ b/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.bndtools.api.ILogger;
@@ -73,7 +74,7 @@ public class RepoBundleSelectionWizardPage extends WizardPage {
 																				Object parentElement, Object element) {
 																				String search = selectionSearchTxt
 																					.getText()
-																					.toLowerCase();
+																					.toLowerCase(Locale.ROOT);
 
 																				String bsn = null;
 																				if (element instanceof RepositoryBundle) {
@@ -86,7 +87,7 @@ public class RepoBundleSelectionWizardPage extends WizardPage {
 
 																				if (bsn != null) {
 																					if (search.length() > 0
-																						&& bsn.toLowerCase()
+																						&& bsn.toLowerCase(Locale.ROOT)
 																							.indexOf(search) == -1) {
 																						return false;
 																					}

--- a/bndtools.core/test/org/bndtools/core/templating/repobased/ReposTemplateLoaderTest.java
+++ b/bndtools.core/test/org/bndtools/core/templating/repobased/ReposTemplateLoaderTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -96,7 +97,7 @@ public class ReposTemplateLoaderTest {
 		byte[] digest = digestStream.getMessageDigest()
 			.digest();
 		assertEquals("ea5d770bc2deddb1f9a20df3ad337bdc1490ba7b35fa41c33aa4e9a534e82ada", Hex.toHexString(digest)
-			.toLowerCase());
+			.toLowerCase(Locale.ROOT));
 
 		entry = iter.next();
 		assertEquals("src/main/java/", entry.getKey());
@@ -146,7 +147,7 @@ public class ReposTemplateLoaderTest {
 		byte[] digest = digestStream.getMessageDigest()
 			.digest();
 		assertEquals("ea5d770bc2deddb1f9a20df3ad337bdc1490ba7b35fa41c33aa4e9a534e82ada", Hex.toHexString(digest)
-			.toLowerCase());
+			.toLowerCase(Locale.ROOT));
 
 		entry = iter.next();
 		assertEquals("src/main/java/", entry.getKey());
@@ -212,7 +213,7 @@ public class ReposTemplateLoaderTest {
 		byte[] digest = digestStream.getMessageDigest()
 			.digest();
 		assertEquals("ea5d770bc2deddb1f9a20df3ad337bdc1490ba7b35fa41c33aa4e9a534e82ada", Hex.toHexString(digest)
-			.toLowerCase());
+			.toLowerCase(Locale.ROOT));
 	}
 
 }

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.core.filesystem.EFS;
@@ -342,8 +343,8 @@ public class JARPrintPage extends FormPage {
 		if (findText == null || findText.isEmpty())
 			return Collections.emptyList();
 
-		content = content.toLowerCase();
-		findText = findText.toLowerCase();
+		content = content.toLowerCase(Locale.ROOT);
+		findText = findText.toLowerCase(Locale.ROOT);
 		List<Integer> indexes = new ArrayList<>();
 		int index = 0;
 		int wordLength = 0;

--- a/bndtools.release/src/bndtools/release/ui/InfoLabelProvider.java
+++ b/bndtools.release/src/bndtools/release/ui/InfoLabelProvider.java
@@ -1,5 +1,7 @@
 package bndtools.release.ui;
 
+import java.util.Locale;
+
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -32,14 +34,14 @@ public class InfoLabelProvider extends ColumnLabelProvider {
 			}
 			return BundleTreeImages.resolveImage("bundle", apiDiff.getDelta() //$NON-NLS-1$
 				.toString()
-				.toLowerCase(), null, null);
+				.toLowerCase(Locale.ROOT), null, null);
 		}
 		if (element instanceof Info) {
 			Info tree = (Info) element;
 			String type = "package"; //$NON-NLS-1$
 			String delta = "changed" + '_' + tree.packageDiff.getDelta() //$NON-NLS-1$
 				.toString()
-				.toLowerCase();
+				.toLowerCase(Locale.ROOT);
 			String impExp = "export"; //$NON-NLS-1$
 			return BundleTreeImages.resolveImage(type, delta, impExp, null);
 		}

--- a/bndtools.release/src/bndtools/release/ui/TreeLabelProvider.java
+++ b/bndtools.release/src/bndtools/release/ui/TreeLabelProvider.java
@@ -1,5 +1,7 @@
 package bndtools.release.ui;
 
+import java.util.Locale;
+
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.graphics.Image;
 
@@ -56,13 +58,13 @@ public class TreeLabelProvider extends ColumnLabelProvider {
 			return BundleTreeImages.resolveImage("bundle", ((Baseline) element).getDiff() //$NON-NLS-1$
 				.getDelta()
 				.toString()
-				.toLowerCase(), null, null);
+				.toLowerCase(Locale.ROOT), null, null);
 		}
 		if (element instanceof Diff) {
 			Diff tree = (Diff) element;
 			String type = tree.getType()
 				.toString()
-				.toLowerCase();
+				.toLowerCase(Locale.ROOT);
 
 			String strDelta = getDeltaString(tree);
 			String impExp = null;
@@ -81,7 +83,7 @@ public class TreeLabelProvider extends ColumnLabelProvider {
 			Tree tree = (Tree) element;
 			String type = tree.getType()
 				.toString()
-				.toLowerCase();
+				.toLowerCase(Locale.ROOT);
 			String impExp = null;
 			if (tree.getType() == Type.PACKAGE) {
 				impExp = "export"; //$NON-NLS-1$
@@ -100,7 +102,7 @@ public class TreeLabelProvider extends ColumnLabelProvider {
 	private static String getDeltaString(Diff diff) {
 		return diff.getDelta()
 			.toString()
-			.toLowerCase();
+			.toLowerCase(Locale.ROOT);
 	}
 
 }


### PR DESCRIPTION
Using enum types in the CLASS retention bundle annotations is causing
issues for those using the annotations. Various tools, such as javadoc,
attempt to reify the elements in the annotations and since the
osgi.annotation jar is generally a scope=provided dependency, the enum
types are not available to downstream users of the jars using the
OSGi annotations and so tools generates an annoying warning.

See https://github.com/quarkusio/quarkus/issues/19970 and
https://github.com/eclipse/microprofile-config/issues/716.

We support the use of enum values or string values as the annotation
element value through existing conversion support. The OSGi change in
https://github.com/osgi/osgi/pull/404 will move from using enum types
to use string values which are case-insensitive equivalent to the
enum value names.

We seamlessly handle old and new annotations using the old enum values
or the new string values. Prior to this fix, Bnd already handled the
change through a fallback in Converter which uppercased the string value
before converting to an internal enum value. This change avoids the
internal enum type and processes the string value or string name of the
enum value when processing older versions of the OSGi annotations.