### PR TITLE
Support a "project" attribute to name the bsn source project

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Container.java
@@ -68,7 +68,7 @@ public class Container {
 	}
 
 	public Container(Project project, String bsn, File file, Map<String, String> attributes) {
-		this(project, bsn, "project", TYPE.PROJECT, file, null, attributes, null);
+		this(project, bsn, Constants.VERSION_ATTR_PROJECT, TYPE.PROJECT, file, null, attributes, null);
 	}
 
 	public Container(Project project, File file, Map<String, String> attributes) {
@@ -84,7 +84,7 @@ public class Container {
 	}
 
 	public Container(File file, DownloadBlocker db, Attrs attributes) {
-		this(null, bsnFromFile(file), "project", TYPE.EXTERNAL, file, null, attributes, db);
+		this(null, bsnFromFile(file), Constants.VERSION_ATTR_PROJECT, TYPE.EXTERNAL, file, null, attributes, db);
 	}
 
 	private Container(Project project, String message) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1467,7 +1467,7 @@ public class Project extends Processor {
 	 * @throws Exception
 	 */
 	private Container getBundleFromProject(String bsn, Map<String, String> attrs) throws Exception {
-		String pname = bsn;
+		String pname = attrs.getOrDefault("project", bsn);
 		while (true) {
 			Project p = getWorkspace().getProject(pname);
 			if (p != null && p.isValid()) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2899,8 +2899,12 @@ public class Project extends Processor {
 		try (ProjectBuilder pb = getBuilder(null)) {
 			for (Builder b : pb.getSubBuilders()) {
 				if (b.getBsn()
-					.equals(bsn))
-					return new Container(this, bsn, getOutputFile(bsn, b.getVersion()), attrs);
+					.equals(bsn)) {
+					String version = b.getVersion();
+					Container c = new Container(this, bsn, version, Container.TYPE.PROJECT, getOutputFile(bsn, version),
+						null, attrs, null);
+					return c;
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
Normally, Bnd expects the bsn of a bundle built in the workspace to be
prefixed by the project name. This convention allows a quick lookup
from a bsn to find the project which builds the bundle with the bsn.

However, sometimes you need to refactor code, or when transforming,
use a completely different bsn for one of the sub bundles. The bundle
building works fine. But if another project refers to the bsn which
is not prefixed by the project name, Bnd cannot find the bundle and
fails.

Bnd could just exhaustively search the workspace but this would be cost
prohibitive in very large workspaces such as Open Liberty.

So this change introduces a "project" attribute which can be used on
a buildpath/testpath entry to name the project in which to look for the
bsn. So this does not affect the normal project-name=bsn case but allows
for bsn refactoring in a build at the cost of specifying the "project"
attribute. Fortunately, decoration can be used to centralize the
mappings of bsn to project name.