### PR TITLE
macro: Fix osfile macro to return OS specific path

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1471,7 +1471,7 @@ public class Macro {
 		verifyCommand(args, _osfileHelp, null, 3, 3);
 		File base = new File(args[1]);
 		File f = IO.getFile(base, args[2]);
-		return IO.absolutePath(f);
+		return f.getAbsolutePath(); // Need to return path in OS specific form
 	}
 
 	public String _path(String[] args) {


### PR DESCRIPTION
https://github.com/bndtools/bnd/commit/c7f942b0d4fe67403ec0de949dd8e90d5d0069e2 incorrectly changed osfile to use forward slash path.

Fixes https://github.com/bndtools/bnd/issues/5364

