### PR TITLE
[m2e] Remove references to internal packages and avoid static methods

### DIFF
--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -45,7 +45,7 @@ Bundle-ActivationPolicy: lazy
 Import-Package: \
 	org.apache.maven.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
 	org.eclipse.aether.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
-	org.eclipse.m2e.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,4);${@bundleversion}}";version=!,\
+	org.eclipse.m2e.core.*;bundle-symbolic-name="${@bundlesymbolicname}";bundle-version="${range;[==,3);${@bundleversion}}";version=!,\
 	${eclipse.importpackage},\
 	*
 

--- a/bndtools.m2e/src/bndtools/m2e/AbstractMavenRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/AbstractMavenRepository.java
@@ -7,7 +7,6 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -19,9 +18,13 @@ import aQute.bnd.osgi.repository.BaseRepository;
 import aQute.bnd.service.RepositoryPlugin;
 
 public abstract class AbstractMavenRepository extends BaseRepository
-	implements MavenRunListenerHelper, Repository, RepositoryPlugin, IMavenProjectChangedListener {
+	implements Repository, RepositoryPlugin, IMavenProjectChangedListener {
 
-	final IMavenProjectRegistry mavenProjectRegistry = MavenPlugin.getMavenProjectRegistry();
+	final IMavenProjectRegistry mavenProjectRegistry;
+
+	protected AbstractMavenRepository(IMavenProjectRegistry mavenProjectRegistry) {
+		this.mavenProjectRegistry = mavenProjectRegistry;
+	}
 
 	@Override
 	public boolean canWrite() {

--- a/bndtools.m2e/src/bndtools/m2e/Activator.java
+++ b/bndtools.m2e/src/bndtools/m2e/Activator.java
@@ -1,32 +1,59 @@
 package bndtools.m2e;
 
-import org.eclipse.m2e.core.internal.MavenPluginActivator;
-import org.eclipse.m2e.core.internal.project.registry.MavenProjectManager;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.osgi.annotation.bundle.Header;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 import aQute.bnd.osgi.Constants;
 
 @Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")
 public class Activator implements BundleActivator {
 
+	/**
+	 * M2E version 2 has implicit support for whiteboard listeners and registers
+	 * services. This activator helps us to work in both situations.
+	 */
+	private boolean								isM2E_v2;
+
 	private MavenProjectChangedListenersTracker projectChangedListenersTracker;
 
 	@Override
 	public void start(BundleContext context) throws Exception {
-		projectChangedListenersTracker = new MavenProjectChangedListenersTracker();
-		MavenProjectManager projectManager = MavenPluginActivator.getDefault()
-			.getMavenProjectManager();
-		projectManager.addMavenProjectChangedListener(projectChangedListenersTracker);
+		Bundle bundle = FrameworkUtil.getBundle(MavenPlugin.class);
+		isM2E_v2 = bundle.getVersion()
+			.getMajor() == 2;
+
+		if (!isM2E_v2) {
+			projectChangedListenersTracker = new MavenProjectChangedListenersTracker();
+			IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
+			projectManager.addMavenProjectChangedListener(projectChangedListenersTracker);
+
+			registerM2EServices(context);
+		}
+	}
+
+	/**
+	 * These services should only be registered if running on M2E 1.x
+	 *
+	 * @param context
+	 */
+	private void registerM2EServices(BundleContext context) {
+		context.registerService(IMaven.class, MavenPlugin.getMaven(), null);
+		context.registerService(IMavenProjectRegistry.class, MavenPlugin.getMavenProjectRegistry(), null);
 	}
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
-		MavenProjectManager projectManager = MavenPluginActivator.getDefault()
-			.getMavenProjectManager();
-		projectManager.removeMavenProjectChangedListener(projectChangedListenersTracker);
-		projectChangedListenersTracker.close();
+		if (!isM2E_v2) {
+			IMavenProjectRegistry projectManager = MavenPlugin.getMavenProjectRegistry();
+			projectManager.removeMavenProjectChangedListener(projectChangedListenersTracker);
+			projectChangedListenersTracker.close();
+		}
 	}
 
 }

--- a/bndtools.m2e/src/bndtools/m2e/LaunchPropertyTester.java
+++ b/bndtools.m2e/src/bndtools/m2e/LaunchPropertyTester.java
@@ -1,5 +1,8 @@
 package bndtools.m2e;
 
+import static bndtools.m2e.MavenRunListenerHelper.getMavenProjectFacade;
+import static bndtools.m2e.MavenRunListenerHelper.hasBndTestingMavenPlugin;
+
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
 import org.eclipse.core.expressions.PropertyTester;
@@ -8,8 +11,9 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 
-public class LaunchPropertyTester extends PropertyTester implements MavenRunListenerHelper {
+public class LaunchPropertyTester extends PropertyTester {
 	private static final ILogger	logger									= Logger
 		.getLogger(LaunchPropertyTester.class);
 
@@ -17,6 +21,13 @@ public class LaunchPropertyTester extends PropertyTester implements MavenRunList
 	public static final String		PROP_IS_RESOLVABLE_BND_MAVEN_PROJECT	= "isResolvableBndMavenProject";
 	public static final String		PROP_IS_TESTABLE_BND_MAVEN_PROJECT		= "isTestableBndMavenProject";
 	static final String				MAVEN_NATURE							= "org.eclipse.m2e.core.maven2Nature";
+
+	private final IMavenProjectRegistry mavenProjectRegistry;
+
+	public LaunchPropertyTester(IMavenProjectRegistry mavenProjectRegistry) {
+		this.mavenProjectRegistry = mavenProjectRegistry;
+
+	}
 
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
@@ -48,9 +59,9 @@ public class LaunchPropertyTester extends PropertyTester implements MavenRunList
 		switch (property) {
 			case PROP_IS_IN_BND_MAVEN_PROJECT :
 				try {
-					IMavenProjectFacade projectFacade = getMavenProjectFacade(resource);
+					IMavenProjectFacade projectFacade = getMavenProjectFacade(mavenProjectRegistry, resource);
 
-					return (projectFacade != null) && hasBndMavenPlugin(projectFacade);
+					return (projectFacade != null) && MavenRunListenerHelper.hasBndMavenPlugin(projectFacade);
 				} catch (CoreException e) {
 					logger.logError("Error testing '" + PROP_IS_IN_BND_MAVEN_PROJECT + "' property on java element.",
 						e);
@@ -58,9 +69,9 @@ public class LaunchPropertyTester extends PropertyTester implements MavenRunList
 				}
 			case PROP_IS_RESOLVABLE_BND_MAVEN_PROJECT :
 				try {
-					IMavenProjectFacade projectFacade = getMavenProjectFacade(resource);
+					IMavenProjectFacade projectFacade = getMavenProjectFacade(mavenProjectRegistry, resource);
 
-					return (projectFacade != null) && hasBndResolverMavenPlugin(projectFacade);
+					return (projectFacade != null) && MavenRunListenerHelper.hasBndResolverMavenPlugin(projectFacade);
 				} catch (CoreException e) {
 					logger.logError(
 						"Error testing '" + PROP_IS_RESOLVABLE_BND_MAVEN_PROJECT + "' property on java element.", e);
@@ -68,7 +79,7 @@ public class LaunchPropertyTester extends PropertyTester implements MavenRunList
 				}
 			case PROP_IS_TESTABLE_BND_MAVEN_PROJECT :
 				try {
-					IMavenProjectFacade projectFacade = getMavenProjectFacade(resource);
+					IMavenProjectFacade projectFacade = getMavenProjectFacade(mavenProjectRegistry, resource);
 
 					return (projectFacade != null) && hasBndTestingMavenPlugin(projectFacade);
 				} catch (CoreException e) {

--- a/bndtools.m2e/src/bndtools/m2e/M2ETypeAccess.java
+++ b/bndtools.m2e/src/bndtools/m2e/M2ETypeAccess.java
@@ -1,0 +1,8 @@
+package bndtools.m2e;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = M2ETypeAccess.class)
+public class M2ETypeAccess {
+
+}

--- a/bndtools.m2e/src/bndtools/m2e/MavenDependenciesRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenDependenciesRepository.java
@@ -11,9 +11,12 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.WorkspaceRepository;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +31,14 @@ public class MavenDependenciesRepository extends MavenWorkspaceRepository {
 	private final static Logger	logger		= LoggerFactory.getLogger(MavenDependenciesRepository.class);
 
 	private final Set<String>	allScopes	= Sets.of("compile", "provided", "runtime", "system", "test");
+
+	@Reference
+	IMaven						maven;
+
+	@Reference
+	void setRegistry(IMavenProjectRegistry mavenProjectRegistry) {
+		this.mavenProjectRegistry = mavenProjectRegistry;
+	}
 
 	@Override
 	public String getName() {
@@ -47,8 +58,8 @@ public class MavenDependenciesRepository extends MavenWorkspaceRepository {
 		}
 
 		try {
-			MavenBndrunContainer mavenBndrunContainer = MavenBndrunContainer.getBndrunContainer(projectFacade, null,
-				true, true, allScopes, monitor);
+			MavenBndrunContainer mavenBndrunContainer = MavenBndrunContainer.getBndrunContainer(maven,
+				mavenProjectRegistry, projectFacade, null, true, true, allScopes, monitor);
 
 			mavenBndrunContainer.resolve()
 				.values()

--- a/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -41,7 +42,9 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 	private final Run						run;
 	private final IPath						bndrunFilePath;
 
-	public MavenImplicitProjectRepository(IMavenProjectFacade projectFacade, Run run) {
+	public MavenImplicitProjectRepository(IMavenProjectRegistry mavenProjectRegistry,
+		IMavenProjectFacade projectFacade, Run run) {
+		super(mavenProjectRegistry);
 		this.projectFacade = projectFacade;
 		this.run = run;
 
@@ -125,7 +128,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 	}
 
 	protected void createRepo(IMavenProjectFacade projectFacade, IProgressMonitor monitor) {
-		MavenProject mavenProject = getMavenProject(projectFacade);
+		MavenProject mavenProject = MavenRunListenerHelper.getMavenProject(projectFacade);
 		try {
 			BndrunContainer bndrunContainer = run.getPlugin(BndrunContainer.class);
 

--- a/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRunListener.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRunListener.java
@@ -1,15 +1,24 @@
 package bndtools.m2e;
 
+import static bndtools.m2e.MavenRunListenerHelper.getResource;
+import static bndtools.m2e.MavenRunListenerHelper.isMavenProject;
+
 import org.bndtools.api.RunListener;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 import aQute.bnd.build.Run;
 import aQute.bnd.build.Workspace;
 
 @Component(property = Constants.SERVICE_RANKING + ":Integer=1000")
-public class MavenImplicitProjectRunListener implements MavenRunListenerHelper, RunListener {
+public class MavenImplicitProjectRunListener implements RunListener {
+
+	@Reference
+	IMavenProjectRegistry mavenProjectRegistry;
 
 	@Override
 	public void create(Run run) throws Exception {}
@@ -18,7 +27,7 @@ public class MavenImplicitProjectRunListener implements MavenRunListenerHelper, 
 	public void end(Run run) throws Exception {
 		IResource resource = getResource(run);
 
-		if (!isMavenProject(resource)) {
+		if (!isMavenProject(mavenProjectRegistry, resource)) {
 			return;
 		}
 
@@ -28,7 +37,8 @@ public class MavenImplicitProjectRunListener implements MavenRunListenerHelper, 
 
 		if (repo != null) {
 			mavenProjectRegistry.removeMavenProjectChangedListener(repo);
-			iWorkspace.removeResourceChangeListener(repo);
+			ResourcesPlugin.getWorkspace()
+				.removeResourceChangeListener(repo);
 		}
 	}
 

--- a/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
@@ -23,7 +23,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
@@ -34,11 +33,12 @@ import aQute.bnd.maven.lib.configuration.Bndruns;
 
 public interface MavenRunListenerHelper {
 
-	IMaven					maven					= MavenPlugin.getMaven();
-	IMavenProjectRegistry	mavenProjectRegistry	= MavenPlugin.getMavenProjectRegistry();
-	IWorkspace				iWorkspace				= ResourcesPlugin.getWorkspace();
+	// IMaven maven = MavenPlugin.getMaven();
+	// IMavenProjectRegistry mavenProjectRegistry =
+	// MavenPlugin.getMavenProjectRegistry();
+	// IWorkspace iWorkspace = ResourcesPlugin.getWorkspace();
 
-	default IResource getResource(Run run) {
+	static IResource getResource(Run run) {
 		File propertiesFile = run.getPropertiesFile();
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IWorkspaceRoot root = workspace.getRoot();
@@ -54,7 +54,7 @@ public interface MavenRunListenerHelper {
 		return shortest;
 	}
 
-	default MavenProject getMavenProject(IMavenProjectFacade mavenProjectFacade) {
+	static MavenProject getMavenProject(IMavenProjectFacade mavenProjectFacade) {
 		try {
 			return mavenProjectFacade.getMavenProject(new NullProgressMonitor());
 		} catch (CoreException e) {
@@ -62,56 +62,61 @@ public interface MavenRunListenerHelper {
 		}
 	}
 
-	default IMavenProjectFacade getMavenProjectFacade(IResource resource) {
+	static IMavenProjectFacade getMavenProjectFacade(IMavenProjectRegistry mavenProjectRegistry, IResource resource) {
 		return mavenProjectRegistry.getProject(resource.getProject());
 	}
 
-	default boolean isMavenProject(IResource resource) {
-		if ((resource != null) && (resource.getProject() != null) && (getMavenProjectFacade(resource) != null)) {
+	static boolean isMavenProject(IMavenProjectRegistry mavenProjectRegistry, IResource resource) {
+		if ((resource != null) && (resource.getProject() != null)
+			&& (getMavenProjectFacade(mavenProjectRegistry, resource) != null)) {
 			return true;
 		}
 
 		return false;
 	}
 
-	default boolean hasBndMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
+	static boolean hasBndMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
 		return getBndMavenPlugin(projectFacade).isPresent();
 	}
 
-	default Optional<PluginExecution> getBndMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
+	static Optional<PluginExecution> getBndMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
 		return getBndMavenPluginById(projectFacade, "biz.aQute.bnd:bnd-maven-plugin");
 	}
 
-	default boolean hasBndResolverMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
+	static boolean hasBndResolverMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
 		return getBndResolverMavenPlugin(projectFacade).isPresent();
 	}
 
-	default Optional<PluginExecution> getBndResolverMavenPlugin(IMavenProjectFacade projectFacade)
+	static Optional<PluginExecution> getBndResolverMavenPlugin(IMavenProjectFacade projectFacade)
 		throws CoreException {
 		return getBndMavenPluginById(projectFacade, "biz.aQute.bnd:bnd-resolver-maven-plugin");
 	}
 
-	default MojoExecution getBndResolverMojoExecution(IMavenProjectFacade projectFacade, IProgressMonitor monitor)
+	static MojoExecution getBndResolverMojoExecution(IMaven maven, IMavenProjectFacade projectFacade,
+		IProgressMonitor monitor)
 		throws CoreException {
-		return getMojoExecution(projectFacade, "biz.aQute.bnd:bnd-resolver-maven-plugin", "bnd-resolver:resolve@",
+		return getMojoExecution(maven, projectFacade, "biz.aQute.bnd:bnd-resolver-maven-plugin",
+			"bnd-resolver:resolve@",
 			exe -> true, monitor);
 	}
 
-	default MojoExecution getBndResolverMojoExecution(IMavenProjectFacade projectFacade,
+	static MojoExecution getBndResolverMojoExecution(IMaven maven, IMavenProjectFacade projectFacade,
 		Predicate<MojoExecution> predicate, IProgressMonitor monitor) throws CoreException {
-		return getMojoExecution(projectFacade, "biz.aQute.bnd:bnd-resolver-maven-plugin", "bnd-resolver:resolve@",
+		return getMojoExecution(maven, projectFacade, "biz.aQute.bnd:bnd-resolver-maven-plugin",
+			"bnd-resolver:resolve@",
 			predicate, monitor);
 	}
 
-	default boolean hasBndTestingMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
+	static boolean hasBndTestingMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
 		return getBndTestingMavenPlugin(projectFacade).isPresent();
 	}
 
-	default Optional<PluginExecution> getBndTestingMavenPlugin(IMavenProjectFacade projectFacade) throws CoreException {
+	static Optional<PluginExecution> getBndTestingMavenPlugin(IMavenProjectFacade projectFacade)
+		throws CoreException {
 		return getBndMavenPluginById(projectFacade, "biz.aQute.bnd:bnd-testing-maven-plugin");
 	}
 
-	default Optional<PluginExecution> getBndMavenPluginById(IMavenProjectFacade projectFacade, String id)
+	static Optional<PluginExecution> getBndMavenPluginById(IMavenProjectFacade projectFacade, String id)
 		throws CoreException {
 		return Optional.ofNullable(getMavenProject(projectFacade).getPlugin(id))
 			.map(Plugin::getExecutions)
@@ -120,19 +125,21 @@ public interface MavenRunListenerHelper {
 			.findFirst();
 	}
 
-	default MojoExecution getBndTestingMojoExecution(IMavenProjectFacade projectFacade, IProgressMonitor monitor)
+	static MojoExecution getBndTestingMojoExecution(IMaven maven, IMavenProjectFacade projectFacade,
+		IProgressMonitor monitor)
 		throws CoreException {
-		return getMojoExecution(projectFacade, "biz.aQute.bnd:bnd-testing-maven-plugin", "bnd-testing:testing@",
+		return getMojoExecution(maven, projectFacade, "biz.aQute.bnd:bnd-testing-maven-plugin", "bnd-testing:testing@",
 			exe -> true, monitor);
 	}
 
-	default MojoExecution getBndTestingMojoExecution(IMavenProjectFacade projectFacade,
+	static MojoExecution getBndTestingMojoExecution(IMaven maven, IMavenProjectFacade projectFacade,
 		Predicate<MojoExecution> predicate, IProgressMonitor monitor) throws CoreException {
-		return getMojoExecution(projectFacade, "biz.aQute.bnd:bnd-testing-maven-plugin", "bnd-testing:testing@",
+		return getMojoExecution(maven, projectFacade, "biz.aQute.bnd:bnd-testing-maven-plugin", "bnd-testing:testing@",
 			predicate, monitor);
 	}
 
-	default MojoExecution getMojoExecution(IMavenProjectFacade projectFacade, String pluginId, String executionPrefix,
+	static MojoExecution getMojoExecution(IMaven maven, IMavenProjectFacade projectFacade, String pluginId,
+		String executionPrefix,
 		Predicate<MojoExecution> predicate, IProgressMonitor monitor) throws CoreException {
 		MavenProject mavenProject = getMavenProject(projectFacade);
 		Plugin plugin = getMavenProject(projectFacade).getPlugin(pluginId);
@@ -165,7 +172,7 @@ public interface MavenRunListenerHelper {
 		return builder.toString();
 	}
 
-	default boolean isOffline() {
+	static boolean isOffline(IMaven maven) {
 		try {
 			return maven.getSettings()
 				.isOffline();
@@ -174,19 +181,27 @@ public interface MavenRunListenerHelper {
 		}
 	}
 
-	default <T> T lookupComponent(Class<T> clazz) {
+	static <T> T lookupComponent(IMaven maven, Class<T> clazz) {
 		try {
 			Method lookupComponentMethod = maven.getClass()
-				.getMethod("lookupComponent", Class.class);
+				.getMethod("lookup", Class.class);
 
 			return clazz.cast(lookupComponentMethod.invoke(maven, clazz));
 		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
 			| SecurityException e) {
-			return null;
+			try {
+				Method lookupComponentMethod = maven.getClass()
+					.getMethod("lookupComponent", Class.class);
+
+				return clazz.cast(lookupComponentMethod.invoke(maven, clazz));
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+				| NoSuchMethodException | SecurityException e2) {
+				return null;
+			}
 		}
 	}
 
-	default boolean containsBndrun(MojoExecution mojoExecution, MavenProject mavenProject, File bndrunFile,
+	static boolean containsBndrun(IMaven maven, MojoExecution mojoExecution, MavenProject mavenProject, File bndrunFile,
 		IProgressMonitor monitor) {
 		try {
 			Bndruns bndruns = maven.getMojoParameterValue(mavenProject, mojoExecution, "bndruns", Bndruns.class,

--- a/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
@@ -28,12 +28,14 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.resource.Resource;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.repository.ExpressionCombiner;
 import org.osgi.service.repository.RequirementExpression;
 import org.osgi.util.promise.Promise;
@@ -67,7 +69,7 @@ import bndtools.central.Central;
 	IMavenProjectChangedListener.class, MavenWorkspaceRepository.class, RepositoryPlugin.class
 })
 public class MavenWorkspaceRepository extends AbstractIndexingRepository<IProject, Artifact>
-	implements IMavenProjectChangedListener, MavenRunListenerHelper, PopulatedRepository, RepositoryPlugin, Actionable {
+	implements IMavenProjectChangedListener, PopulatedRepository, RepositoryPlugin, Actionable {
 
 	enum Kind {
 		ADDED(MavenProjectChangedEvent.KIND_ADDED),
@@ -99,6 +101,9 @@ public class MavenWorkspaceRepository extends AbstractIndexingRepository<IProjec
 	private final BiFunction<String, Version, RequirementExpression>	identificationAndVersionExpressionFunction;
 	private final RequirementExpression									identificationExpression;
 	private final ProjectArtifactCollector								projectArtifactCollector	= new ProjectArtifactCollector();
+
+	@Reference
+	IMavenProjectRegistry												mavenProjectRegistry;
 
 	public MavenWorkspaceRepository() {
 		super();

--- a/bndtools.m2e/src/bndtools/m2e/ServiceAwareM2EConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/ServiceAwareM2EConfigurator.java
@@ -1,0 +1,39 @@
+package bndtools.m2e;
+
+import org.eclipse.m2e.core.embedder.IMaven;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
+import org.eclipse.m2e.core.project.configurator.AbstractProjectConfigurator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+public abstract class ServiceAwareM2EConfigurator extends AbstractProjectConfigurator {
+
+	protected IMaven getMaven() {
+		IMaven service = getService(IMaven.class);
+		this.maven = service;
+		return service;
+	}
+
+	protected IMavenProjectRegistry getRegistry() {
+		return getService(IMavenProjectRegistry.class);
+	}
+
+	private <T> T getService(Class<T> clz) {
+		BundleContext ctx = FrameworkUtil.getBundle(IndexConfigurator.class)
+			.getBundleContext();
+		if (ctx == null) {
+			throw new IllegalStateException("Bndtools M2E integration is not started");
+		}
+		ServiceReference<T> ref = ctx.getServiceReference(clz);
+		if (ref == null) {
+			throw new IllegalStateException(String.format("M2E service %s is missing", clz.getName()));
+		}
+		T service = ctx.getService(ref);
+		if (service == null) {
+			throw new IllegalStateException(String.format("M2E service %s is missing", clz.getName()));
+		}
+		return service;
+	}
+
+}

--- a/bndtools.m2e/src/bndtools/m2e/WorkspaceProjectPostProcessor.java
+++ b/bndtools.m2e/src/bndtools/m2e/WorkspaceProjectPostProcessor.java
@@ -11,18 +11,22 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import aQute.bnd.maven.lib.resolve.PostProcessor;
 
-class WorkspaceProjectPostProcessor implements MavenRunListenerHelper, PostProcessor {
+class WorkspaceProjectPostProcessor implements PostProcessor {
 
 	private static final Logger		logger	= LoggerFactory.getLogger(WorkspaceProjectPostProcessor.class);
 
 	private final IProgressMonitor	monitor;
 
-	WorkspaceProjectPostProcessor(IProgressMonitor monitor) {
+	private final IMavenProjectRegistry	mavenProjectRegistry;
+
+	WorkspaceProjectPostProcessor(IMavenProjectRegistry mavenProjectRegistry, IProgressMonitor monitor) {
+		this.mavenProjectRegistry = mavenProjectRegistry;
 		this.monitor = monitor;
 	}
 


### PR DESCRIPTION
The latest m2e updates have moved methods in internal packages. This breaks m2e support in Bndtools where we were going around the official API. This is primarily an attempt to remove the usage of internal types in an effort to remain compatible between versions. Furthermore we need to coexist in scenarios where:

* A maven project change listener whiteboard is built in to M2E 2+ and replaces the one we created
* Services are used for M2E objects such as IMaven - access these in a consistent way
* Public lookup methods now exist, but we must still use reflection while 1.x is supported

A good deal of cleanup will be possible once we have a base of 2.0, but for now this is a good next step.

Known issues: The bndrun "Browse Repos" section populates, but then disappears again after about a second. Resolving is possible.

Signed-off-by: Tim Ward <timothyjward@apache.org>