### PR TITLE
maven: Add testFailureIgnore configuration to bnd-testing-maven-plugin

### DIFF
--- a/maven/bnd-testing-maven-plugin/README.md
+++ b/maven/bnd-testing-maven-plugin/README.md
@@ -67,6 +67,7 @@ An *implicit repository* containing the project artifact and project dependencie
 |`reportsDir`                    | The output directory for test reports. A subdirectory of `${bndrun}` will be created for each bndrun file supplied. _Defaults to `${project.build.directory}/test-reports`._|
 |`cwd`                           | The current working directory of the test process. A subdirectory of `${bndrun}` will be created for each bndrun file supplied. _Defaults to `${project.build.directory}/test`._|
 |`skipTests` OR `maven.test.skip`| Does not execute any tests. Used from the command line via `-D`. _Defaults to `false`._|
+|`testFailureIgnore`| Does not fail mojo if any tests fail. Used from the command line via `-Dbnd.testing.failure.ignore=true`. _Defaults to `false`._|
 |`testingSelect`                 | A file path to a test file, overrides anything else. _Defaults to `${testing.select}`._ Override with property `testing.select`.|
 |`testing`                       | A glob expression that is matched against the file name of the listed bndrun files. _Defaults to `${testing}`._ Override with property `testing`.|
 |`test`                          | A comma separated list of the fully qualified names of test classes to run. If not set, or empty, then all the test classes listed in the `Test-Classes` manifest header are run. Use a colon (:) to specify a test method to run on the specified test class. Override with property `test`.|

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/bnd.bnd
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/bnd.bnd
@@ -1,0 +1,1 @@
+Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/invoker.properties
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/invoker.properties
@@ -1,0 +1,10 @@
+invoker.goals=--no-transfer-progress integration-test
+
+# Run mvn with --debug for debug logging
+#invoker.debug=true
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult=failure
+
+# Run mvn in debugging mode and wait for a debugger to attach
+#invoker.environmentVariables.MAVEN_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/pom.xml
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+		<relativePath>../parent</relativePath>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>test-failure</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.junit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.framework</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-testing-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-indexer-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/src/main/java/bnd/test/FailingBndTest.java
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/src/main/java/bnd/test/FailingBndTest.java
@@ -1,0 +1,15 @@
+package bnd.test;
+
+import static org.junit.Assert.assertNull;
+import static org.osgi.framework.FrameworkUtil.getBundle;
+
+import org.junit.Test;
+
+public class FailingBndTest {
+
+	@Test
+	public void test() {
+		assertNull(getBundle(FailingBndTest.class).getBundleContext());
+	}
+	
+}

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/src/main/java/bnd/test/SimpleBndTest.java
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/src/main/java/bnd/test/SimpleBndTest.java
@@ -1,0 +1,15 @@
+package bnd.test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.osgi.framework.FrameworkUtil.getBundle;
+
+import org.junit.Test;
+
+public class SimpleBndTest {
+
+	@Test
+	public void test() {
+		assertNotNull(getBundle(SimpleBndTest.class).getBundleContext());
+	}
+	
+}

--- a/maven/bnd-testing-maven-plugin/src/it/test-failure/test.bndrun
+++ b/maven/bnd-testing-maven-plugin/src/it/test-failure/test.bndrun
@@ -1,0 +1,6 @@
+-standalone: target/index.xml
+
+-runfw: 		org.apache.felix.framework;version='[5.6.10,5.6.10]'
+-runee: 		JavaSE-1.8
+
+-runbundles: biz.aQute.junit, test-failure;version='[0.0.1,0.0.2)'

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/bnd.bnd
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/bnd.bnd
@@ -1,0 +1,1 @@
+Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/invoker.properties
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/invoker.properties
@@ -1,0 +1,7 @@
+invoker.goals=--no-transfer-progress integration-test
+
+# Run mvn with --debug for debug logging
+#invoker.debug=true
+
+# Run mvn in debugging mode and wait for a debugger to attach
+#invoker.environmentVariables.MAVEN_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/pom.xml
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>test</artifactId>
+		<version>0.0.1</version>
+		<relativePath>../parent</relativePath>
+	</parent>
+
+	<groupId>biz.aQute.bnd-test</groupId>
+	<artifactId>test-ignore-failure</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.junit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.framework</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-testing-maven-plugin</artifactId>
+				<configuration>
+					<testFailureIgnore>true</testFailureIgnore>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-indexer-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/postbuild.groovy
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/postbuild.groovy
@@ -1,0 +1,9 @@
+import groovy.xml.XmlSlurper
+
+File testsuite_xml = new File(basedir, "target/test-reports/test/TEST-test-ignore-failure-0.0.1.xml")
+assert testsuite_xml.isFile();
+testsuite = new XmlSlurper().parse(testsuite_xml)
+assert testsuite.@name == "test.test-ignore-failure"
+assert testsuite.@tests == 2
+assert testsuite.@errors == 1
+assert testsuite.@failures == 0

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/src/main/java/bnd/test/FailingBndTest.java
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/src/main/java/bnd/test/FailingBndTest.java
@@ -1,0 +1,15 @@
+package bnd.test;
+
+import static org.junit.Assert.assertNull;
+import static org.osgi.framework.FrameworkUtil.getBundle;
+
+import org.junit.Test;
+
+public class FailingBndTest {
+
+	@Test
+	public void test() {
+		assertNull(getBundle(FailingBndTest.class).getBundleContext());
+	}
+	
+}

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/src/main/java/bnd/test/SimpleBndTest.java
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/src/main/java/bnd/test/SimpleBndTest.java
@@ -1,0 +1,15 @@
+package bnd.test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.osgi.framework.FrameworkUtil.getBundle;
+
+import org.junit.Test;
+
+public class SimpleBndTest {
+
+	@Test
+	public void test() {
+		assertNotNull(getBundle(SimpleBndTest.class).getBundleContext());
+	}
+	
+}

--- a/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/test.bndrun
+++ b/maven/bnd-testing-maven-plugin/src/it/test-ignore-failure/test.bndrun
@@ -1,0 +1,6 @@
+-standalone: target/index.xml
+
+-runfw: 		org.apache.felix.framework;version='[5.6.10,5.6.10]'
+-runee: 		JavaSE-1.8
+
+-runbundles: biz.aQute.junit, test-ignore-failure;version='[0.0.1,0.0.2)'

--- a/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -56,6 +56,9 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(property = "maven.test.skip", defaultValue = "false")
 	private boolean												skip;
 
+	@Parameter(property = "bnd.testing.failure.ignore", defaultValue = "false")
+	private boolean												testFailureIgnore;
+
 	@Parameter
 	private Bndruns												bndruns	= new Bndruns();
 
@@ -160,8 +163,9 @@ public class TestingMojo extends AbstractMojo {
 			throw new MojoExecutionException(e.getMessage(), e);
 		}
 
-		if (errors > 0)
+		if (!isTestFailureIgnore() && (errors > 0)) {
 			throw new MojoFailureException(errors + " errors found");
+		}
 	}
 
 	private List<String> getTests() {
@@ -171,6 +175,10 @@ public class TestingMojo extends AbstractMojo {
 			return null;
 		}
 		return Strings.split(test);
+	}
+
+	private boolean isTestFailureIgnore() {
+		return testFailureIgnore;
 	}
 
 	private Operation getOperation() {


### PR DESCRIPTION
This can be set from the command line with:

    -Dbnd.testing.failure.ignore=true

Fixes https://github.com/bndtools/bnd/issues/5295