### PR TITLE
maven: Use actual file name for jar file type test

### DIFF
--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -302,8 +302,7 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 					builder.updateModified(cpeJar.lastModified(), cpe.getPath());
 					buildpath.add(cpeJar);
 				} else {
-					if (!artifact.getType()
-						.equals("jar")) {
+					if (!cpe.getName().endsWith(".jar")) {
 						/*
 						 * Check if it is a valid zip file. We don't create a
 						 * Jar object here because we want to avoid the cost of


### PR DESCRIPTION
Since we care about the file and not just the artifact object, we check
the file name for ending in ".jar" (jar extension) instead of relying
on the artifact reporting the "jar" type.

Fixes https://github.com/bndtools/bnd/issues/5349
