### PR TITLE
decoration: Fix attribute removal support to allow "!" value

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/InstructionTest.java
+++ b/biz.aQute.bndlib.tests/test/test/InstructionTest.java
@@ -165,7 +165,7 @@ public class InstructionTest {
 
 	@Test
 	public void removal() {
-		Instructions instrs = new Instructions("a;x=1;k=!;q=!,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
+		Instructions instrs = new Instructions("a;x=1;!k=;!q=,b*;y=2, literal;n=1, foo.com.example.bar;startlevel=10");
 		Parameters params = new Parameters("foo.com.example.bar;version=1, a;v=0, bbb;v=1, a;k=1, a;z=9", null, true);
 		instrs.decorate(params, true);
 		System.out.println(params);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Instructions.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -434,15 +433,21 @@ public class Instructions implements Map<Instruction, Attrs> {
 
 	private Attrs decorateAttrs(Attrs target, Attrs decoration) {
 		decoration.forEach((key, value) -> {
-			if (Objects.equals("!", value)) { // ! value means remove
-				target.remove(key);
-				return;
-			}
 			Type type = decoration.getType(key);
-			if (key.startsWith("~")) { // ~key means no overwrite
-				key = key.substring(1);
-				if (target.containsKey(key)) {
-					return;
+			if (key.length() > 1) {
+				switch (key.charAt(0)) {
+					case '!' :
+						key = key.substring(1);
+						target.remove(key);
+						return;
+					case '~' :
+						key = key.substring(1);
+						if (target.containsKey(key)) {
+							return;
+						}
+						break;
+					default :
+						break;
 				}
 			}
 			target.put(key, type, value);

--- a/docs/_chapters/820-instructions.md
+++ b/docs/_chapters/820-instructions.md
@@ -99,7 +99,8 @@ Instructions can also be _decorated_. A _decorator_ is a header that ends with a
 The decorator is a Parameters, it consists of a key and a set of attributes. The decorator key is usually a glob. 
 
 After the instruction is merged, the key of each Parameter entry is matched against all globs in the decorator following the order of the decorator. When the first match is found, the attributes of the decorator clause that matches are stored with the attributes of the Parameter entry, overriding any attribute with the same attribute key. A Parameter entry key can only match one decorator glob.
-If the value of the decorator clause attribute is `!`, then the attribute is removed from the Parameter entry. If the name of the  decorator clause attribute starts with `~`, then, using the attribute name after removing the leading `~`, the attribute value will not overwrite an existing value.
+If the name of the decorator clause attribute starts with `!`, then the attribute, using the attribute name after removing the leading `!`, is removed from the Parameter entry.
+If the name of the decorator clause attribute starts with `~`, then the decorator clause attribute value will not overwrite an existing value of the Parameter entry attribute, using the attribute name after removing the leading `~`.
 
 Example:
 


### PR DESCRIPTION
The attribute value "!" is used on some places such as import package
to indicate that attribute should be removed from the result. So we
need to allow decoration to decorate an attribute with the "!" value.

