### PR TITLE
[doc] Use of class

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-seo-tag'
+
+gem "webrick", "~> 1.7"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
     zeitwerk (2.5.2)
 
 PLATFORMS
@@ -278,6 +279,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-seo-tag
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/docs/_chapters/400-commands.md
+++ b/docs/_chapters/400-commands.md
@@ -34,10 +34,23 @@ In this text `bnd` is used as if it is a command line program. This should be se
 
 
 <div>
-<dl class="property-index">
 
-{% for c in site.commands %}<dt><a href="{{ c.url | prepend: site.baseurl }}">{{c.title | escape}}</a></dt><dd>{{c.summary | escape}}</dd>
-{% endfor %}
-
-</dl>
+<div>
+<table class="property-index">
+    <thead>
+        <th>page</th>
+        <th>Description</th>
+        <th>Class</th>
+    </thead>
+    <tbody>
+        {% for page in site.commands %}
+        <tr>
+            <td><a href="{{ page.url | prepend: site.baseurl }}">{{page.title | escape}}</a></td>
+            <td>{{page.summary | escape}}</td>
+            <td>{{page.class}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
 </div>

--- a/docs/_chapters/800-headers.md
+++ b/docs/_chapters/800-headers.md
@@ -6,8 +6,24 @@ layout: default
 <div>
 <dl class="property-index">
 
-{% for instruction in site.heads %}<dt><a href="{{ instruction.url | prepend: site.baseurl }}">{{instruction.title}}</a></dt><dd>{{instruction.summary}}</dd>
-{% endfor %}
+<div>
+<table class="property-index">
+    <thead>
+        <th>page</th>
+        <th>Description</th>
+        <th>Class</th>
+    </thead>
+    <tbody>
+        {% for page in site.heads %}
+        <tr>
+            <td><a href="{{ page.url | prepend: site.baseurl }}">{{page.title | escape}}</a></td>
+            <td>{{page.summary | escape}}</td>
+            <td>{{page.class}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
 
 </dl>
 </div>

--- a/docs/_chapters/825-instructions-ref.md
+++ b/docs/_chapters/825-instructions-ref.md
@@ -4,10 +4,20 @@ layout: default
 ---
 
 <div>
-<dl class="property-index">
-
-{% for instruction in site.instructions %}<dt><a href="{{ instruction.url | prepend: site.baseurl }}">{{instruction.title | escape}}</a></dt><dd>{{instruction.summary | escape}}</dd>
-{% endfor %}
-
-</dl>
+<table class="property-index">
+    <thead>
+        <th>Instruction</th>
+        <th>Description</th>
+        <th>Class</th>
+    </thead>
+    <tbody>
+        {% for instruction in site.instructions %}
+        <tr>
+            <td><a href="{{ instruction.url | prepend: site.baseurl }}">{{instruction.title | escape}}</a></td>
+            <td>{{instruction.summary | escape}}</td>
+            <td>{{instruction.class}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 </div>

--- a/docs/_chapters/850-macros.md
+++ b/docs/_chapters/850-macros.md
@@ -21,6 +21,7 @@ For example:
     Bundle-Version= ${version}
     Bundle-Description= This bundle has version ${version}
 
+
 ## Macro patterns
 The default macro pattern is the `${...}` pattern, a dollar sign ('$') followed by a left curly bracket ('{') and closed by a right curly bracket ('}'). However, since bndlib is often used inside other systems it also supports alternative macro patterns:
 

--- a/docs/_chapters/855-macros-ref.md
+++ b/docs/_chapters/855-macros-ref.md
@@ -6,8 +6,24 @@ layout: default
 <div>
 <dl class="property-index">
 
-{% for macro in site.macros %}<dt><a href="{{ macro.url | prepend: site.baseurl }}">{{macro.title | escape}}</a></dt><dd>{{macro.summary | escape}}</dd>
-{% endfor %}
+<div>
+<table class="property-index">
+    <thead>
+        <th>page</th>
+        <th>Description</th>
+        <th>Class</th>
+    </thead>
+    <tbody>
+        {% for page in site.macros %}
+        <tr>
+            <td><a href="{{ page.url | prepend: site.baseurl }}">{{page.title | escape}}</a></td>
+            <td>{{page.summary | escape}}</td>
+            <td>{{page.class}}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
 
 </dl>
 </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -17,6 +17,12 @@
 			
 		<li span=9>
 			<div class=notes-margin>
+			    {% if page.class %}
+                   <div class="pageclass">
+                      {{page.class}}
+                   </div>
+                {% endif %}     
+			
 				<h1>{{h1}} {{page.title}}</h1>
 				{{content}}
 			</div>

--- a/docs/css/style.scss
+++ b/docs/css/style.scss
@@ -164,3 +164,24 @@ embed.illustration {
 .releases:hover .dropbtn {
   background-color: #99594b;
 }
+
+.pageclass {
+    background-color: #99594b;
+    color: white;
+    width: 80px;
+    float: right;
+    text-align: center;
+    border-radius: 5px;
+    padding:2px;
+    transform: rotateY(0deg);
+    animation-name: turn;
+    animation-duration: 1s;
+ }
+ 
+ @keyframes turn {
+  from {
+        transform: rotateY(90deg);
+    }
+  to {    transform: rotateY(0deg);
+    }
+}


### PR DESCRIPTION
Each page indicates its class (Project,Workspace,Analyzer,...)
as a class property in the YAML header. We were not showing this

This change adds a button to the page that specifies this class property.

Also rewrote the index pages to be a bit more compact

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>