### PR TITLE
[resolve] Add cache mode

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
@@ -78,6 +78,11 @@ public interface ResolutionInstructions {
 		@SyntaxAnnotation(lead = "A resolve will take place before launching when in batch mode (e.g. Gradle) but not in IDE mode (e.g. Eclipse)")
 		batch,
 
+		/**
+		 * Run the resolver before launching during batch mode
+		 */
+		@SyntaxAnnotation(lead = "Resolve when the runbundles are needed unless there is a cache file that is newer than the bndrun/project & workspace. The cache file has the same name as the project/bndrun file but starts with a '.'")
+		cache,
 	}
 
 	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched, batchlaunch is like beforelaunch but only in batch mode", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch|batch)")

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.4.0")
+@org.osgi.annotation.versioning.Version("1.5.0")
 package aQute.bnd.help.instructions;

--- a/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
@@ -1,4 +1,4 @@
-@Version("8.1.0")
+@Version("8.2.0")
 package biz.aQute.resolve;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
@@ -1,7 +1,9 @@
 package biz.aQute.resolve;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
@@ -116,6 +118,48 @@ public class RunResolutionTest {
 			.getRunbundles();
 		runbundles.forEach(c -> System.out.println(c.getFile()));
 		// assertThat(runbundles).hasSize(22);
+	}
+
+	@Test
+	public void testResolveCached() throws Exception {
+
+		Bndrun bndrun = Bndrun.createBndrun(workspace, IO.getFile(ws.toFile(), "test.simple/resolve.bndrun"));
+		File file = bndrun.getPropertiesFile();
+		bndrun.testIgnoreDownloadErrors = true;
+		assertTrue(bndrun.check());
+		File cache = bndrun.getCacheFile(file);
+
+		System.out.println("get the embedded list of runbundles");
+		bndrun.setProperty("-resolve", "manual");
+		Collection<Container> manual = bndrun.getRunbundles();
+
+		System.out.println("remove the embedded list and set mode to 'cache'");
+		bndrun.setProperty("-resolve", "cache");
+		bndrun.unsetProperty("-runbundles");
+
+		assertThat(cache).doesNotExist();
+
+		System.out.println("First time we should resolve & create a cache file");
+		Collection<Container> cached = bndrun.getRunbundles();
+		assertThat(cache).isFile();
+		assertThat(cached).containsAll(manual);
+		assertThat(cached).hasSize(manual.size());
+		assertThat(cache.lastModified()).isGreaterThan(file.lastModified());
+
+		System.out
+			.println("Second time, the cache file should used, so make it valid but empty ");
+		long lastModified = cache.lastModified();
+		IO.store("-runbundles ", cache);
+		cache.setLastModified(file.lastModified() + 1000);
+		cached = bndrun.getRunbundles();
+		assertThat(cached).isEmpty();
+
+		System.out.println("Now make cache invalid, which be ignored");
+		IO.store("-runbundles is not a valid file", cache);
+		cache.setLastModified(file.lastModified() + 1000);
+		cached = bndrun.getRunbundles();
+		assertThat(manual).containsAll(cached);
+
 	}
 
 	@Test

--- a/biz.aQute.resolve/testdata/pre-buildworkspace/test.simple/resolve.bndrun
+++ b/biz.aQute.resolve/testdata/pre-buildworkspace/test.simple/resolve.bndrun
@@ -1,3 +1,4 @@
+-include empty-included-in-resolve.bnd
 -runfw: org.eclipse.osgi;version='[3.13.0,3.13.1)'
 -runee: JavaSE-1.8
 -runrequires: osgi.identity;filter:='(osgi.identity=test.simple)'

--- a/docs/_instructions/resolve.md
+++ b/docs/_instructions/resolve.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 class: Workspace
-title: -resolve (manual|auto|beforelaunch|batch)
+title: -resolve (manual|auto|beforelaunch|batch|cache)
 summary: Defines when/how resolving is done to calculate the -runbundles
 ---
 
@@ -13,6 +13,8 @@ The values are:
 * `auto` – Whenever the initial requirements are saved, the resolver will be used to set new `-runbundles`
 * `beforelaunch` – Calculate the `-runbundles` on demand. This ignores the value of the `-runbundles` and runs the resolver. The results of the resolver are cached. This cache works by creating a checksum over all the properties of the project.
 * `batch` – When running in batch mode, the run bundles will be resolved. In all other modes this will only resolve when the `-runbundles` are empty.
+* `cache` – Will use a cache file in the workspace cache. If that file is stale relative to the workspace or project or it does not exist, then the bnd(run) file will be resolved and the result is stored in the cache file.
+
  
 ## Example
 


### PR DESCRIPTION
cache – Will use a cache file in the workspace cache. If that file is stale relative to the workspace or project or it does not exist, then the bnd(run) file will be resolved and the result is stored in the cache file.


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>