### PR TITLE
Make BND compatible with SLF4J-2

### DIFF
--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -36,7 +36,7 @@
 
 
 Import-Package: \
- org.slf4j,\
+ org.slf4j;version="${range;[==,3)}",\
  !com.google.appengine.*,\
  !com.google.apphosting.*,\
  !com.cloudius.util.*,\


### PR DESCRIPTION
SLF4J-2 is a binary compatible drop-in replacement for SLF4J-1 and therefore artifacts compiled against the SLF4J-1 API can use SLF4J-2 as well:
- https://www.slf4j.org/faq.html#changesInVersion200
- https://www.slf4j.org/faq.html#compatibility

To make BND compatible with SLF4J-2 it is sufficient to widen the 'Import-Package' version-range for org.slf4j packages to "[1.x,3)". This change allows to use BND in runtimes where either SLF4J-1 or SLF4J-2 is present.

I hope this simple change covers all all relevant cases.