### PR TITLE
Update after Fr. Krieg's request

### DIFF
--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
     - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6
+      uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b


### PR DESCRIPTION
- use submonitor
- realized we'd be prompting inside the bnd lock ...
- made getAllProjects(ws) static
- done early exit when no prompt exists

---
Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>