### PR TITLE
Bnd baseline maven report

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -65,10 +65,10 @@ Bundle-License:         "${SPDX-License-Identifier}";\
                         description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";\
                         link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
 Bundle-DocURL:          https://bnd.bndtools.org/
-Bundle-SCM:             url=https://github.com/bndtools/bnd, \
-                        connection=scm:git:https://github.com/bndtools/bnd.git, \
-                        developerConnection=scm:git:git@github.com:bndtools/bnd.git, \
-                        tag=${Git-Descriptor}
+Bundle-SCM:             url=https://github.com/bndtools/bnd,\
+                        connection=scm:git:https://github.com/bndtools/bnd.git,\
+                        developerConnection=scm:git:git@github.com:bndtools/bnd.git,\
+                        tag=${base.version}${if;${def;-snapshot;SNAPSHOT};-${def;-snapshot;SNAPSHOT}}
 Bundle-Developers: \
     pkriens; \
         email=Peter.Kriens@aQute.biz; \

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -154,6 +154,7 @@ publishing {
 					url.set("https://github.com/bndtools/bnd")
 					connection.set("scm:git:https://github.com/bndtools/bnd.git")
 					developerConnection.set("scm:git:git@github.com:bndtools/bnd.git")
+					tag.set(version.toString())
 				}
 				developers {
 					developer {

--- a/maven/bnd-baseline-maven-plugin/README.md
+++ b/maven/bnd-baseline-maven-plugin/README.md
@@ -194,6 +194,7 @@ It is possible to only check for correct package versions and leave out the bund
 |`continueOnError`      | See [Continue on Error](#continue-on-error). _Defaults to `false`._ Override with property `bnd.baseline.continue.on.error`.|
 |`skip`                 | Skip the baseline process altogether. _Defaults to `false`._ Override with property `bnd.baseline.skip`.|
 |`releaseversions`                 | When searching a version range for the baseline, only consider release versions. That is, don't consider `alpha`, `beta`, `milestone`, or `rc` versions. `snapshot` versions are never considered when searching for the baseline. _Defaults to `false`._ Override with property `bnd.baseline.releaseversions`.|
+|`reportFile`                 | The baseline report is placed in this file. _Defaults to `${project.build.directory}/baseline/${project.build.finalName}.txt`._ Override with property `bnd.baseline.report.file`.|
 
 
 [1]: https://docs.osgi.org/whitepaper/semantic-versioning/

--- a/maven/bnd-baseline-maven-plugin/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/pom.xml
@@ -19,6 +19,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/invalid-with-consumer/pom.xml
@@ -32,7 +32,8 @@
 					</base>
 					<includeDistributionManagement>true</includeDistributionManagement>
 					<continueOnError>true</continueOnError>
-					<fullReport>true</fullReport>
+					<fullReport>false</fullReport>
+					<reportFile>${project.build.directory}/baseline/${project.build.finalName}.text</reportFile>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
+++ b/maven/bnd-baseline-maven-plugin/src/test/resources/integration-test/test/verify.groovy
@@ -11,28 +11,36 @@ def build_log = build_log_file.text
 assert build_log =~ Pattern.quote('[WARNING] No previous version of biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 could be found to baseline against')
 
 // With previous-same
-assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-previous-same:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1')
+File valid_with_previous_same = new File("${basedir}/valid-with-previous-same/target/baseline/valid-with-previous-same-1.0.2.txt")
+assert valid_with_previous_same.isFile()
+assert build_log =~ Pattern.quote("[INFO] Baseline check succeeded. See the report in ${valid_with_previous_same}")
 
 // With previous-provider
-assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1')
+File valid_with_provider = new File("${basedir}/valid-with-provider/target/baseline/valid-with-provider-1.0.2.txt")
+assert valid_with_provider.isFile()
+assert build_log =~ Pattern.quote("[INFO] Baseline check succeeded. See the report in ${valid_with_provider}")
 
 // With provider (no bundle version change required)
-assert build_log =~ Pattern.quote('[INFO] Baselining check succeeded checking biz.aQute.bnd-test:valid-with-provider-no-bundle-version-change:jar:1.0.1 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1')
+File valid_with_provider_no_bundle_version_change = new File("${basedir}/valid-with-provider-no-bundle-version-change/target/baseline/valid-with-provider-no-bundle-version-change-1.0.1.txt")
+assert valid_with_provider_no_bundle_version_change.isFile()
+assert build_log =~ Pattern.quote("[INFO] Baseline check succeeded. See the report in ${valid_with_provider_no_bundle_version_change}")
 
 // With provider
-assert build_log =~ Pattern.quote('[ERROR] * bnd.test                                           PACKAGE    MINOR      1.0.0      1.0.0      1.1.0      -')
-
-assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
+File invalid_with_provider = new File("${basedir}/invalid-with-provider/target/baseline/invalid-with-provider-1.0.2.txt")
+assert invalid_with_provider.isFile()
+assert build_log =~ Pattern.quote("[WARNING] Baseline problems detected. See the report in ${invalid_with_provider}")
+assert build_log =~ Pattern.quote('* bnd.test                                           PACKAGE    MINOR      1.0.0      1.0.0      1.1.0      -')
 
 // With provider (require bundle version change)
-assert build_log =~ Pattern.quote('[ERROR] * valid-no-previous                                  BUNDLE     MAJOR      1.0.1      1.0.1      1.1.0')
-
-assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-provider-require-bundle-version-change:jar:1.0.1 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
-
+File invalid_with_provider_require_bundle_version_change = new File("${basedir}/invalid-with-provider-require-bundle-version-change/target/baseline/invalid-with-provider-require-bundle-version-change-1.0.1.txt")
+assert invalid_with_provider_require_bundle_version_change.isFile()
+assert build_log =~ Pattern.quote("[WARNING] Baseline problems detected. See the report in ${invalid_with_provider_require_bundle_version_change}")
+assert build_log =~ Pattern.quote('* valid-no-previous                                  BUNDLE     MAJOR      1.0.1      1.0.1      1.1.0')
 
 // With consumer
-assert build_log =~ Pattern.quote('[ERROR] * bnd.test                                           PACKAGE    MAJOR      1.0.0      1.0.0      2.0.0      1.1.0')
-
-assert build_log =~ Pattern.quote('[WARNING] The baselining check failed when checking biz.aQute.bnd-test:invalid-with-consumer:jar:1.0.2 against biz.aQute.bnd-test:valid-no-previous:jar:1.0.1 but the bnd-baseline-maven-plugin is configured not to fail the build.')
+File invalid_with_consumer = new File("${basedir}/invalid-with-consumer/target/baseline/invalid-with-consumer-1.0.2.text")
+assert invalid_with_consumer.isFile()
+assert build_log =~ Pattern.quote("[WARNING] Baseline problems detected. See the report in ${invalid_with_consumer}")
+assert build_log =~ Pattern.quote('* bnd.test                                           PACKAGE    MAJOR      1.0.0      1.0.0      2.0.0      1.1.0')
 
 

--- a/maven/bnd-export-maven-plugin/pom.xml
+++ b/maven/bnd-export-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-indexer-maven-plugin/pom.xml
+++ b/maven/bnd-indexer-maven-plugin/pom.xml
@@ -19,6 +19,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-maven-plugin/pom.xml
+++ b/maven/bnd-maven-plugin/pom.xml
@@ -19,6 +19,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-plugin-parent/pom.xml
+++ b/maven/bnd-plugin-parent/pom.xml
@@ -48,6 +48,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 	<developers>
 		<developer>

--- a/maven/bnd-reporter-maven-plugin/pom.xml
+++ b/maven/bnd-reporter-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-resolver-maven-plugin/pom.xml
+++ b/maven/bnd-resolver-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-run-maven-plugin/pom.xml
+++ b/maven/bnd-run-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>

--- a/maven/bnd-testing-maven-plugin/pom.xml
+++ b/maven/bnd-testing-maven-plugin/pom.xml
@@ -17,6 +17,7 @@
 		<url>https://github.com/bndtools/bnd</url>
 		<connection>scm:git:https://github.com/bndtools/bnd.git</connection>
 		<developerConnection>scm:git:git@github.com:bndtools/bnd.git</developerConnection>
+		<tag>${revision}</tag>
 	</scm>
 
 	<prerequisites>


### PR DESCRIPTION
When baselining fails in m2e, you only get an exception that it failed
but you have no useful information since that we only sent to the slf4j
log which you don't see in Eclipse. So we change the plugin to behave
like the gradle baseline task. It now writes a baseline report to a
file in the output directory and, if the baseline fails, the contents
of the report are made part of the failure exception.