### PR TITLE
Removed use of SecurityManager

### DIFF
--- a/biz.aQute.tester.junit-platform/bnd.bnd
+++ b/biz.aQute.tester.junit-platform/bnd.bnd
@@ -22,7 +22,8 @@ Import-Package: \
 
 -includepackage: \
 	!aQute.tester.plugin,\
-	aQute.tester.*
+	aQute.tester.*, \
+	aQute.junit.system
 	
 -includeresource.perm: OSGI-INF/permissions.perm;literal="(java.security.AllPermission)"
 
@@ -38,7 +39,7 @@ Import-Package: \
 	osgi.core,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot,\
-	biz.aQute.tester;version=snapshot;packages='aQute.junit.constants',\
+	biz.aQute.tester;version=snapshot;packages="aQute.junit.constants,aQute.junit.system",\
 	junit:junit;version='${junit4.tester.version}',\
 	org.junit.platform:junit-platform-commons;version='${junit.platform.tester.version}',\
 	org.junit.platform:junit-platform-engine;version='${junit.platform.tester.version}',\

--- a/biz.aQute.tester.junit-platform/src/aQute/junit/system/BndSystem.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/junit/system/BndSystem.java
@@ -1,0 +1,17 @@
+package aQute.junit.system;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntConsumer;
+
+/**
+ * Centralizes calling exit
+ */
+public class BndSystem {
+
+	public static AtomicReference<IntConsumer> exit = new AtomicReference<>(System::exit);
+
+	public static void exit(int code) {
+		exit.get()
+			.accept(code);
+	}
+}

--- a/biz.aQute.tester.junit-platform/src/aQute/junit/system/package-info.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/junit/system/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package aQute.junit.system;

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
@@ -59,6 +59,7 @@ import org.osgi.framework.Constants;
 import org.osgi.util.tracker.BundleTracker;
 import org.osgi.util.tracker.ServiceTracker;
 
+import aQute.junit.system.BndSystem;
 import aQute.tester.bundle.engine.BundleEngine;
 import aQute.tester.bundle.engine.discovery.BundleSelector;
 import aQute.tester.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener;
@@ -156,7 +157,7 @@ public class Activator implements BundleActivator, Runnable {
 				} catch (Exception e) {
 					System.err.println(
 						"Cannot create link Eclipse JUnit control on port " + port + " (rerunIDE: " + rerunIDE + ')');
-					System.exit(254);
+					BndSystem.exit(254);
 				}
 			}
 
@@ -352,7 +353,7 @@ public class Activator implements BundleActivator, Runnable {
 				trace("test ran");
 				if (queue.isEmpty() && !continuous) {
 					trace("queue %s", queue);
-					System.exit((int) result);
+					BndSystem.exit((int) result);
 				}
 			} catch (InterruptedException e) {
 				trace("tests bundle queue interrupted");
@@ -360,7 +361,7 @@ public class Activator implements BundleActivator, Runnable {
 				break;
 			} catch (Exception e) {
 				error("Not sure what happened anymore %s", e);
-				System.exit(254);
+				BndSystem.exit(254);
 			}
 		}
 	}

--- a/biz.aQute.tester.test/bnd.bnd
+++ b/biz.aQute.tester.test/bnd.bnd
@@ -31,7 +31,7 @@
 	aQute.libg,\
 	biz.aQute.bnd.util;version=snapshot,\
 	biz.aQute.bndlib;version=snapshot;packages=aQute.bnd.osgi,\
-	biz.aQute.tester;version=snapshot;packages=aQute.junit.constants,\
+	biz.aQute.tester;version=snapshot;packages="aQute.junit.constants,aQute.junit.system",\
 	biz.aQute.launchpad;version=project,\
 	biz.aQute.tester.junit-platform;version=project;packages=aQute.tester.bundle.engine,\
 	org.xmlunit:xmlunit-core;version=latest,\

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ActivatorJUnitPlatformTest.java
@@ -372,14 +372,13 @@ public class ActivatorJUnitPlatformTest extends AbstractActivatorCommonTest {
 					.set(TESTER_TRACE, "true");
 			}
 			lp = null;
