### PR TITLE
External plugin customize

### DIFF
--- a/biz.aQute.bnd.util/src/aQute/bnd/result/Err.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/result/Err.java
@@ -74,7 +74,7 @@ final class Err<V> implements Result<V> {
 	 */
 	@Override
 	public V unwrap() {
-		throw new ResultException("Not an Ok value");
+		throw new ResultException(error);
 	}
 
 	/**

--- a/biz.aQute.bndall.tests/resources/ws-1/cnf/build.bnd
+++ b/biz.aQute.bndall.tests/resources/ws-1/cnf/build.bnd
@@ -1,1 +1,1 @@
--plugin java.util.concurrent.Callable
+-plugin java.util.concurrent.Callable;world=plugin-attrs

--- a/biz.aQute.bndall.tests/src/biz/aQute/bndall/tests/plugin_1/CallablePlugin.java
+++ b/biz.aQute.bndall.tests/src/biz/aQute/bndall/tests/plugin_1/CallablePlugin.java
@@ -2,26 +2,40 @@ package biz.aQute.bndall.tests.plugin_1;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
+import aQute.bnd.service.Plugin;
 import aQute.bnd.service.externalplugin.ExternalPlugin;
+import aQute.service.reporter.Reporter;
 
 @ExternalPlugin(name = "hellocallable", objectClass = Callable.class)
-public class CallablePlugin implements Callable<String>, Closeable {
+public class CallablePlugin implements Callable<String>, Closeable, Plugin {
 	boolean closed;
+	String	world	= "world";
 
 	@Override
 	public String call() throws Exception {
 		if (closed)
-			return "goodbye";
+			return "goodbye, " + world;
 		else
-			return "hello";
+			return "hello, " + world;
 	}
 
 	@Override
 	public void close() throws IOException {
 		System.out.println("closed");
 		closed = true;
+	}
+
+	@Override
+	public void setProperties(Map<String, String> map) throws Exception {
+		world = map.get("world");
+	}
+
+	@Override
+	public void setReporter(Reporter processor) {
+		// ignore
 	}
 
 }

--- a/biz.aQute.bndall.tests/test/biz/aQute/externalplugin/ExternalPluginHandlerTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/externalplugin/ExternalPluginHandlerTest.java
@@ -40,7 +40,7 @@ public class ExternalPluginHandlerTest {
 				});
 			System.out.println(call);
 			assertThat(call.isOk()).isTrue();
-			assertThat(call.unwrap()).isEqualTo("hello");
+			assertThat(call.unwrap()).isEqualTo("hello, world");
 		}
 	}
 
@@ -59,7 +59,7 @@ public class ExternalPluginHandlerTest {
 			assertThat(unwrap).hasSize(1);
 
 			callable = unwrap.get(0);
-			assertThat(callable.call()).isEqualTo("hello");
+			assertThat(callable.call()).isEqualTo("hello, world");
 		}
 	}
 
@@ -86,9 +86,9 @@ public class ExternalPluginHandlerTest {
 
 			plugin = ws.getPlugin(Callable.class);
 			assertThat(plugin).isNotNull();
-			assertThat(plugin.call()).isEqualTo("hello");
+			assertThat(plugin.call()).isEqualTo("hello, plugin-attrs");
 		}
-		assertThat(plugin.call()).isEqualTo("goodbye");
+		assertThat(plugin.call()).isEqualTo("goodbye, plugin-attrs");
 	}
 
 	@Test

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/PluginsContainer.java
@@ -107,11 +107,18 @@ public class PluginsContainer extends AbstractSet<Object> implements Set<Object>
 				if (ws == null) {
 					return Collections.emptyList();
 				}
+				logger.debug("Loading external plugins {}", this.serviceClass);
 				Result<List<T>> implementations = ws.getExternalPlugins()
 					.getImplementations(this.serviceClass, this.attrs);
 				implementations.accept(
-					ok -> ok.forEach(p -> ws.customize(p, this.attrs, PluginsContainer.this)),
-					error -> ws.error("%s", error));
+					ok -> ok.forEach(p -> {
+						logger.debug("Customizing external plugin {} with [{}]", p, this.attrs);
+						processor.customize(p, this.attrs, PluginsContainer.this);
+					}),
+					error -> {
+						logger.debug("Loading external plugins {} failed with error {}", this.serviceClass, error);
+						processor.error("Loading external plugins %s failed with error %s", this.serviceClass, error);
+					});
 				return implementations.orElseGet(Collections::emptyList);
 			});
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -508,17 +508,26 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	 */
 	protected <T> T customize(T plugin, Attrs map, PluginsContainer pluginsContainer) {
 		if (plugin instanceof Plugin) {
-			((Plugin) plugin).setReporter(this);
 			try {
-				if (map == null)
+				((Plugin) plugin).setReporter(this);
+			} catch (Exception e) {
+				exception(e, "While setting reporter on plugin %s", plugin);
+			}
+			try {
+				if (map == null) {
 					map = Attrs.EMPTY_ATTRS;
+				}
 				((Plugin) plugin).setProperties(map);
 			} catch (Exception e) {
 				exception(e, "While setting properties %s on plugin %s", map, plugin);
 			}
 		}
 		if (plugin instanceof RegistryPlugin) {
-			((RegistryPlugin) plugin).setRegistry(pluginsContainer);
+			try {
+				((RegistryPlugin) plugin).setRegistry(pluginsContainer);
+			} catch (Exception e) {
+				exception(e, "While setting registry on plugin %s", plugin);
+			}
 		}
 		return plugin;
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Verifier.java
@@ -665,8 +665,7 @@ public class Verifier extends Processor {
 					endHandleErrors(previous);
 				}
 			} catch (Exception e) {
-				e.printStackTrace(System.err);
-				error("Verifier Plugin %s failed %s", plugin, e);
+				exception(e, "Verifier Plugin %s failed %s", plugin, e);
 			}
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/Plugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/Plugin.java
@@ -6,7 +6,7 @@ import aQute.service.reporter.Reporter;
 
 /**
  * An optional interface for plugins. If a plugin implements this interface then
- * it can receive the reminaing attributes and directives given in its clause as
+ * it can receive the remaining attributes and directives given in its clause as
  * well as the reporter to use.
  */
 public interface Plugin {


### PR DESCRIPTION
Update the external plugin support to allow external plugins to implement Plugin and RegistryPlugin whose methods are called by Processor.customize to supply information
to plugins including any attributes on the -plugin instruction.