### PR TITLE
[remote link] Made tracing optional

### DIFF
--- a/biz.aQute.remote/src/aQute/remote/util/Link.java
+++ b/biz.aQute.remote/src/aQute/remote/util/Link.java
@@ -44,6 +44,7 @@ public class Link<L, R> extends Thread implements Closeable {
 	final AtomicInteger						id			= new AtomicInteger(10000);
 	final ConcurrentMap<Integer, Result>	promises	= new ConcurrentHashMap<>();
 	final AtomicBoolean						quit		= new AtomicBoolean(false);
+	final boolean							tracing;
 	volatile boolean						transfer	= false;
 	private ThreadLocal<Integer>			msgid		= new ThreadLocal<>();
 
@@ -69,6 +70,8 @@ public class Link<L, R> extends Thread implements Closeable {
 		this.local = local == null ? (L) this : local;
 		this.in = new DataInputStream(in);
 		this.out = new DataOutputStream(out);
+		this.tracing = Boolean.getBoolean(Link.class.getName() + ".trace");
+
 	}
 
 	public Link(Class<R> type, L local, Socket socket) throws IOException {
@@ -276,7 +279,7 @@ public class Link<L, R> extends Thread implements Closeable {
 							String msg = codec.dec()
 								.from(result.value)
 								.get(String.class);
-							System.out.println("Exception " + msg);
+							trace("Exception " + msg);
 							throw new RuntimeException(msg);
 						}
 
@@ -307,7 +310,8 @@ public class Link<L, R> extends Thread implements Closeable {
 	}
 
 	private void trace(String string) {
-		System.out.println("# " + string);
+		if (tracing)
+			System.out.println("# " + string);
 	}
 
 	/*

--- a/docs/_chapters/300-launching.md
+++ b/docs/_chapters/300-launching.md
@@ -266,6 +266,8 @@ It is possible to specity multiple remote clauses. All sections are started simu
 * `agent` – The port on which the agent is listening, the default is ${aQute.agent.server.port}.
 * `timeout` – Timeout in seconds for the debug connection
 
+Additionally, the communication can be traced by setting the `aQute.remote.util.Link.trace` system property to `true` on the target system.
+
 ### Example bndrun
 
 An example remote bndrun file:


### PR DESCRIPTION
The code always used system.out to print tracing information. This
has been made optional with a system property `aQute.remote.util.Link.trace`,
if it is set to "true", the trace will send output to the console. Otherwise
it is silent.

Closes #5420


Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>