### PR TITLE
Add multi-release support to aQute.bnd.osgi.Jar

### DIFF
--- a/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/plugins/entries/bundle/ImportJarResourcePluginTest.java
+++ b/biz.aQute.bnd.reporter/test/biz/aQute/bnd/reporter/plugins/entries/bundle/ImportJarResourcePluginTest.java
@@ -28,8 +28,7 @@ public class ImportJarResourcePluginTest {
 			plugin.setReporter(p);
 			plugin.setRegistry(p);
 
-			jar.getResources()
-				.put("myDir/file.cool", new EmbeddedResource("test=test", 0L));
+			jar.putResource("myDir/file.cool", new EmbeddedResource("test=test", 0L));
 
 			final Map<String, String> prop = new HashMap<>();
 			prop.put(ImportJarResourcePlugin.PATH_PROPERTY, "myDir/file.cool");

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("4.3.0")
+@Version("4.4.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package aQute.bnd.junit;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -143,6 +143,7 @@ public class Analyzer extends Processor {
 	private Set<PackageRef>							nonClassReferences		= new HashSet<>();
 	private Set<Check>								checks;
 	private final Map<TypeRef, String>				bcpTypes				= map();
+	private int										release					= -1;
 
 	public enum Check {
 		ALL,
@@ -168,6 +169,10 @@ public class Analyzer extends Processor {
 	protected void setTypeSpecificPlugins(PluginsContainer pluginsContainer) {
 		super.setTypeSpecificPlugins(pluginsContainer);
 		pluginsContainer.add(new ClassIndexerAnalyzer());
+	}
+
+	public void setRelease(int release) {
+		this.release = release;
 	}
 
 	/**
@@ -201,6 +206,10 @@ public class Analyzer extends Processor {
 	public void analyze() throws Exception {
 		if (!analyzed) {
 			analyzed = true;
+			if (release > -1) {
+				getClasspath().forEach(j -> j.setRelease(release));
+				dot.setRelease(release);
+			}
 			analyzeContent();
 
 			// Execute any plugins

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -384,7 +384,7 @@ public class Jar implements Closeable {
 		} else if (release == ReleaseEntry.NO_RELEASE) {
 			// check if this is a multi release path...
 			Matcher matcher = ReleaseEntry.MULTI_RELEASE_PATH.matcher(path);
-			if (matcher.matches() && isMultireleaseJar()) {
+			if (matcher.matches() && (!manifestFirst || isMultireleaseJar())) {
 				release = Integer.parseInt(matcher.group(1));
 				path = matcher.group(2);
 			}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ReleaseEntry.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ReleaseEntry.java
@@ -1,0 +1,208 @@
+package aQute.bnd.osgi;
+
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+
+import aQute.bnd.classfile.ClassFile;
+import aQute.bnd.classfile.ModuleAttribute;
+import aQute.bnd.exceptions.Exceptions;
+import aQute.lib.io.ByteBufferDataInput;
+import aQute.lib.io.IO;
+
+class ReleaseEntry {
+
+	static final int											NO_RELEASE			= 0;
+	static final Pattern										MULTI_RELEASE_PATH	= Pattern
+		.compile("^META-INF/versions/(\\d+)/(.*)$", Pattern.CASE_INSENSITIVE);
+
+	private final NavigableMap<String, Resource>				resources			= new TreeMap<>();
+	private final NavigableMap<String, Map<String, Resource>>	directories			= new TreeMap<>();
+
+	private Jar													jar;
+	private Optional<Manifest>									manifest;
+	private Optional<ModuleAttribute>							moduleAttribute;
+
+	private int													release;
+
+	ReleaseEntry(Jar jar, int release) {
+		this.jar = jar;
+		this.release = release;
+	}
+
+	boolean putResource(String path, Resource resource, boolean overwrite) {
+		if (path.equals(jar.getManifestName())) {
+			manifest = null;
+		} else if (path.equals(Constants.MODULE_INFO_CLASS)) {
+			moduleAttribute = null;
+		}
+		String dir = getParent(path);
+		Map<String, Resource> s = directories.get(dir);
+		if (s == null) {
+			s = new TreeMap<>();
+			directories.put(dir, s);
+			// make ancestor directories
+			for (int n; (n = dir.lastIndexOf('/')) > 0;) {
+				dir = dir.substring(0, n);
+				if (directories.containsKey(dir))
+					break;
+				directories.put(dir, null);
+			}
+		}
+		boolean duplicate = s.containsKey(path);
+		if (!duplicate || overwrite) {
+			resources.put(path, resource);
+			s.put(path, resource);
+			jar.updateModified(resource.lastModified(), getFullPath(path));
+		}
+		return duplicate;
+	}
+
+	NavigableMap<String, Map<String, Resource>> getDirectories() {
+		return directories;
+	}
+
+	Resource remove(String path) {
+		Resource resource = resources.remove(path);
+		if (resource != null) {
+			String dir = getParent(path);
+			Map<String, Resource> mdir = directories.get(dir);
+			// must be != null
+			mdir.remove(path);
+		}
+		return resource;
+	}
+
+	void removePrefix(String prefixLow) {
+		String prefixHigh = prefixLow.concat("\uFFFF");
+		resources.subMap(prefixLow, prefixHigh)
+			.clear();
+		if (prefixLow.endsWith("/")) {
+			prefixLow = prefixLow.substring(0, prefixLow.length() - 1);
+			prefixHigh = prefixLow.concat("\uFFFF");
+		}
+		directories.subMap(prefixLow, prefixHigh)
+			.clear();
+	}
+
+	void removeSubDirs(String dir) {
+		if (!dir.endsWith("/")) {
+			dir = dir.concat("/");
+		}
+		List<String> subDirs = new ArrayList<>(directories.subMap(dir, dir.concat("\uFFFF"))
+			.keySet());
+		subDirs.forEach(subDir -> removePrefix(subDir.concat("/")));
+	}
+
+	boolean rename(String oldPath, String newPath) {
+		Resource resource = remove(oldPath);
+		if (resource == null) {
+			return false;
+		}
+		return putResource(newPath, resource, true);
+	}
+
+	boolean isEmpty() {
+		return resources.isEmpty();
+	}
+
+	boolean exists(String path) {
+		return resources.containsKey(path);
+	}
+
+	Optional<Manifest> manifest() {
+		Optional<Manifest> optional = manifest;
+		if (optional != null) {
+			return optional;
+		}
+		try {
+			Resource manifestResource = getResource(jar.manifestName);
+			if (manifestResource == null) {
+				return manifest = Optional.empty();
+			}
+			try (InputStream in = manifestResource.openInputStream()) {
+				return manifest = Optional.of(new Manifest(in));
+			}
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	void setManifest(Manifest manifest) {
+		this.manifest = Optional.ofNullable(manifest);
+	}
+
+	Optional<ModuleAttribute> moduleAttribute() {
+		Optional<ModuleAttribute> optional = moduleAttribute;
+		if (optional != null) {
+			return optional;
+		}
+		Resource module_info_resource = getResource(Constants.MODULE_INFO_CLASS);
+		if (module_info_resource == null) {
+			return moduleAttribute = Optional.empty();
+		}
+		try {
+			ClassFile module_info;
+			ByteBuffer bb = module_info_resource.buffer();
+			if (bb != null) {
+				module_info = ClassFile.parseClassFile(ByteBufferDataInput.wrap(bb));
+			} else {
+				try (DataInputStream din = new DataInputStream(module_info_resource.openInputStream())) {
+					module_info = ClassFile.parseClassFile(din);
+				}
+			}
+			return moduleAttribute = Arrays.stream(module_info.attributes)
+				.filter(ModuleAttribute.class::isInstance)
+				.map(ModuleAttribute.class::cast)
+				.findFirst();
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	Resource getResource(String path) {
+		return resources.get(path);
+	}
+
+	NavigableMap<String, Resource> getResources() {
+		return resources;
+	}
+
+	String getFullPath(String basePath) {
+		if (release == NO_RELEASE) {
+			return basePath;
+		}
+		return String.format("META-INF/versions/%d/%s", release, basePath);
+	}
+
+	boolean hasDirectory(String path) {
+		return directories.containsKey(path);
+	}
+
+	private String getParent(String path) {
+		jar.check();
+		int n = path.lastIndexOf('/');
+		if (n < 0)
+			return "";
+
+		return path.substring(0, n);
+	}
+
+	public void close() {
+		resources.values()
+			.forEach(IO::close);
+		resources.clear();
+		directories.clear();
+		manifest = null;
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
@@ -1,4 +1,4 @@
-@Version("5.6.0")
+@Version("6.0.0")
 package aQute.bnd.osgi;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/test/aQute/bnd/osgi/JarTest.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/osgi/JarTest.java
@@ -1,0 +1,86 @@
+package aQute.bnd.osgi;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Collections;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JarTest {
+
+	private static final String	MODULE_INFO_CLASS	= "module-info.class";
+	private static final String	TEST_CLASS_PATH		= "a/test/package/Test.class";
+
+	@TempDir
+	File						tempDir;
+
+	@Test
+	public void testMultiReleaseJar() throws Exception {
+		File jarfile = new File(tempDir, "packed.jar");
+		try (Jar jar = new Jar("testme")) {
+			jar.ensureManifest();
+			Resource moduleInfo = resource();
+			Resource testClass = resource();
+			jar.putResource(TEST_CLASS_PATH, testClass);
+			jar.setRelease(9);
+			jar.putResource(MODULE_INFO_CLASS, moduleInfo);
+			assertEquals(moduleInfo, jar.getResource(MODULE_INFO_CLASS));
+			assertEquals(testClass, jar.getResource(TEST_CLASS_PATH));
+			jar.setRelease(0);
+			assertNull(jar.getResource(MODULE_INFO_CLASS));
+			jar.writeFolder(tempDir);
+			assertTrue(new File(tempDir, TEST_CLASS_PATH).isFile());
+			assertFalse(new File(tempDir, MODULE_INFO_CLASS).isFile());
+			assertTrue(new File(tempDir, "META-INF/versions/9/" + MODULE_INFO_CLASS).isFile());
+			File file = new File(tempDir, JarFile.MANIFEST_NAME);
+			assertTrue(file.isFile());
+			try (FileInputStream is = new FileInputStream(file)) {
+				Manifest manifest = new Manifest(is);
+				assertEquals("true", manifest.getMainAttributes()
+					.getValue("Multi-Release"));
+			}
+			jar.write(jarfile);
+		}
+		try (JarFile jar = new JarFile(jarfile)) {
+			assertEquals("true", jar.getManifest()
+				.getMainAttributes()
+				.getValue("Multi-Release"));
+			Set<String> collect = Collections.list(jar.entries())
+				.stream()
+				.map(JarEntry::getName)
+				.collect(Collectors.toSet());
+			assertFalse(collect.contains(MODULE_INFO_CLASS));
+			assertTrue(collect.contains(TEST_CLASS_PATH));
+			assertTrue(collect.contains("META-INF/versions/9/" + MODULE_INFO_CLASS));
+		}
+	}
+
+	@Test
+	public void testGson() throws Exception {
+		// just for demontration purpose...
+		File f = new File("/tmp/gson-2.9.0.jar");
+		if (f.isFile()) {
+			try (Jar jar = new Jar(f)) {
+				assertNull(jar.getModuleName());
+				jar.setRelease(9);
+				assertEquals("com.google.gson", jar.getModuleName());
+			}
+		}
+	}
+
+	private Resource resource() {
+		return new aQute.bnd.osgi.EmbeddedResource(new byte[0], System.currentTimeMillis());
+	}
+
+}

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -39,23 +39,6 @@ import java.util.stream.Stream;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
-import aQute.bnd.build.Project;
-import aQute.bnd.exceptions.Exceptions;
-import aQute.bnd.header.OSGiHeader;
-import aQute.bnd.maven.PomPropertiesResource;
-import aQute.bnd.maven.lib.configuration.BeanProperties;
-import aQute.bnd.osgi.Builder;
-import aQute.bnd.osgi.Constants;
-import aQute.bnd.osgi.FileResource;
-import aQute.bnd.osgi.Jar;
-import aQute.bnd.osgi.Processor;
-import aQute.bnd.osgi.Resource;
-import aQute.bnd.version.MavenVersion;
-import aQute.bnd.version.Version;
-import aQute.lib.io.IO;
-import aQute.lib.strings.Strings;
-import aQute.lib.utf8properties.UTF8Properties;
-import aQute.service.reporter.Report.Location;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
@@ -80,6 +63,24 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.build.incremental.BuildContext;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.maven.PomPropertiesResource;
+import aQute.bnd.maven.lib.configuration.BeanProperties;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.FileResource;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Resource;
+import aQute.bnd.version.MavenVersion;
+import aQute.bnd.version.Version;
+import aQute.lib.io.IO;
+import aQute.lib.strings.Strings;
+import aQute.lib.utf8properties.UTF8Properties;
+import aQute.service.reporter.Report.Location;
 
 /**
  * Abstract base class for all bnd-maven-plugin mojos.
@@ -165,6 +166,14 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 	@SuppressWarnings("unused")
 	String					bnd;
 
+	/**
+	 * This is similar to the release parameter of the maven-compiler plugin and
+	 * enables the processing of classes and resources for the given release,
+	 * the default value is 0 that is using the default release (pre Java 9)
+	 */
+	@Parameter(defaultValue = "0")
+	int						release;
+
 	@Component
 	BuildContext			buildContext;
 
@@ -233,6 +242,7 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 		}
 
 		try (Builder builder = new Builder(new Processor(mavenProperties, false))) {
+			builder.setRelease(release);
 			builder.setTrace(logger.isDebugEnabled());
 
 			builder.setBase(project.getBasedir());

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/BndMavenPlugin.java
@@ -42,6 +42,13 @@ public class BndMavenPlugin extends AbstractBndMavenPlugin {
 	File											manifestPath;
 
 	/**
+	 * if enabled and a release is given the output folder is adjusted to put
+	 * the data into the appropriate versioned folder
+	 */
+	@Parameter
+	boolean											multiReleaseOutput;
+
+	/**
 	 * Skip this goal.
 	 */
 	@Parameter(property = "bnd.skip", defaultValue = "false")
@@ -69,6 +76,12 @@ public class BndMavenPlugin extends AbstractBndMavenPlugin {
 
 	@Override
 	public File getManifestPath() {
+		if (multiReleaseOutput && release > 0) {
+			File parent = manifestPath.getParentFile();
+			String name = manifestPath.getName();
+			String versionedPath = String.format("versions/%d/%s", release, name);
+			return new File(parent, versionedPath);
+		}
 		return manifestPath;
 	}
 


### PR DESCRIPTION
Currently the aQute.bnd.osgi.Jar is not a capable of processing
multi-release jars in a convenient way, especially if one likes to
support the multi-release modules support as well as the multi-release
OSGi manifest part.

This adds first-class support of multi-release jar to the
aQute.bnd.osgi.Jar other modules can build on top in a way as the
JarFile#getJarEntry would behave, that is a resource that is requested
is returned for the most specific selected release.

Relates to:
- https://github.com/bndtools/bnd/issues/2227
- https://github.com/bndtools/bnd/issues/5327
- https://github.com/ClickHouse/clickhouse-jdbc/pull/1009
