### PR TITLE
[libg] Restore old package

### DIFF
--- a/aQute.libg/src/aQute/lib/exceptions/BiConsumerWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/BiConsumerWithException.java
@@ -1,0 +1,41 @@
+package aQute.lib.exceptions;
+
+import java.util.function.BiConsumer;
+
+/**
+ * BiConsumer interface that allows exceptions.
+ *
+ * @param <T> the type of the first argument
+ * @param <U> the type of the second argument
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface BiConsumerWithException<T, U> {
+	void accept(T t, U u) throws Exception;
+
+	default BiConsumer<T, U> orElseThrow() {
+		return (t, u) -> {
+			try {
+				accept(t, u);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default BiConsumer<T, U> ignoreException() {
+		return (t, u) -> {
+			try {
+				accept(t, u);
+			} catch (Exception e) {}
+		};
+	}
+
+	static <T, U> BiConsumer<T, U> asBiConsumer(BiConsumerWithException<T, U> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T, U> BiConsumer<T, U> asBiConsumerIgnoreException(BiConsumerWithException<T, U> unchecked) {
+		return unchecked.ignoreException();
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/BiFunctionWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/BiFunctionWithException.java
@@ -1,0 +1,63 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * BiFunction interface that allows exceptions.
+ *
+ * @param <T> the type 1 of the argument
+ * @param <U> the type 2 of the argument
+ * @param <R> the result type
+ */
+@Deprecated() // move to package aQute.bnd.exceptions 
+@FunctionalInterface
+public interface BiFunctionWithException<T, U, R> {
+	R apply(T t, U u) throws Exception;
+
+	default BiFunction<T, U, R> orElseThrow() {
+		return (t, u) -> {
+			try {
+				return apply(t, u);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default BiFunction<T, U, R> orElse(R orElse) {
+		return (t, u) -> {
+			try {
+				return apply(t, u);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	default BiFunction<T, U, R> orElseGet(Supplier<? extends R> orElseGet) {
+		requireNonNull(orElseGet);
+		return (t, u) -> {
+			try {
+				return apply(t, u);
+			} catch (Exception e) {
+				return orElseGet.get();
+			}
+		};
+	}
+
+	static <T, U, R> BiFunction<T, U, R> asBiFunction(BiFunctionWithException<T, U, R> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T, U, R> BiFunction<T, U, R> asBiFunctionOrElse(BiFunctionWithException<T, U, R> unchecked, R orElse) {
+		return unchecked.orElse(orElse);
+	}
+
+	static <T, U, R> BiFunction<T, U, R> asBiFunctionOrElseGet(BiFunctionWithException<T, U, R> unchecked,
+		Supplier<? extends R> orElseGet) {
+		return unchecked.orElseGet(orElseGet);
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/BiPredicateWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/BiPredicateWithException.java
@@ -1,0 +1,62 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiPredicate;
+import java.util.function.BooleanSupplier;
+
+/**
+ * BiPredicate interface that allows exceptions.
+ *
+ * @param <T> the type of the first argument
+ * @param <U> the type of the second argument
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface BiPredicateWithException<T, U> {
+	boolean test(T t, U u) throws Exception;
+
+	default BiPredicate<T, U> orElseThrow() {
+		return (t, u) -> {
+			try {
+				return test(t, u);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default BiPredicate<T, U> orElse(boolean orElse) {
+		return (t, u) -> {
+			try {
+				return test(t, u);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	default BiPredicate<T, U> orElseGet(BooleanSupplier orElseGet) {
+		requireNonNull(orElseGet);
+		return (t, u) -> {
+			try {
+				return test(t, u);
+			} catch (Exception e) {
+				return orElseGet.getAsBoolean();
+			}
+		};
+	}
+
+	static <T, U> BiPredicate<T, U> asBiPredicate(BiPredicateWithException<T, U> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T, U> BiPredicate<T, U> asBiPredicateOrElse(BiPredicateWithException<T, U> unchecked, boolean orElse) {
+		return unchecked.orElse(orElse);
+	}
+
+	static <T, U> BiPredicate<T, U> asBiPredicateOrElseGet(BiPredicateWithException<T, U> unchecked,
+		BooleanSupplier orElseGet) {
+		return unchecked.orElseGet(orElseGet);
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/ConsumerWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/ConsumerWithException.java
@@ -1,0 +1,40 @@
+package aQute.lib.exceptions;
+
+import java.util.function.Consumer;
+
+/**
+ * Consumer interface that allows exceptions.
+ *
+ * @param <T> the type of the argument
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface ConsumerWithException<T> {
+	void accept(T t) throws Exception;
+
+	default Consumer<T> orElseThrow() {
+		return t -> {
+			try {
+				accept(t);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default Consumer<T> ignoreException() {
+		return t -> {
+			try {
+				accept(t);
+			} catch (Exception e) {}
+		};
+	}
+
+	static <T> Consumer<T> asConsumer(ConsumerWithException<T> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T> Consumer<T> asConsumerIgnoreException(ConsumerWithException<T> unchecked) {
+		return unchecked.ignoreException();
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
+++ b/aQute.libg/src/aQute/lib/exceptions/Exceptions.java
@@ -1,0 +1,91 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.StringJoiner;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Deprecated() // move to package aQute.bnd.exceptions
+public class Exceptions {
+	final static Pattern DISPLAY_P = Pattern.compile("(.*)(Exception|Error)");
+
+	private Exceptions() {}
+
+	public static <V> V unchecked(Callable<? extends V> callable) {
+		try {
+			return callable.call();
+		} catch (Exception t) {
+			throw duck(t);
+		}
+	}
+
+	public static void unchecked(RunnableWithException runnable) {
+		try {
+			runnable.run();
+		} catch (Exception t) {
+			throw duck(t);
+		}
+	}
+
+	public static RuntimeException duck(Throwable t) {
+		Exceptions.throwsUnchecked(t);
+		throw new AssertionError("unreachable");
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <E extends Throwable> void throwsUnchecked(Throwable throwable) throws E {
+		throw (E) throwable;
+	}
+
+	public static String toString(Throwable t) {
+		StringWriter sw = new StringWriter();
+		t.printStackTrace(new PrintWriter(sw));
+		return sw.toString();
+	}
+
+	public static Throwable unrollCause(Throwable t, Class<? extends Throwable> unrollType) {
+		requireNonNull(t);
+		for (Throwable cause; unrollType.isInstance(t) && ((cause = t.getCause()) != null);) {
+			t = cause;
+		}
+		return t;
+	}
+
+	public static Throwable unrollCause(Throwable t) {
+		return unrollCause(t, Throwable.class);
+	}
+
+	public static String causes(Throwable t) {
+		StringJoiner sj = new StringJoiner(" -> ");
+		while (t != null) {
+			String message = t.getMessage();
+			sj.add(message == null ? t.getClass()
+				.getSimpleName() : message);
+			t = t.getCause();
+		}
+		return sj.toString();
+	}
+
+	/**
+	 * Return a display name of an exception type. This is basically removing
+	 * the package and the Exception or Error suffix.
+	 *
+	 * @param e the exception
+	 * @return a display name for its type
+	 */
+	public static String getDisplayTypeName(Throwable e) {
+		String name = e.getClass()
+			.getSimpleName();
+
+		Matcher m = DISPLAY_P.matcher(name);
+		if (m.matches()) {
+			return m.group(1);
+		} else
+			return name;
+	}
+
+}

--- a/aQute.libg/src/aQute/lib/exceptions/FunctionWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/FunctionWithException.java
@@ -1,0 +1,62 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Function interface that allows exceptions.
+ *
+ * @param <T> the type of the argument
+ * @param <R> the result type
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface FunctionWithException<T, R> {
+	R apply(T t) throws Exception;
+
+	default Function<T, R> orElseThrow() {
+		return t -> {
+			try {
+				return apply(t);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default Function<T, R> orElse(R orElse) {
+		return t -> {
+			try {
+				return apply(t);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	default Function<T, R> orElseGet(Supplier<? extends R> orElseGet) {
+		requireNonNull(orElseGet);
+		return t -> {
+			try {
+				return apply(t);
+			} catch (Exception e) {
+				return orElseGet.get();
+			}
+		};
+	}
+
+	static <T, R> Function<T, R> asFunction(FunctionWithException<T, R> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T, R> Function<T, R> asFunctionOrElse(FunctionWithException<T, R> unchecked, R orElse) {
+		return unchecked.orElse(orElse);
+	}
+
+	static <T, R> Function<T, R> asFunctionOrElseGet(FunctionWithException<T, R> unchecked,
+		Supplier<? extends R> orElseGet) {
+		return unchecked.orElseGet(orElseGet);
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/PredicateWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/PredicateWithException.java
@@ -1,0 +1,60 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+
+/**
+ * Predicate interface that allows exceptions.
+ *
+ * @param <T> the type of the argument
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface PredicateWithException<T> {
+	boolean test(T t) throws Exception;
+
+	default Predicate<T> orElseThrow() {
+		return t -> {
+			try {
+				return test(t);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default Predicate<T> orElse(boolean orElse) {
+		return t -> {
+			try {
+				return test(t);
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	default Predicate<T> orElseGet(BooleanSupplier orElseGet) {
+		requireNonNull(orElseGet);
+		return t -> {
+			try {
+				return test(t);
+			} catch (Exception e) {
+				return orElseGet.getAsBoolean();
+			}
+		};
+	}
+
+	static <T> Predicate<T> asPredicate(PredicateWithException<T> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <T> Predicate<T> asPredicateOrElse(PredicateWithException<T> unchecked, boolean orElse) {
+		return unchecked.orElse(orElse);
+	}
+
+	static <T> Predicate<T> asPredicateOrElseGet(PredicateWithException<T> unchecked, BooleanSupplier orElseGet) {
+		return unchecked.orElseGet(orElseGet);
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/RunnableWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/RunnableWithException.java
@@ -1,0 +1,36 @@
+package aQute.lib.exceptions;
+
+/**
+ * Runnable interface that allows exceptions.
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface RunnableWithException {
+	void run() throws Exception;
+
+	default Runnable orElseThrow() {
+		return () -> {
+			try {
+				run();
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default Runnable ignoreException() {
+		return () -> {
+			try {
+				run();
+			} catch (Exception e) {}
+		};
+	}
+
+	static Runnable asRunnable(RunnableWithException unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static Runnable asRunnableIgnoreException(RunnableWithException unchecked) {
+		return unchecked.ignoreException();
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/SupplierWithException.java
+++ b/aQute.libg/src/aQute/lib/exceptions/SupplierWithException.java
@@ -1,0 +1,59 @@
+package aQute.lib.exceptions;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+
+/**
+ * Supplier interface that allows exceptions.
+ *
+ * @param <R> the result type
+ */
+@Deprecated() // move to package aQute.bnd.exceptions
+@FunctionalInterface
+public interface SupplierWithException<R> {
+	R get() throws Exception;
+
+	default Supplier<R> orElseThrow() {
+		return () -> {
+			try {
+				return get();
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		};
+	}
+
+	default Supplier<R> orElse(R orElse) {
+		return () -> {
+			try {
+				return get();
+			} catch (Exception e) {
+				return orElse;
+			}
+		};
+	}
+
+	default Supplier<R> orElseGet(Supplier<? extends R> orElseGet) {
+		requireNonNull(orElseGet);
+		return () -> {
+			try {
+				return get();
+			} catch (Exception e) {
+				return orElseGet.get();
+			}
+		};
+	}
+
+	static <R> Supplier<R> asSupplier(SupplierWithException<R> unchecked) {
+		return unchecked.orElseThrow();
+	}
+
+	static <R> Supplier<R> asSupplierOrElse(SupplierWithException<R> unchecked, R orElse) {
+		return unchecked.orElse(orElse);
+	}
+
+	static <R> Supplier<R> asSupplierOrElseGet(SupplierWithException<R> unchecked, Supplier<? extends R> orElseGet) {
+		return unchecked.orElseGet(orElseGet);
+	}
+}

--- a/aQute.libg/src/aQute/lib/exceptions/package-info.java
+++ b/aQute.libg/src/aQute/lib/exceptions/package-info.java
@@ -1,0 +1,3 @@
+@Version("2.4.0")
+package aQute.lib.exceptions;
+import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
When we moved to 6.1 (not a major release) we lost
the package aQute.lib.exceptions because we also
made it available via aQute.bnd.util.

This would've been a nice use case for my shading
code but until we've got something like that we cannot
just remove a package in a minor release.

This is causing so much pain in all my builds that
I am restoring it, unfortunately now having a 
duplicate. 

I am ok to deprecate one of them but this is
a giant pita.

This is the content of the package  at 5.3.0

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>