### PR TITLE
gradle: Use an ArtifactView for jar library elements selection

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -255,7 +255,8 @@ public class BndPlugin implements Plugin<Project> {
 					AbstractCompile.class, t -> {
 						t.getDestinationDirectory()
 							.fileValue(destinationDir);
-						jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
+						FileCollection jarLibraryElements = jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
+						t.setClasspath(jarLibraryElements.plus(t.getClasspath()));
 					});
 				generateInputAction.ifPresent(compileTask::configure);
 				sourceSet.getOutput()
@@ -280,7 +281,8 @@ public class BndPlugin implements Plugin<Project> {
 					AbstractCompile.class, t -> {
 						t.getDestinationDirectory()
 							.fileValue(destinationDir);
-						jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
+						FileCollection jarLibraryElements = jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
+						t.setClasspath(jarLibraryElements.plus(t.getClasspath()));
 					});
 				sourceSet.getOutput()
 					.dir(Maps.of("builtBy", compileTask.getName()), destinationDir);
@@ -535,8 +537,9 @@ public class BndPlugin implements Plugin<Project> {
 						.withPropertyName("projectFolder");
 					/* bnd can include from -buildpath */
 					t.getInputs()
-						.files(sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-							.getCompileClasspath())
+						.files(tasks.named(sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+								.getCompileJavaTaskName(), AbstractCompile.class)
+							.map(AbstractCompile::getClasspath))
 						.withNormalizer(ClasspathNormalizer.class)
 						.withPropertyName("buildpath");
 					/* bnd can include from -dependson */

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BundleTaskExtension.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BundleTaskExtension.java
@@ -210,7 +210,7 @@ public class BundleTaskExtension {
 		outputDirectory = objects.directoryProperty();
 		SourceSet mainSourceSet = sourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 		setSourceSet(mainSourceSet);
-		classpath(mainSourceSet.getCompileClasspath());
+		classpath(jarLibraryElements(task, mainSourceSet.getCompileClasspathConfigurationName()));
 		properties = objects.mapProperty(String.class, Object.class)
 			.convention(Maps.of("project", "__convention__"));
 		defaultBundleSymbolicName = task.getArchiveBaseName()
@@ -335,8 +335,6 @@ public class BundleTaskExtension {
 			.getTasks()
 			.named(sourceSet.getCompileJavaTaskName(), AbstractCompile.class)
 			.flatMap(AbstractCompile::getDestinationDirectory));
-
-		jarLibraryElements(getTask(), sourceSet.getCompileClasspathConfigurationName());
 	}
 
 	ConfigurableFileCollection getAllSource() {

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBundlePlugin.groovy
@@ -409,4 +409,27 @@ class TestBundlePlugin extends Specification {
 		result.task(":jar").outcome == UP_TO_DATE
 		result.task(":testOSGi").outcome == UP_TO_DATE
 	}
+
+	def "Bundle Extension added to Jar Task with Local Project Dependency receives jar file"() {
+		given:
+		String testProject = "builderplugin5"
+		File testProjectDir = new File(testResources, testProject).canonicalFile
+		assert testProjectDir.isDirectory()
+		File compileClasspath = new File(testProjectDir,"util/build/classes/java/main")
+		File bundleExtensionClasspath = new File(testProjectDir,"util/build/libs/util-1.7.8.jar")
+
+		when:
+		def result = TestHelper.getGradleRunner()
+				.withProjectDir(testProjectDir)
+				.withArguments("--parallel", "--stacktrace", "--debug", "--configuration-cache", "jarlibraryelements")
+				.withPluginClasspath()
+				.forwardOutput()
+				.build()
+
+		then:
+		result.task(":jar") == null // Jar tasks never run
+		result.task(":jarlibraryelements").outcome == SUCCESS
+		result.output =~ Pattern.quote("### compileClasspath: ${compileClasspath.absolutePath}")
+		result.output =~ Pattern.quote("### bundleExtensionClasspath: ${bundleExtensionClasspath.absolutePath}")
+	}
 }

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/build.gradle
@@ -1,0 +1,34 @@
+import aQute.bnd.gradle.BundleTaskExtension
+
+plugins {
+    id 'biz.aQute.bnd.builder' apply false
+    id 'java-library'
+}
+
+group = "com.example.main"
+version = "2.5.1"
+
+dependencies {
+    implementation project(":util")
+}
+
+// Replicate the JUnit 5 build, which lazily configures the Jar task to add the bundle extension and its action but does NOT apply any BND plugins
+tasks.withType(Jar).configureEach {
+    BundleTaskExtension bundle = extensions.create(BundleTaskExtension.NAME, BundleTaskExtension.class, it)
+    bundle.bnd('Import-Package': 'com.example.util.*')
+
+    doLast(bundle.buildAction())
+}
+
+tasks.register("jarlibraryelements") {
+    def compileClasspath = configurations.compileClasspath
+    def bundleExtensionClasspath = tasks.named("jar").map {it.extensions.findByType(BundleTaskExtension.class).classpath }
+    dependsOn compileClasspath
+
+    doLast {
+        // Compile classpath will be the main classes directory
+		println "### compileClasspath: ${compileClasspath.asPath}"
+		// The classpath used by the extension will be the jar file
+		println "### bundleExtensionClasspath: ${bundleExtensionClasspath.get().asPath}"
+    }
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/settings.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/settings.gradle
@@ -1,0 +1,1 @@
+include "util"

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/src/main/java/com/example/main/Main.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/src/main/java/com/example/main/Main.java
@@ -1,0 +1,9 @@
+package com.example.main;
+
+import com.example.util.Util;
+
+public class Main {
+    public String getValue() {
+        return "main " + Util.getUtil();
+    }
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/build.gradle
@@ -1,0 +1,16 @@
+import aQute.bnd.gradle.BundleTaskExtension
+
+plugins {
+    id "java-library"
+}
+
+group = "com.example.util"
+version = "1.7.8"
+
+// Replicate the JUnit 5 build, which lazily configures the Jar task to add the bundle extension and its action but does NOT apply any BND plugins
+tasks.withType(Jar).configureEach {
+    BundleTaskExtension bundle = extensions.create(BundleTaskExtension.NAME, BundleTaskExtension.class, it)
+    bundle.bnd("""-exportcontents: com.example.util.*""")
+
+    doLast(bundle.buildAction())
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/src/main/java/com/example/util/Util.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin5/util/src/main/java/com/example/util/Util.java
@@ -1,0 +1,7 @@
+package com.example.util;
+
+public class Util {
+    public static String getUtil() {
+        return "util";
+    }
+}


### PR DESCRIPTION
Using an ArtifactView avoids ordering issues when the Jar task is
realized prior to the compileClasspath configuration being modified
just before resolution.  It makes the attributes used to resolve
libraries more predictable, and prevents an internal behavior change in
Gradle 8.2 from affecting this process.

This also avoids modifying attributes on Gradle-created configurations,
which should be avoided.