### PR TITLE
[analyzer] Internal attributes not well defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Archive
 /generated/
 /install-jdk.sh
 .to
-docs/.jekyll-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Archive
 /generated/
 /install-jdk.sh
 .to
+docs/.jekyll-metadata

--- a/biz.aQute.bndlib.tests/test/test/ProcessorTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ProcessorTest.java
@@ -16,12 +16,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.osgi.resource.Capability;
 
+import aQute.bnd.header.Attrs;
+import aQute.bnd.osgi.AttributeClasses;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.OSInformation;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
+import aQute.lib.collections.ExtList;
 import aQute.lib.strings.Strings;
 import aQute.service.reporter.Reporter.SetLocation;
 
@@ -489,4 +492,25 @@ public class ProcessorTest {
 		}
 	}
 
+	@Test
+	public void isInternalTest() {
+		assertThat(AttributeClasses.MANIFEST.test("attribubte")).isTrue();
+		assertThat(AttributeClasses.MANIFEST.test("-foobar")).isTrue();
+		assertThat(AttributeClasses.MANIFEST.test("-internal-key")).isFalse();
+		assertThat(AttributeClasses.MANIFEST.test(Constants.SPLIT_PACKAGE_DIRECTIVE)).isFalse();
+		assertThat(AttributeClasses.MANIFEST.test(Constants.FROM_DIRECTIVE)).isFalse();
+	}
+
+	@Test
+	public void toExternalTest() {
+		Attrs attrs = new Attrs();
+		ExtList<String> value = new ExtList<>("a", "b", "c");
+		attrs.putTyped("foo", value);
+		attrs.putTyped("-internal-foo", value);
+		attrs.putTyped(Constants.SPLIT_PACKAGE_DIRECTIVE, "foobar;strategy=merge-first");
+		Attrs ext = attrs.select(AttributeClasses.MANIFEST);
+
+		assertThat(ext).hasSize(1);
+		assertThat(ext.getTyped("foo")).isEqualTo(value);
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -629,8 +629,7 @@ public class Attrs implements Map<String, String> {
 		Attrs attrs = new Attrs();
 		forEach((k, v) -> {
 			if (predicate.test(k)) {
-				attrs.map.put(k, v);
-				attrs.types.put(k, this.types.get(k));
+				attrs.put(k, this.types.get(k), v);
 			}
 		});
 		return attrs;

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -613,5 +614,25 @@ public class Attrs implements Map<String, String> {
 	public Attrs with(String key, String value) {
 		put(key, value);
 		return this;
+	}
+
+	/**
+	 * Return a new Attrs that has only the attributes that match the predicate.
+	 * The primary use case for this is AttributeClasses.
+	 *
+	 * @param predicate a predicate that returns true if the attribute must be
+	 *            included in the result
+	 * @return a new Attrs that can be used and modified by the caller
+	 */
+
+	public Attrs select(Predicate<String> predicate) {
+		Attrs attrs = new Attrs();
+		forEach((k, v) -> {
+			if (predicate.test(k)) {
+				attrs.map.put(k, v);
+				attrs.types.put(k, this.types.get(k));
+			}
+		});
+		return attrs;
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -661,10 +661,12 @@ public class Analyzer extends Processor {
 
 		//
 		// The manifest has priority over the packageinfo or package-info.java
+		// so if any user defined attributes are set, skip this package info
 		//
 
 		Attrs attrs = map.get(packageRef);
-		if (attrs != null && attrs.size() > 1)
+		if (attrs != null && !attrs.select(AttributeClasses.MANIFEST)
+			.isEmpty())
 			return;
 
 		//

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AttributeClasses.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AttributeClasses.java
@@ -1,0 +1,49 @@
+package aQute.bnd.osgi;
+
+import java.util.function.Predicate;
+
+import aQute.bnd.header.Parameters;
+
+/**
+ * Defines a number of attribute classes. Attributes are set on {@link Packages}
+ * and {@link Parameters}. The primary purpose is to print these attributes in
+ * the manifest. However, over time a number of use cases made the code use the
+ * attributes to control bnd processing and/or are actually set by bnd. This
+ * enum provides access to these classes. Each enum value is a predicate that
+ * can test a key.
+ */
+public enum AttributeClasses implements Predicate<String> {
+
+	/**
+	 * Attributes that would show up in the manifest.
+	 */
+	MANIFEST {
+		@Override
+		public boolean test(String key) {
+			return !INTERNAL.test(key) && !BND_USE.test(key);
+		}
+	},
+	/**
+	 * Attributes set and used by bnd code to maintain inernal correlations.
+	 * These attributes are never set by users. For example,
+	 * {@value Constants#INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE} These attributes
+	 * must not end up in the manifest.
+	 */
+	INTERNAL {
+		@Override
+		public boolean test(String key) {
+			return key.startsWith(Constants.INTERNAL_PREFIX);
+		}
+	},
+	/**
+	 * Attributes set by the user but solely with the purpose to control bnd
+	 * processing. For example {@value Constants#SPLIT_PACKAGE_DIRECTIVE}. These
+	 * attributes must not end up in the manifest.
+	 */
+	BND_USE {
+		@Override
+		public boolean test(String key) {
+			return Constants.BND_USE_ATTRIBUTES.contains(key);
+		}
+	};
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AttributeClasses.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AttributeClasses.java
@@ -20,7 +20,7 @@ public enum AttributeClasses implements Predicate<String> {
 	MANIFEST {
 		@Override
 		public boolean test(String key) {
-			return !INTERNAL.test(key) && !BND_USE.test(key);
+			return manifest.test(key);
 		}
 	},
 	/**
@@ -46,4 +46,7 @@ public enum AttributeClasses implements Predicate<String> {
 			return Constants.BND_USE_ATTRIBUTES.contains(key);
 		}
 	};
+
+	private final static Predicate<String> manifest = INTERNAL.or(BND_USE)
+		.negate();
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -328,6 +328,7 @@ public interface Constants {
 	String		INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE		= "-internal-bundlesymbolicname:";
 	String		INTERNAL_BUNDLEVERSION_DIRECTIVE			= "-internal-bundleversion:";
 	String		INTERNAL_EXPORT_TO_MODULES_DIRECTIVE		= "-internal-export-to-modules:";
+	String		INTERNAL_MODULE_DIRECTIVE					= "-internal-module:";
 	String		INTERNAL_MODULE_VERSION_DIRECTIVE			= "-internal-module-version:";
 	String		INTERNAL_OPEN_TO_MODULES_DIRECTIVE			= "-internal-open-to-modules:";
 	String		INTERNAL_SOURCE_DIRECTIVE					= "-internal-source:";
@@ -533,6 +534,21 @@ public interface Constants {
 	String		LAUNCH_RUNBUNDLES_ATTRS						= "launch.runbundles.attrs";
 	String		LAUNCH_ACTIVATORS							= "launch.activators";
 	String		LAUNCH_ACTIVATION_EAGER						= "launch.activation.eager";
+
+	/**
+	 * Any attributes that should be removed from the attributes before
+	 * printing.
+	 */
+	Set<String>	BND_USE_ATTRIBUTES							= Sets.of(
+		//@formatter:off
+		FROM_DIRECTIVE,
+		NO_IMPORT_DIRECTIVE,
+		PROVIDE_DIRECTIVE,
+		SPLIT_PACKAGE_DIRECTIVE
+		//@formatter:on
+	);
+
+	String		INTERNAL_PREFIX								= "-internal-";
 
 	/*
 	 * Deprecated Section

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1182,7 +1182,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 			for (Entry<String, String> entry : attrs.entrySet()) {
 				String key = entry.getKey();
 				// Skip directives we do not recognize
-				if (skipPrint(key))
+				if (!AttributeClasses.MANIFEST.test(key))
 					continue;
 
 				sb.append(";");
@@ -1193,7 +1193,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 				String key = entry.getKey()
 					.toString();
 				// Skip directives we do not recognize
-				if (skipPrint(key))
+				if (!AttributeClasses.MANIFEST.test(key))
 					continue;
 
 				sb.append(";");
@@ -1205,23 +1205,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		}
 	}
 
-	private static boolean skipPrint(String key) {
-		switch (key) {
-			case INTERNAL_EXPORTED_DIRECTIVE :
-			case INTERNAL_EXPORT_TO_MODULES_DIRECTIVE :
-			case INTERNAL_OPEN_TO_MODULES_DIRECTIVE :
-			case INTERNAL_SOURCE_DIRECTIVE :
-			case NO_IMPORT_DIRECTIVE :
-			case PROVIDE_DIRECTIVE :
-			case SPLIT_PACKAGE_DIRECTIVE :
-			case FROM_DIRECTIVE :
-			case INTERNAL_BUNDLESYMBOLICNAME_DIRECTIVE :
-			case INTERNAL_BUNDLEVERSION_DIRECTIVE :
-				return true;
-			default :
-				return false;
-		}
-	}
 
 	/**
 	 * @param sb

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,4 @@
 /_site/
 /.bundle/
 /vendor/
+/.jekyll-metadata


### PR DESCRIPTION
In  #5136 i observed that the fix suggested was not really helping to solve the confusion about the internal attributes. Internal attributes crept in as a quick hack to solve a problem but there were many similar problems. This is a proposal to define this concept properly. 

## Problem
It was observed that Analyzer decided to not learn a package if there was already an attribute set on that package in the manifest. However, over time lots and lots of 'internal' attributes entered the fray. 

## Solution
This patch defines the concept of internal attributes and an `isInternal` method and a toExternal to clean up an Attrs.

It also creates constant in Constants that holds all the internal attributes. However, isInternal will treat any attribute key that starts with an INTERNAL_PREFIX ('-internal-') as internal.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>