### PR TITLE
#5407 Decision to include project bin directory

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -82,9 +82,33 @@ public class BuilderTest {
 	@Test
 	public void testIncludePackageZeroMatchesForWildcard() throws Exception {
 		try (Builder b = new Builder()) {
-			b.setProperty("-includepackage", "*;foo:=notexistent");
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("-includepackage", "*;from:=osgi");
+			Jar build = b.build();
+			assertFalse(b.check("The JAR is empty: "));
+		}
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.setProperty("-includepackage", "*;from:=nonexistent");
 			Jar build = b.build();
 			assertTrue(b.check("The JAR is empty: "));
+		}
+	}
+
+	/**
+	 * Check if
+	 */
+
+	@Test
+	public void testIncludeWholeProject() throws Exception {
+		try (Builder b = new Builder()) {
+			Jar jar = new Jar(IO.getFile("jar/osgi.jar"));
+			jar.putResource(Constants.PROJECT_MARKER, new EmbeddedResource("", 0L));
+			b.addClasspath(jar);
+			b.setProperty("-includepackage", Constants.ALL_FROM_PROJECT);
+			Jar build = b.build();
+			assertThat(build.getResource("org/osgi/service/log/LogService.class")).isNotNull();
+			assertThat(build.getResource("org/osgi/service/event/EventHandler.class")).isNotNull();
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -856,7 +856,7 @@ public class ProjectBuilder extends Builder {
 		if (!project.isNoBundles() && builder.getJar() == null && project.getOutput()
 			.isDirectory()) {
 
-			if (!builder.isHeaderSet(EXPAND_HEADERS)) {
+			if (!builder.isPropertySet(EXPAND_HEADERS)) {
 				builder.setProperty(Constants.INCLUDEPACKAGE, ALL_FROM_PROJECT);
 			}
 		}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectBuilder.java
@@ -37,6 +37,7 @@ import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.BundleId;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Descriptors.TypeRef;
+import aQute.bnd.osgi.EmbeddedResource;
 import aQute.bnd.osgi.Instruction;
 import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Jar;
@@ -191,7 +192,9 @@ public class ProjectBuilder extends Builder {
 
 				File output = project.getOutput();
 				if (output.exists()) {
-					addClasspath(output);
+					Jar jar = new Jar(output);
+					jar.putResource(PROJECT_MARKER, new EmbeddedResource("project marker", 0L));
+					addClasspath(jar);
 				}
 
 				if (includeTestpath) {
@@ -524,8 +527,7 @@ public class ProjectBuilder extends Builder {
 			// We have a repo
 			// Baselining 0.x is uninteresting
 			// x.0.0 is a new major version so maybe there is no baseline
-			if ((version.getMajor() > 0) &&
-				((version.getMinor() > 0) || (version.getMicro() > 0))) {
+			if ((version.getMajor() > 0) && ((version.getMinor() > 0) || (version.getMicro() > 0))) {
 				warning(
 					"There is no baseline for %s in the baseline repo %s. The build is for version %s, which is higher than %s which suggests that there should be a prior version.",
 					getBsn(), repo, version.getWithoutQualifier(), new Version(version.getMajor()));
@@ -840,6 +842,7 @@ public class ProjectBuilder extends Builder {
 		return super.builds();
 	}
 
+
 	/**
 	 * Called when we start to build a builder. We reset our map of bsn ->
 	 * version and set the default contents of the bundle.
@@ -850,39 +853,15 @@ public class ProjectBuilder extends Builder {
 
 		project.versionMap.remove(builder.getBsn());
 
-		/*
-		 * During discussion on bndtools/bndtools#1270, @rotty3000 raised the
-		 * issue that, in a workspace build, bnd will not include anything in a
-		 * bundle by default. One must specify Private-Package, Export-Package,
-		 * Include-Resource, -includepackage, or -includeresource to put any
-		 * content in a bundle. And new users make mistakes and end up with
-		 * empty bundles which will be unexpected. This is different than the
-		 * non-workspace modes such as the bnd gradle plugin or the
-		 * bnd-maven-plugin which always include default content (gradle: normal
-		 * jar task content, maven: target/classes folder). So we change
-		 * ProjectBuilder (not Builder which is used by non-workspace builds) to
-		 * use the source output folder (e.g. bin folder) as the default
-		 * contents if the bundle's bnd file does not specify any of the
-		 * following instructions: -resourceonly, -includepackage,
-		 * Private-Package, -privatepackage, Export-Package, Include-Resource,
-		 * or -includeresource. If the bnd file specifies any of these
-		 * instructions, then they will fully control the contents of the
-		 * bundle.
-		 */
-		if (!project.isNoBundles() && (builder.getJar() == null)
-			&& (builder.getProperty(Constants.RESOURCEONLY) == null)
-			&& (builder.getProperty(Constants.INCLUDEPACKAGE) == null)
-			&& (builder.getProperty(Constants.PRIVATE_PACKAGE) == null)
-			&& (builder.getProperty(Constants.PRIVATEPACKAGE) == null)
-			&& (builder.getProperty(Constants.EXPORT_PACKAGE) == null)
-			&& (builder.getProperty(Constants.INCLUDE_RESOURCE) == null)
-			&& (builder.getProperty(Constants.INCLUDERESOURCE) == null) && project.getOutput()
-				.isDirectory()) {
-			Jar outputDirJar = new Jar(project.getName(), project.getOutput());
-			outputDirJar.setManifest(new Manifest());
-			builder.setJar(outputDirJar);
+		if (!project.isNoBundles() && builder.getJar() == null && project.getOutput()
+			.isDirectory()) {
+
+			if (!builder.isHeaderSet(EXPAND_HEADERS)) {
+				builder.setProperty(Constants.INCLUDEPACKAGE, ALL_FROM_PROJECT);
+			}
 		}
 	}
+
 
 	/**
 	 * Called when we're done with a builder. In this case we retrieve package

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("4.4.0")
+@Version("4.5.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.3.0")
+@Version("3.4.0")
 package aQute.bnd.maven;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -379,6 +379,7 @@ public interface Constants {
 	String		BUNDLE_SYMBOLIC_NAME_ATTRIBUTE				= "bundle-symbolic-name";
 	String		BUNDLE_VERSION_ATTRIBUTE					= "bundle-version";
 	String		FROM_DIRECTIVE								= "from:";
+	String		FROM_DIRECTIVE_PROJECT						= "project";
 
 	String		KEYSTORE_LOCATION_DIRECTIVE					= "keystore:";
 	String		KEYSTORE_PROVIDER_DIRECTIVE					= "provider:";
@@ -491,7 +492,29 @@ public interface Constants {
 	 */
 	String		DEFAULT_PREPROCESSS_MATCHERS				= "!*.(ico|jpg|jpeg|jif|jfif|jp2|jpx|j2k|j2c|fpx|png|gif|swf|doc|pdf|tiff|tif|raw|bmp|ppm|pgm|pbm|pnm|pfm|webp|zip|jar|gz|tar|tgz|exe|com|bin|mp[0-9]|mpeg|mov|):i, *";
 
-	/*
+	/**
+	 * Headers that if **all** are absent will trigger the -includepackage
+	 * `*;from:=project` (include all packages from the project's output.
+	 */
+	String[]	EXPAND_HEADERS							= {
+		Constants.RESOURCEONLY, Constants.INCLUDEPACKAGE, Constants.PRIVATE_PACKAGE, Constants.PRIVATEPACKAGE,
+		Constants.EXPORT_PACKAGE,
+	};
+
+	/**
+	 * Marker resource set by the ProjectBuilder to mark a JAR as the project
+	 * output's entry in the classpath. Used for the
+	 * {@link #EXPAND_HEADERS} processing.
+	 */
+	String		PROJECT_MARKER								= "META-INF/.project";
+
+	/**
+	 * Value for a *package instruction to include everything from the bin
+	 * directory
+	 */
+	String		ALL_FROM_PROJECT							= "*;" + FROM_DIRECTIVE + "=" + FROM_DIRECTIVE_PROJECT;
+
+	/**
 	 * Default properties as listed in defaults.bnd
 	 */
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -496,10 +496,10 @@ public interface Constants {
 	 * Headers that if **all** are absent will trigger the -includepackage
 	 * `*;from:=project` (include all packages from the project's output.
 	 */
-	String[]	EXPAND_HEADERS							= {
+	Set<String>	EXPAND_HEADERS							= Sets.of(
 		Constants.RESOURCEONLY, Constants.INCLUDEPACKAGE, Constants.PRIVATE_PACKAGE, Constants.PRIVATEPACKAGE,
-		Constants.EXPORT_PACKAGE,
-	};
+		Constants.EXPORT_PACKAGE
+	);
 
 	/**
 	 * Marker resource set by the ProjectBuilder to mark a JAR as the project

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2635,14 +2635,14 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	}
 
 	/**
-	 * Answer true if any of the headers is set as a property
+	 * Answer true if any of the property keys is set as a property
 	 *
-	 * @param headers list of headers
-	 * @return true if any of the headers is set
+	 * @param keys list of property keys
+	 * @return true if any of the property values is set
 	 */
-	public boolean isHeaderSet(String... headers) {
-		for (String header : headers) {
-			if (getProperty(header) != null)
+	public boolean isPropertySet(Set<String> keys) {
+		for (String key : keys) {
+			if (getProperty(key) != null)
 				return true;
 		}
 		return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -2633,4 +2633,18 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	public void setPropertiesFile(File source) {
 		this.propertiesFile = source;
 	}
+
+	/**
+	 * Answer true if any of the headers is set as a property
+	 *
+	 * @param headers list of headers
+	 * @return true if any of the headers is set
+	 */
+	public boolean isHeaderSet(String... headers) {
+		for (String header : headers) {
+			if (getProperty(header) != null)
+				return true;
+		}
+		return false;
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.0.0")
+@Version("3.1.0")
 package aQute.bnd.osgi.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.print;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package aQute.bnd.service.generate;


### PR DESCRIPTION
Bnd was changed a couple of years ago to have a default expand when there were no instructions like -includeresource, Private-Package, etc. The implementation decided to put the whole output directory of the project directly in the to be build JAR. This meant that the normal processing did not happen. You had to use -exportcontents to export packages.

This PR changes the following

- It introduces a magic keyword for the `from:` directive. If this is `project`, it will search the class path entry that is the project's output directory and will include only from there. Therefore, doing a `-includepackage *;from:=project` will include the _whole_ project output directory.
- Created a set of EXPAND_HEADERS in Constants. The -includresource was not include.
- Updated the Project builder to set the `-includepackage *;from:=project` instruction in the builder when none of the EXPAND_HEADERS was set
