### PR TITLE
bndtools container: Rename ide to source

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
+++ b/bndtools.builder/src/org/bndtools/builder/classpath/BndContainerInitializer.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.jar.Manifest;
@@ -384,10 +385,10 @@ public class BndContainerInitializer extends ClasspathContainerInitializer imple
 						IPath projectPath = root.getFile(path)
 							.getProject()
 							.getFullPath();
-						List<String> options = Strings.split(c.getAttributes()
-							.get("ide"));
+						String source = c.getAttributes()
+							.getOrDefault("source", "project");
 						boolean versionProject = isVersionProject(c);
-						if (versionProject || !options.contains("jar-only")) {
+						if (versionProject || Objects.equals(source, "project")) {
 							addProjectEntry(projectPath, accessRules, extraAttrs);
 						}
 						// if not version=project, add entry for generated jar


### PR DESCRIPTION
To be more general, we reframe the attribute to `source` with the
default value of `project`. This is the prior behavior.

So saying `source=none` on a -buildpath entry, Bndtools
will include the built jar and not include the project in the
class path container.

In the future, other values of `source`, such as a file, could be
specified. But for now, the value `project` includes the project in
the classpath. All other values do not include the project.