### PR TITLE
P2 Repositories lost synthetic resources for MRJs

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.3.1")
+@Version("1.4.0")
 package aQute.bnd.repository.p2.provider;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
See https://bnd.discourse.group/t/multirelease-jar-and-resolution/308/7 for the sob story

It is complicated.

MRJs are now build as a SupportingResource. This is the primary resource and some other resources you need to properly resolve. For an MRJ this is a synthetic resource that contains a capability unique for the MRJ that requires the EE and the requirements specific for the EE.

I.e. in some places we need to be careful that we expand a Resource. These places are few.

In the P2Indexer, we had an optimization for refresh. The existing Resource objects were reused if the MD5 of a request matched the existing resource. If the existing resource was used, then there were two situations. The existing index had been parsed from the network. In that case things worked fine since the SupportingResource was linked to the synthetic resources.

However, when the index was read from the cache (an XML file) the shit hit the fan. Generally no resources were fetched from the network so only the existing resources were used. However, these resources were read from the XML and had no link to the associated supporting resources. So after constructing a new index from the old resources, it wrote the new index to the XML, losing the supporting resources.

The fix is to remove the optimization scheme. This code was executed in a plugin refresh. Such a large potentially expensive actions should be more specific. So the refresh reinitializes the the plugin but will use the index if present. A menu was added to provide a proper refresh entry that will remove the index file and reread the repo.
