### PR TITLE
[m2e] Fix missed bundle version ranges for M2E imports

### DIFF
--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -45,6 +45,7 @@ Bundle-ActivationPolicy: lazy
 Import-Package: \
 	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
 	org.eclipse.aether.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
+	org.eclipse.m2e.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
 	${eclipse.importpackage},\
 	*
 


### PR DESCRIPTION
The recent fix for #5417 correctly picked up the Maven API imports, but the  macro also generated some imports with problematic ranges

Signed-off-by: Tim Ward <timothyjward@apache.org>