### PR TITLE
[analyzer] clarify that precedence of manifest metadata happens when …

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -663,8 +663,8 @@ public class Analyzer extends Processor {
 		// The manifest has priority over the packageinfo or package-info.java
 		//
 
-		Attrs attrs = map.get(packageRef);
-		if (attrs != null && attrs.size() > 1)
+		if (MapStream.ofNullable(map.get(packageRef))
+			.anyMatch((k, __) -> !k.startsWith("-internal")))
 			return;
 
 		//


### PR DESCRIPTION
…at-least-one user specified attribte is found

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>