### PR TITLE
Catch exceptions when copying stdin in Command

### DIFF
--- a/aQute.libg/src/aQute/libg/command/Command.java
+++ b/aQute.libg/src/aQute/libg/command/Command.java
@@ -159,7 +159,7 @@ public class Command {
 						} catch (InterruptedIOException e) {
 							// Ignore here
 						} catch (Exception e) {
-							// Who cares?
+							logger.debug("stdin copy exception in thread", e);
 						} finally {
 							IO.close(stdin);
 						}
@@ -169,6 +169,8 @@ public class Command {
 				} else {
 					try {
 						IO.copy(in, stdin);
+					} catch (Exception e) {
+						logger.debug("stdin copy exception", e);
 					} finally {
 						IO.close(stdin);
 					}


### PR DESCRIPTION
We still sometimes see "Stream closed" exceptions in parallel builds when using the bnd-testing-maven-plugin.
There was a previous fix in #4509 which already fixed most of these issues for us.

The reason we have these issues is because we also use the spotless-maven-plugin which [executes its SpotBugsMojo using AntBuilder](https://github.com/spotbugs/spotbugs-maven-plugin/blob/aa8a2b1bcd3556ac26c0dcbec7d963b6bd4edd0d/src/main/groovy/org/codehaus/mojo/spotbugs/SpotBugsMojo.groovy#L1082).
The AntBuilder [replaces](https://github.com/apache/groovy/blob/301fef366dbf0aa7f1f30faeb9b14a07927fbd98/subprojects/groovy-ant/src/main/java/groovy/ant/AntBuilder.java#L261-L308) System.in/out/err streams and closes these streams when it has finished execution.

So if meanwhile bnd started using System.in it fails with the following stacktrace:

```
[ERROR]  Failed to execute goal biz.aQute.bnd:bnd-testing-maven-plugin:6.2.0:testing (default) on project org.openhab.core.thing.tests: Stream closed -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal biz.aQute.bnd:bnd-testing-maven-plugin:6.2.0:testing (default) on project org.openhab.core.thing.tests: Stream closed
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: org.apache.maven.plugin.MojoExecutionException: Stream closed
    at aQute.bnd.maven.testing.plugin.TestingMojo.execute (TestingMojo.java:160)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
Caused by: java.io.IOException: Stream closed
    at java.io.BufferedInputStream.getBufIfOpen (BufferedInputStream.java:168)
    at java.io.BufferedInputStream.read (BufferedInputStream.java:334)
    at aQute.lib.io.IO.read (IO.java:327)
    at aQute.lib.io.IO.copy (IO.java:348)
    at aQute.libg.command.Command.execute (Command.java:171)
    at aQute.bnd.build.ProjectLauncher.launch (ProjectLauncher.java:380)
    at aQute.launcher.plugin.ProjectLauncherImpl.launch (ProjectLauncherImpl.java:199)
    at aQute.tester.junit.platform.plugin.ProjectTesterImpl.test (ProjectTesterImpl.java:99)
    at aQute.bnd.build.Project.test (Project.java:2545)
    at aQute.bnd.maven.testing.plugin.TestingMojo.lambda$getOperation$1 (TestingMojo.java:207)
    at aQute.bnd.maven.lib.resolve.BndrunContainer.execute (BndrunContainer.java:179)
    at aQute.bnd.maven.testing.plugin.TestingMojo.execute (TestingMojo.java:157)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:186)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:833)
```
