### PR TITLE
#5062 JVM crash

### DIFF
--- a/bndtools.core/src/bndtools/explorer/Model.java
+++ b/bndtools.core/src/bndtools/explorer/Model.java
@@ -102,12 +102,27 @@ class Model {
 	}
 
 	void update() {
-		dirty.set(true);
+		if (dirty.getAndSet(true))
+			return;
+
 		Display.getDefault()
 			.asyncExec(this::update0);
 	}
 
+	/*
+	 * This runs async on the display thread.
+	 */
 	private void update0() {
+		try {
+			// coalesce some more updates on
+			// the worker thread(s).
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			Thread.currentThread()
+				.interrupt();
+			return;
+		}
+
 		if (dirty.getAndSet(false)) {
 			updates.forEach(Runnable::run);
 		}


### PR DESCRIPTION
Another desperate attempt to fix the JVM crash
in the bndtools explorer. 

This fix coalesces some update events by waiting 
10 ms before starting to do the UI work.

This should reduce the rate at which we call SWT 
and this _might_ solve this stupid SWT bug


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>