### PR TITLE
Support indexing of Multi-Release bundles

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/MultiReleaseTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MultiReleaseTest.java
@@ -31,7 +31,6 @@ import aQute.bnd.osgi.Resource;
 import aQute.bnd.osgi.repository.ResourcesRepository;
 import aQute.bnd.osgi.repository.XMLResourceGenerator;
 import aQute.bnd.osgi.repository.XMLResourceParser;
-import aQute.bnd.osgi.resource.MultiReleaseNamespace;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.service.resource.SupportingResource;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
@@ -218,26 +217,23 @@ public class MultiReleaseTest {
 		assertThat(r.hasIdentity()).isTrue();
 
 		testResource(r, "(&(osgi.wiring.package=org.osgi.framework)(version>=1.5.0)(!(version>=2.0.0)))",
-			null, false);
-		assertThat(r.getSupportingResources()).hasSize(4);
-		testResource(r.getSupportingResources()
-			.get(0), "(&(osgi.wiring.package=org.osgi.framework)(version>=1.5.0)(!(version>=2.0.0)))",
-			"(&(osgi.ee=JavaSE)(&(version>=1.8.0)(!(version>=9.0.0))))", true);
+			"(&(osgi.ee=JavaSE)(&(version>=1.8.0)(!(version>=9.0.0))))");
+		assertThat(r.getSupportingResources()).hasSize(3);
 
 		testResource(r.getSupportingResources()
-			.get(1), null, "(&(osgi.ee=JavaSE)(&(version>=9.0.0)(!(version>=12.0.0))))", true);
+			.get(0), null, "(&(osgi.ee=JavaSE)(&(version>=9.0.0)(!(version>=12.0.0))))");
 		testResource(r.getSupportingResources()
-			.get(2), "(&(osgi.wiring.package=org.osgi.service.url)(version>=1.0.0)(!(version>=2.0.0)))",
-			"(&(osgi.ee=JavaSE)(&(version>=12.0.0)(!(version>=17.0.0))))", true);
+			.get(1), "(&(osgi.wiring.package=org.osgi.service.url)(version>=1.0.0)(!(version>=2.0.0)))",
+			"(&(osgi.ee=JavaSE)(&(version>=12.0.0)(!(version>=17.0.0))))");
 		testResource(r.getSupportingResources()
-			.get(3),
+			.get(2),
 			"(&(osgi.wiring.package=org.osgi.service.startlevel)(version>=1.1.0)(!(version>=2.0.0))),(&(osgi.wiring.package=org.osgi.service.url)(version>=1.0.0)(!(version>=2.0.0)))",
-			"(&(osgi.ee=JavaSE)(version>=17.0.0))", true);
+			"(&(osgi.ee=JavaSE)(version>=17.0.0))");
 
 		// check the expansion of the SupportingResources
 		ResourcesRepository repo = new ResourcesRepository();
 		repo.add(r);
-		assertThat(repo.getResources()).hasSize(5);
+		assertThat(repo.getResources()).hasSize(4);
 
 		// check the expansion of the SupportingResource & roundtrip through XML
 
@@ -249,31 +245,22 @@ public class MultiReleaseTest {
 		System.out.println(s);
 		List<org.osgi.resource.Resource> l = XMLResourceParser
 			.getResources(new ByteArrayInputStream(bout.toByteArray()), new URI(""));
-		assertThat(l).hasSize(5);
+		assertThat(l).hasSize(4);
 
 	}
 
 	final static org.osgi.framework.Version lowest = new org.osgi.framework.Version("0");
 
