### PR TITLE
launcher: ProjectLauncherImpl.executable() Builder is not resourceonly

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -310,7 +310,6 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 		try (Builder builder = new Builder()) {
 			Project project = getProject();
 			builder.setBase(project.getBase());
-			builder.setProperty(Constants.RESOURCEONLY, Boolean.TRUE.toString());
 
 			Jar jar = new Jar(project.getName());
 			builder.setJar(jar);


### PR DESCRIPTION
Remove setting of -resourceonly=true since we need the Builder to run
the VerifierPlugins to process the -jpms-module-info instruction.

