### PR TITLE
Add multi-release processing support

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -293,6 +293,7 @@ public interface Constants {
 	String		WORKINGSET									= "-workingset";
 	String		WORKINGSET_MEMBER							= "member";
 	String		REQUIRE_BND									= "-require-bnd";
+	String		JAVA_RELEASE								= "-release";
 
 	// Deprecated
 	String		CLASSPATH									= "-classpath";
@@ -314,7 +315,7 @@ public interface Constants {
 		CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE, REPRODUCIBLE, INCLUDEPACKAGE,
 		CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK, MAVEN_SCOPE, RUNSTARTLEVEL,
 		RUNOPTIONS, NOCLASSFORNAME, EXPORT_APIGUARDIAN, RESOLVE, DEFINE_CONTRACT, GENERATE, RUNFRAMEWORKRESTART,
-		NOIMPORTJAVA, VERSIONDEFAULTS, LIBRARY);
+		NOIMPORTJAVA, VERSIONDEFAULTS, LIBRARY, JAVA_RELEASE);
 
 	// Ignore bundle specific headers. These headers do not make a lot of sense
 	// to inherit

--- a/docs/_instructions/release.md
+++ b/docs/_instructions/release.md
@@ -1,0 +1,13 @@
+---
+layout: default
+class: Analyzer
+title: -release NUMBER
+summary: Specify the java release for which the Analyzer should generate meta-data. 
+---
+The `-release` instruction is very similar to the `--release` option of javac and instructs the Analyser to process Multi-Release-JARs with the specified release as defined in [JEP 238: Multi-Release JAR Files](https://openjdk.org/jeps/238).
+
+If the `-release` is not specified or NUMBER is smaller than 0 then release processing is **disabled** no further processing is done
+
+If the `-release` is specified and NUMBER is smaller than or equal to 8 the **default content** is processed, that means for every jar entries in the META-INF/versions/* directories are effectively ignored by the processor.
+
+If the `-release` is specified and NUMBER is larger or equal than 9 the content is processed as with the rules from JEP 238 possibly hiding some of the default content.


### PR DESCRIPTION
Currently bnd is not a capable of processing multi-release jars, this
adds support of multi-release processing by a new directive -release
where one can select what release version should be processed by bnd.

Fixes https://github.com/bndtools/bnd/issues/5346