### PR TITLE
[clause manager] A clause manager for Processor

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/AttrsTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AttrsTest.java
@@ -1,5 +1,6 @@
 package test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
@@ -8,6 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import aQute.bnd.header.Attrs;
+import aQute.bnd.header.OSGiHeader;
 import aQute.bnd.version.Version;
 
 public class AttrsTest {
@@ -63,6 +65,27 @@ public class AttrsTest {
 		assertEquals("1.2.3", attr.get("version"));
 		assertEquals("1.2.3,2.1.0", attr.get("versions"));
 		assertEquals("version:Version=\"1.2.3\";versions:List<Version>=\"1.2.3,2.1.0\"", attr.toString());
+	}
+
+	@Test
+	public void testSorting() {
+		assertThat(attrs("b=1;a=2;c=3;d=4;$:=0").sort()
+			.toString()).isEqualTo("$:=0;a=2;b=1;c=3;d=4");
+	}
+
+	@Test
+	public void testComparing() {
+		assertThat(attrs("a=1").compareTo(attrs("a=1"))).isEqualTo(0);
+		assertThat(attrs("a=1").compareTo(attrs("a=2"))).isEqualTo(-1);
+		assertThat(attrs("a=2").compareTo(attrs("a=1"))).isEqualTo(1);
+
+		assertThat(attrs("a=1").compareTo(attrs("a=1;b=1"))).isEqualTo(-1);
+		assertThat(attrs("a=1;b=1").compareTo(attrs("a=1"))).isEqualTo(1);
+	}
+
+	private Attrs attrs(String string) {
+		return OSGiHeader.parseHeader("x;" + string)
+			.get("x");
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("4.3.0")
+@Version("4.4.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/Attrs.java
@@ -4,7 +4,9 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,8 @@ public class Attrs implements Map<String, String> {
 	public static final DataType<List<Double>>	LIST_DOUBLE		= () -> Type.DOUBLES;
 	public static final DataType<List<Version>>	LIST_VERSION	= () -> Type.VERSIONS;
 
+	public static Comparator<Attrs>				COMPARATOR		= Attrs::compareTo;
+
 	/**
 	 * Pattern for List with list type
 	 */
@@ -86,6 +90,7 @@ public class Attrs implements Map<String, String> {
 		this.map = map;
 		this.types = types;
 	}
+
 
 	public Attrs() {
 		this(new LinkedHashMap<>(), new HashMap<>());
@@ -634,4 +639,53 @@ public class Attrs implements Map<String, String> {
 		});
 		return attrs;
 	}
+
+	/**
+	 * Return a new Attributes that is sorted by key
+	 *
+	 * @return a sorted attributes
+	 */
+	public Attrs sort() {
+		Attrs attrs = new Attrs();
+		this.entrySet()
+			.stream()
+			.sorted((a, b) -> a.getKey()
+				.compareTo(b.getKey()))
+			.forEach(e -> attrs.put(e.getKey(), e.getValue()));
+		return attrs;
+	}
+
+	public Attrs set(String k, String v) {
+		put(k, v);
+		return this;
+	}
+
+	public int compareTo(Attrs b) {
+		Attrs a = this;
+		Iterator<Map.Entry<String, String>> ia = a.entrySet()
+			.iterator();
+		Iterator<Map.Entry<String, String>> ib = b.entrySet()
+			.iterator();
+		while (ia.hasNext()) {
+			if (!ib.hasNext())
+				return 1;
+
+			Entry<String, String> ea = ia.next();
+			Entry<String, String> eb = ib.next();
+			int n = ea.getKey()
+				.compareTo(eb.getKey());
+			if (n != 0)
+				return n;
+
+			n = ea.getValue()
+				.compareTo(eb.getValue());
+			if (n != 0)
+				return n;
+		}
+		if (ib.hasNext()) {
+			return -1;
+		}
+		return 0;
+	}
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/header/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.5.0")
+@Version("2.6.0")
 package aQute.bnd.header;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/junit/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.1.0")
+@org.osgi.annotation.versioning.Version("2.2.0")
 package aQute.bnd.junit;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.3.0")
+@Version("3.4.0")
 package aQute.bnd.maven;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ClauseManager.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ClauseManager.java
@@ -1,0 +1,77 @@
+package aQute.bnd.osgi;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.service.parameters.ConsolidateParameters;
+
+class ClauseManager {
+	final static Logger				logger		= LoggerFactory.getLogger(ClauseManager.class);
+	final Processor					processor;
+
+	final Map<String, Parameters>	parameters	= new HashMap<>();
+
+	ClauseManager(Processor processor) {
+		this.processor = processor;
+	}
+
+	void addClause(String key, String name, Attrs ps) {
+		Parameters p = getParameters(key);
+		p.add(name, ps);
+	}
+
+	Parameters getParameters(String key) {
+		return parameters.computeIfAbsent(key, k -> {
+			String property = processor.getProperty(key);
+			return new Parameters(property);
+		});
+	}
+
+	Optional<Parameters> getOptionalParameters(String key) {
+		return Optional.ofNullable(parameters.get(key));
+	}
+
+	void reset(String key) {
+		if (parameters.remove(key) != null) {
+			logger.info(
+				"a clause was set but then cleared due a property overwrite. This might indicate that not all code treats the  header {} the same",
+				key);
+		}
+	}
+
+	void reset() {
+		parameters.clear();
+	}
+
+	void consolidate(String key) {
+		Parameters parameters = this.parameters.get(key);
+		if (parameters == null)
+			return;
+
+		try {
+			for (ConsolidateParameters cp : processor.getPlugins(ConsolidateParameters.class)) {
+				Parameters consolidated = cp.consolidate(key, parameters);
+				if (consolidated != null) {
+					processor.setProperty(key, consolidated.toString());
+					return;
+				}
+			}
+			processor.setProperty(key, parameters.toString());
+		} finally {
+			assert !this.parameters.containsKey(key) : "should be cleared by processor";
+		}
+	}
+
+	void consolidate() {
+		for (String key : new ArrayList<>(parameters.keySet())) {
+			consolidate(key);
+		}
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.0.0")
+@Version("3.1.0")
 package aQute.bnd.osgi.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.print;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package aQute.bnd.service.generate;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/parameters/ConsolidateParameters.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/parameters/ConsolidateParameters.java
@@ -1,0 +1,26 @@
+package aQute.bnd.service.parameters;
+
+import aQute.bnd.header.Parameters;
+
+/**
+ * This interface is a Processor plugin that is consolidating a Parameters. In
+ * OSGi most headers follow Parameters syntax. However, different parts of the
+ * system might contribute one or more clauses to the same header. The addClause
+ * method in Processor can be used to add a single clause. This interface is
+ * used to consolidate the aggregate. Some headers need the removal of
+ * duplicates and and other headers require sorting to ensure they are
+ * consistent between builds. The default ordering of the Parameters is in order
+ * of insert. Note that the Parameters can handle duplicate keys by suffixing
+ * them with a `~`.
+ */
+public interface ConsolidateParameters {
+	/**
+	 * Consolidate a Parameters. If the key is not recognized, return null.
+	 *
+	 * @param key the key/header, for example Require-Capability
+	 * @param parameters the parameters to consolidate. Do not modify it.
+	 * @return null if unknown key, otherwise a consolidated Parameters
+	 */
+	Parameters consolidate(String key, Parameters parameters);
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/parameters/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/parameters/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package aQute.bnd.service.parameters;


### PR DESCRIPTION
See https://github.com/bndtools/bnd/issues/5363

This is the first part of #5363

This part adds a clause manager that allows
code to set arbitrary clauses instead of doing
lots of string processing. If a property is gotten
that was managed with addClauses, this property
will be consolidated. This goes through the
plugins: see ConsolidatedParameters.

The code intents to be completely backward 
compatible. 



Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>
