### PR TITLE
Revert "Upgrade to plexus-build-api 1.1.0"

### DIFF
--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -37,7 +37,7 @@
 	org.eclipse.m2e.core,\
 	org.eclipse.m2e.jdt,\
 	org.eclipse.osgi,\
-	org.codehaus.plexus:plexus-build-api
+	org.sonatype.plexus:plexus-build-api
 
 Bundle-SymbolicName: ${p};singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/bndtools.test/tester/cnf/ext/repositories.bnd
+++ b/bndtools.test/tester/cnf/ext/repositories.bnd
@@ -19,7 +19,7 @@ mavencentral:           https://repo.maven.apache.org/maven2
         cache="${workspace}/cnf/cache/stable/Eclipse-2018-12",\
     aQute.bnd.repository.maven.pom.provider.BndPomRepository;\
         name="Eclipse m2e 1.10.0 Dependencies";\
-        revision="org.apache.maven:maven-core:3.5.3,org.apache.maven:maven-aether-provider:3.3.9,org.codehaus.plexus:plexus-build-api:1.1.0";\
+        revision="org.apache.maven:maven-core:3.5.3,org.apache.maven:maven-aether-provider:3.3.9,org.sonatype.plexus:plexus-build-api:0.0.7";\
         releaseUrls="${mavencentral}";\
         location="${workspace}/cnf/cache/stable/Eclipse-m2e-1.10.0/index.xml"
 

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -161,6 +161,6 @@ org.apache.maven:maven-plugin-api:${maven.target.version}
 org.apache.maven:maven-repository-metadata:${maven.target.version}
 org.apache.maven:maven-settings:${maven.target.version}
 org.eclipse.aether:aether-api:${aether.version}
-org.codehaus.plexus:plexus-build-api:1.1.0
+org.sonatype.plexus:plexus-build-api:0.0.7
 org.codehaus.plexus:plexus-utils:3.0.22
 org.codehaus.plexus:plexus-classworlds:2.5.2

--- a/maven-plugins/bnd-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
 			<artifactId>maven-mapping</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
+			<groupId>org.sonatype.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 		</dependency>
 		<dependency>

--- a/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -74,7 +74,7 @@ import org.apache.maven.shared.mapping.MappingUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.codehaus.plexus.build.BuildContext;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
  * Abstract base class for all bnd-maven-plugin mojos.

--- a/maven-plugins/bnd-plugin-parent/pom.xml
+++ b/maven-plugins/bnd-plugin-parent/pom.xml
@@ -114,9 +114,9 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.codehaus.plexus</groupId>
+				<groupId>org.sonatype.plexus</groupId>
 				<artifactId>plexus-build-api</artifactId>
-				<version>1.1.0</version>
+				<version>0.0.7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>

--- a/maven-plugins/bnd-reporter-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-reporter-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
 			<artifactId>maven-mapping</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
+			<groupId>org.sonatype.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This reverts commit 24439733d9b5003bfb231eb274de3e7bb56addc8.

The current  Eclipse we're using is still based on the sonatype code base. In Eclipse, with ecj, the patch generates an error that it clearly does not do on javac/gradle.

![image](https://github.com/bndtools/bnd/assets/200494/daafe448-db70-4b1a-ad5d-a1a24a3247d3)

![image](https://github.com/bndtools/bnd/assets/200494/4d216f51-f02f-4b4b-a670-14241d413f59)

![image](https://github.com/bndtools/bnd/assets/200494/84cf4f24-ef59-468b-951e-36141f239081)
    
      The type org.sonatype.plexus.build.incremental.BuildContext cannot be resolved. It is indirectly referenced from required type 
org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant

@gnodet, can you take a look? I'd love to take it but not sure if we can do this without going to a later Eclipse?

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>