### PR TITLE
[resolve] Repository validation

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -34,7 +35,8 @@ import aQute.maven.api.Program;
 @Description("Maintain Maven Bnd Repository GAV files")
 @SuppressWarnings("deprecation")
 public class MbrCommand extends Processor {
-	final static Pattern					SNAPSHOTLIKE_P				= Pattern.compile("-[^.]+$");
+	final static Pattern					SNAPSHOTLIKE_P				= Pattern
+		.compile("(-[^.]+)|(.*(beta|alfa|alpha|rc).?\\d+$)", Pattern.CASE_INSENSITIVE);
 	final static Predicate<MavenVersion>	notSnapshotlikePredicate	= v -> !SNAPSHOTLIKE_P.matcher(v.toString())
 		.find();
 
@@ -163,7 +165,7 @@ public class MbrCommand extends Processor {
 			bnd.trace("repo %s", repo.getName());
 			Map<Archive, MavenVersion> content = new HashMap<>();
 
-			for (Archive archive : repo.getArchives()) {
+			for (Archive archive : new TreeSet<>(repo.getArchives())) {
 				List<MavenVersion> list = updates.get(archive);
 				if (list == null || list.isEmpty()) {
 					content.put(archive, archive.revision.version);

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -1645,7 +1645,7 @@ public class Workspace extends Processor {
 	/**
 	 * Strategy to use when creating a workspace ResourceRepository.
 	 */
-	enum ResourceRepositoryStrategy {
+	public enum ResourceRepositoryStrategy {
 		/**
 		 * All Repository plugins and the Workspace repository.
 		 * <p>
@@ -1671,7 +1671,7 @@ public class Workspace extends Processor {
 	 * @return an aggregate repository
 	 * @throws Exception
 	 */
-	Repository getResourceRepository(ResourceRepositoryStrategy strategy) throws Exception {
+	public Repository getResourceRepository(ResourceRepositoryStrategy strategy) throws Exception {
 		List<Repository> plugins;
 
 		switch (strategy) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/FilterParser.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/FilterParser.java
@@ -16,8 +16,8 @@ import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 
-import aQute.bnd.version.Version;
 import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.version.Version;
 import aQute.lib.strings.Strings;
 
 public class FilterParser {
@@ -1086,13 +1086,19 @@ public class FilterParser {
 	}
 
 	public static String toString(Requirement r) {
+		return toString(r, true);
+	}
+
+	public static String toString(Requirement r, boolean namespace) {
 		try {
 			StringBuilder sb = new StringBuilder();
-			String category = namespaceToCategory(r.getNamespace());
-			if (category != null && category.length() > 0)
-				sb.append(namespaceToCategory(category))
-					.append(": ");
 
+			if (namespace) {
+				String category = namespaceToCategory(r.getNamespace());
+				if (category != null && category.length() > 0)
+					sb.append(namespaceToCategory(category))
+						.append(": ");
+			}
 			FilterParser fp = new FilterParser();
 			String filter = r.getDirectives()
 				.get("filter");

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -67,10 +67,38 @@ import aQute.lib.strings.Strings;
 
 public class ResourceUtils {
 
+	public static final Comparator<Requirement>			REQUIREMENT_COMPARATOR		=																	//
+
+		(Requirement o1, Requirement o2) -> {
+			if (o1 == o2)
+				return 0;
+
+			if (o1 == null)
+				return -1;
+
+			if (o2 == null)
+				return 1;
+
+			if (o1.equals(o2))
+				return 0;
+
+			String ns1 = o1.getNamespace();
+			String ns2 = o2.getNamespace();
+			int compareTo = ns1.compareTo(ns2);
+			if (compareTo != 0)
+				return compareTo;
+
+			String f1 = o1.getDirectives()
+				.get("filter");
+			String f2 = o2.getDirectives()
+				.get("filter");
+			return f1.compareTo(f2);
+		};
+
 	/**
 	 * A comparator that compares the identity versions
 	 */
-	public static final Comparator<? super Resource>	IDENTITY_VERSION_COMPARATOR	=								//
+	public static final Comparator<? super Resource>		IDENTITY_VERSION_COMPARATOR	=								//
 		(o1, o2) -> {
 			if (o1 == o2)
 				return 0;
@@ -99,7 +127,7 @@ public class ResourceUtils {
 			return new Version(v1).compareTo(new Version(v2));
 		};
 
-	private static final Comparator<? super Resource>	RESOURCE_COMPARATOR			=								//
+	private static final Comparator<? super Resource>		RESOURCE_COMPARATOR			=								//
 		(o1, o2) -> {
 			if (o1 == o2)
 				return 0;
@@ -120,10 +148,10 @@ public class ResourceUtils {
 				.compareTo(o2.toString());
 		};
 
-	public static final Resource						DUMMY_RESOURCE				= new ResourceBuilder().build();
-	public static final String							WORKSPACE_NAMESPACE			= "bnd.workspace.project";
+	public static final Resource							DUMMY_RESOURCE				= new ResourceBuilder().build();
+	public static final String								WORKSPACE_NAMESPACE			= "bnd.workspace.project";
 
-	private static final Converter						cnv							= new Converter()
+	private static final Converter							cnv							= new Converter()
 		.hook(Version.class, (dest, o) -> toVersion(o));
 
 	public interface IdentityCapability extends Capability {
@@ -690,6 +718,15 @@ public class ResourceUtils {
 	public static int compareTo(Resource a, Resource b) {
 		IdentityCapability left = ResourceUtils.getIdentityCapability(a);
 		IdentityCapability right = ResourceUtils.getIdentityCapability(b);
+		if (left == right)
+			return 0;
+
+		if (left == null) {
+			return 1;
+		}
+		if (right == null) {
+			return -1;
+		}
 
 		int compare = Objects.compare(left.osgi_identity(), right.osgi_identity(), nullsFirst);
 		if (compare != 0) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.HashMap;
@@ -502,6 +503,11 @@ class IndexFile {
 		return archives.keySet();
 	}
 
+	Collection<Resource> getResources() {
+		sync(updateSerializer);
+		return archives.values();
+	}
+
 	Archive find(String bsn, Version version) throws Exception {
 
 		//
@@ -633,4 +639,5 @@ class IndexFile {
 		}
 		return null;
 	}
+
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -962,6 +962,11 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 		return index.getArchives();
 	}
 
+	public Collection<org.osgi.resource.Resource> getResources() {
+		init();
+		return index.getResources();
+	}
+
 	public List<Revision> getRevisions(Program program) throws Exception {
 		if (!init())
 			return Collections.emptyList();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -958,12 +958,14 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 	}
 
 	public Set<Archive> getArchives() {
-		init();
+		if (!init())
+			return Collections.emptySet();
 		return index.getArchives();
 	}
 
 	public Collection<org.osgi.resource.Resource> getResources() {
-		init();
+		if (!init())
+			return Collections.emptyList();
 		return index.getResources();
 	}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.9.1")
+@Version("1.10.0")
 package aQute.bnd.repository.maven.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
@@ -1,4 +1,4 @@
-@Version("8.0.0")
+@Version("8.1.0")
 package biz.aQute.resolve;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Updating an older repository set can be painful. We already had the `bnd mbr` command to do some validation and updating of the mvn files. However, these commands lacked an overview.

This PR updates the `bnd resolve validate` command. It used to require a OBR index, and it can still accept it. However, without the index, it will assume that it is in a workspace. It will then resolve all files in the workspace and all configured repositories stand alone. 

Added the following options:

-x Print a requirement -> set resource for missing resources

-u print unused resources in the repository. That is, no workspace resource requires it.



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>