-	private void testResource(org.osgi.resource.Resource r, String imports, String requires, boolean isSupport) {
+	private void testResource(org.osgi.resource.Resource r, String imports, String requires) {
 		testFilters(r, PackageNamespace.PACKAGE_NAMESPACE, Strings.split(imports));
 		testFilters(r, ExecutionEnvironmentNamespace.EXECUTION_ENVIRONMENT_NAMESPACE, Strings.split(requires));
-		if (isSupport) {
-			Capability capability = r.getCapabilities(MultiReleaseNamespace.MULTI_RELEASE_NAMESPACE)
-				.get(0);
-			assertThat(capability.getAttributes()
-				.get(MultiReleaseNamespace.CAPABILITY_VERSION_ATTRIBUTE)).isEqualTo(lowest);
-			assertThat(capability.getAttributes()
-				.get(MultiReleaseNamespace.MULTI_RELEASE_NAMESPACE)).isEqualTo("multirelease.main");
-		} else {
-			Capability capability = r.getCapabilities(BundleNamespace.BUNDLE_NAMESPACE)
-				.get(0);
-			assertThat(capability.getAttributes()
-				.get(BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE)).isEqualTo(lowest);
-			assertThat(capability.getAttributes()
-				.get(BundleNamespace.BUNDLE_NAMESPACE)).isEqualTo("multirelease.main");
 
-		}
+		Capability capability = r.getCapabilities(BundleNamespace.BUNDLE_NAMESPACE)
+			.get(0);
+		assertThat(capability.getAttributes()
+			.get(BundleNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE)).isEqualTo(lowest);
+		assertThat(capability.getAttributes()
+			.get(BundleNamespace.BUNDLE_NAMESPACE)).isEqualTo("multirelease.main");
 
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -3635,7 +3635,7 @@ public class Project extends Processor {
 				return result;
 
 			for (File f : fs) {
-				ResourceBuilder rb = new ResourceBuilder();
+				ResourceBuilder rb = new ResourceBuilder(this);
 				rb.addFile(f, f.toURI());
 				rb.addWorkspaceNamespace(getName());
 				result.add(rb.build());

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -461,7 +461,14 @@ public class HttpClient implements Closeable, URLConnector {
 				//
 
 				if ("file".equalsIgnoreCase(url.getProtocol())) {
-					File sourceFile = new File(uri);
+					// HTTP clients are required to strip fragments before
+					// querying so we should remove any fragment here
+					File sourceFile;
+					if (uri.getFragment() == null) {
+						sourceFile = new File(uri);
+					} else {
+						sourceFile = new File(uri.getPath());
+					}
 					if (!sourceFile.isFile()) {
 						return new TaggedData(uri, HTTP_NOT_FOUND, null);
 					}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/SimpleIndexer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/SimpleIndexer.java
@@ -189,7 +189,7 @@ public class SimpleIndexer {
 
 	private Resource indexFile(File file) {
 		try {
-			ResourceBuilder resourceBuilder = new ResourceBuilder();
+			ResourceBuilder resourceBuilder = new ResourceBuilder(reporter);
 			if (resourceBuilder.addFile(file, relativize(file))) {
 				if (analyzer != null) {
 					analyzer.analyzeFile(file, resourceBuilder.safeResourceBuilder());

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MultiReleaseNamespace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MultiReleaseNamespace.java
@@ -26,7 +26,40 @@ public class MultiReleaseNamespace {
 
 	/**
 	 * The marker fragment attribute added to the content capability url
+	 * Deprecated for removal before releasing bnd 7.0
 	 */
+	@Deprecated
 	public static final String	MULTI_RELEASE_VERSION_ATTRIBUTE	= "mr-version";
+
+	/**
+	 * A system property for temporary use in enabling one multi-release
+	 * indexing format vs another. Deprecated for removal before releasing bnd
+	 * 7.0
+	 */
+	@Deprecated
+	public static final String	MULTI_RELEASE_INDEXING				= "bnd.multirelease.indexing";
+
+	/**
+	 * A bnd instruction for temporary use in enabling one multi-release
+	 * indexing format vs another. Deprecated for removal before releasing bnd
+	 * 7.0
+	 */
+	@Deprecated
+	public static final String	MULTI_RELEASE_INDEXING_INSTRUCTION	= "-xxxmultireleaseindexing";
+
+	/**
+	 * Multiple resource indexing. Each resource is an osgi.bundle Deprecated
+	 * for removal before releasing bnd 7.0
+	 */
+	@Deprecated
+	public static final String	MULTI_RELEASE_INDEXING_MULTIPLE		= "multiple";
+
+	/**
+	 * Synthetic resource indexing. There is one main bundle and additional
+	 * synthetic resources of type bnd.synthetic Deprecated for removal before
+	 * releasing bnd 7.0
+	 */
+	@Deprecated
+	public static final String	MULTI_RELEASE_INDEXING_SYNTHETIC	= "synthetic";
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MultiReleaseNamespace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/MultiReleaseNamespace.java
@@ -4,15 +4,14 @@ package aQute.bnd.osgi.resource;
  * Multi release jars (MRJ) have different requirements based on the VM they
  * run.
  * <p>
- * This class defines constants related to the osgi.multirelease namespace used
+ * This class defines constants related to the multi-release capabilities used
  * for multi-release JAR files in OSGi. These jars contain content that varies
- * depending on the JVM release it is deployed. This could be modeled with a
- * supporting resource. The primary resource requires a multi-release
- * capability. For each range of VMs as used in the MRJ, a supporting resource
- * is created that provides the special capability and requires the proper VM
- * range. The only way to resolve this constellation is to pick one of the
- * synthetic resources that provides the capability and can resolve all its
- * requirements.
+ * depending on the JVM release it is deployed. This could be modelled with a
+ * supporting resource. For each range of VMs in the MRJ, a supporting resource
+ * is created that has a marker attribute in the identity capability and
+ * requires the proper VM range. The only way to resolve this constellation is
+ * to pick one of the synthetic resources that provides the capability and can
+ * resolve all its requirements.
  */
 public class MultiReleaseNamespace {
 
@@ -24,4 +23,10 @@ public class MultiReleaseNamespace {
 	 * The version attribute.
 	 */
 	public static final String	CAPABILITY_VERSION_ATTRIBUTE	= "version";
+
+	/**
+	 * The marker fragment attribute added to the content capability url
+	 */
+	public static final String	MULTI_RELEASE_VERSION_ATTRIBUTE	= "mr-version";
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/service/resource/SupportingResource.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/resource/SupportingResource.java
@@ -7,13 +7,13 @@ import org.osgi.framework.namespace.IdentityNamespace;
 import org.osgi.resource.Resource;
 
 /**
- * The SupportingResource interface represents a resource that requires other
- * resources that are needed to resolve the primary resource. It was introduced
+ * The SupportingResource interface represents a resource that has multiple
+ * different representations for the same underlying content. It was introduced
  * to support Multi Release Jars (MRJ). These jars contain content that varies
- * depending on the JVM release it is deployed. This could be modeled with a
- * supporting resource. The primary resource required a special capability. For
+ * depending on the JVM release it is deployed in. This could be modeled with a
+ * supporting resource. The primary resource represents the "base" content. For
  * each range of VMs as used in the MRJ, a supporting resource is created that
- * provides the special capability and requires the proper VM range.
+ * provides the same capabilities and requires the appropriate requirements.
  * <p>
  * However, this could be useful in other cases so the current specification is
  * independent of this use case.

--- a/biz.aQute.repository/src/aQute/bnd/repository/fileset/FileSetRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/fileset/FileSetRepository.java
@@ -95,7 +95,7 @@ public class FileSetRepository extends BaseRepository implements Plugin, Reposit
 			if (!file.isFile()) {
 				return null;
 			}
-			ResourceBuilder rb = new ResourceBuilder();
+			ResourceBuilder rb = new ResourceBuilder(reporter);
 			try {
 				boolean hasIdentity = rb.addFile(file, null);
 				if (!hasIdentity) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -328,7 +328,7 @@ class IndexFile {
 	}
 
 	private Map<Archive, Resource> parseSingle(Archive archive, File single) throws Exception {
-		ResourceBuilder rb = new ResourceBuilder();
+		ResourceBuilder rb = new ResourceBuilder(reporter);
 		MavenVersion version = archive.revision.version;
 		boolean hasIdentity = rb.addFile(single, single.toURI());
 		if (!hasIdentity) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -46,6 +46,7 @@ import aQute.bnd.osgi.repository.ResourcesRepository;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.osgi.resource.ResourceUtils.BundleCap;
+import aQute.bnd.service.resource.SupportingResource;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
@@ -597,7 +598,8 @@ class IndexFile {
 			return null;
 
 		Archive archive = MapStream.of(archives)
-			.filterValue(v -> v == resource)
+			.filterValue(v -> v == resource || (v instanceof SupportingResource sr && sr.getSupportingResources()
+				.contains(resource)))
 			.keys()
 			.findFirst()
 			.orElse(null);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/NexusCommand.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/NexusCommand.java
@@ -590,7 +590,7 @@ public class NexusCommand extends Processor {
 	private void parseJar(ResourcesRepository repo, URI jar, File go)
 		throws IOException, NoSuchAlgorithmException, Exception {
 		SHA256.digest(go);
-		ResourceBuilder rb = new ResourceBuilder();
+		ResourceBuilder rb = new ResourceBuilder(this);
 		rb.addFile(go, jar);
 		Resource resource = rb.build();
 		repo.add(resource);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/ReleasePluginImpl.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/ReleasePluginImpl.java
@@ -106,7 +106,7 @@ class ReleasePluginImpl {
 			try {
 				Promise<File> promise = storage.get(pom.binaryArchive());
 				File file = promise.getValue();
-				ResourceBuilder rb = new ResourceBuilder();
+				ResourceBuilder rb = new ResourceBuilder(indexProject);
 				String uri = prefix + pom.binaryArchive().remotePath;
 				rb.addFile(file, new URI(uri));
 				repo.add(rb.build());

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
@@ -187,7 +187,7 @@ class P2Indexer implements Closeable {
 				}
 				return fetch(a, 2, 1000L).map(tag -> processor.unpackAndLinkIfNeeded(tag, null))
 					.map(file -> {
-						ResourceBuilder rb = new ResourceBuilder();
+						ResourceBuilder rb = new ResourceBuilder(processor);
 						rb.addFile(file, a.uri);
 						if (a.md5 != null) {
 							rb.addCapability(

--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndrunResolveContext.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import java.util.jar.Manifest;
 
 import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
@@ -40,7 +39,6 @@ import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Constants;
-import aQute.bnd.osgi.Domain;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.OSInformation;
 import aQute.bnd.osgi.Processor;
@@ -295,10 +293,10 @@ public class BndrunResolveContext extends AbstractResolveContext {
 					.get(NAMESPACE_WHITELIST))
 					.forEach(ignoredNamespaces::remove);
 
-				Manifest manifest = c.getManifest();
-				if (manifest != null) {
-					ResourceBuilder rb = new ResourceBuilder();
-					rb.addManifest(Domain.domain(manifest));
+				File file = c.getFile();
+				if (file != null) {
+					ResourceBuilder rb = new ResourceBuilder(properties);
+					rb.addFile(file);
 					system.copyCapabilities(ignoredNamespaces, rb.build());
 				}
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceResourcesRepository.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/WorkspaceResourcesRepository.java
@@ -52,6 +52,7 @@ public class WorkspaceResourcesRepository extends AbstractIndexingRepository<Pro
 	protected BiFunction<ResourceBuilder, File, ResourceBuilder> indexer(Project project) {
 		String name = project.getName();
 		return (rb, file) -> {
+			rb.setProcessor(project);
 			rb = fileIndexer(rb, file);
 			if (rb == null) {
 				return null; // file is not a file

--- a/biz.aQute.resolve/test/biz/aQute/resolve/ProjectResolverTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/ProjectResolverTest.java
@@ -64,7 +64,7 @@ public class ProjectResolverTest {
 	}
 
 	private void add(ResourcesRepository fr, File file) throws Exception {
-		ResourceBuilder rb = new ResourceBuilder();
+		ResourceBuilder rb = new ResourceBuilder(ws);
 		rb.addFile(file, file.toURI());
 		Resource resource = rb.build();
 		fr.add(resource);

--- a/biz.aQute.resolve/test/biz/aQute/resolve/StandaloneTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/StandaloneTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.namespace.ExecutionEnvironmentNamespace;
 import org.osgi.resource.Requirement;
-import org.osgi.resource.Resource;
 import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.Container;
@@ -23,9 +22,7 @@ import aQute.bnd.build.Run;
 import aQute.bnd.build.model.EE;
 import aQute.bnd.osgi.repository.ResourcesRepository;
 import aQute.bnd.osgi.repository.XMLResourceGenerator;
-import aQute.bnd.osgi.resource.MultiReleaseNamespace;
 import aQute.bnd.osgi.resource.ResourceBuilder;
-import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.repository.osgi.OSGiRepository;
 import aQute.lib.io.IO;
 
@@ -61,7 +58,7 @@ public class StandaloneTest {
 			RunResolution resolve = run.resolve();
 			assertThat(resolve.isOK());
 			System.out.println(resolve.log);
-			assertThat(resolve.getOrderedResources()).hasSize(2);
+			assertThat(resolve.getOrderedResources()).hasSize(1);
 			Collection<Container> runbundles = run.getRunbundles();
 			assertThat(runbundles).hasSize(1);
 			assertThat(runbundles.iterator()
@@ -69,14 +66,8 @@ public class StandaloneTest {
 				.getFile()
 				.getName()).isEqualTo("multirelease.main-0.0.0.jar");
 
-			Resource synthetic = resolve.getOrderedResources()
-				.stream()
-				.flatMap(r -> ResourceUtils.capabilityStream(r, MultiReleaseNamespace.MULTI_RELEASE_NAMESPACE))
-				.findFirst()
-				.get()
-				.getResource();
-
-			Requirement requirement = synthetic
+			Requirement requirement = resolve.getOrderedResources()
+				.get(0)
 				.getRequirements(ExecutionEnvironmentNamespace.EXECUTION_ENVIRONMENT_NAMESPACE)
 				.get(0);
 			SortedSet<EE> ees = EE.getEEsFromRequirement(requirement.toString());

--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -64,6 +64,11 @@ public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProj
 	protected BiFunction<ResourceBuilder, File, ResourceBuilder> indexer(IProject project) {
 		String name = project.getName();
 		return (rb, file) -> {
+			try {
+				rb.setProcessor(Central.getProject(project));
+			} catch (Exception e) {
+				// Oh well - this is going to be removed anyway
+			}
 			rb = fileIndexer(rb, file);
 			if (rb == null) {
 				return null; // file is not a file

--- a/bndtools.core/src/bndtools/model/repo/RepositoryEntry.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryEntry.java
@@ -21,6 +21,7 @@ import org.osgi.service.repository.OrExpression;
 import org.osgi.service.repository.Repository;
 import org.osgi.util.promise.Promise;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.service.RemoteRepositoryPlugin;
@@ -29,7 +30,7 @@ import aQute.bnd.service.ResourceHandle;
 import aQute.bnd.service.ResourceHandle.Location;
 import aQute.bnd.service.Strategy;
 import aQute.bnd.version.Version;
-import aQute.bnd.exceptions.Exceptions;
+import bndtools.central.Central;
 
 abstract class VersionFinder {
 	String		versionSpec;
@@ -174,7 +175,7 @@ public abstract class RepositoryEntry implements IAdaptable, ResourceProvider {
 			File file = repositoryPlugin.get(bsn, versionFinder.findVersion(), null);
 
 			if (file != null && file.exists()) {
-				ResourceBuilder rb = new ResourceBuilder();
+				ResourceBuilder rb = new ResourceBuilder(Central.getWorkspaceIfPresent());
 				rb.addFile(file, file.toURI());
 				return rb.build();
 			}

--- a/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenWorkspaceRepository.java
@@ -315,6 +315,7 @@ public class MavenWorkspaceRepository extends AbstractIndexingRepository<IProjec
 		String name = project.getName();
 		return (rb, artifact) -> {
 			try {
+				rb.setProcessor(Central.getProject(project));
 				rb = fileIndexer(rb, artifact.getFile());
 				if (rb == null) {
 					return null;


### PR DESCRIPTION
This PR is an extension to #5616 and adjusts the implementation to use real resources rather than synthetic resources.

In addition the code adjusts the equals method for `ResourceImpl` to take into account an attribute in the identity capability. This is necessary as otherwise resources with overlapping content capabilities are considered equal, making it impossible to use them in resolve operations. The problems with `equals` also impact the synthetic case, and if any two synthetic resources have overlapping content capabilities then they too would fail to resolve properly.