### PR TITLE
bndtools container: Allow user to exclude project and have only jar

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -384,9 +384,14 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 						IPath projectPath = root.getFile(path)
 							.getProject()
 							.getFullPath();
-						addProjectEntry(projectPath, accessRules, extraAttrs);
+						List<String> options = Strings.split(c.getAttributes()
+							.get("ide"));
+						boolean versionProject = isVersionProject(c);
+						if (versionProject || !options.contains("jar-only")) {
+							addProjectEntry(projectPath, accessRules, extraAttrs);
+						}
 						// if not version=project, add entry for generated jar
-						if (!isVersionProject(c)) {
+						if (!versionProject) {
 							/*
 							 * Supply an empty index for the generated JAR of a
 							 * workspace project dependency. This prevents the


### PR DESCRIPTION
This is useful for version=snapshot or version=latest when the
project's built jar contains transformed classes and we want the
Eclipse compiler to use the jar's classes and not the project's
untransformed classes which lead to compilation errors.

By adding `ide=jar-only` to the -buildpath entry, Bndtools
will include the built jar and not include the project in the
class path container.
