### PR TITLE
#5462 Limit the Launcher to set startlevels to only the bundles in scope

### DIFF
--- a/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
+++ b/aQute.libg/src/aQute/lib/startlevel/StartLevelRuntimeHandler.java
@@ -157,16 +157,28 @@ public class StartLevelRuntimeHandler implements Closeable {
 	static public StartLevelRuntimeHandler create(Trace logger, Map<String, String> outerConfiguration) {
 
 		String defaultStartlevelString = outerConfiguration.get(LAUNCH_STARTLEVEL_DEFAULT);
-		if (defaultStartlevelString == null) {
+		if (defaultStartlevelString == null || defaultStartlevelString.equals("0")) {
 			logger.trace("startlevel: not handled");
 			return absent();
 		}
 
-		int defaultStartlevel = toInt(defaultStartlevelString, 1);
+		int defaultStartlevel;
+		boolean manageAll;
+
+		int tmp = toInt(defaultStartlevelString, 1);
+		if (tmp > 0) {
+			manageAll = true;
+			defaultStartlevel = tmp;
+		} else {
+			manageAll = false;
+			defaultStartlevel = -tmp;
+		}
+
 		int beginningStartlevel = toInt(outerConfiguration.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL), 1);
 		outerConfiguration.put(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, "1");
 
-		logger.trace("startlevel: handled begin=%s default=%s", beginningStartlevel, defaultStartlevel);
+		logger.trace("startlevel: handled begin=%s default=%s managed=%s", beginningStartlevel, defaultStartlevel,
+			manageAll ? "all" : "narrow");
 
 		//
 		// We need to remove it otherwise the framework reacts to it
@@ -185,15 +197,8 @@ public class StartLevelRuntimeHandler implements Closeable {
 
 				this.systemBundle = systemBundle;
 
-				for (Bundle bundle : systemBundle.getBundleContext()
-					.getBundles()) {
-					if (bundle.getBundleId() == 0) {
-						continue;
-					}
-					if (bundle.getSymbolicName() == null) {
-						continue;
-					}
-					installed.put(bundle, new BundleIdentity(bundle));
+				if (manageAll) {
+					manageAll(systemBundle);
 				}
 
 				updateConfiguration(outerConfiguration);
@@ -220,6 +225,15 @@ public class StartLevelRuntimeHandler implements Closeable {
 					});
 				logger.trace("startlevel: default=%s, beginning=%s", defaultStartlevel, beginningStartlevel);
 
+			}
+
+			private void manageAll(Framework systemBundle) {
+				for (Bundle bundle : systemBundle.getBundleContext()
+					.getBundles()) {
+					if (bundle.getBundleId() != 0 && bundle.getSymbolicName() != null) {
+						installed.put(bundle, new BundleIdentity(bundle));
+					}
+				}
 			}
 
 			@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/build/7.0.0.bnd
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/7.0.0.bnd
@@ -1,1 +1,2 @@
-__versiondefaults__                7.0.0
+__versiondefaults__                 7.0.0
+-launcher                           manage = all

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -767,8 +767,21 @@ public abstract class ProjectLauncher extends Processor {
 				int defaultLevel = maxLevel + 1;
 				int beginningLevel = maxLevel + 2;
 
-				if (!properties.containsKey(LAUNCH_STARTLEVEL_DEFAULT))
-					properties.put(LAUNCH_STARTLEVEL_DEFAULT, Integer.toString(defaultLevel));
+				if (!properties.containsKey(LAUNCH_STARTLEVEL_DEFAULT)) {
+					switch (project.instructions.launcher()
+						.manage()) {
+						default :
+						case all :
+							properties.put(LAUNCH_STARTLEVEL_DEFAULT, Integer.toString(defaultLevel));
+							break;
+						case narrow :
+							properties.put(LAUNCH_STARTLEVEL_DEFAULT, Integer.toString(-defaultLevel));
+							break;
+						case none :
+							properties.put(LAUNCH_STARTLEVEL_DEFAULT, "0");
+							break;
+					}
+				}
 
 				if (beginningLevelString == null) {
 					properties.put(FRAMEWORK_BEGINNING_STARTLEVEL, Integer.toString(beginningLevel));

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ProjectInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ProjectInstructions.java
@@ -62,8 +62,55 @@ public interface ProjectInstructions {
 		@SyntaxAnnotation(lead = "Specify a JAR version for a Main class plugin (name in generate must be a fqn class name)")
 		Optional<String> version();
 
-		@SyntaxAnnotation(lead = "Determins if the output directory needs to be cleared before the generator runs. The default is true.")
+		@SyntaxAnnotation(lead = "Determines if the output directory needs to be cleared before the generator runs. The default is true.")
 		Optional<Boolean> clear();
+	}
+
+	/**
+	 * The -launcher function is intended to hold options for the runtime
+	 * launcher.
+	 */
+
+	@SyntaxAnnotation(name = Constants.LAUNCHER, lead = "Return specific options for the launcher", example = "-launcher manage=all")
+	LauncherOptions launcher();
+
+	/**
+	 * the -launcher instruction is a set of properties, represented in this
+	 * interface
+	 */
+	interface LauncherOptions {
+
+		/**
+		 * When the framework is launched, the launcher might find bundles that
+		 * were not part of the run bundles. This is valid if one of the managed
+		 * bundles is a management agent that installs these bundles, for
+		 * example via a remote management system. In that case, the launcher
+		 * should not touch those other bundles. However, sometimes the bundles
+		 * are installed manually. In that case they should be managed.
+		 * <p>
+		 * This was added because the launcher was originally always assuming a
+		 * management agent and kept its hands off these bundles. However, a
+		 * change was introduced that made the launcher set the start level of
+		 * all bundles and this was not discovered for 3 versions. Therefore
+		 * this option was introduced with a default of
+		 * {@link LauncherManage#all}
+		 */
+		@SyntaxAnnotation(lead = "Option to set the bundles that need to be managed by the launcher. narrow means only "
+			+ "the bundles that are defined or calculated in the run bundles, all means all installed bundles, and "
+			+ "none means that no bundles should be managed. Aspects that fall under management are: startlevel", example = "-launcher manage=all")
+		LauncherManage manage();
+	}
+
+	/**
+	 * Possible values for for the `manage` option.
+	 */
+	enum LauncherManage {
+		@SyntaxAnnotation(lead = "Only manage the bundles specified in -runbundles")
+		narrow,
+		@SyntaxAnnotation(lead = "Manage all bundles")
+		all,
+		@SyntaxAnnotation(lead = "Manage no bundles")
+		none;
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.5.0")
+@org.osgi.annotation.versioning.Version("1.6.0")
 package aQute.bnd.help.instructions;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -167,6 +167,8 @@ public interface Constants {
 	String		JAVAC										= "javac";
 	String		JAVA										= "java";
 	String		JAVA_DEBUG									= "java.debug";
+	String		LAUNCHER									= "-launcher";
+
 	String		MAKE										= "-make";
 	String		METATYPE_ANNOTATIONS						= "-metatypeannotations";
 	String		METATYPE_ANNOTATIONS_OPTIONS				= "-metatypeannotations-options";
@@ -531,6 +533,16 @@ public interface Constants {
 	 * Launch constants that should be shared by launchers
 	 */
 	String		LAUNCH_TRACE								= "launch.trace";
+
+	/**
+	 * Specifies the default bundle start level but it has more meanings. If it
+	 * is 0, no start levels are handled. If is > 0, it manages the startlevels
+	 * of all installed bundles, also from previous installations are ensure to
+	 * have this start level if they do not appear in the set of runbundles. If
+	 * it less than 0, its negated value is the default start level but _only_
+	 * the bundles listed in the run bundles are managed. See -launcher
+	 * instruction.
+	 */
 	String		LAUNCH_STARTLEVEL_DEFAULT					= "launch.startlevel.default";
 	String		LAUNCH_RUNBUNDLES_ATTRS						= "launch.runbundles.attrs";
 	String		LAUNCH_ACTIVATORS							= "launch.activators";
@@ -541,7 +553,7 @@ public interface Constants {
 	 * printing.
 	 */
 	Set<String>	BND_USE_ATTRIBUTES							= Sets.of(
-		//@formatter:off
+	//@formatter:off
 		FROM_DIRECTIVE,
 		NO_IMPORT_DIRECTIVE,
 		PROVIDE_DIRECTIVE,

--- a/docs/_chapters/305-startlevels.md
+++ b/docs/_chapters/305-startlevels.md
@@ -6,7 +6,7 @@ layout: default
 
 One of the primary authors of bnd has always objected to startlevels. His motivation was twofold:
 
-* A dynamic OSGi system should be ablet to startup in any order. Startlevels are often abused to hide bundles
+* A dynamic OSGi system should be able to startup in any order. Startlevels are often abused to hide bundles
   that do not handle their dynamic dependencies correctly. Hiding these bugs by controlling the start ordering
   is dangerous since it removes the symptom but the cause can still bite at a later inconvenient time.
 * Start levels are global data about a set of bundles. OSGi is quite elegant that it stores virtually all
@@ -34,13 +34,29 @@ assign the `startlevel` attributes to specific bundles. For this reason there is
 instructions. A decorator is a header with the same name but ending with a plus sign (`+`). This instruction acts like a selector
 and can be used to assign `startlevel` attributes on the `-runbundles`.
 
+For example:
+
+    -runbundles: \
+        org.apache.servicemix.bundles.junit;version='[4.13.0,5)',\
+        org.apache.felix.log, \
+        demo;version='[1.0.0,1.0.1)'
+    
+    -runbundles+: \
+        demo;startlevel=11,\
+        *;startlevel=99
+
+
 ### Launching
 
 The [launcher] is responsible for installing the bundles after starting or communicating with a framework. The
 default bnd launcher will assign each bundle a startlevel, where bundles that do not have a specified `startlevel` are
 assigned one level higher than the maximum specified levels.
 
-The default launcher will then move the framework startlevel to 2 higher than the highest specified start level.
+The launcher supports _narrow_ managed mode or _all_ via the [`-launcher`] instruction. In narrow mode, the start levels
+will only be assigned to the scope, the set of bundles listed in the run bundles. In the all mode, all bundles
+that are installed at launch time will be assigned the default start level.
+
+The default launcher will then move the framework start level to 2 higher than the highest specified start level.
 
 ### Resolving
 
@@ -72,12 +88,17 @@ is to assign bundles sequentially in selected order from an initial level steppi
 can provide the initial level and the step if desired.
 
 The launcher will by default move the framework then to a start level that includes any used start levels. This
-default behavior can be blocked by specifyig the `org.osgi.framework.startlevel.beginning` property. If this
+default behavior can be blocked by specifying the `org.osgi.framework.startlevel.beginning` property. If this
 property is set bnd will assume that there is an agent that will handle the runtime start levels.
 
+## Runtime
 
+A quick way to disable the start level handling by the launch is to set the property used to convey the default 
+start level, `launch.startlevel.default` to 0. This will disable the complete start level handling regardless
+of other settings.
 
 [1]: https://osgi.org/specification/osgi.cmpn/7.0.0/service.configurator.html 
+[-launcher]: /instructions/launcher.html
 [-runbundles]: /instructions/runbundles.html
 [-runstartlevel]: /instructions/runstartlevel.html
 [launcher]: /chapters/launching.html

--- a/docs/_instructions/launcher.md
+++ b/docs/_instructions/launcher.md
@@ -1,0 +1,31 @@
+---
+layout: default
+class: Project
+title: -launcher
+summary: Options for the runtime launcher
+---
+
+This instruction has as purpose to collect options and special settings for the launcher. The
+following options are architected:
+
+* `manage`  – Indicates to the launcher how to treat unrecognized bundles. When the launcher starts 
+  it gets a list of run bundles, also called its _scope_. However, previous runs could've installed
+  other bundles that do not occur in the scope. By default the launcher should manage _all_
+  bundles. However, sometimes these bundles were installed by an agent and the launcher should
+  not touch them. Therefore the values for the 'manage' part are:
+  * `all` – This is the default and the launcher assumes it owns all the bundles
+  * `narrow` – The launcher will only touch the bundles that are part of its scope
+  * `none` – The launcher should defer from managing any bundles. 
+  
+## Example
+
+    -launcher manage = all  
+
+
+## Background
+
+This instruction was primarily designed to handle start levels. Originally the launcher was
+_narrowly_ managing only the bundles that were in its scope. However, this was inadvertently
+changed and not discovered for several reasons. The option to narrowly manage was therefore
+introduced with the default being the latest behavior.
+


### PR DESCRIPTION
During bnd 6.2.0 the behavior of the launcher was changed to set start levels on all bundles installed, even if they were not listed in the run bundles scope. This was recently discovered to wreak havoc in systems that use an agent to install additional bundles. I.e. the core set of run bundles were used to create an executable JAR that provided an environment that allowed the agent to install the bundles needed to satisfy the constraints of a remote management system. This management system also provided start levels. The change caused the launcher to set all bundles the agent introduced to the default level. Since the agent used higher numbers, any required ordering was lost.

This change introduces the idea of _narrow_ and _all_ scope. It provides a `-launcher` instruction that can set the `manage` option. This options is either `all` (default), `narrow`, and `none`. This `manage` scope is not limited to start levels in the future. It indicates that the launcher must be aware of additional bundles that are not in its run bundles.

The Project Launcher uses this instruction to set `launch.startlevel.default` to either 0 (none), a negative value (narrow), or a positive value for all. This is then processed appropriately in the Launcher.

The default for the manage instruction is set in the current 7.0.0 defaults.bnd

---
Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>