### PR TITLE
Preparation to upgrade build to Gradle 8.2

### DIFF
--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -27,6 +27,7 @@ junit: ${junit-osgi},\
 junit-osgi: \
 	junit-platform-commons;version=latest,\
 	junit-platform-engine;version=latest,\
+	junit-platform-launcher;version=latest,\
 	assertj-core;version=latest,\
 	net.bytebuddy.byte-buddy;version=latest,\
 	org.opentest4j;version=latest,\

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -175,6 +175,12 @@ publishing {
 	}
 }
 
+// Java compiler options
+tasks.withType<JavaCompile>() {
+	options.compilerArgs.add("-Xlint:deprecation")
+	options.compilerArgs.add("-Xlint:unchecked")
+}
+
 // Use same jvm target for kotlin code as for java code
 tasks.withType<KotlinCompilationTask<KotlinJvmCompilerOptions>>().configureEach {
 	compilerOptions {

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -44,29 +44,26 @@ repositories {
 }
 
 // SourceSet for Kotlin DSL code so that it can be built after the main SourceSet
-val dsl by sourceSets.registering
+val dsl: SourceSet by sourceSets.creating
 sourceSets {
-	dsl {
+	dsl.apply {
 		compileClasspath += main.get().output
 		runtimeClasspath += main.get().output
 	}
 	test {
-		compileClasspath += dsl.get().output
-		runtimeClasspath += dsl.get().output
+		compileClasspath += dsl.output
+		runtimeClasspath += dsl.output
 	}
 }
 
 configurations {
-	val dslCompileOnly by existing
-	dslCompileOnly {
+	dsl.compileOnlyConfigurationName {
 		extendsFrom(compileOnly.get())
 	}
-	val dslImplementation by existing
-	dslImplementation {
+	dsl.implementationConfigurationName {
 		extendsFrom(implementation.get())
 	}
-	val dslRuntimeOnly by existing
-	dslRuntimeOnly {
+	dsl.runtimeOnlyConfigurationName {
 		extendsFrom(runtimeOnly.get())
 	}
 }
@@ -78,6 +75,8 @@ dependencies {
 	implementation("biz.aQute.bnd:biz.aQute.repository:${version}")
 	implementation("biz.aQute.bnd:biz.aQute.resolve:${version}")
 	runtimeOnly("biz.aQute.bnd:biz.aQute.bnd.embedded-repo:${version}")
+	testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
 }
 
@@ -209,17 +208,17 @@ tasks.withType<Javadoc>().configureEach {
 
 tasks.pluginUnderTestMetadata {
 	// Include dsl SourceSet
-	pluginClasspath.from(dsl.get().output)
+	pluginClasspath.from(dsl.output)
 }
 
 tasks.jar {
 	// Include dsl SourceSet
-	from(dsl.get().output)
+	from(dsl.output)
 }
 
 tasks.named<Jar>("sourcesJar") {
 	// Include dsl SourceSet
-	from(dsl.get().allSource)
+	from(dsl.allSource)
 }
 
 val testresourcesOutput = layout.buildDirectory.dir("testresources")

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -1,5 +1,6 @@
 package aQute.bnd.gradle;
 
+import static aQute.bnd.gradle.BndUtils.isGradleCompatible;
 import static aQute.bnd.gradle.BndUtils.jarLibraryElements;
 import static aQute.bnd.gradle.BndUtils.logReport;
 import static aQute.bnd.gradle.BndUtils.sourceSets;
@@ -58,7 +59,6 @@ import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePluginExtension;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.HelpTasksPlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -300,10 +300,11 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					@SuppressWarnings("deprecation")
-					Convention sourceSetConvention = new DslObject(sourceSet).getConvention();
-					sourceSetConvention.getPlugins()
-						.forEach((name, plugin) -> {
+					if (!isGradleCompatible("8.0")) { // only for pre 8.0
+						@SuppressWarnings("deprecation")
+						Map<String, Object> plugins = new DslObject(sourceSet).getConvention()
+							.getPlugins();
+						plugins.forEach((name, plugin) -> {
 							if (!sourceDirectorySets.containsKey(name)) {
 								Object sds = getter(plugin, name);
 								if (sds instanceof SourceDirectorySet sourceDirectorySet) {
@@ -311,6 +312,7 @@ public class BndPlugin implements Plugin<Project> {
 								}
 							}
 						});
+					}
 					Provider<Directory> destinationDir = sourceSet.getJava()
 						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
@@ -347,10 +349,11 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					@SuppressWarnings("deprecation")
-					Convention sourceSetConvention = new DslObject(sourceSet).getConvention();
-					sourceSetConvention.getPlugins()
-						.forEach((name, plugin) -> {
+					if (!isGradleCompatible("8.0")) { // only for pre 8.0
+						@SuppressWarnings("deprecation")
+						Map<String, Object> plugins = new DslObject(sourceSet).getConvention()
+							.getPlugins();
+						plugins.forEach((name, plugin) -> {
 							if (!sourceDirectorySets.containsKey(name)) {
 								Object sds = getter(plugin, name);
 								if (sds instanceof SourceDirectorySet sourceDirectorySet) {
@@ -358,6 +361,7 @@ public class BndPlugin implements Plugin<Project> {
 								}
 							}
 						});
+					}
 					Provider<Directory> destinationDir = sourceSet.getJava()
 						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask1/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 jar {
 	manifest {
-		attributes('Implementation-Title': project.archivesBaseName,
+		attributes('Implementation-Title': base.archivesName,
 		'Implementation-Version': project.version,
 		'-includeresource': '{bar.txt}',
 		'-include': 'other.bnd',

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask2/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask2/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = 'biz.aQute.bnd'
-archivesBaseName = 'biz.aQute.bndlib'
+base.archivesName = 'biz.aQute.bndlib'
 version = '3.1.0'
 
 jar {

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask4/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/baselinetask4/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 jar {
 	manifest {
-		attributes('Implementation-Title': project.archivesBaseName,
+		attributes('Implementation-Title': base.archivesName,
 		'Implementation-Version': project.version,
 		'-includeresource': '{bar.txt}',
 		'-include': 'other.bnd',

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin1/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 jar {
 	ext.taskprop = 'prop.task'
 	manifest {
-		attributes('Implementation-Title': providers.provider({ -> project.archivesBaseName}),
+		attributes('Implementation-Title': base.archivesName,
 		'Implementation-Version': project.version,
 		'-includeresource': '{${.}/bar.txt}',
 		'-include': '${.}/other.bnd',

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin3/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin3/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 tasks.jar {
 	val taskprop by extra("prop.task")
 	manifest {
-		attributes(mapOf("Implementation-Title" to project.base.archivesBaseName,
+		attributes(mapOf("Implementation-Title" to base.archivesName,
 		"Implementation-Version" to project.version,
 		"-includeresource" to "{\${.}/bar.txt}",
 		"-include" to "\${.}/other.bnd",

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin4/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/builderplugin4/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 def jar = tasks.named('jar') {
 	manifest {
-		attributes('Implementation-Title': project.archivesBaseName,
+		attributes('Implementation-Title': base.archivesName,
 		'Implementation-Version': project.version,
 		'-includeresource': '{${.}/bar.txt}',
 		'-include': '${.}/other.bnd',

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/indexplugin1/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 jar {
 	ext.taskprop = 'prop.task'
 	manifest {
-		attributes('Implementation-Title': project.archivesBaseName,
+		attributes('Implementation-Title': base.archivesName,
 		'Implementation-Version': project.version,
 		'-includeresource': '{${.}/bar.txt}',
 		'-include': '${.}/other.bnd',
@@ -38,7 +38,7 @@ jar {
 task bundle(type: Bundle) {
 	description = 'Bundle'
 	from sourceSets.test.output
-	archiveBaseName = "${project.archivesBaseName}_bundle"
+	archiveBaseName = base.archivesName.map { "${it}_bundle" }
 	bundle {
 		bnd = '''
 -exportcontents: doubler.impl
@@ -69,7 +69,7 @@ artifacts {
 task indexer(type: Index) {
 	description = 'Indexer'
 	repositoryName = project.name
-	bundles fileTree(destinationDirectory.dir(libsDirName)) {
+	bundles fileTree(destinationDirectory.dir('libs')) {
 		include '**/*.jar'
 		exclude '**/*-latest.jar'
 		exclude '**/*-sources.jar'

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/testosgitask1/build.gradle
@@ -10,8 +10,10 @@ plugins {
 }
 
 version = '1.0.0'
-sourceCompatibility = '17'
-targetCompatibility = '17'
+java {
+	sourceCompatibility = '17'
+	targetCompatibility = '17'
+}
 
 repositories {
 	mavenLocal().metadataSources { mavenPom(); artifact() }


### PR DESCRIPTION
We cannot currently use Gradle 8.2 in the build due to https://github.com/gradle/gradle/issues/25609. The gradle plugin build requires no warnings (`--warning-mode=fail`). Once that fix is released, we can update the build to the fixed Gradle release.