### PR TITLE
build: Remove use of "{xxx}" non-literals on + decorations

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -28,13 +28,10 @@ Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
 -diffignore:            Bundle-Version
 
 # Decorations
-# We use non-literals, "{xxx}", to make sure we don't force the dependency onto
-# the instruction
-
 -buildpath+: \
-    "{aQute.libg}";version=project;packages="!aQute.lib.exceptions.*,*",\
-    "{osgi.annotation}";~version=latest;~maven-scope=provided,\
-    "{osgi.core}";~version=latest;~maven-scope=provided,\
+    "aQute.libg";version=project;packages="!aQute.lib.exceptions.*,*",\
+    "osgi.annotation";~version=latest;~maven-scope=provided,\
+    "osgi.core";~version=latest;~maven-scope=provided,\
     "org.osgi.namespace.*";~version=latest;~maven-scope=provided,\
     "org.osgi.service.*.annotations";~version=latest;~maven-scope=provided
 
@@ -42,9 +39,9 @@ Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
     =!aQute.lib.exceptions.*
 
 -testpath+: \
-    "{aQute.libg}";version=project;packages="!aQute.lib.exceptions.*,*",\
-    "{osgi.annotation}";~version=latest,\
-    "{osgi.core}";~version=latest,\
+    "aQute.libg";version=project;packages="!aQute.lib.exceptions.*,*",\
+    "osgi.annotation";~version=latest,\
+    "osgi.core";~version=latest,\
     "org.osgi.namespace.*";~version=latest,\
     "org.osgi.service.*.annotations";~version=latest
 

--- a/cnf/includes/bndtools.bnd
+++ b/cnf/includes/bndtools.bnd
@@ -9,4 +9,4 @@ eclipse.importpackage: \
  org.eclipse.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,+);${@bundleversion}}";version=!;ui.workbench=!;common=!;registry=!;texteditor=!;text=!
 
  # Decorate Equinox OSGi framework dependency
--buildpath+.equinox: "{org.eclipse.osgi}";maven-scope=provided
+-buildpath+.equinox: "org.eclipse.osgi";maven-scope=provided


### PR DESCRIPTION
With the reversion to having + decorations not include literals, we
can stop using the "{xxx}" construct to be non-literal.