### PR TITLE
[export] JPMS module info calculation fails

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
+++ b/biz.aQute.launcher/src/aQute/launcher/plugin/ProjectLauncherImpl.java
@@ -357,19 +357,24 @@ public class ProjectLauncherImpl extends ProjectLauncher {
 				}
 			}
 
-			List<String> bcpList = new ArrayList<>();
-			bcpList.add(".");
-			bcpList.addAll(classpath);
-			bcpList.addAll(actualPaths);
+			String moduleProperty = builder.getProperty(JPMS_MODULE_INFO);
+			if (moduleProperty != null) {
 
-			builder.setProperty(BUNDLE_CLASSPATH, bcpList.stream()
-				.collect(joining(",")));
-			builder.setProperty(EXPORT_CONTENTS, "aQute.launcher.pre");
+				List<String> bcpList = new ArrayList<>();
+				bcpList.add(".");
+				bcpList.addAll(classpath);
+				bcpList.addAll(actualPaths);
 
-			// Ignore common warnings resulting from the Bundle-ClassPath which
-			// are irrelevant in this use case
-			builder.setProperty(FIXUPMESSAGES,
-				"Classes found in the wrong directory, private references, Export-Package duplicate package name, Invalid package name: * in Export-Package");
+				builder.setProperty(BUNDLE_CLASSPATH, bcpList.stream()
+					.collect(joining(",")));
+				builder.setProperty(EXPORT_CONTENTS, "aQute.launcher.pre");
+
+				// Ignore common warnings resulting from the Bundle-ClassPath
+				// which
+				// are irrelevant in this use case
+				builder.setProperty(FIXUPMESSAGES,
+					"Classes found in the wrong directory, private references, Export-Package duplicate package name, Invalid package name: * in Export-Package");
+			}
 
 			LauncherConstants lc = getConstants(actualPaths, true);
 			lc.embedded = true;


### PR DESCRIPTION
There was a recent change https://github.com/bndtools/bnd/commit/dd2f0c56f9c102b9b7aa969c389787f541e76528 that took a shortcut to calculate the embedded packages unconditionally. It used the bundle class path analysis to analyze all the jars in the executable. 

However, this significantly slows down Eclipse but worse, it then tries to reinterpret the annotation headers. In my case, I got 3 types on the Bundle-Activator.

The analysis should only be done when it is needed and I'd suggest to do it either in a separate Builder or try to analyze the manifests for speedup.

This patch just makes the analysis conditional but that is a temporary fix to make it compatible with the the previous code.

This needs to be cherry picked for 6.3.0 since it is a very serious regression.

Fixes  #5257

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>