### PR TITLE
[http client] Limit the # of concurrent connections

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/SettingsParserTest.java
@@ -54,6 +54,7 @@ public class SettingsParserTest {
 			assertThat(ws.check()).isTrue();
 			URLConnectionHandler handler = plugin.findMatchingHandler(new URL("http://httpbin.org"));
 			assertThat(handler).isNotNull();
+			assertThat(handler.maxConcurrentConnections()).isEqualTo(10);
 		}
 	}
 
@@ -191,7 +192,7 @@ public class SettingsParserTest {
 	public void testWildcardURL() throws Exception {
 		try (Processor proc = new Processor(); HttpClient hc = new HttpClient()) {
 			proc.setProperty("-connection-settings",
-				"server;id=\"https://*.server.net:8080\";username=\"myUser\";password=\"myPassword\","
+				"server;id=\"https://*.server.net:8080\";username=\"myUser\";password=\"myPassword\";maxConcurrentConnections=11,"
 					+ "server;id=\"https://*.server.net/\";username=\"myUser\";password=\"myPassword\"");
 			ConnectionSettings cs = new ConnectionSettings(proc, hc);
 			cs.readSettings();
@@ -199,11 +200,12 @@ public class SettingsParserTest {
 			assertEquals(2, serverDTOs.size());
 
 			ServerDTO s = serverDTOs.get(0);
-
+			assertThat(s.maxConcurrentConnections).isEqualTo(11);
 			assertEquals("https://*.server.net:8080", s.id);
 
 			URLConnectionHandler handler = cs.createURLConnectionHandler(s);
 
+			assertThat(handler.maxConcurrentConnections()).isEqualTo(11);
 			assertTrue(handler.matches(new URL("https://www.server.net:8080")));
 
 			s = serverDTOs.get(1);

--- a/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/valid.xml
+++ b/biz.aQute.bndlib.comm.tests/testresources/ws/cnf/valid.xml
@@ -1,8 +1,7 @@
 
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-                          http://maven.apache.org/xsd/settings-1.0.0.xsd">
+>
 	<localRepository />
 	<interactiveMode />
 	<usePluginRegistry />
@@ -13,6 +12,7 @@
 			<id>http://httpbin.org</id>
 			<username>user</username>
 			<password>passwd</password>
+            <maxConcurrentConnections>10</maxConcurrentConnections>
 		</server>
 	</servers>
 	<mirrors />

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -295,9 +295,11 @@ public class ConnectionSettings {
 		private final Glob					match;
 		private final URLConnectionHandler	handler;
 		private final URLConnectionHandler	https;
+		private final int					maxConcurrentConnections;
 
 		SettingsURLConnectionHandler(ServerDTO serverDTO, Processor processor) {
 			match = new Glob(serverDTO.match != null ? serverDTO.match : serverDTO.id);
+			maxConcurrentConnections = serverDTO.maxConcurrentConnections;
 			if (serverDTO.password == null) {
 				handler = null;
 			} else if (serverDTO.username != null) {
@@ -335,6 +337,10 @@ public class ConnectionSettings {
 			}
 		}
 
+		@Override
+		public int maxConcurrentConnections() {
+			return maxConcurrentConnections;
+		}
 		private boolean isHttps(URLConnection connection) {
 			return "https".equalsIgnoreCase(connection.getURL()
 				.getProtocol());
@@ -342,7 +348,8 @@ public class ConnectionSettings {
 
 		@Override
 		public String toString() {
-			return "Server [ match=" + match + ", handler=" + handler + ", https=" + https + "]";
+			return "Server [ match=" + match + ", handler=" + handler + ", maxConcurrentConnections="
+				+ maxConcurrentConnections + ", https=" + https + "]";
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ServerDTO.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ServerDTO.java
@@ -19,4 +19,5 @@ public class ServerDTO extends DTO {
 	public String	match;
 	public boolean	verify	= true;
 	public String	trust;
+	public int		maxConcurrentConnections	= 0;
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/URLConnectionHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/URLConnectionHandler.java
@@ -48,4 +48,14 @@ public interface URLConnectionHandler {
 	 * @return true if matched, false if not.
 	 */
 	boolean matches(URL url);
+
+	/**
+	 * Limit the number of concurrent connections for this handler. If this
+	 * returns 0, there is no limit.
+	 *
+	 * @return the number of max concurrent connections or 0 for no limit
+	 */
+	default int maxConcurrentConnections() {
+		return 0;
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/url/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/docs/_instructions/connection-settings.md
+++ b/docs/_instructions/connection-settings.md
@@ -72,6 +72,7 @@ The settings files have the following XML structure:
 	        <password>password</password>
 		    <verify> true | false </verify>
 		    <trust> comma separated paths to X509 certificates </trust>
+            <maxConcurrentConnections>10</maxConcurrentConnections>
 	    </server>
 	  </servers>
 	</settings>
@@ -116,7 +117,8 @@ The first server that matches the id will provide the parameters.
 | `username`        |              |                | User name for authentication to the server |
 | `password`        |              |                | Password for authentication to the server  |
 | `verify`          |  `true`      | `false | true` | Enable/disable the verification of the host name against a certificate for HTTPS |
-| `trust`           |              |                | Provide paths to certificate that provide trust to the host certificate. The format most of a X.509 certificat file. Normally the extension is `.cer` |
+| `trust`           |              |                | Provide paths to certificate that provide trust to the host certificate. The format most of a X.509 certificate file. Normally the extension is `.cer` |
+| `maxConcurrentConnections`|0 (unlimited)|0..      | Limits the number of parallel connections to a host. Some hosts use the number of concurrent connections as a sign of a denial of service attack. |
 
 ## oAuth2 authentication
 


### PR DESCRIPTION
This change fixes  #5035

Sometimes a host limits the number of connections
because it sees too many connections from one client
as an attack.

This patch enables a `maxConcurrentConnections` field in the Maven XML or in the ServerDTO. If this is 0, no limit is applied. Otherwise the connection to that host will be limited to that number. Different hosts can have different numbers.

The implementation is unsophisticated. The client uses
the URL Connection Handler to get this limit from the
ServerDTO. If not zero, he URL Connection Handler is then used
as a key in a map to a Semaphore that is initialized with the
URL handler maxConcurrentConnections value.

Each connection to that host will then first acquire a
token and will return it at the end.

To simplify the code, a dummy semaphore is returned for
non limited cases.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>