### PR TITLE
Add an example to verify maven multi-release jar build with maven

### DIFF
--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/README.txt
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/README.txt
@@ -1,0 +1,8 @@
+This is an example Multi-Release-Jar bundle.
+
+It compiles a class HttpClient in three flavors:
+- default version (Java 8) that uses a library to perform some task not part of JDK 8
+- version 9 (Java 9) that uses the now build in support added in JDK 9
+- version 11 (Java 11) that uses the new Java HttpClient added in JDK 11
+
+This emulates what one often find in external libs where OSGi headers has to be added as part of a maven build.

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/invoker.properties
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/invoker.properties
@@ -1,0 +1,7 @@
+invoker.goals=--no-transfer-progress package
+
+# Run mvn with --debug for debug logging
+#invoker.debug=true
+
+# Run mvn in debugging mode and wait for a debugger to attach
+#invoker.environmentVariables.MAVEN_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/pom.xml
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>bnd.test</groupId>
+	<artifactId>mr</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>BND MR-JAR TestCase</name>
+	<description>The simplest form of a MR Jar Project that adds BND headers to an existing library project that produces MR-Content jar.</description>
+
+	<properties>
+		<minJDK>1.8</minJDK>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<bnd.version>${bnd.version}</bnd.version>
+	</properties>
+
+	<dependencies>
+		<!-- required for java < 9 -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<!-- compile the sources -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<source>${minJDK}</source>
+					<target>${minJDK}</target>
+					<release>8</release>
+				</configuration>
+				<executions>
+					<execution>
+						<id>java9</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>9</release>
+							<jdkToolchain>
+								<version>9</version>
+							</jdkToolchain>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+							</compileSourceRoots>
+							<multiReleaseOutput>true</multiReleaseOutput>
+						</configuration>
+					</execution>
+					<execution>
+						<id>java11</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>11</release>
+							<jdkToolchain>
+								<version>11</version>
+							</jdkToolchain>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+							</compileSourceRoots>
+							<multiReleaseOutput>true</multiReleaseOutput>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- generate the header -->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>${bnd.version}</version>
+				<executions>
+					<execution>
+						<id>bnd-process</id>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<bnd>
+						<![CDATA[
+							Export-Package: bnd.mr.example.*
+							Import-Package: *
+							Multi-Release: true
+						]]>
+					</bnd>
+				</configuration>
+			</plugin>
+			<!-- put the result into the jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-jar</id>
+						<configuration>
+							<archive>
+								<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+							</archive>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/postbuild.groovy
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/postbuild.groovy
@@ -1,0 +1,42 @@
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.Manifest
+
+import static org.assertj.core.api.Assertions.assertThat
+
+File mr_bundle = new File(basedir, 'target/mr-0.0.1-SNAPSHOT.jar')
+File target_directory = new File(basedir, 'target/classes')
+assertThat(mr_bundle).isFile()
+assertThat(target_directory).isDirectory()
+
+JarFile mr_jar = new JarFile(mr_bundle)
+//check that all manifests are there
+JarEntry java9Entry = mr_jar.getEntry('META-INF/versions/9/OSGI-INF/MANIFEST.MF')
+JarEntry java11Entry = mr_jar.getEntry('META-INF/versions/11/OSGI-INF/MANIFEST.MF')
+assert java9Entry != null
+assert java11Entry != null
+
+//check that a main OSGi Manifest was added with the wanted headers
+Attributes default_manifest = mr_jar.getManifest().getMainAttributes()
+assert default_manifest.getValue('Bundle-SymbolicName') == 'mr'
+assert default_manifest.getValue('Multi-Release') == 'true'
+assert default_manifest.getValue('Require-Capability').contains('osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"')
+assert default_manifest.getValue('Import-Package').contains('org.apache.commons.io;version=')
+
+//check no unwanted module-info is there
+assert mr_jar.getEntry('module-info.class') == null
+assert mr_jar.getEntry('META-INF/versions/9/module-info.class') == null
+assert mr_jar.getEntry('META-INF/versions/11/module-info.class') == null
+
+//check the manifests itself
+Attributes java9_manifest = new Manifest(mr_jar.getInputStream(java9Entry)).getMainAttributes();
+assert java9_manifest.getValue('Require-Capability').contains('osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=9))"')
+assert !java9_manifest.getValue('Import-Package').contains('org.apache.commons.io')
+
+Attributes java11_manifest = new Manifest(mr_jar.getInputStream(java11Entry)).getMainAttributes();
+assert java11_manifest.getValue('Require-Capability').contains('osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"')
+assert java11_manifest.getValue('Import-Package').contains('java.net.http')
+assert !java11_manifest.getValue('Import-Package').contains('org.apache.commons.io')
+
+true // success

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java/bnd/mr/example/HttpClient.java
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java/bnd/mr/example/HttpClient.java
@@ -1,0 +1,17 @@
+package bnd.mr.example;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.apache.commons.io.IOUtils;
+
+public class HttpClient {
+
+	public byte[] fetchBytes(URL url) throws IOException {
+		try (InputStream stream = url.openStream()) {
+			// For Java < 9 we need to use an external library!
+			return IOUtils.toByteArray(stream);
+		}
+	}
+}

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java/bnd/mr/example/Main.java
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java/bnd/mr/example/Main.java
@@ -1,0 +1,18 @@
+package bnd.mr.example;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		if (args.length == 0) {
+			System.err.println("Please specify at laest one file to fetch!");
+			System.exit(1);
+		}
+		HttpClient client = new HttpClient();
+		for (String arg : args) {
+			byte[] bytes = client.fetchBytes(new URL(arg));
+			System.out.println("URL " + arg + " has provided " + bytes.length + " bytes!");
+		}
+	}
+}

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java11/bnd/mr/example/HttpClient.java
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java11/bnd/mr/example/HttpClient.java
@@ -1,0 +1,36 @@
+package bnd.mr.example;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+
+public class HttpClient {
+
+	public byte[] fetchBytes(URL url) throws IOException {
+		// For From Java 11 we can even you a true client with HTTP/2 support!
+		java.net.http.HttpClient client = java.net.http.HttpClient.newBuilder()//
+				.followRedirects(Redirect.NORMAL)//
+				.connectTimeout(Duration.ofSeconds(20)) //
+				.build();
+		try {
+			HttpRequest request = HttpRequest.newBuilder().uri(url.toURI()).build();
+			HttpResponse<byte[]> response = client.send(request, BodyHandlers.ofByteArray());
+			if (response.statusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+				throw new FileNotFoundException(url.toString());
+			}
+			return response.body();
+		} catch (URISyntaxException e) {
+			throw new IOException("invalid: " + url, e);
+		} catch (InterruptedException e) {
+			throw new InterruptedIOException();
+		}
+	}
+}

