### PR TITLE
Default properties were not set in the analyzer

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/MultiReleaseTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MultiReleaseTest.java
@@ -175,6 +175,35 @@ public class MultiReleaseTest {
 
 	}
 
+	@Test
+	public void testPlainBuilder() throws Exception {
+		try (Builder builder = new Builder()) {
+			builder.setProperty("-includeresource", """
+				sun_1_8/=compilerversions/src/sun_1_8/, \
+				META-INF/versions/9/jdk_9_0/=compilerversions/src/jdk_9_0/, \
+				META-INF/versions/11/jdk_11_0/=compilerversions/src/jdk_11_0/, \
+				META-INF/versions/17/jdk_17/=compilerversions/src/jdk_17/, \
+				META-INF/versions/19/jdk_19/=compilerversions/src/jdk_19/, \
+				""");
+
+			Jar jar = builder.build();
+			assertThat(builder.check()).isTrue();
+
+			assertThat(jar.getResource("META-INF/versions/9/META-INF/MANIFEST.MF")).isNotNull();
+			assertThat(jar.getResource("META-INF/versions/9/module-info.class")).isNotNull();
+
+			assertThat(jar.getResource("META-INF/versions/11/META-INF/MANIFEST.MF")).isNotNull();
+			assertThat(jar.getResource("META-INF/versions/11/module-info.class")).isNotNull();
+
+			assertThat(jar.getResource("META-INF/versions/17/META-INF/MANIFEST.MF")).isNotNull();
+			assertThat(jar.getResource("META-INF/versions/17/module-info.class")).isNotNull();
+
+			assertThat(jar.getResource("META-INF/versions/19/META-INF/MANIFEST.MF")).isNotNull();
+			assertThat(jar.getResource("META-INF/versions/19/module-info.class")).isNotNull();
+
+		}
+	}
+
 	Workspace getWorkspace() throws Exception {
 		File file = IO.getFile("testresources/ws-multirelease");
 		IO.copy(file, tmp);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -155,9 +155,11 @@ public class Analyzer extends Processor {
 		EXPORTS;
 	}
 
+	public Analyzer() {
+	}
+
 	public Analyzer(Jar jar) throws Exception {
-		super();
-		this.dot = Objects.requireNonNull(jar);
+		this.dot = Objects.requireNonNull(jar, "the jar must not be null");
 		Manifest manifest = dot.getManifest();
 		if (manifest != null)
 			copyFrom(Domain.domain(manifest));
@@ -206,7 +208,6 @@ public class Analyzer extends Processor {
 		return copy;
 	}
 
-	public Analyzer() {}
 
 	@Override
 	protected void setTypeSpecificPlugins(PluginsContainer pluginsContainer) {
@@ -1810,10 +1811,9 @@ public class Analyzer extends Processor {
 		if (inited == false) {
 			inited = true;
 			super.begin();
-
 			updateModified(getBndLastModified(), "bnd last modified");
+			About.fixup(this);
 			verifyManifestHeadersCase(getProperties());
-
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSMultReleasePlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/plugin/jpms/JPMSMultReleasePlugin.java
@@ -21,7 +21,6 @@ import aQute.bnd.service.ManifestPlugin;
  */
 public class JPMSMultReleasePlugin implements ManifestPlugin {
 
-
 	/**
 	 * We need to calculate alternative files for versioned JARS
 	 */
@@ -41,6 +40,8 @@ public class JPMSMultReleasePlugin implements ManifestPlugin {
 		Analyzer copy = Analyzer.copy(analyzer);
 
 		copy.addBasicPlugin(new JPMSModuleInfoPlugin());
+		if (copy.getProperty(Constants.JPMS_MODULE_INFO) == null)
+			copy.setProperty(Constants.JPMS_MODULE_INFO, "");
 
 		Jar baseline = copy.getJar();
 		baseline.removePrefix(JPMSModule.VERSIONS_PATH);
@@ -64,7 +65,10 @@ public class JPMSMultReleasePlugin implements ManifestPlugin {
 				older = newer;
 			}
 
-			Resource resource = baseline.getResource(MODULE_INFO_CLASS);
+			Resource resource = delta.getResource(MODULE_INFO_CLASS);
+			if (resource == null) {
+				resource = baseline.getResource(MODULE_INFO_CLASS);
+			}
 			if (resource != null) {
 				jpms.putResource(release, MODULE_INFO_CLASS, resource);
 			}


### PR DESCRIPTION
The analyzer therefore ignored multi release jars. The analyzer is now fixed up with the default properties __versiondefaults__ is not set, will never overwrite though.

Also fixed a small oversights:

* If the JAR already contains a module-info.class then it will not be overridden.
* The delta calculations will not set the module info flag

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>