### PR TITLE
Revert "build(deps): Bump maven-deploy-plugin from 2.8.2 to 3.0.0 in /maven"

### DIFF
--- a/maven/bnd-plugin-parent/pom.xml
+++ b/maven/bnd-plugin-parent/pom.xml
@@ -280,7 +280,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>2.8.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Reverts bndtools/bnd#5324

maven-deploy-plugin 3.0.0 requires (the not yet released) maven 3.9.0 to deploy maven plugins. https://issues.apache.org/jira/browse/MNG-7055

```
[INFO] --- maven-deploy-plugin:3.0.0:deploy (default-deploy) @ bnd-indexer-maven-plugin ---
Warning:  
Warning:  You are about to deploy a maven-plugin using Maven 3.8.6.
Warning:  This plugin should be used ONLY with Maven 3.9.0 and newer, as MNG-7055
Warning:  is fixed in those versions of Maven only!
Warning:  
```

So until maven 3.9.0 is released and we update to use it, we cannot use maven-deploy-plugin 3.x.