### PR TITLE
[m2e] Avoid runtime errors due to API changes between 1.x and 2.x

### DIFF
--- a/bndtools.m2e/src/bndtools/m2e/AbstractMavenRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/AbstractMavenRepository.java
@@ -2,15 +2,18 @@ package bndtools.m2e;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.List;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.m2e.core.embedder.ArtifactKey;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
+import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
 import org.eclipse.osgi.service.datalocation.Location;
 import org.osgi.service.repository.Repository;
 
@@ -89,6 +92,13 @@ public abstract class AbstractMavenRepository extends BaseRepository
 
 	void cleanup() {
 		mavenProjectRegistry.removeMavenProjectChangedListener(this);
+	}
+
+	/**
+	 * Needed in M2E version 2.0
+	 */
+	public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
+		mavenProjectChanged(events.toArray(new MavenProjectChangedEvent[0]), monitor);
 	}
 
 }

--- a/bndtools.m2e/src/bndtools/m2e/MavenProjectChangedListenersTracker.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenProjectChangedListenersTracker.java
@@ -1,5 +1,7 @@
 package bndtools.m2e;
 
+import java.util.List;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.m2e.core.project.IMavenProjectChangedListener;
 import org.eclipse.m2e.core.project.MavenProjectChangedEvent;
@@ -17,6 +19,23 @@ public class MavenProjectChangedListenersTracker extends
 		super(FrameworkUtil.getBundle(MavenProjectChangedListenersTracker.class)
 			.getBundleContext(), IMavenProjectChangedListener.class, null);
 		open();
+	}
+
+	/**
+	 * Needed in M2E version 2.0
+	 */
+	public void mavenProjectChanged(List<MavenProjectChangedEvent> events, IProgressMonitor monitor) {
+		getTracked().values()
+			.stream()
+			.forEach(listener -> {
+				try {
+					IMavenProjectChangedListener.class
+						.getMethod("mavenProjectChanged", List.class, IProgressMonitor.class)
+						.invoke(listener, events, monitor);
+				} catch (Throwable t) {
+					logger.error(t.getMessage(), t);
+				}
+			});
 	}
 
 	@Override


### PR DESCRIPTION
Several types in M2E have been updated to use Lists rather than arrays. We have to implement the extra interface methods (where needed) and use reflective calls to avoid linking to a method which may not exist. All of this code is ugly, and should be removed once we can use a base of M2E 2.x.

Signed-off-by: Tim Ward <timothyjward@apache.org>