### PR TITLE
[resolve] Add a default native capability when none set

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import java.util.jar.Manifest;
 
 import org.osgi.framework.namespace.IdentityNamespace;
+import org.osgi.framework.namespace.NativeNamespace;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
@@ -38,6 +39,7 @@ import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.OSInformation;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.repository.AggregateRepository;
 import aQute.bnd.osgi.repository.AugmentRepository;
@@ -59,6 +61,8 @@ import aQute.lib.utf8properties.UTF8Properties;
  * BndEditModel & Project
  */
 public class BndrunResolveContext extends AbstractResolveContext {
+	private static final String			ALWAYS_TRUE					= "(!(_+_foo=bar))";
+
 	private final static Logger			logger						= LoggerFactory
 		.getLogger(BndrunResolveContext.class);
 
@@ -226,6 +230,11 @@ public class BndrunResolveContext extends AbstractResolveContext {
 					loadPath(system, runpath, Constants.RUNPATH);
 			}
 
+			if (system.findCapabilities(NativeNamespace.NATIVE_NAMESPACE, ALWAYS_TRUE)
+				.isEmpty()) {
+				Capability cap = OSInformation.getDefaultNativeCapability();
+				system.addCapability(cap);
+			}
 			//
 			// We've not gathered all the capabilities of the system
 			// so we can create the resource and set it as the system resource

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ProjectResolver.java
@@ -32,6 +32,8 @@ import aQute.bnd.service.Strategy;
  * which is a Run which extends Project). This class is supposed to simplify the
  * sometimes bewildering number of moving cogs in resolving. It is a processor
  * and uses the facilities to provide the different logging schemes used.
+ * <p>
+ * See RunResolution for a replacement
  */
 
 @Deprecated

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ResolveTest.java
@@ -125,6 +125,40 @@ public class ResolveTest {
 	}
 
 	/**
+	 * Check if we add a native capability when no native is around
+	 */
+
+	@Test
+	public void testDefaultNativeCapability() throws Exception {
+		try (Bndrun run = (Bndrun) Bndrun.createRun(null, IO.getFile("testdata/nativecap/native.bndrun"))) {
+			// require _any_ native capability
+			run.setProperty("-runrequires", "osgi.native;filter:=\"(osgi.native.osname=*)\"");
+			RunResolution resolve = run.resolve();
+			// only resolves when there was at least 1 native capability
+			assertThat(resolve.getRequired()).hasSize(1);
+		}
+
+	}
+
+	/**
+	 * Check if we do not add a native capability when no native is around
+	 */
+
+	@Test
+	public void testNoDefaultNativeCapability() throws Exception {
+		try (Bndrun run = (Bndrun) Bndrun.createRun(null, IO.getFile("testdata/nativecap/native.bndrun"))) {
+			// require _any_ native capability
+			run.setProperty("-runrequires", "osgi.native;filter:=\"(osgi.native.osname=*)\"");
+			// provide an invalid native capability so the previous filter does
+			// not match but we also do not add a capability
+			run.setProperty("-runsystemcapabilities", "osgi.native;foobar=1");
+			RunResolution resolve = run.resolve();
+			assertThat(resolve.getRequired()).isNull();
+		}
+
+	}
+
+	/**
 	 * The enRoute base guard resolved but is missing bundles, the runbundles do
 	 * not run
 	 */


### PR DESCRIPTION
This patch adds a default native capability when
there is no native capability is set. The default
capability reflects the native environment in which
the resolver runs.

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>
