### PR TITLE
WIP:[maven] use outputDir and waroutputDir correctly

### DIFF
--- a/maven/bnd-maven-plugin/README.md
+++ b/maven/bnd-maven-plugin/README.md
@@ -50,8 +50,8 @@ The `jar` goal is not executed by default, therefore at least one explicit execu
 |`classifier`          | A string added to the artifact indicating a supplemental artifact produced by the project. If no value is provided it indicates the main artifact produced by the project. _Defaults to no value_.||`manifestPath`         | Specify the path to a manifest file to use. _Defaults to `${project.build.outputDirectory}/META-INF/MANIFEST.MF`._|
 |`classesDir`           | The directory where the `maven-compiler-plugin` places its output. _Defaults to `${project.build.outputDirectory}`._|
 |`includeClassesDir` | Include the entire contents of `classesDir` in the bundle. *Defaults to `true`*. |
-|`outputDir`            | The directory where the `bnd-maven-plugin` will extract it's contents. _Defaults to `${project.build.outputDirectory}`._|
-|`warOutputDir`            | The directory where the `bnd-maven-plugin` will extract it's contents when packaging is `war`. _Defaults to `${project.build.directory}/${project.build.finalName}`._|
+|`outputDir`            | The directory where the `bnd-maven-plugin` will place the jar when packaging. _Defaults to `${project.build.directory}`._|
+|`warOutputDir`            | The directory where the `bnd-maven-plugin` will place the war when packaging is `war`. _Defaults to `${project.build.directory}`._|
 |`packagingTypes`                | The list of maven packaging types for which the plugin will execute. *Defaults to `jar,war`*. Override with property `bnd.packagingTypes`. |
 |`skip`                 | Skip the project. _Defaults to `false`._ Override with property `bnd.skip`.|
 |`skipIfEmpty`         | Skip processing if `includeClassesDir` is `true` and the `${project.build.outputDirectory}` is empty. _Defaults to `false`._ Override with property `bnd.skipIfEmpty`.|

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -246,7 +246,7 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 				if (wabProperty == null) {
 					builder.setProperty(Constants.WAB, "");
 				}
-				outputDir = warOutputDir;
+				outputDir = getWarOutputDir();
 				logger
 					.info("WAB mode enabled. Bnd output will be expanded into the 'maven-war-plugin' <webappDirectory>:"
 						+ outputDir);
@@ -508,14 +508,14 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 						// Add META-INF/maven metadata to jar
 						addMavenMetadataToJar(bndJar);
 						// Write the jar directly and attach it to the project
-						attachArtifactToProject(bndJar);
+						attachArtifactToProject(bndJar, outputDir);
 					} else {
 						throw new MojoExecutionException(String.format(
 							"In order to use the bnd-maven-plugin packaging goal %s, <extensions>true</extensions> must be set on the plugin",
 							goal));
 					}
 				} else {
-					// Expand Jar into target/classes
+					// Expand Jar into outputDir
 					expandJar(bndJar, outputDir);
 				}
 			} else {
@@ -529,6 +529,10 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 		} catch (Exception e) {
 			throw new MojoExecutionException("bnd error: " + e.getMessage(), e);
 		}
+	}
+
+	protected File getWarOutputDir() {
+		return warOutputDir;
 	}
 
 	/**
@@ -569,9 +573,8 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 		return builder;
 	}
 
-	private void attachArtifactToProject(Jar bndJar) throws Exception {
-		File artifactFile = createArtifactFile();
-		File outputDir = artifactFile.getParentFile();
+	private void attachArtifactToProject(Jar bndJar, File outputDir) throws Exception {
+		File artifactFile = createArtifactFile(outputDir);
 
 		if (!outputDir.exists()) {
 			IO.mkdirs(outputDir);
@@ -617,8 +620,8 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 		bndJar.putResource(pomProperties.getWhere(), pomProperties);
 	}
 
-	private File createArtifactFile() {
-		return new File(targetDir, project.getBuild()
+	private File createArtifactFile(File outputDir) {
+		return new File(outputDir, project.getBuild()
 			.getFinalName()
 			+ getClassifier().map("-"::concat)
 				.orElse("")

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPackagingPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPackagingPlugin.java
@@ -1,5 +1,6 @@
 package aQute.bnd.maven.plugin;
 
+import java.io.File;
 import java.util.Optional;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,6 +13,22 @@ public class BndMavenPackagingPlugin extends BndMavenPlugin {
 
 	@Parameter
 	private String classifier;
+
+	@Parameter(defaultValue = "${project.build.directory}")
+	private File	outputDir;
+
+	@Parameter(defaultValue = "${project.build.directory}")
+	private File					warOutputDir;
+
+	@Override
+	public File getOutputDir() {
+		return outputDir;
+	}
+
+	@Override
+	protected File getWarOutputDir() {
+		return warOutputDir;
+	}
 
 	@Override
 	public Optional<String> getClassifier() {

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPackagingTestsPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPackagingTestsPlugin.java
@@ -1,5 +1,6 @@
 package aQute.bnd.maven.plugin;
 
+import java.io.File;
 import java.util.Optional;
 
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -12,6 +13,14 @@ public class BndMavenPackagingTestsPlugin extends BndMavenTestsPlugin {
 
 	@Parameter(defaultValue = "tests")
 	private String classifier;
+
+	@Parameter(defaultValue = "${project.build.directory}")
+	private File	outputDir;
+
+	@Override
+	public File getOutputDir() {
+		return outputDir;
+	}
 
 	@Override
 	public Optional<String> getClassifier() {


### PR DESCRIPTION
The new `jar`and `testjar`goals / BndMavenPackagingTestsPlugin and BndMavenPackagingPlugin could be configures according the documentation using the confguration-propertiers `outputDir` and `waroutputDir`. But this properties are not used to save the jars in this position.

TODO: 
- test that shows that a not default `outputDir` and `waroutputDir` work properly.
- since `waroutputDir` and `outputDir` never worked we can decide to use only `outputDirectory` for both like in maven-jar-plugin and `maven-war-plgin`