### PR TITLE
Decoration updates

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/InstructionTest.java
+++ b/biz.aQute.bndlib.tests/test/test/InstructionTest.java
@@ -145,6 +145,25 @@ public class InstructionTest {
 	}
 
 	@Test
+	public void duplicates() {
+		Instructions instrs = new Instructions("a;x=1,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
+		Parameters params = new Parameters("foo.com.example.bar;version=1, a;v=0, bbb;v=1, a;k=1, a;z=9", null, true);
+		instrs.decorate(params, true);
+		System.out.println(params);
+		assertThat(params.keySet()).containsExactly("foo.com.example.bar", "a", "bbb", "a~", "a~~", "literal");
+
+		assertThat(params.get("a")).containsOnly(entry("v", "0"), entry("x", "1"));
+		assertThat(params.get("a~")).containsOnly(entry("k", "1"), entry("x", "1"));
+		assertThat(params.get("a~~")).containsOnly(entry("z", "9"), entry("x", "1"));
+
+		assertThat(params.get("bbb")).containsOnly(entry("v", "1"), entry("y", "2"));
+
+		assertThat(params.get("foo.com.example.bar")).containsOnly(entry("version", "1"), entry("startlevel", "10"));
+
+		assertThat(params.get("literal")).containsOnly(entry("n", "1"));
+	}
+
+	@Test
 	public void testDecoratePriority() {
 		Instructions instrs = new Instructions("def;x=1, *;x=0");
 		Parameters params = new Parameters("abc, def, ghi");

--- a/biz.aQute.bndlib.tests/test/test/InstructionTest.java
+++ b/biz.aQute.bndlib.tests/test/test/InstructionTest.java
@@ -164,6 +164,44 @@ public class InstructionTest {
 	}
 
 	@Test
+	public void removal() {
+		Instructions instrs = new Instructions("a;x=1;k=!;q=!,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
+		Parameters params = new Parameters("foo.com.example.bar;version=1, a;v=0, bbb;v=1, a;k=1, a;z=9", null, true);
+		instrs.decorate(params, true);
+		System.out.println(params);
+		assertThat(params.keySet()).containsExactly("foo.com.example.bar", "a", "bbb", "a~", "a~~", "literal");
+
+		assertThat(params.get("a")).containsOnly(entry("v", "0"), entry("x", "1"));
+		assertThat(params.get("a~")).containsOnly(entry("x", "1"));
+		assertThat(params.get("a~~")).containsOnly(entry("z", "9"), entry("x", "1"));
+
+		assertThat(params.get("bbb")).containsOnly(entry("v", "1"), entry("y", "2"));
+
+		assertThat(params.get("foo.com.example.bar")).containsOnly(entry("version", "1"), entry("startlevel", "10"));
+
+		assertThat(params.get("literal")).containsOnly(entry("n", "1"));
+	}
+
+	@Test
+	public void no_overwrite() {
+		Instructions instrs = new Instructions("a;x=1;~k=4,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
+		Parameters params = new Parameters("foo.com.example.bar;version=1, a;x=0, bbb;v=1, a;k=1, a;z=9", null, true);
+		instrs.decorate(params, true);
+		System.out.println(params);
+		assertThat(params.keySet()).containsExactly("foo.com.example.bar", "a", "bbb", "a~", "a~~", "literal");
+
+		assertThat(params.get("a")).containsOnly(entry("x", "1"), entry("k", "4"));
+		assertThat(params.get("a~")).containsOnly(entry("k", "1"), entry("x", "1"));
+		assertThat(params.get("a~~")).containsOnly(entry("z", "9"), entry("x", "1"), entry("k", "4"));
+
+		assertThat(params.get("bbb")).containsOnly(entry("v", "1"), entry("y", "2"));
+
+		assertThat(params.get("foo.com.example.bar")).containsOnly(entry("version", "1"), entry("startlevel", "10"));
+
+		assertThat(params.get("literal")).containsOnly(entry("n", "1"));
+	}
+
+	@Test
 	public void testDecoratePriority() {
 		Instructions instrs = new Instructions("def;x=1, *;x=0");
 		Parameters params = new Parameters("abc, def, ghi");

--- a/biz.aQute.bndlib.tests/test/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MacroTest.java
@@ -267,7 +267,7 @@ public class MacroTest {
 		try (Processor proc = new Processor()) {
 			proc.setProperty("foo", "a;v=1, b;v=2;x='3,4,5'");
 			proc.setProperty("foo.1", "c;v=3");
-			proc.setProperty("foo+", "*;v=0");
+			proc.setProperty("foo+", "z;v=1,*;v=0");
 			String process = proc.getReplacer()
 				.process("${decorated;foo}");
 			assertThat(process).isEqualTo("a;v=0,b;v=0;x=\"3,4,5\",c;v=0");
@@ -282,7 +282,7 @@ public class MacroTest {
 			proc.setProperty("foo+", "z;v=1,*;v=0");
 			String process = proc.getReplacer()
 				.process("${decorated;foo;true}");
-			assertThat(process).isEqualTo("a;v=0,b;v=0;x=\"3,4,5\",c;v=0,z;v=1");
+			assertThat(process).isEqualTo("z;v=1,a;v=0,b;v=0;x=\"3,4,5\",c;v=0");
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -616,12 +616,13 @@ public class Project extends Processor {
 	 */
 
 	public List<Container> getBundles(Strategy strategyx, String spec, String source) throws Exception {
-		Instructions decorator = new Instructions(mergeProperties(source + "+"));
+		Parameters bundles = parseHeader(spec);
+		if (source != null) {
+			Instructions decorator = new Instructions(mergeProperties(source + "+"));
+			decorator.decorate(bundles);
+		}
 
 		List<Container> result = new ArrayList<>();
-		Parameters bundles = new Parameters(spec, this);
-		decorator.decorate(bundles);
-
 		try {
 			for (Entry<String, Attrs> entry : bundles.entrySet()) {
 				String bsn = removeDuplicateMarker(entry.getKey());

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -619,7 +619,7 @@ public class Project extends Processor {
 		Parameters bundles = parseHeader(spec);
 		if (source != null) {
 			Instructions decorator = new Instructions(mergeProperties(source + "+"));
-			decorator.decorate(bundles);
+			decorator.decorate(bundles, true);
 		}
 
 		List<Container> result = new ArrayList<>();

--- a/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.4.0")
+@Version("2.5.0")
 package aQute.bnd.header;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -402,7 +402,7 @@ public class Builder extends Analyzer {
 	@Override
 	protected Jar getExtra() throws Exception {
 		Parameters conditionals = getMergedParameters(CONDITIONAL_PACKAGE);
-		conditionals.putAll(getMergedParameters(CONDITIONALPACKAGE));
+		conditionals.putAll(decorated(CONDITIONALPACKAGE, true));
 		if (conditionals.isEmpty())
 			return null;
 		logger.debug("do Conditional Package {}", conditionals);
@@ -628,9 +628,9 @@ public class Builder extends Analyzer {
 		}
 
 		Parameters private_package = getParameters(PRIVATE_PACKAGE);
-		Parameters privatepackage = getParameters(PRIVATEPACKAGE);
+		Parameters privatepackage = decorated(PRIVATEPACKAGE, true);
 		Parameters testpackage = new Parameters();
-		Parameters includepackage = buildInstrs.includepackage();
+		Parameters includepackage = decorated(INCLUDEPACKAGE, true);
 
 		if (buildInstrs.undertest()) {
 			String h = mergeProperties(Constants.TESTPACKAGES, "test;presence:=optional");
@@ -900,16 +900,15 @@ public class Builder extends Analyzer {
 	 * @throws FileNotFoundException
 	 */
 	private void doIncludeResources(Jar jar) throws Exception {
-		String includes = getProperty("Bundle-Includes");
-		if (includes == null) {
-			includes = mergeProperties(INCLUDERESOURCE);
-			if (includes == null || includes.length() == 0)
-				includes = mergeProperties(Constants.INCLUDE_RESOURCE);
-		} else
+		Parameters includes = parseHeader(getProperty("Bundle-Includes"));
+		if (includes.isEmpty()) {
+			includes = decorated(Constants.INCLUDERESOURCE, true);
+			includes.putAll(getMergedParameters(Constants.INCLUDE_RESOURCE));
+		} else {
 			warning("Please use -includeresource instead of Bundle-Includes");
+		}
 
 		doIncludeResource(jar, includes);
-
 	}
 
 	private void doIncludeResource(Jar jar, String includes) throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
@@ -386,7 +386,8 @@ public class Instructions implements Map<Instruction, Attrs> {
 			.iterator(); it.hasNext();) {
 			Entry<String, Attrs> next = it.next();
 
-			Instruction matching = matcher(next.getKey());
+			String key = Processor.removeDuplicateMarker(next.getKey());
+			Instruction matching = matcher(key);
 			if (matching != null) {
 				if (addLiterals) {
 					int index = unused.indexOf(matching);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
@@ -7,10 +7,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -380,16 +380,20 @@ public class Instructions implements Map<Instruction, Attrs> {
 	 * @param addLiterals add literals to the output
 	 */
 	public void decorate(Parameters parameters, boolean addLiterals) {
-		Iterator<Map.Entry<String, Attrs>> it = parameters.entrySet()
-			.iterator();
-		Set<Instruction> used = new HashSet<>(keySet());
+		List<Instruction> unused = addLiterals ? new ArrayList<>(keySet()) : Collections.emptyList();
 
-		while (it.hasNext()) {
+		for (Iterator<Entry<String, Attrs>> it = parameters.entrySet()
+			.iterator(); it.hasNext();) {
 			Entry<String, Attrs> next = it.next();
 
 			Instruction matching = matcher(next.getKey());
 			if (matching != null) {
-				used.remove(matching);
+				if (addLiterals) {
+					int index = unused.indexOf(matching);
+					if (index >= 0) {
+						unused.set(index, null);
+					}
+				}
 				if (matching.isNegated())
 					it.remove();
 				else {
@@ -399,14 +403,30 @@ public class Instructions implements Map<Instruction, Attrs> {
 			}
 		}
 
+		// Add the literals
 		if (addLiterals) {
-			//
-			// Add the literals
-			used.stream()
-				.filter(Instruction::isLiteral)
-				.forEach(i -> {
-					parameters.put(i.getLiteral(), new Attrs(get(i)));
-				});
+			Parameters copy = null;
+			for (ListIterator<Instruction> li = unused.listIterator(); li.hasNext();) {
+				Instruction ins = li.next();
+				if ((ins == null) || !ins.isLiteral() || ins.isNegated()) {
+					if (copy != null) {
+						// end inserting at beginning
+						parameters.putAll(copy);
+						copy = null;
+					}
+					continue;
+				}
+				// ins is a non-negated literal
+				if (li.previousIndex() == 0) {
+					// if first item, start insert at beginning
+					copy = new Parameters(parameters);
+					parameters.clear();
+				}
+				parameters.put(ins.getLiteral(), new Attrs(get(ins)));
+			}
+			if (copy != null) {
+				parameters.putAll(copy);
+			}
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2546,7 +2546,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 */
 
 	public Parameters decorated(String key, boolean literalsIncluded) {
-		Parameters parameters = new Parameters(mergeProperties(key), this);
+		Parameters parameters = getMergedParameters(key);
 		Instructions decorator = new Instructions(mergeProperties(key + "+"));
 		decorator.decorate(parameters, literalsIncluded);
 		return parameters;

--- a/bndtools.core/src/bndtools/editor/completion/BndHover.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndHover.java
@@ -66,7 +66,7 @@ public class BndHover extends DefaultTextHover {
 					sb.append("\nE.g. ");
 					sb.append(syntax.getExample());
 				}
-				Parameters decorated = properties.decorated(key);
+				Parameters decorated = properties.decorated(key, true);
 				if (!decorated.isEmpty()) {
 					sb.append("\n")
 						.append(key)

--- a/docs/_chapters/820-instructions.md
+++ b/docs/_chapters/820-instructions.md
@@ -96,9 +96,10 @@ This will result in a buildpath of (when debug is not false) of: `com.example.fo
 
 Instructions can also be _decorated_. A _decorator_ is a header that ends with a `+` sign. A header `-runbundles` is first merged and then decorated by getting all the properties with the keys that match`-runbundles+(.*)`.  Notice that for the decorator the root key includes the `+` sign, the suffixes must come after the `+` sign.
 
-The decorator is a Parameters, it consists of a key and a set of attributes. The decoratar key is usually a glob. 
+The decorator is a Parameters, it consists of a key and a set of attributes. The decorator key is usually a glob. 
 
-After the instruction is merged, each key is matched against all globs in the decorator following the order of the decorator. When the first match is found, the attributes of the decorator clause that matches are stored with the attributes of the instruction, overriding any attribute with the same attribute key. A key in the instruction can only match one decorator glob.
+After the instruction is merged, the key of each Parameter entry is matched against all globs in the decorator following the order of the decorator. When the first match is found, the attributes of the decorator clause that matches are stored with the attributes of the Parameter entry, overriding any attribute with the same attribute key. A Parameter entry key can only match one decorator glob.
+If the value of the decorator clause attribute is `!`, then the attribute is removed from the Parameter entry. If the name of the  decorator clause attribute starts with `~`, then, using the attribute name after removing the leading `~`, the attribute value will not overwrite an existing value.
 
 Example:
 


### PR DESCRIPTION
A series of improvements to the decoration support.

1. Unused literals at the front of the decorator are added to the front of the decorated Parameters. So this will allow adding items at the front which is important for negations in things like conditional package.
2. Handles duplicate keys in the Parameters. This is useful when decorating a Parameters which supports duplicate keys.
3. Supports the removal of an attr by using the `!` value in the decorator.
4. Supports not overwriting an existing attr by prefixing the attr name with `~` in the decorator. This allows the decorator to supply default attr values which do not overwrite supplied values.
5. Adds decoration support to more Bnd instructions. `-conditionalpackage`, `-privatepackage`, `-includepackage`, and `-includeresource` now support decoration with unused literal inclusion. `-privatepackage` now also supports merged parameters. The various bundle path instructions (`-buildpath`, etc.) are also updated to decorate with unused literal inclusion.