### PR TITLE
#5060 No automatic build when build.bnd changes

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
+++ b/bndtools.builder/src/org/bndtools/builder/BndtoolsDynamicReferenceProvider.java
@@ -39,9 +39,12 @@ public class BndtoolsDynamicReferenceProvider implements IDynamicReferenceProvid
 		Project model = ws.getProject(project.getName());
 		if (model != null) {
 			List<IProject> result = new ArrayList<>();
+			IProject cnf = eclipse.getProject(Workspace.CNFDIR);
+			if (cnf != null)
+				result.add(cnf);
 			for (Project dep : model.getBuildDependencies()) {
 				IProject idep = eclipse.getProject(dep.getName());
-				if (idep != null)
+				if (idep != null && !dep.isCnf())
 					result.add(idep);
 			}
 			return result;

--- a/bndtools.core/src/bndtools/central/sync/WorkspaceChange.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceChange.java
@@ -1,0 +1,63 @@
+package bndtools.central.sync;
+
+import java.util.Collection;
+
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import aQute.bnd.build.Workspace;
+import aQute.bnd.service.RepositoryPlugin;
+
+@Component
+public class WorkspaceChange {
+	final static IWorkspace	workspace	= ResourcesPlugin.getWorkspace();
+
+	@Reference
+	Workspace				ws;
+
+	boolean					first		= true;
+	volatile boolean		cancel		= false;
+
+	@Activate
+	void activate() {
+		ws.on("workspace-changes")
+			.initial(this::init)
+			.repositoriesReady(this::done);
+	}
+
+	private void done(Collection<RepositoryPlugin> repos) {
+		if (first) {
+			first = false;
+			return;
+		}
+		cancel = false;
+		Job job = Job.create("workspace-changes", this::done0);
+		job.schedule(2000);
+	}
+
+	private IStatus done0(IProgressMonitor monitor) {
+		try {
+			if (cancel || monitor.isCanceled())
+				return Status.CANCEL_STATUS;
+
+			workspace.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+		} catch (CoreException e) {
+			return Status.error("trying to build", e);
+		}
+		return Status.OK_STATUS;
+	}
+
+	private void init(Workspace workspace) {
+		cancel = true;
+	}
+
+}


### PR DESCRIPTION
I could not get Eclipse to recognize the dependency between the cnf project changes and the other projects. So I used the new notifier mechanism to get changes in the workspace. When the repos are reported to be ready (and it is not the first time) a new full build is started.

Notice that whenever the registration is done, the notifier will send init/repos. That is why the first time it is ignored.

