### PR TITLE
Resolve artifact's finalName immediately before BndMaven*Plugin execution

### DIFF
--- a/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -59,6 +59,12 @@ public class IndexerMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project}", readonly = true, required = true)
 	private MavenProject				project;
 
+	/**
+	 * The name of the created artifact (excluding extension and classifier).
+	 */
+	@Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+	private String						finalName;
+
 	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
 	private RepositorySystemSession		session;
 
@@ -191,8 +197,7 @@ public class IndexerMojo extends AbstractMojo {
 				.equals("jar")) {
 				File current = new File(project.getBuild()
 					.getDirectory(),
-					project.getBuild()
-						.getFinalName() + ".jar");
+					finalName + ".jar");
 				if (current.exists()) {
 					ResourceBuilder resourceBuilder = new ResourceBuilder();
 					resourceBuilder.addFile(current, current.toURI());

--- a/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -99,7 +99,13 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 	 * The directory where the webapp is built when packaging is {@code war}.
 	 */
 	@Parameter(alias = "warOutputDir", defaultValue = "${project.build.directory}/${project.build.finalName}")
-	File                    webappDirectory;
+	File					webappDirectory;
+
+	/**
+	 * The name of the created artifact (excluding extension and classifier).
+	 */
+	@Parameter(defaultValue = "${project.build.finalName}", readonly = true)
+	String					finalName;
 
 	@Parameter(defaultValue = "${project}", required = true, readonly = true)
 	MavenProject			project;
@@ -656,11 +662,8 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 	}
 
 	private File getArtifactFile() {
-		return new File(getOutputDir(), project.getBuild()
-			.getFinalName()
-			+ getClassifier().map("-"::concat)
-				.orElse("")
-			+ "." + getExtension(project.getPackaging()));
+		return new File(getOutputDir(), finalName + getClassifier().map("-"::concat)
+			.orElse("") + "." + getExtension(project.getPackaging()));
 	}
 
 	private String getExtension(String type) {


### PR DESCRIPTION
If one wants to customize the name of the artifact build for a project in a Maven build, the property `project.build.finalName` can be set respectively has to be used the following approach:
```
<project>
	...
	<build>
	<finalName>${project.artifactId}-${qualifiedVersion}</finalName>
	...
	<Execute a mojo that creates the 'qualifiedVersion' property>
	...
	<Execute the `bnd-maven-plugin:jar` goal>
	</build>
</project>
```
Unfortunately the `bnd-maven-plugin:jar` goal does not consider properties that are only created by other previous mojo executions for the same project.
The reason is that the `finalName` is read directly from the `MavenProject`'s `Build` object, which is created at the beginning of the (project) build and whose field values are only resolved against the properties initially available. Later no further attempt is done to resolve unresolved references in the fields of that object.
But when the value of 'project.build.finalName' is injected as Mojo parameter the value is resolved against the then available properties and therefore considers properties that were created in a previous mojo execution for the same project.

In order to consider properties created during previous mojo executions the value has to be injected as parameter. This is the way the `maven-jar-plugin` reads the value from the model:
https://github.com/apache/maven-jar-plugin/blob/6eda00939b31aeddcb28cd49763a28ba86fdce5b/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java#L76-L80

Could this also be considered for BND 6.4?