### PR TITLE
Strange SWT dispose problem. This seems not to be introduced by the r…

### DIFF
--- a/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
@@ -35,7 +35,7 @@ public class CapabilityLabelProvider extends StyledCellLabelProvider {
 		cell.setStyleRanges(label.getStyleRanges());
 
 		// Get the icon from the capability namespace
-		Image icon = Icons.image(R5LabelFormatter.getNamespaceImagePath(cap.getNamespace()), false);
+		Image icon = Icons.image(R5LabelFormatter.getNamespaceImagePath(cap.getNamespace()));
 		cell.setImage(icon);
 	}
 

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
@@ -29,9 +29,8 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
 		if (element instanceof RequirementWrapper) {
 			RequirementWrapper rw = (RequirementWrapper) element;
 
-			Image icon = Icons.image(R5LabelFormatter.getNamespaceImagePath(rw.requirement.getNamespace()), true);
-			if (icon != null)
-				cell.setImage(icon);
+			Image icon = Icons.image(R5LabelFormatter.getNamespaceImagePath(rw.requirement.getNamespace()));
+			cell.setImage(icon);
 
 			StyledString label = getLabel(rw.requirement);
 			if (rw.resolved)

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionTreeLabelProvider.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionTreeLabelProvider.java
@@ -37,7 +37,7 @@ public class ResolutionTreeLabelProvider extends StyledCellLabelProvider {
 
 			// Get the icon from the capability namespace
 			icon = Icons.image(R5LabelFormatter.getNamespaceImagePath(item.getCapability()
-				.getNamespace()), true);
+				.getNamespace()));
 		} else if (element instanceof Requirement) {
 			Requirement requirement = (Requirement) element;
 			if (Namespace.RESOLUTION_OPTIONAL.equals(requirement.getDirectives()

--- a/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
+++ b/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
@@ -131,8 +131,11 @@ public final class Icons {
 
 		Key k = new Key(name);
 		synchronized (images) {
-			Image image = desc.createImage();
-			images.put(k, image);
+			Image image = images.get(k);
+			if (image == null) {
+				image = desc.createImage();
+				images.put(k, image);
+			}
 			return image;
 		}
 	}


### PR DESCRIPTION
…ecent change but might be an interaction with Eclipse. I noticed this in the last version also. It looks like a helper object is used to detect that anSWT object is not disposed properly. It looks like the Icons class was not properly using the caching map for one method. Now properly cached.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>