### PR TITLE
ci: Display build dependencies for rebuild-build

### DIFF
--- a/.github/scripts/rebuild-build.sh
+++ b/.github/scripts/rebuild-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ev
 ./gradlew --no-daemon --version
-./gradlew --no-daemon -Dmaven.repo.local=dist/m2 :publish
+./gradlew --no-daemon -Dmaven.repo.local=dist/m2 :buildscriptDependencies :publish
 ./gradlew --no-daemon -Dmaven.repo.local=dist/m2 --warning-mode=fail :gradle-plugins:build
 ./gradlew --no-daemon -Dmaven.repo.local=dist/m2 :gradle-plugins:publish


### PR DESCRIPTION
This is useful for checking the Bnd version used to build Bnd.