### PR TITLE
ci: Separate Gradle Wrapper validation into its own workflow

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -4,19 +4,17 @@ on:
   push:
     branches-ignore:
     - 'dependabot/**'
-    paths-ignore:
-    - 'docs/**'
-    - '.github/**/*docs*'
-    - '.github/**/*codeql*'
-    - '.github/**/*rebuild*'
-    - '.github/*.yml'
+    paths:
+    - '**'
+    - '!docs/**'
+    - '!.github/**'
+    - '.github/**/*ci*'
   pull_request:
-    paths-ignore:
-    - 'docs/**'
-    - '.github/**/*docs*'
-    - '.github/**/*codeql*'
-    - '.github/**/*rebuild*'
-    - '.github/*.yml'
+    paths:
+    - '**'
+    - '!docs/**'
+    - '!.github/**'
+    - '.github/**/*ci*'
 
 env:
   LC_ALL: en_US.UTF-8
@@ -62,8 +60,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: ${{ matrix.fetch-depth }}
-    - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,8 +44,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-    - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -4,19 +4,17 @@ on:
   push:
     branches-ignore:
     - 'dependabot/**'
-    paths-ignore:
-    - 'docs/**'
-    - '.github/**/*docs*'
-    - '.github/**/*codeql*'
-    - '.github/**/*ci*'
-    - '.github/*.yml'
+    paths:
+    - '**'
+    - '!docs/**'
+    - '!.github/**'
+    - '.github/**/*rebuild*'
   pull_request:
-    paths-ignore:
-    - 'docs/**'
-    - '.github/**/*docs*'
-    - '.github/**/*codeql*'
-    - '.github/**/*ci*'
-    - '.github/*.yml'
+    paths:
+    - '**'
+    - '!docs/**'
+    - '!.github/**'
+    - '.github/**/*rebuild*'
 
 env:
   LC_ALL: en_US.UTF-8
@@ -50,8 +48,6 @@ jobs:
     steps:
     - name: Git Checkout
       uses: actions/checkout@v3
-    - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,0 +1,35 @@
+name: 'Wrapper'
+
+on:
+  push:
+    branches-ignore:
+    - 'dependabot/**'
+    paths:
+    - 'gradle/wrapper/**'
+    - 'gradlew*'
+    - '.github/**/*wrapper*'
+  pull_request:
+    paths:
+    - 'gradle/wrapper/**'
+    - 'gradlew*'
+    - '.github/**/*wrapper*'
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Gradle Wrapper
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Git Checkout
+      uses: actions/checkout@v3
+    - name: Gradle Wrapper Validation
+      uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Sometimes gradle wrapper validation fails due to network issues.
By separating the wrapper validation into its own workflow, we can
easily rerun the failed workflow without rerunning all the longer
running workflows.