### PR TITLE
[cached resolve] The test failed on Windows

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -212,19 +212,7 @@ public class Bndrun extends Run {
 		File ours = getPropertiesFile();
 		File cache = getCacheFile(ours);
 
-		long cacheLastModified = cache.lastModified();
-
-		CacheReason reason;
-		if (ws.getLayout() != WorkspaceLayout.BND)
-			reason = CacheReason.NOT_A_BND_LAYOUT;
-		else if (!cache.isFile())
-			reason = CacheReason.NO_CACHE_FILE;
-		else if (cacheLastModified < ws.lastModified())
-			reason = CacheReason.CACHE_STALE_WORKSPACE;
-		else if (cacheLastModified < lastModified())
-			reason = CacheReason.CACHE_STALE_PROJECT;
-		else
-			reason = CacheReason.USE_CACHE;
+		CacheReason reason = getCacheReason(cache);
 
 		testReason = reason;
 
@@ -271,6 +259,23 @@ public class Bndrun extends Run {
 			}
 			return containers;
 		}
+	}
+
+	CacheReason getCacheReason(File cached) {
+		long cacheLastModified = cached.lastModified();
+
+		CacheReason reason;
+		if (getWorkspace().getLayout() != WorkspaceLayout.BND)
+			reason = CacheReason.NOT_A_BND_LAYOUT;
+		else if (!cached.isFile())
+			reason = CacheReason.NO_CACHE_FILE;
+		else if (cacheLastModified < getWorkspace().lastModified())
+			reason = CacheReason.CACHE_STALE_WORKSPACE;
+		else if (cacheLastModified < lastModified())
+			reason = CacheReason.CACHE_STALE_PROJECT;
+		else
+			reason = CacheReason.USE_CACHE;
+		return reason;
 	}
 
 


### PR DESCRIPTION
I think this was caused by faster window machines.
The reason for the operation was USE_CACHE which
can only happen if the bndrun file did not pick up
the time of the included file.

I've added a 100 ms delay before taking a time,
this 100 ms should be more than the resolution of
the file system.

So setting the time on the included file was not
seen as later than the project file.

I also added checks to see what the cache reason is
before we call getRunBundles().

Lets see what happens

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>