-			oldManager = System.getSecurityManager();
-			System.setSecurityManager(new ExitCheck());
+			oldManager = setExitToThrowExitCode();
 		}
 
 		@SuppressWarnings("removal")
 		@AfterEach
 		public void tearDown() {
-			System.setSecurityManager(oldManager);
+			IO.close(oldManager);
 			IO.close(lp);
 			IO.close(builder);
 		}

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ExitCode.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/ExitCode.java
@@ -1,0 +1,18 @@
+package aQute.tester.junit.platform.test;
+
+/**
+ * This extends Error rather than SecurityException so that it can traverse the
+ * catch(Exception) statements in the code-under-test.
+ */
+
+public class ExitCode extends Error {
+	private static final long	serialVersionUID	= -1498037177123939551L;
+	public final int			exitCode;
+	public final StackTraceElement[]	stack;
+
+	public ExitCode(int exitCode) {
+		this.exitCode = exitCode;
+		this.stack = Thread.currentThread()
+			.getStackTrace();
+	}
+}

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/GogoShellTests.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/GogoShellTests.java
@@ -74,8 +74,7 @@ public class GogoShellTests extends AbstractActivatorTest {
 				.set(TESTER_TRACE, "true");
 		}
 		lp = null;
-		oldManager = System.getSecurityManager();
-		System.setSecurityManager(new ExitCheck());
+		oldManager = setExitToThrowExitCode();
 
 		controlSock = new ServerSocket(0);
 		controlSock.setSoTimeout(10000);
@@ -151,7 +150,7 @@ public class GogoShellTests extends AbstractActivatorTest {
 	void afterAll() {
 		IO.close(sock);
 		IO.close(controlSock);
-		System.setSecurityManager(oldManager);
+		IO.close(oldManager);
 		IO.close(lp);
 		IO.close(builder);
 	}

--- a/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/test/ActivatorTest.java
@@ -17,6 +17,7 @@ import org.xmlunit.assertj.XmlAssert;
 
 import aQute.junit.UnresolvedTester;
 import aQute.lib.xml.XML;
+import aQute.tester.junit.platform.test.ExitCode;
 import aQute.tester.test.assertions.CustomAssertionError;
 import aQute.tester.test.utils.TestRunData;
 import aQute.tester.testbase.AbstractActivatorCommonTest;

--- a/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorCommonTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/testbase/AbstractActivatorCommonTest.java
@@ -20,6 +20,7 @@ import org.osgi.framework.Bundle;
 
 import aQute.launchpad.LaunchpadBuilder;
 import aQute.lib.io.IO;
+import aQute.tester.junit.platform.test.ExitCode;
 import aQute.tester.testclasses.JUnit3Test;
 import aQute.tester.testclasses.JUnit4Test;
 import aQute.tester.testclasses.With1Error1Failure;
@@ -203,14 +204,13 @@ public abstract class AbstractActivatorCommonTest extends AbstractActivatorTest 
 				.set(TESTER_TRACE, "true");
 		}
 		lp = null;
-		oldManager = System.getSecurityManager();
-		System.setSecurityManager(new ExitCheck());
+		oldManager = setExitToThrowExitCode();
 	}
 
 	@SuppressWarnings("removal")
 	@AfterEach
 	public void tearDown() {
-		System.setSecurityManager(oldManager);
+		IO.close(oldManager);
 		IO.close(lp);
 		IO.close(builder);
 	}

--- a/biz.aQute.tester/src/aQute/junit/Activator.java
+++ b/biz.aQute.tester/src/aQute/junit/Activator.java
@@ -51,6 +51,7 @@ import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.util.tracker.BundleTracker;
 
