### PR TITLE
Fixes NPE in classloading

### DIFF
--- a/biz.aQute.launchpad.tests/bnd.bnd
+++ b/biz.aQute.launchpad.tests/bnd.bnd
@@ -1,6 +1,8 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/includes/jdt.bnd
 
+-dependson biz.aQute.bndlib,biz.aQute.repository,biz.aQute.resolve
+
 -buildpath: \
     org.osgi.service.component.annotations;version='1.3.0', \
     osgi.annotation,\

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/WorkspaceTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/WorkspaceTest.java
@@ -1,0 +1,42 @@
+package aQute.xlaunchpad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+
+import aQute.launchpad.Launchpad;
+import aQute.launchpad.LaunchpadBuilder;
+
+/**
+ * Collect tests for running bndlib in an OSGi framework without Eclipse. This
+ * does not seem a common use case but there are some class loading issues to
+ * consider for the plugins.
+ */
+public class WorkspaceTest {
+	static LaunchpadBuilder builder = new LaunchpadBuilder().bndrun("workspace.bndrun");
+
+	/**
+	 * Check if the ActivelyClosingClassLoader will load from other bundles.
+	 */
+
+	@Test
+	@SuppressWarnings({
+		"rawtypes", "unchecked"
+	})
+	public void test() throws Exception {
+		try (Launchpad lp = builder.create()) {
+			Bundle bndlib = lp.getBundle("biz.aQute.bndlib")
+				.get();
+			Class accl = bndlib.loadClass("aQute.bnd.osgi.ActivelyClosingClassLoader");
+
+			Constructor constructor = accl.getDeclaredConstructor();
+			constructor.setAccessible(true);
+			ClassLoader cl = (ClassLoader) constructor.newInstance();
+			Class<?> resolver = cl.loadClass("biz.aQute.resolve.BndResolver");
+			assertThat(resolver).isNotNull();
+		}
+	}
+}

--- a/biz.aQute.launchpad.tests/workspace.bndrun
+++ b/biz.aQute.launchpad.tests/workspace.bndrun
@@ -1,0 +1,23 @@
+-runrequires: \
+	osgi.identity;filter:='(osgi.identity=biz.aQute.bndlib)',\
+	osgi.identity;filter:='(osgi.identity=biz.aQute.resolve)',\
+	osgi.identity;filter:='(osgi.identity=biz.aQute.repository)'
+-runfw: org.apache.felix.framework;version='[6.0.5,6.0.5]'
+-runee: JavaSE-17
+-runpath: slf4j.api,slf4j.simple,aQute.libg
+-runbundles: \
+	org.apache.felix.log;version='[1.2.0,1.2.1)',\
+	org.osgi.service.coordinator;version='[1.0.2,1.0.3)',\
+	org.osgi.service.repository;version='[1.1.0,1.1.1)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	biz.aQute.bnd.transform;version=snapshot,\
+	biz.aQute.bnd.util;version=snapshot,\
+	biz.aQute.bndlib;version=snapshot,\
+	biz.aQute.repository;version=snapshot,\
+	biz.aQute.resolve;version=snapshot
+-resolve: manual
+-runtrace true
+-runrepos: \
+	Maven Central,\
+	Workspace


### PR DESCRIPTION
If a class was not found it reverted to OSGi but not in a very good way, this could cause NPEs. This patch removes the NPE possibility and actually now searches all bundles that import or require the bndlib. This should probably make the Auxiliary extension superfluous that is used in Eclipse/bndtools.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>