--- a/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java9/bnd/mr/example/HttpClient.java
+++ b/maven-plugins/bnd-maven-plugin/src/it/mr-jar/src/main/java9/bnd/mr/example/HttpClient.java
@@ -1,0 +1,17 @@
+package bnd.mr.example;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.apache.commons.io.IOUtils;
+
+public class HttpClient {
+
+	public byte[] fetchBytes(URL url) throws IOException {
+		try (InputStream stream = url.openStream()) {
+			// For Java >= 9 we can use the build-in
+			return stream.readAllBytes();
+		}
+	}
+}


### PR DESCRIPTION
It compiles a class HttpClient in three flavors:
- default version (Java 8) that uses a library to perform some task not part of JDK 8
- version 9 (Java 9) that uses the now build in support added in JDK 9
- version 11 (Java 11) that uses the new Java HttpClient added in JDK 11

This emulates what one often find in external libs where OSGi headers has to be added as part of a maven build.


----

@pkriens (FYI @stbischof) Here we go with an MR-Maven-Build that is a common setup (e.g. on the [clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-java) driver), currently it shows the following issues:

1. BND generates a module-info.class (but only in the versioned folders) even though JPMS is not enabled in the BND instructions
2. Java 9 + Java 11 Manifests import the package `org.apache.commons.io` even though in that version(s) the package is never used.