### PR TITLE
build(deps): Bump com.gradle.plugin-publish in /gradle-plugins

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 	groovy
 	`kotlin-dsl`
 	id("maven-publish")
-	id("com.gradle.plugin-publish") version "0.20.0"
+	id("com.gradle.plugin-publish") version "0.21.0"
 }
 
 interface Injected {


### PR DESCRIPTION
Bumps com.gradle.plugin-publish from 0.20.0 to 0.21.0.