+import aQute.junit.system.BndSystem;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -125,7 +126,7 @@ public class Activator implements BundleActivator, Runnable {
 				jUnitEclipseReport = new JUnitEclipseReport(port);
 			} catch (Exception e) {
 				System.err.println("Cannot create link Eclipse JUnit on port " + port);
-				System.exit(254);
+				BndSystem.exit(254);
 			}
 		}
 
@@ -172,7 +173,7 @@ public class Activator implements BundleActivator, Runnable {
 					// ignore
 				}
 				if (err != 0) {
-					System.exit(err);
+					BndSystem.exit(err);
 				}
 			}
 		}
@@ -196,10 +197,10 @@ public class Activator implements BundleActivator, Runnable {
 				try (Writer report = getReportWriter(reportDir, reportDir.getName())) {
 					errors = test(null, testCases(testcases), report);
 				}
-				System.exit(errors);
+				BndSystem.exit(errors);
 			} catch (Exception e) {
 				e.printStackTrace();
-				System.exit(254);
+				BndSystem.exit(254);
 			}
 		}
 	}
@@ -268,7 +269,7 @@ public class Activator implements BundleActivator, Runnable {
 				}
 				if (queue.isEmpty() && !continuous) {
 					trace("queue %s", queue);
-					System.exit(result);
+					BndSystem.exit(result);
 				}
 			} catch (InterruptedException e) {
 				trace("tests bundle queue interrupted");
@@ -276,7 +277,7 @@ public class Activator implements BundleActivator, Runnable {
 				break;
 			} catch (Exception e) {
 				error("Not sure what happened anymore %s", e);
-				System.exit(254);
+				BndSystem.exit(254);
 			}
 		}
 	}

--- a/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
+++ b/biz.aQute.tester/src/aQute/junit/JUnitEclipseReport.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.Bundle;
 
+import aQute.junit.system.BndSystem;
 import junit.framework.AssertionFailedError;
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
@@ -65,7 +66,7 @@ public class JUnitEclipseReport implements TestReporter {
 				new PrintWriter(Channels.newWriter(channel, UTF_8.newEncoder(), -1)));
 		} catch (IOException e) {
 			System.err.println("Cannot open the JUnit Port: " + port + " " + e);
-			System.exit(254);
+			BndSystem.exit(254);
 			throw new AssertionError("unreachable");
 		}
 	}

--- a/biz.aQute.tester/src/aQute/junit/system/BndSystem.java
+++ b/biz.aQute.tester/src/aQute/junit/system/BndSystem.java
@@ -1,0 +1,17 @@
+package aQute.junit.system;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntConsumer;
+
+/**
+ * Centralizes calling exit
+ */
+public class BndSystem {
+
+	public static AtomicReference<IntConsumer> exit = new AtomicReference<>(System::exit);
+
+	public static void exit(int code) {
+		exit.get()
+			.accept(code);
+	}
+}

--- a/biz.aQute.tester/src/aQute/junit/system/package-info.java
+++ b/biz.aQute.tester/src/aQute/junit/system/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package aQute.junit.system;

--- a/bndtools.core.test/bnd.bnd
+++ b/bndtools.core.test/bnd.bnd
@@ -28,7 +28,8 @@
     org.bndtools.templating.gitrepo,\
     org.bndtools.templating,\
     org.bndtools.versioncontrol.ignores.manager,\
-    org.bndtools.versioncontrol.ignores.plugin.git
+    org.bndtools.versioncontrol.ignores.plugin.git, \
+    org.bndtools.remoteinstall
 
 # These are bundles that are not required for building but for debugging when doing
 # code inspection.


### PR DESCRIPTION
- Added a BndSystm.exit method that could be overridden
- this was added to the aQute.bnd.tester
- Adapted the applicable code to call BndSystem.exit
- Changed the test code to override the exit

Fixes #5114

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>