### PR TITLE
resource: Defer SHA-256 calculation into the future

### DIFF
--- a/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Lists.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Lists.java
@@ -1,8 +1,11 @@
 package aQute.bnd.unmodifiable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 
 @SuppressWarnings("unchecked")
 public class Lists {
@@ -70,5 +73,12 @@ public class Lists {
 			return of();
 		}
 		return new ImmutableList<E>(collection.toArray());
+	}
+
+	public static <E> Collector<E, ?, List<E>> toList() {
+		return Collector.of((Supplier<List<E>>) ArrayList::new, List::add, (l, r) -> {
+			l.addAll(r);
+			return l;
+		}, Lists::copyOf);
 	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Sets.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Sets.java
@@ -69,6 +69,9 @@ public class Sets {
 		if (collection.isEmpty()) {
 			return of();
 		}
+		if (collection instanceof Set) {
+			return new ImmutableSet<E>(collection.toArray());
+		}
 		return new ImmutableSet<E>(collection.stream()
 			.distinct()
 			.toArray());

--- a/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Sets.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/Sets.java
@@ -2,7 +2,10 @@ package aQute.bnd.unmodifiable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 
 @SuppressWarnings("unchecked")
 public class Sets {
@@ -75,5 +78,12 @@ public class Sets {
 		return new ImmutableSet<E>(collection.stream()
 			.distinct()
 			.toArray());
+	}
+
+	public static <E> Collector<E, ?, Set<E>> toSet() {
+		return Collector.of((Supplier<Set<E>>) LinkedHashSet::new, Set::add, (l, r) -> {
+			l.addAll(r);
+			return l;
+		}, Sets::copyOf);
 	}
 }

--- a/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/package-info.java
+++ b/biz.aQute.bnd.util/src/aQute/bnd/unmodifiable/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.unmodifiable;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bnd.util/test/aQute/bnd/unmodifiable/ListsTest.java
+++ b/biz.aQute.bnd.util/test/aQute/bnd/unmodifiable/ListsTest.java
@@ -550,4 +550,23 @@ public class ListsTest {
 			Spliterator.SUBSIZED, Spliterator.NONNULL);
 	}
 
+	@Test
+	public void collector() {
+		List<String> source = new ArrayList<>();
+		source.add("e1");
+		source.add("e2");
+		source.add("e1");
+		List<String> list = source.stream()
+			.collect(Lists.toList());
+		source.set(0, "changed");
+		assertThat(list).hasSize(3)
+			.containsExactly("e1", "e2", "e1");
+		assertThat(list.stream()).hasSize(3)
+			.containsExactly("e1", "e2", "e1");
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> list.add("a"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> list.remove("a"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> list.remove("e1"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> list.clear());
+	}
+
 }

--- a/biz.aQute.bnd.util/test/aQute/bnd/unmodifiable/SetsTest.java
+++ b/biz.aQute.bnd.util/test/aQute/bnd/unmodifiable/SetsTest.java
@@ -40,7 +40,7 @@ public class SetsTest {
 	public void one() {
 		Set<String> set = Sets.of("e1");
 		assertThat(set).hasSize(1)
-			.containsExactlyInAnyOrder("e1");
+			.containsExactly("e1");
 		assertThat(set.stream()).hasSize(1)
 			.containsExactly("e1");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -53,7 +53,7 @@ public class SetsTest {
 	public void two() {
 		Set<String> set = Sets.of("e1", "e2");
 		assertThat(set).hasSize(2)
-			.containsExactlyInAnyOrder("e1", "e2");
+			.containsExactly("e1", "e2");
 		assertThat(set.stream()).hasSize(2)
 			.containsExactly("e1", "e2");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -66,7 +66,7 @@ public class SetsTest {
 	public void three() {
 		Set<String> set = Sets.of("e1", "e2", "e3");
 		assertThat(set).hasSize(3)
-			.containsExactlyInAnyOrder("e1", "e2", "e3");
+			.containsExactly("e1", "e2", "e3");
 		assertThat(set.stream()).hasSize(3)
 			.containsExactly("e1", "e2", "e3");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -79,7 +79,7 @@ public class SetsTest {
 	public void four() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4");
 		assertThat(set).hasSize(4)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4");
+			.containsExactly("e1", "e2", "e3", "e4");
 		assertThat(set.stream()).hasSize(4)
 			.containsExactly("e1", "e2", "e3", "e4");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -92,7 +92,7 @@ public class SetsTest {
 	public void five() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5");
 		assertThat(set).hasSize(5)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5");
+			.containsExactly("e1", "e2", "e3", "e4", "e5");
 		assertThat(set.stream()).hasSize(5)
 			.containsExactly("e1", "e2", "e3", "e4", "e5");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -105,7 +105,7 @@ public class SetsTest {
 	public void six() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5", "e6");
 		assertThat(set).hasSize(6)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6");
 		assertThat(set.stream()).hasSize(6)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -118,7 +118,7 @@ public class SetsTest {
 	public void seven() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5", "e6", "e7");
 		assertThat(set).hasSize(7)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6", "e7");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7");
 		assertThat(set.stream()).hasSize(7)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -131,7 +131,7 @@ public class SetsTest {
 	public void eight() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8");
 		assertThat(set).hasSize(8)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8");
 		assertThat(set.stream()).hasSize(8)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -144,7 +144,7 @@ public class SetsTest {
 	public void nine() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9");
 		assertThat(set).hasSize(9)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9");
 		assertThat(set.stream()).hasSize(9)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -157,7 +157,7 @@ public class SetsTest {
 	public void ten() {
 		Set<String> set = Sets.of("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10");
 		assertThat(set).hasSize(10)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10");
 		assertThat(set.stream()).hasSize(10)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -174,7 +174,7 @@ public class SetsTest {
 		Set<String> set = Sets.of(entries);
 		entries[0] = "changed";
 		assertThat(set).hasSize(11)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11");
+			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11");
 		assertThat(set.stream()).hasSize(11)
 			.containsExactly("e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -209,7 +209,7 @@ public class SetsTest {
 		Set<String> set = Sets.copyOf(source);
 		source.set(0, "changed");
 		assertThat(set).hasSize(2)
-			.containsExactlyInAnyOrder("e1", "e2");
+			.containsExactly("e1", "e2");
 		assertThat(set.stream()).hasSize(2)
 			.containsExactly("e1", "e2");
 		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
@@ -230,7 +230,7 @@ public class SetsTest {
 		Set<String> source = Sets.of("e1", "e2", "e3", "e4", "e5");
 		Object[] array = source.toArray();
 		assertThat(array).hasSize(5)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5");
+			.containsExactly("e1", "e2", "e3", "e4", "e5");
 	}
 
 	@Test
@@ -240,12 +240,12 @@ public class SetsTest {
 		String[] array = source.toArray(target);
 		assertThat(array).isNotSameAs(target)
 			.hasSize(5)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5");
+			.containsExactly("e1", "e2", "e3", "e4", "e5");
 
 		target = new String[source.size() + 1];
 		array = source.toArray(target);
 		assertThat(array).isSameAs(target)
-			.containsExactlyInAnyOrder("e1", "e2", "e3", "e4", "e5", null);
+			.containsExactly("e1", "e2", "e3", "e4", "e5", null);
 		assertThat(array[target.length - 1]).isNull();
 	}
 
@@ -295,7 +295,7 @@ public class SetsTest {
 
 		Set<String> set = Sets.of("e1", "polygenelubricants", "GydZG_", "DESIGNING WORKHOUSES", "e5");
 
-		assertThat(set).containsExactlyInAnyOrder("e5", "polygenelubricants", "GydZG_", "DESIGNING WORKHOUSES", "e1");
+		assertThat(set).containsExactly("e1", "polygenelubricants", "GydZG_", "DESIGNING WORKHOUSES", "e5");
 	}
 
 	@Test
@@ -391,6 +391,25 @@ public class SetsTest {
 		Holder<String> holder = new Holder<>();
 		assertThatCode(() -> iterator.forEachRemaining(holder)).doesNotThrowAnyException();
 		assertThat(holder.set).isFalse();
+	}
+
+	@Test
+	public void collector() {
+		List<String> source = new ArrayList<>();
+		source.add("e1");
+		source.add("e2");
+		source.add("e1");
+		Set<String> set = source.stream()
+			.collect(Sets.toSet());
+		source.set(0, "changed");
+		assertThat(set).hasSize(2)
+			.containsExactly("e1", "e2");
+		assertThat(set.stream()).hasSize(2)
+			.containsExactly("e1", "e2");
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("a"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.remove("a"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.remove("e1"));
+		assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.clear());
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReq.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReq.java
@@ -1,15 +1,15 @@
 package aQute.bnd.osgi.resource;
 
-import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
+
+import aQute.bnd.unmodifiable.Maps;
 
 abstract class CapReq {
 	private final String				namespace;
@@ -21,8 +21,8 @@ abstract class CapReq {
 	CapReq(String namespace, Resource resource, Map<String, String> directives, Map<String, Object> attributes) {
 		this.namespace = requireNonNull(namespace);
 		this.resource = resource;
-		this.directives = unmodifiableMap(new HashMap<>(directives));
-		this.attributes = unmodifiableMap(new HashMap<>(attributes));
+		this.directives = Maps.copyOf(directives);
+		this.attributes = new DeferredValueMap<>(Maps.copyOf(attributes));
 	}
 
 	public String getNamespace() {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -150,7 +150,14 @@ public class CapReqBuilder {
 	}
 
 	public CapReqBuilder addAttributes(Map<? extends String, ? extends Object> attributes) {
-		attributes.forEach(this::addAttribute);
+		for (Entry<? extends String, ? extends Object> entry : attributes.entrySet()) {
+			if (entry instanceof DeferredValueEntry) {
+				DeferredValueEntry<? extends String, ? extends Object> deferred = (DeferredValueEntry<? extends String, ? extends Object>) entry;
+				addAttribute(deferred.getKey(), deferred.getDeferredValue());
+			} else {
+				addAttribute(entry.getKey(), entry.getValue());
+			}
+		}
 		return this;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredComparableValue.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredComparableValue.java
@@ -1,0 +1,19 @@
+package aQute.bnd.osgi.resource;
+
+import java.util.function.Supplier;
+
+class DeferredComparableValue<T extends Comparable<T>> extends DeferredValue<T> implements Comparable<T> {
+
+	DeferredComparableValue(Class<T> type, Supplier<? extends T> supplier, int hashCode) {
+		super(type, supplier, hashCode);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public int compareTo(T o) {
+		if (o instanceof DeferredComparableValue) {
+			o = ((DeferredComparableValue<T>) o).get();
+		}
+		return get().compareTo(o);
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValue.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValue.java
@@ -1,0 +1,50 @@
+package aQute.bnd.osgi.resource;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Supplier;
+
+class DeferredValue<T> implements Supplier<T> {
+	private final Class<T>				type;
+	private final Supplier<? extends T>	supplier;
+	private final int					hashCode;
+	private T							value;
+
+	DeferredValue(Class<T> type, Supplier<? extends T> supplier, int hashCode) {
+		this.type = requireNonNull(type);
+		this.supplier = requireNonNull(supplier);
+		this.hashCode = hashCode;
+	}
+
+	@Override
+	public T get() {
+		T v = value;
+		if (v == null) {
+			return value = supplier.get();
+		}
+		return v;
+	}
+
+	Class<T> type() {
+		return type;
+	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof DeferredValue) {
+			obj = ((DeferredValue<T>) obj).get();
+		}
+		return get().equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(get());
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValueEntry.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValueEntry.java
@@ -1,0 +1,57 @@
+package aQute.bnd.osgi.resource;
+
+import java.util.Map.Entry;
+
+class DeferredValueEntry<K, V> implements Entry<K, V> {
+	private final K					key;
+	private final DeferredValue<V>	value;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param key Must not be {@code null}.
+	 * @param value Must not be {@code null}.
+	 */
+	DeferredValueEntry(K key, DeferredValue<V> value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	@Override
+	public K getKey() {
+		return key;
+	}
+
+	@Override
+	public V getValue() {
+		return value.get();
+	}
+
+	DeferredValue<V> getDeferredValue() {
+		return value;
+	}
+
+	@Override
+	public V setValue(V value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int hashCode() {
+		return key.hashCode() ^ value.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Entry)) {
+			return false;
+		}
+		Entry<?, ?> entry = (Entry<?, ?>) obj;
+		return key.equals(entry.getKey()) && value.equals(entry.getValue());
+	}
+
+	@Override
+	public String toString() {
+		return key + "=" + value;
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValueMap.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/DeferredValueMap.java
@@ -1,0 +1,181 @@
+package aQute.bnd.osgi.resource;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+class DeferredValueMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
+	private final Map<K, V> map;
+
+	DeferredValueMap(Map<K, V> map) {
+		this.map = map;
+	}
+
+	@Override
+	public int size() {
+		return map.size();
+	}
+
+	@Override
+	public boolean containsKey(Object key) {
+		return map.containsKey(key);
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		return map.containsValue(value);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public V get(Object key) {
+		V v = map.get(key);
+		if (v instanceof DeferredValue) {
+			v = ((DeferredValue<V>) v).get();
+		}
+		return v;
+	}
+
+	/**
+	 * This get method will not unwrap a DeferredValue.
+	 *
+	 * @param key The map key.
+	 * @return The DeferredValue or value.
+	 */
+	Object getDeferred(Object key) {
+		Object v = map.get(key);
+		return v;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return map.equals(o);
+	}
+
+	@Override
+	public int hashCode() {
+		return map.hashCode();
+	}
+
+	@Override
+	public Set<Entry<K, V>> entrySet() {
+		return new EntrySet<>(map);
+	}
+
+	@Override
+	public Set<K> keySet() {
+		return map.keySet();
+	}
+
+	final static class EntrySet<K, V> extends AbstractSet<Entry<K, V>> {
+		private final Set<Entry<K, V>> entries;
+
+		EntrySet(Map<K, V> map) {
+			this.entries = map.entrySet();
+		}
+
+		@Override
+		public Iterator<Entry<K, V>> iterator() {
+			return new EntryIterator<>(entries);
+		}
+
+		@Override
+		public int size() {
+			return entries.size();
+		}
+	}
+
+	final static class EntryIterator<K, V> implements Iterator<Entry<K, V>> {
+		private final Iterator<Entry<K, V>> iterator;
+
+		EntryIterator(Set<Entry<K, V>> entries) {
+			this.iterator = entries.iterator();
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterator.hasNext();
+		}
+
+		@Override
+		public Entry<K, V> next() {
+			Entry<K, V> entry = iterator.next();
+			V v = entry.getValue();
+			if (v instanceof DeferredValue) {
+				@SuppressWarnings("unchecked")
+				DeferredValue<V> deferred = (DeferredValue<V>) v;
+				return new DeferredValueEntry<>(entry.getKey(), deferred);
+			}
+			return entry;
+		}
+	}
+
+	@Override
+	public V put(K key, V value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V remove(Object key) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> map) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V putIfAbsent(K key, V value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean remove(Object key, Object value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean replace(K key, V oldValue, V newValue) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V replace(K key, V value) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/FilterImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/FilterImpl.java
@@ -27,7 +27,6 @@ import java.security.PrivilegedAction;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.List;
@@ -39,6 +38,8 @@ import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.Version;
+
+import aQute.bnd.unmodifiable.Maps;
 
 /**
  * RFC 1960-based Filter. Filter objects can be created by calling the
@@ -191,7 +192,7 @@ abstract class FilterImpl implements Filter {
 	 */
 	@Override
 	public boolean match(ServiceReference<?> reference) {
-		return matches0((reference != null) ? new ServiceReferenceMap(reference) : Collections.emptyMap());
+		return matches0((reference != null) ? new ServiceReferenceMap(reference) : Maps.of());
 	}
 
 	/**
@@ -208,7 +209,7 @@ abstract class FilterImpl implements Filter {
 	 */
 	@Override
 	public boolean match(Dictionary<String, ?> dictionary) {
-		return matches0((dictionary != null) ? new CaseInsensitiveMap(dictionary) : Collections.emptyMap());
+		return matches0((dictionary != null) ? new CaseInsensitiveMap(dictionary) : Maps.of());
 	}
 
 	/**
@@ -224,7 +225,7 @@ abstract class FilterImpl implements Filter {
 	 */
 	@Override
 	public boolean matchCase(Dictionary<String, ?> dictionary) {
-		return matches0((dictionary != null) ? DictionaryMap.asMap(dictionary) : Collections.emptyMap());
+		return matches0((dictionary != null) ? DictionaryMap.asMap(dictionary) : Maps.of());
 	}
 
 	/**
@@ -241,7 +242,7 @@ abstract class FilterImpl implements Filter {
 	 */
 	@Override
 	public boolean matches(Map<String, ?> map) {
-		return matches0((map != null) ? map : Collections.emptyMap());
+		return matches0((map != null) ? map : Maps.of());
 	}
 
 	abstract boolean matches0(Map<String, ?> map);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -52,6 +52,7 @@ import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Verifier;
+import aQute.bnd.unmodifiable.Lists;
 import aQute.bnd.version.VersionRange;
 import aQute.lib.converter.Converter;
 import aQute.lib.filter.Filter;
@@ -653,7 +654,7 @@ public class ResourceBuilder {
 
 	public List<Capability> findCapabilities(String ns, String filter) {
 		if (filter == null || capabilities.isEmpty())
-			return Collections.emptyList();
+			return Lists.of();
 
 		List<Capability> capabilities = new ArrayList<>();
 		Filter f = new Filter(filter);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -1,5 +1,6 @@
 package aQute.bnd.osgi.resource;
 
+import static aQute.bnd.exceptions.SupplierWithException.asSupplierOrElse;
 import static aQute.bnd.osgi.Constants.DUPLICATE_MARKER;
 import static aQute.bnd.osgi.Constants.MIME_TYPE_BUNDLE;
 import static aQute.bnd.osgi.Constants.MIME_TYPE_JAR;
@@ -705,6 +706,19 @@ public class ResourceBuilder {
 		addCapability(c);
 	}
 
+	void addContentCapability(URI uri, DeferredValue<String> sha256, long length, String mime) {
+		assert uri != null;
+		assert sha256 != null;
+		assert length >= 0;
+
+		CapabilityBuilder c = new CapabilityBuilder(ContentNamespace.CONTENT_NAMESPACE);
+		c.addAttribute(ContentNamespace.CONTENT_NAMESPACE, sha256);
+		c.addAttribute(ContentNamespace.CAPABILITY_URL_ATTRIBUTE, uri.toString());
+		c.addAttribute(ContentNamespace.CAPABILITY_SIZE_ATTRIBUTE, Long.valueOf(length));
+		c.addAttribute(ContentNamespace.CAPABILITY_MIME_ATTRIBUTE, mime != null ? mime : MIME_TYPE_BUNDLE);
+		addCapability(c);
+	}
+
 	public boolean addFile(File file, URI uri) throws Exception {
 		if (uri == null)
 			uri = file.toURI();
@@ -715,14 +729,22 @@ public class ResourceBuilder {
 			hasIdentity = addManifest(manifest);
 		}
 		String mime = hasIdentity ? MIME_TYPE_BUNDLE : MIME_TYPE_JAR;
-		String sha256 = SHA256.digest(file)
-			.asHex();
+		int deferredHashCode = hashCode(file);
+		DeferredValue<String> sha256 = new DeferredComparableValue<>(String.class,
+			asSupplierOrElse(() -> SHA256.digest(file)
+				.asHex(), null),
+			deferredHashCode);
 		addContentCapability(uri, sha256, file.length(), mime);
 
 		if (hasIdentity) {
 			addHashes(file);
 		}
 		return hasIdentity;
+	}
+
+	private static int hashCode(File file) {
+		return file.getAbsoluteFile()
+			.hashCode();
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
@@ -1,9 +1,7 @@
 package aQute.bnd.osgi.resource;
 
 import static aQute.lib.collections.Logic.retain;
-import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -34,7 +32,7 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 	void setCapabilities(List<Capability> capabilities) {
 		allCapabilities = Lists.copyOf(capabilities);
 		capabilityMap = capabilities.stream()
-			.collect(groupingBy(Capability::getNamespace, collectingAndThen(toList(), Lists::copyOf)));
+			.collect(groupingBy(Capability::getNamespace, Lists.toList()));
 
 		locations = null; // clear so equals/hashCode can recompute
 	}
@@ -50,7 +48,7 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 	void setRequirements(List<Requirement> requirements) {
 		allRequirements = Lists.copyOf(requirements);
 		requirementMap = requirements.stream()
-			.collect(groupingBy(Requirement::getNamespace, collectingAndThen(toList(), Lists::copyOf)));
+			.collect(groupingBy(Requirement::getNamespace, Lists.toList()));
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
@@ -1,7 +1,6 @@
 package aQute.bnd.osgi.resource;
 
 import static aQute.lib.collections.Logic.retain;
-import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
@@ -9,7 +8,6 @@ import static java.util.stream.Collectors.toList;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -22,6 +20,7 @@ import org.osgi.service.repository.RepositoryContent;
 
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.resource.ResourceUtils.ContentCapability;
+import aQute.bnd.unmodifiable.Lists;
 
 class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent {
 
@@ -33,9 +32,9 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 	private volatile transient Map<URI, String>		locations;
 
 	void setCapabilities(List<Capability> capabilities) {
-		allCapabilities = unmodifiableList(capabilities);
+		allCapabilities = Lists.copyOf(capabilities);
 		capabilityMap = capabilities.stream()
-			.collect(groupingBy(Capability::getNamespace, collectingAndThen(toList(), Collections::unmodifiableList)));
+			.collect(groupingBy(Capability::getNamespace, collectingAndThen(toList(), Lists::copyOf)));
 
 		locations = null; // clear so equals/hashCode can recompute
 	}
@@ -45,13 +44,13 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 		List<Capability> caps = (namespace != null) ? ((capabilityMap != null) ? capabilityMap.get(namespace) : null)
 			: allCapabilities;
 
-		return (caps != null) ? caps : Collections.emptyList();
+		return (caps != null) ? caps : Lists.of();
 	}
 
 	void setRequirements(List<Requirement> requirements) {
-		allRequirements = unmodifiableList(requirements);
+		allRequirements = Lists.copyOf(requirements);
 		requirementMap = requirements.stream()
-			.collect(groupingBy(Requirement::getNamespace, collectingAndThen(toList(), Collections::unmodifiableList)));
+			.collect(groupingBy(Requirement::getNamespace, collectingAndThen(toList(), Lists::copyOf)));
 	}
 
 	@Override
@@ -59,7 +58,7 @@ class ResourceImpl implements Resource, Comparable<Resource>, RepositoryContent 
 		List<Requirement> reqs = (namespace != null) ? ((requirementMap != null) ? requirementMap.get(namespace) : null)
 			: allRequirements;
 
-		return (reqs != null) ? reqs : Collections.emptyList();
+		return (reqs != null) ? reqs : Lists.of();
 	}
 
 	@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -17,7 +17,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +62,9 @@ import aQute.bnd.osgi.Macro;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.service.library.LibraryNamespace;
 import aQute.bnd.stream.MapStream;
+import aQute.bnd.unmodifiable.Lists;
+import aQute.bnd.unmodifiable.Maps;
+import aQute.bnd.unmodifiable.Sets;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
@@ -442,14 +444,14 @@ public class ResourceUtils {
 
 	public static Set<Resource> getResources(Collection<? extends Capability> providers) {
 		if (providers == null || providers.isEmpty())
-			return Collections.emptySet();
+			return Sets.of();
 
 		return getResources(providers.stream());
 	}
 
 	public static Map<Resource, List<Capability>> getIndexedByResource(Collection<? extends Capability> providers) {
 		if (providers == null || providers.isEmpty())
-			return Collections.emptyMap();
+			return Maps.of();
 		return providers.stream()
 			.collect(groupingBy(Capability::getResource, toCapabilities()));
 	}
@@ -718,7 +720,7 @@ public class ResourceUtils {
 		return runBundles;
 	}
 
-	private final static Collection<Requirement> all = Collections.singleton(createWildcardRequirement());
+	private final static Collection<Requirement> all = Lists.of(createWildcardRequirement());
 
 	/**
 	 * Return all resources from a repository as returned by the wildcard

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -1,8 +1,6 @@
 package aQute.bnd.repository.maven.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toSet;
 
 import java.io.Closeable;
 import java.io.File;
@@ -594,7 +592,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				source = source.replaceAll("(\\s|,|;|\n|\r)+", "\n");
 			}
 			Set<String> multi = Strings.splitAsStream(configuration.multi())
-				.collect(collectingAndThen(toSet(), Sets::copyOf));
+				.collect(Sets.toSet());
 			this.index = new IndexFile(domain, reporter, indexFile, source, storage, client.promiseFactory(), multi);
 			this.index.open();
 


### PR DESCRIPTION
The osgi.content capability must hold the SHA-256 value of the
resource. But this value is rarely used. So, when building a resource
from a file, we defer the SHA-256 calculation until actually needed.
The can help performance of FileSetRepository used by bndtools m2e.

However, we do need the hashCode of the SHA-256 value early, so use
a substitute hashCode value based upon the File object. This is not
perfect since two files can hold identical content and the hashCode of
their SHA-256 values should be identical. But in practice, this should
work when creating a resource from a file since the early need for the
hashCode of the SHA-256 value is in the computing of the hashCode of
the capability so it can be inserted in a set. But creating a resource
from a file only creates a single osgi.content capability.

Fixes https://github.com/bndtools/bnd/issues/5322
