### PR TITLE
The new gradle cannot find Java 8 on the build system

### DIFF
--- a/org.bndtools.p2/build.gradle
+++ b/org.bndtools.p2/build.gradle
@@ -97,7 +97,7 @@ var p2 = tasks.register("p2") {
 	description = "Publish the p2 repositories."
 	group = PublishingPlugin.PUBLISH_TASK_GROUP
 	var javaLauncher = javaToolchains.launcherFor {
-		languageVersion = JavaLanguageVersion.of(8)
+		languageVersion = JavaLanguageVersion.of(17)
 	}
 	inputs.files(p2Plugins).withPropertyName("p2Plugins")
 	inputs.files(p2FeatureMain).withPropertyName("p2FeatureMain")


### PR DESCRIPTION
The p2 uses a launcher from Java 8. Since we're now on 17, needed to be changed