### PR TITLE
Updated Java OSGi Service wizard to use service.png for icon

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -147,7 +147,7 @@
 			category="bndtools.serviceWizardCategory"
 			class="org.bndtools.core.ui.wizards.service.java.NewBndJavaServiceWizardFactory"
 			finalPerspective="bndtools.perspective"
-			preferredPerspectives="bndtools.perspective" icon="icons/bricks.png"
+			preferredPerspectives="bndtools.perspective" icon="icons/service.png"
 			name="Java OSGi Service (api, impl, consumer)" project="false">
 		</wizard>
 	</extension>


### PR DESCRIPTION
Simply uses bndtools service.png for the New OSG Service -> Java Service wizard