### PR TITLE
Use an ArtifactView to gather dependencies for BundleAction

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -409,4 +409,28 @@ class TestBundlePlugin extends Specification {
 		result.task(":jar").outcome == UP_TO_DATE
 		result.task(":testOSGi").outcome == UP_TO_DATE
 	}
+
+	def "Bundle Extension added to Jar Task with Local Project Dependency receives jar file (Gradle = #gradleVersion)"() {
+		given:
+		String testProject = "builderplugin5"
+		File testProjectDir = new File(testResources, testProject).canonicalFile
+		assert testProjectDir.isDirectory()
+
+		when:
+		def result = TestHelper.getGradleRunner()
+				.withProjectDir(testProjectDir)
+				.withArguments("--parallel", "--stacktrace", "resolve")
+				.withPluginClasspath()
+				.withDebug(true)
+				.withGradleVersion(gradleVersion)
+				.forwardOutput()
+				.build()
+
+		then:
+		result.task(":jar") == null // Jar tasks never run
+		result.task(":resolve").outcome == SUCCESS
+
+		where:
+		gradleVersion << ["8.1", "8.2-rc-2"]
+	}
 }

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -421,7 +421,6 @@ class TestBundlePlugin extends Specification {
 				.withProjectDir(testProjectDir)
 				.withArguments("--parallel", "--stacktrace", "resolve")
 				.withPluginClasspath()
-				.withDebug(true)
 				.withGradleVersion(gradleVersion)
 				.forwardOutput()
 				.build()

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/build.gradle
@@ -1,0 +1,44 @@
+import aQute.bnd.gradle.BundleTaskExtension
+
+plugins {
+    id 'biz.aQute.bnd.builder' apply false
+    id 'java-library'
+}
+
+group = "com.example.main"
+version = "2.5.1"
+
+dependencies {
+    implementation project(":util")
+}
+
+// Replicate the JUnit 5 build, which lazily configures the Jar task to add the bundle extension and its action but does NOT apply any BND plugins
+tasks.withType(Jar).configureEach {
+    BundleTaskExtension bundle = extensions.create(BundleTaskExtension.NAME, BundleTaskExtension.class, it)
+    bundle.bnd('Import-Package': 'com.example.util.*')
+
+    println "Configuring jar"
+    doLast(bundle.buildAction())
+}
+
+tasks.register("resolve") {
+    def version = gradle.gradleVersion
+    def conf = configurations.compileClasspath
+    def bundleConf = tasks.named("jar").map {it.extensions.findByType(BundleTaskExtension).classpath }
+    dependsOn configurations.compileClasspath
+
+    doLast {
+        logger.warn("Gradle version: " + version)
+
+        // Compile classpath will changes from the jar file to the main classes directory depending on the gradle version
+        def confFiles = conf.files
+        confFiles.each { logger.warn("Compile classpath: " + it) }
+
+        // After the change to BundleTaskExtension, the classpath used by the bundle will always be the jar file
+        def bundleFiles = bundleConf.get()
+        bundleFiles.each { logger.warn("Bundle extension classpath: " + it) }
+
+        assert confFiles[0].name == "main"
+        assert bundleFiles[0].name == "util-1.7.8.jar"
+    }
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/settings.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/settings.gradle
@@ -1,0 +1,1 @@
+include "util"

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/src/main/java/com/example/main/Main.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/src/main/java/com/example/main/Main.java
@@ -1,0 +1,9 @@
+package com.example.main;
+
+import com.example.util.Util;
+
+public class Main {
+    public String getValue() {
+        return "main " + Util.getUtil();
+    }
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/build.gradle
@@ -1,0 +1,16 @@
+import aQute.bnd.gradle.BundleTaskExtension
+
+plugins {
+    id "java-library"
+}
+
+group = "com.example.util"
+version = "1.7.8"
+
+// Replicate the JUnit 5 build, which lazily configures the Jar task to add the bundle extension and its action but does NOT apply any BND plugins
+tasks.withType(Jar).configureEach {
+    BundleTaskExtension bundle = extensions.create(BundleTaskExtension.NAME, BundleTaskExtension.class, it)
+    bundle.bnd("""-exportcontents: com.example.util.*""")
+
+    doLast(bundle.buildAction())
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/src/main/java/com/example/util/Util.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/src/main/java/com/example/util/Util.java
@@ -1,0 +1,7 @@
+package com.example.util;
+
+public class Util {
+    public static String getUtil() {
+        return "util";
+    }
+}


### PR DESCRIPTION
This fixes #5695.

Using an `ArtifactView` avoids ordering issues with internal Gradle functionality when the `jar` task is realized prior to the `compileClasspath` configuration's attributes being modified just before resolution.  It makes the attributes used to resolve libraries for the `BundleAction` entirely predictable, and thus prevents a behavior change in Gradle 8.2 from affecting this process.

This also stops BND modifying attributes on Gradle-created configurations, which should be avoided.

If you revert the changes to `BundleTaskExtension` you can see the difference in behavior between Gradle version - this fix makes both behave consistently.  This test reproduces the relevant aspects of an issue identified in the JUnit 5 project here: https://github.com/junit-team/junit5/pull/3351#issuecomment-1591316685.