### PR TITLE
#5530  @Header did not support macros

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/StdAnnotationHeadersTest.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/StdAnnotationHeadersTest.java
@@ -51,6 +51,25 @@ public class StdAnnotationHeadersTest {
 	}
 
 	@Test
+	public void testHeaderWithMacros() throws Exception {
+		try (Builder b = new Builder();) {
+			b.addClasspath(IO.getFile("bin_test"));
+			b.setPrivatePackage("test.annotationheaders.div");
+			b.build();
+			b.getJar()
+				.getManifest()
+				.write(System.out);
+			assertTrue(b.check());
+
+			Attributes mainAttributes = b.getJar()
+				.getManifest()
+				.getMainAttributes();
+
+			assertThat(mainAttributes.getValue("Foo")).isEqualTo("a java.lang.String");
+		}
+	}
+
+	@Test
 	public void testResolutionDirectiveOverride() throws Exception {
 		try (Builder b = new Builder();) {
 			b.addClasspath(IO.getFile("bin_test"));

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/div/HeaderWithValues.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/div/HeaderWithValues.java
@@ -1,0 +1,18 @@
+package test.annotationheaders.div;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.osgi.annotation.bundle.Attribute;
+import org.osgi.annotation.bundle.Header;
+
+@Header(name = "Foo", value = "${#a} ${#b}")
+@Retention(RetentionPolicy.CLASS)
+@interface HeaderWithValues {
+	@Attribute
+	String a();
+
+	@Attribute
+	Class<?> b();
+}
+

--- a/biz.aQute.bndlib.tests/test/test/annotationheaders/div/Target.java
+++ b/biz.aQute.bndlib.tests/test/test/annotationheaders/div/Target.java
@@ -1,0 +1,6 @@
+package test.annotationheaders.div;
+
+@HeaderWithValues(a = "a", b = String.class)
+public class Target {
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/AnnotationHeaders.java
@@ -389,6 +389,7 @@ class AnnotationHeaders extends ClassDataCollector implements Closeable {
 					break;
 				case STD_HEADER :
 				case STD_HEADERS :
+					mergeAttributesAndDirectives(a);
 					AnnotationHeaders.this.annotation(a);
 					break;
 				case STD_ATTRIBUTE :


### PR DESCRIPTION
Added support for macros in the @Header (meta) annotation

Closes #5530

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>