### PR TITLE
baseline: Avoid warning at major version boundaries

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/baseline/BaselineTest.java
+++ b/biz.aQute.bndlib.tests/test/test/baseline/BaselineTest.java
@@ -380,7 +380,23 @@ public class BaselineTest {
 			p3.build();
 			assertTrue(p3.check());
 
-			p3.setBundleVersion("5");
+			p3.setBundleVersion("1.0.1");
+			p3.build();
+			assertTrue(p3.check("There is no baseline for p3 in the baseline repo"));
+
+			p3.setBundleVersion("1.1");
+			p3.build();
+			assertTrue(p3.check("There is no baseline for p3 in the baseline repo"));
+
+			p3.setBundleVersion("2.0.0.XXXXXX");
+			p3.build();
+			assertTrue(p3.check());
+
+			p3.setBundleVersion("2.0.1");
+			p3.build();
+			assertTrue(p3.check("There is no baseline for p3 in the baseline repo"));
+
+			p3.setBundleVersion("2.1");
 			p3.build();
 			assertTrue(p3.check("There is no baseline for p3 in the baseline repo"));
 		} finally {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -517,17 +517,18 @@ public class ProjectBuilder extends Builder {
 			return null; // errors reported already
 
 		String bsn = getBsn();
-		Version version = new Version(getVersion());
+		Version version = Version.parseVersion(getVersion());
 		SortedSet<Version> versions = removeStagedAndFilter(repo.versions(bsn), repo, bsn);
 
 		if (versions.isEmpty()) {
 			// We have a repo
-			Version v = Version.parseVersion(getVersion())
-				.getWithoutQualifier();
-			if (v.compareTo(Version.ONE) > 0) {
+			// Baselining 0.x is uninteresting
+			// x.0.0 is a new major version so maybe there is no baseline
+			if ((version.getMajor() > 0) &&
+				((version.getMinor() > 0) || (version.getMicro() > 0))) {
 				warning(
-					"There is no baseline for %s in the baseline repo %s. The build is for version %s, which is higher than 1.0.0 which suggests that there should be a prior version.",
-					getBsn(), repo, v);
+					"There is no baseline for %s in the baseline repo %s. The build is for version %s, which is higher than %s which suggests that there should be a prior version.",
+					getBsn(), repo, version.getWithoutQualifier(), new Version(version.getMajor()));
 			}
 			return null;
 		}


### PR DESCRIPTION
There is nothing which requires the first release to use version 1.0. Especially with the desire to rename things at major boundaries, it is not unexpected that the first release of an artifact may be version 2.0 or 3.0. And in this case, a warning about missing baseline is noise.

