### PR TITLE
[jvm crash in swt] It is still happening

### DIFF
--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -242,6 +242,12 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 
 	@Override
 	public int tryToReveal(Object element) {
+		int result = super.tryToReveal(element);
+		afterReveal(element);
+		return result;
+	}
+
+	private void afterReveal(Object element) {
 		if (element instanceof IResource) {
 			model.setActualSelection(element);
 			model.setSelectedProject(getProject((IResource) element));
@@ -249,13 +255,12 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 			model.setActualSelection(null);
 			model.setSelectedProject(null);
 		}
-		return super.tryToReveal(element);
 	}
 
 	@Override
 	public void selectAndReveal(Object element) {
-		tryToReveal(element);
 		super.selectAndReveal(element);
+		afterReveal(element);
 	}
 
 	@Override

--- a/bndtools.core/src/bndtools/explorer/Model.java
+++ b/bndtools.core/src/bndtools/explorer/Model.java
@@ -116,7 +116,7 @@ class Model {
 		try {
 			// coalesce some more updates on
 			// the worker thread(s).
-			Thread.sleep(10);
+			Thread.sleep(50);
 		} catch (InterruptedException e) {
 			Thread.currentThread()
 				.interrupt();


### PR DESCRIPTION
As a try, I've increased the coalesce time
and then also tried to rearrange some of the overridden
methods. Instead of calling the super last, moved it
to first.

Bit desperate ... it is pretty ok now, it happens
to me once every month. But very frustrating that
we cannot pin this down.

If anybody has a full crash report, appreciated.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>