### PR TITLE
#5062 JVM Crash in bndtools explorer

### DIFF
--- a/bndtools.core/src/bndtools/Plugin.java
+++ b/bndtools.core/src/bndtools/Plugin.java
@@ -70,7 +70,7 @@ public class Plugin extends AbstractUIPlugin {
 		plugin = this;
 		this.bundleContext = context;
 
-		scheduler = Executors.newScheduledThreadPool(1);
+		scheduler = Executors.newScheduledThreadPool(4);
 
 		bndActivator = new Activator();
 		bndActivator.start(context);

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -336,9 +336,11 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 		if (!installed) {
 			installed = true;
 			installFilter();
+			model.filterDirty.set(true);
 		}
 
-		getTreeViewer().refresh();
+		if (model.filterDirty.getAndSet(false))
+			getTreeViewer().refresh();
 	}
 
 	private void installFilter() {


### PR DESCRIPTION
I was able to consistently crash the VM by
selecting a binary class file in rt.jar from
the VM project item and then closing the VM project item.

After hundreds of trials I found that the bug was
triggered when the getTreeViewer().refresh() was
called during a model update. For the record,
this happened on the main thread so I cannot
see any issue with this.

I then made the refresh conditional on a change
in the filter text field. For this, an
AtomicBoolean dirtyFilter was added.

This seemed to work fine now.

Of course this does not remove the bug. There
is an SWT bug lurking but closing an tree item
in the bnd explorer will no longer trigger it.

Fixes #5062

Signed-off-by: Peter Kriens <Peter.Kriens@aqute.biz>