### PR TITLE
Adds double check idiom for the init method

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -63,7 +63,7 @@ public class BndPomRepository extends BaseRepository
 	private static final String	MAVEN_REPO_LOCAL	= System.getProperty("maven.repo.local", "~/.m2/repository");
 	private static final int	DEFAULT_POLL_TIME	= 300;
 
-	private Promise<Boolean>	initialized;
+	private volatile Promise<Boolean>	initialized;
 
 	private PomConfiguration	configuration;
 	private Registry			registry;
@@ -80,11 +80,14 @@ public class BndPomRepository extends BaseRepository
 
 	private String				status;
 
-	@SuppressWarnings("deprecation")
 	private boolean init() {
 		try {
 			if (initialized == null) {
-				prepare();
+				synchronized (configuration) {
+					if (initialized == null) {
+						prepare();
+					}
+				}
 			}
 			return initialized.getValue();
 		} catch (Exception e) {


### PR DESCRIPTION
if the init is called in parallel, it might go wrong and the init will
happen twice.

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>