### PR TITLE
bnd-maven-plugin: Set alternate source for classpath directories

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -1061,6 +1061,10 @@ public class Jar implements Closeable {
 		return source;
 	}
 
+	public void setSource(File source) {
+		this.source = source;
+	}
+
 	public boolean addAll(Jar src) {
 		check();
 		return addAll(src, null);

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -269,6 +269,7 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 				}
 				if (cpe.isDirectory()) {
 					Jar cpeJar = new Jar(cpe);
+					cpeJar.setSource(new File(cpe.getParentFile(), createArtifactName(artifact)));
 					builder.addClose(cpeJar);
 					builder.updateModified(cpeJar.lastModified(), cpe.getPath());
 					buildpath.add(cpeJar);
@@ -623,6 +624,15 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 			+ getClassifier().map("-"::concat)
 				.orElse("")
 			+ "." + project.getPackaging());
+	}
+
+	private String createArtifactName(Artifact artifact) {
+		String classifier = artifact.getClassifier();
+		if ((classifier == null) || classifier.isEmpty()) {
+			return String.format("%s-%s.%s", artifact.getArtifactId(), artifact.getVersion(), artifact.getType());
+		}
+		return String.format("%s-%s-%s.%s", artifact.getArtifactId(), artifact.getVersion(), classifier,
+			artifact.getType());
 	}
 
 	private File loadProperties(Builder builder) throws Exception {


### PR DESCRIPTION
In command line maven, maven always supplies artifact files which are
the built jar. Either in m2 or in a project's target folder.

However, in m2e, probably since the jar goal is not normally executed,
the artifact file for another project the reactor is for the project's
target/classes folder. This causes jar name matching in
-includeresource to fail since it matched in the file name and all the
file names for these project artifacts is "classes".

So we change the plugin to supply the directory classpath entries with
a file name which is synthesized from the artifact information. This
will then be matched to -includeresource references in m2e as well as
command line maven.

Fixes https://github.com/bndtools/bnd/issues/5081