### PR TITLE
[m2e] Expand bundle version ranges for M2E imports

### DIFF
--- a/biz.aQute.bnd.maven/bnd.bnd
+++ b/biz.aQute.bnd.maven/bnd.bnd
@@ -6,9 +6,9 @@ Bundle-Description:	    Shared logic used by bnd maven plugins
 -includepackage: aQute.bnd.maven.lib.*
 
 Import-Package: \
-	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,+);${@bundleversion}}";version=!,\
-	org.eclipse.aether.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,+);${@bundleversion}}";version=!,\
-	org.codehaus.plexus.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,+);${@bundleversion}}";version=!,\
+	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
+	org.eclipse.aether.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
+	org.codehaus.plexus.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
 	*
 
 # Decorate maven runtime dependencies

--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -43,7 +43,8 @@ Bundle-SymbolicName: ${p};singleton:=true
 Bundle-ActivationPolicy: lazy
 
 Import-Package: \
-	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,+);${@bundleversion}}";version=!,\
+	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
+	org.eclipse.aether.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
 	${eclipse.importpackage},\
 	*
 


### PR DESCRIPTION
In recent versions (2022-06 and later) of Eclipse the version of the M2E maven runtime bundle has stopped matching the M2E version and now uses a higher version related to the maven it packages. We need to be able to use this if M2E support is to keep working.

Fixes #5417

Signed-off-by: Tim Ward <timothyjward@apache.org>