### PR TITLE
[httpclient] Implement log as specified in doc

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientServerTest.java
@@ -85,7 +85,6 @@ public class HttpClientServerTest {
 			p.setProperty("-connection-log", log.toURI()
 				.getPath());
 			p.setProperty("-connection-settings", settings);
-			hc.setLog(log);
 
 			ConnectionSettings cs = new ConnectionSettings(p, hc);
 			cs.readSettings();

--- a/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/connection/settings/ConnectionSettings.java
@@ -35,6 +35,7 @@ import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.http.HttpClient;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Processor.FileLine;
 import aQute.bnd.service.url.ProxyHandler;
@@ -73,6 +74,13 @@ public class ConnectionSettings {
 	public ConnectionSettings(Processor processor, HttpClient client) throws Exception {
 		this.processor = Objects.requireNonNull(processor);
 		this.client = client;
+		String logfile = processor.getProperty(Constants.CONNECTION_LOG);
+		if (Strings.nonNullOrEmpty(logfile)) {
+			File file = IO.getFile(logfile);
+			file.getParentFile()
+				.mkdirs();
+			this.client.setLog(file);
+		}
 		mavenMasterPassphrase = new MasterPassphrase(processor);
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -116,6 +116,8 @@ public interface Constants {
 	String		DEFINE_CONTRACT								= "-define-contract";
 	String		CONDITIONALPACKAGE							= "-conditionalpackage";
 	String		CONNECTION_SETTINGS							= "-connection-settings";
+	String		CONNECTION_LOG								= "-connection-log";
+
 	String		COMPRESSION									= "-compression";
 	String		DIFFIGNORE									= "-diffignore";
 	String		DIFFPACKAGES								= "-diffpackages";

--- a/docs/_instructions/connection-settings.md
+++ b/docs/_instructions/connection-settings.md
@@ -45,7 +45,7 @@ You can create a log file specific for the connections by specifying:
 
 	-connection-log: somefile.txt
 
-This file will contain the detailed trace output
+This file will contain the detailed trace output. The file given is relative to the working directory.
 
 ## Syntax
 


### PR DESCRIPTION
The documentation specified a -connection-log instruction 
but the code did not implement it. This patch
sets the log when the http client's -connection-log
when the property is set.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>