### PR TITLE
Apply Runtime classpath normalization and sort to the bundles input

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
@@ -118,11 +118,13 @@ public abstract class AbstractBndrun extends DefaultTask {
 
 	/**
 	 * Wrapper of the {@link #getBundles()} method to allow <code>@Classpath</code> normalization and sorting.
+	 * <p>
+	 * This method is only relevant for Gradle task input fingerprinting and should not be used.
 	 *
 	 * @return The sorted bundles.
 	 */
 	@Classpath
-	public Provider<List<File>> getBundlesSorted() {
+	Provider<List<File>> getBundlesSorted() {
 		return getBundles().getElements().map(
 			c -> c.stream()
 				.map(FileSystemLocation::getAsFile)


### PR DESCRIPTION
## Issue
When some files added to the `bundles` input of the `AbstractBndrun` Gradle task are containing some data changing build over build (typical could be a _build time_ in a `Manifest` file for instance), a build cache miss occurs on the Gradle task.

## Reason
the `bundles` input is using [PathSensitivity.NONE](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/PathSensitivity.html#NONE) as file inputs normalization which prevents from using [Runtime normalization](https://docs.gradle.org/current/userguide/build_cache_concepts.html#runtime_classpath).

## Fix
Change the current normalization of the `bundles` property to [@Internal](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/Internal.html) and add an extra property with the [@Classpath](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/Classpath.html) normalization which allows Runtime normalization.

This extra property is sorted as `@Classpath` normalization takes order into consideration, although the `bundles` items are not necessarily added in a consistent order.

fixes https://github.com/bndtools/bnd/issues/5666