### PR TITLE
temp workspace was created in the wrong location

### DIFF
--- a/maven/bnd-generate-maven-plugin/src/main/java/aQute/bnd/maven/generate/plugin/BndContainer.java
+++ b/maven/bnd-generate-maven-plugin/src/main/java/aQute/bnd/maven/generate/plugin/BndContainer.java
@@ -153,6 +153,7 @@ public class BndContainer {
 			bnd.setProperties(properties.replaceHere(project.getBasedir()));
 
 			bnd.setProperty("project.output", workingDir.getCanonicalPath());
+			bnd.setProperty(aQute.bnd.osgi.Constants.DEFAULT_PROP_TARGET_DIR, workingDir.getCanonicalPath());
 
 			if (logger.isDebugEnabled()) {
 				logger.debug("Generate Project Properties");
@@ -170,7 +171,7 @@ public class BndContainer {
 	}
 
 	public Project init(String task, File wsDir, File workingDir, Properties mavenProperties) throws Exception {
-		File temporaryDir = workingDir.toPath()
+		File temporaryDir = wsDir.toPath()
 			.resolve("tmp")
 			.resolve(task)
 			.toFile();


### PR DESCRIPTION
Due to the use of the wrong workspace folder some remnant directories have been created in the projects root directory instead of the target directory

Signed-off-by: Juergen Albert <j.albert@data-in-motion.biz>