### PR TITLE
Switch to not generate REQ `osgi.extender=osgi.serviceloader.registrar`

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/SPIAnnotationsTest.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/SPIAnnotationsTest.java
@@ -64,6 +64,27 @@ public class SPIAnnotationsTest {
 	}
 
 	@Test
+	public void testServiceProviderWithoutServiceLoaderRegistrar() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin_test"));
+			b.setPrivatePackage("test.annotationheaders.spi.providerF");
+			b.set("-noserviceloaderregistrar", "true");
+			b.build();
+			b.getJar()
+				.getManifest()
+				.write(System.out);
+			assertTrue(b.check());
+
+			Attributes mainAttributes = b.getJar()
+				.getManifest()
+				.getMainAttributes();
+
+			Header req = Header.parseHeader(mainAttributes.getValue(Constants.REQUIRE_CAPABILITY));
+			assertEquals(1, req.size());
+		}
+	}
+
+	@Test
 	public void testServiceProvider_existingdescriptor() throws Exception {
 		try (Builder b = new Builder();) {
 			b.addClasspath(IO.getFile("bin_test"));

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -568,6 +568,8 @@ public class Syntax implements Constants {
 
 		new Syntax(NOEE, "Do not calculate the osgi.ee name space Execution Environment from the class file version.",
 			NOEE + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
+		new Syntax(NOSERVICELOADERREGISTRAR, "Do not put the requirement `serviceloader.registrar` in the manifest.",
+			NOEE + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
 		new Syntax(NAMESECTION,
 			"Create a name section (second part of manifest) with optional property expansion and addition of custom attributes. Patterns not ending with \"/\" target resources. Those ending with \"/\" target packages.",
 			NAMESECTION + "=*;baz=true, abc/def/bar/X.class;bar=3", null, null),

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -63,12 +63,14 @@ import aQute.bnd.osgi.Clazz.JAVA;
 import aQute.bnd.osgi.Descriptors.Descriptor;
 import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.osgi.Descriptors.TypeRef;
+import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.service.AnalyzerPlugin;
 import aQute.bnd.service.classparser.ClassParser;
 import aQute.bnd.signatures.ClassSignature;
 import aQute.bnd.signatures.FieldSignature;
 import aQute.bnd.signatures.MethodSignature;
 import aQute.bnd.stream.MapStream;
+import aQute.bnd.unmodifiable.Maps;
 import aQute.bnd.version.Version;
 import aQute.bnd.version.VersionRange;
 import aQute.lib.base64.Base64;
@@ -1116,6 +1118,21 @@ public class Analyzer extends Processor {
 				// we add a
 
 				requirements.add(ExecutionEnvironmentNamespace.EXECUTION_ENVIRONMENT_NAMESPACE, attrs);
+			}
+
+			if (isTrue(getProperty(NOSERVICELOADERREGISTRAR))) {
+				Attrs a = requirements.get("osgi.extender");
+
+				if (a.containsKey("filter:")) {
+					String filter = a.get("filter:");
+					Map<String, Object> testMatch = Maps.of("osgi.extender",
+						aQute.bnd.annotation.spi.Constants.SERVICELOADER_REGISTRAR, "version", "1.0.0");
+
+					if (ResourceUtils.filterPredicate(filter)
+						.test(testMatch)) {
+						requirements.remove("osgi.extender");
+					}
+				}
 			}
 
 			if (!requirements.isEmpty())

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -182,6 +182,7 @@ public interface Constants {
 	String		NOJUNIT										= "-nojunit";
 	String		NOJUNITOSGI									= "-nojunitosgi";
 	String		NOEE										= "-noee";
+	String		NOSERVICELOADERREGISTRAR					= "-noserviceloaderregistrar";
 
 	String		NOMANIFEST									= "-nomanifest";
 	String		MANIFEST_NAME								= "-manifest-name";
@@ -312,7 +313,7 @@ public interface Constants {
 		CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE, REPRODUCIBLE, INCLUDEPACKAGE,
 		CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK, MAVEN_SCOPE, RUNSTARTLEVEL,
 		RUNOPTIONS, NOCLASSFORNAME, EXPORT_APIGUARDIAN, RESOLVE, DEFINE_CONTRACT, GENERATE, RUNFRAMEWORKRESTART,
-		NOIMPORTJAVA, VERSIONDEFAULTS, LIBRARY);
+		NOIMPORTJAVA, VERSIONDEFAULTS, LIBRARY, NOSERVICELOADERREGISTRAR);
 
 	// Ignore bundle specific headers. These headers do not make a lot of sense
 	// to inherit

--- a/docs/_chapters/240-spi-annotations.md
+++ b/docs/_chapters/240-spi-annotations.md
@@ -42,7 +42,7 @@ public class JsonProviderImpl extends JsonProvider {
 }
 ```
 
-`@ServiceProvider` also grants the developer control in defining many facets of the generated OSGi requirements and capabilities such as additional attributes and directives (attributes becoming service properties), `cardinality`, `effective` time, `resolution`, and package `uses`.
+`@ServiceProvider` also grants the developer control in defining many facets of the generated OSGi requirements and capabilities such as additional attributes and directives (attributes becoming service properties), `cardinality`, `effective` time, `resolution`, and package `uses`. The `@aQute.bnd.annotation.spi.ServiceProvider` annotation also generates a `osgi.serviceloader.registrar` requirement into the manifest. To avoid this you can use the `-noserviceloaderregistrar` instruction.
 
 #### OSGi Services
 


### PR DESCRIPTION
in some cases you want use the features of the `@ServiceProvicer`
annotation but not generate the requirement for
`osgi.serviceloader.registrar`.

If there are better solutions for this please give me a hint.