### PR TITLE
classloader: Update class loader classes to register as parallel

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceExternalPluginHandler.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/WorkspaceExternalPluginHandler.java
@@ -352,6 +352,10 @@ public class WorkspaceExternalPluginHandler implements AutoCloseable {
 	 * interface class.
 	 */
 	static class ProxyClassLoader extends ClassLoader {
+		static {
+			ClassLoader.registerAsParallelCapable();
+		}
+
 		private final Class<?>[]	classes;
 		private final ClassLoader[]	loaders;
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/ActivelyClosingClassLoader.java
@@ -35,6 +35,10 @@ import aQute.lib.io.IO;
  * This class loader can load classes from JAR files.
  */
 class ActivelyClosingClassLoader extends URLClassLoader implements Closeable {
+	static {
+		ClassLoader.registerAsParallelCapable();
+	}
+
 	final AtomicReference<Map<File, Wrapper>>	wrappers	= new AtomicReference<>(new LinkedHashMap<>());
 	final AtomicBoolean							open		= new AtomicBoolean(true);
 	final Processor								processor;
@@ -81,7 +85,6 @@ class ActivelyClosingClassLoader extends URLClassLoader implements Closeable {
 	ActivelyClosingClassLoader(Processor processor, ClassLoader parent) {
 		super(new URL[0], parent);
 		this.processor = processor;
-		registerAsParallelCapable();
 	}
 
 	void add(File file) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1448,6 +1448,9 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	public static class CL extends ActivelyClosingClassLoader {
+		static {
+			ClassLoader.registerAsParallelCapable();
+		}
 
 		public CL(Processor p) {
 			super(p, p.getClass()

--- a/biz.aQute.launcher/src/aQute/launcher/minifw/BundleClassLoader.java
+++ b/biz.aQute.launcher/src/aQute/launcher/minifw/BundleClassLoader.java
@@ -9,6 +9,10 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleReference;
 
 class BundleClassLoader extends URLClassLoader implements BundleReference {
+	static {
+		ClassLoader.registerAsParallelCapable();
+	}
+
 	private final Bundle bundle;
 
 	BundleClassLoader(File file, ClassLoader parent, Bundle bundle) throws IOException {

--- a/biz.aQute.launcher/src/aQute/launcher/pre/EmbeddedLauncher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/pre/EmbeddedLauncher.java
@@ -295,6 +295,10 @@ public class EmbeddedLauncher {
 	}
 
 	public static class Loader extends URLClassLoader {
+		static {
+			ClassLoader.registerAsParallelCapable();
+		}
+
 		public Loader(URL[] urls, ClassLoader parent) {
 			super(urls, parent);
 		}


### PR DESCRIPTION
All classes in the hierarchy need to call the registerAsParallelCapable method.

