### PR TITLE
reporter - create dirs for exported file

### DIFF
--- a/maven/bnd-reporter-maven-plugin/src/main/java/aQute/bnd/maven/reporter/plugin/ExportMojo.java
+++ b/maven/bnd-reporter-maven-plugin/src/main/java/aQute/bnd/maven/reporter/plugin/ExportMojo.java
@@ -1,6 +1,7 @@
 package aQute.bnd.maven.reporter.plugin;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -124,6 +125,8 @@ public class ExportMojo extends AbstractMojo {
 
 			for (Entry<String, Resource> result : reportResults.entrySet()) {
 				File file = new File(result.getKey());
+				Files.createDirectories(file.getParentFile()
+					.toPath());
 				try {
 					result.getValue()
 						.write(file);


### PR DESCRIPTION
fixes:

```
Caused by: org.apache.maven.plugin.MojoExecutionException: Failed to write the report at /home/stbischof/dev/git/org.eclipse.aaa.bbb/prototype/core/target/docs_a_metadata.json
    at aQute.bnd.maven.reporter.plugin.ExportMojo.execute (ExportMojo.java:132)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:301)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:211)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:165)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:157)
```