### PR TITLE
ee: For Java 1.1, we change the osgi.ee name to JRE

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -116,7 +116,7 @@ public class Clazz {
 	private final static Logger logger = LoggerFactory.getLogger(Clazz.class);
 
 	public enum JAVA {
-		Java_1_1(45, "JRE-1.1", "(&(osgi.ee=JavaSE)(version=1.1))"), //
+		Java_1_1(45, "JRE-1.1", "(&(osgi.ee=JRE)(version=1.1))"), //
 		Java_1_2(46, "J2SE-1.2", "(&(osgi.ee=JavaSE)(version=1.2))"), //
 		Java_1_3(47, "J2SE-1.3", "(&(osgi.ee=JavaSE)(version=1.3))"), //
 		Java_1_4(48, "J2SE-1.4", "(&(osgi.ee=JavaSE)(version=1.4))"), //


### PR DESCRIPTION
While this is outside of the OSGi specification, which does not
address Java 1.1 as it was already superseded by Java 1.2 when OSGi
was first released, Equinox uses the osgi.ee name of JRE instead of
JavaSE. Since Java 1.1-only bundles are minuscule and Java 1.1 is
outside of the OSGi specifications, we just follow what the framework
implementation does.

