### PR TITLE
Maven release archive option

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1727,6 +1727,7 @@ public class Project extends Processor {
 
 	private void install(RepositoryPlugin repo, Processor context, File f, Attrs value) throws Exception {
 		try (Processor p = new Processor(context)) {
+			p.use(context);
 			p.getProperties()
 				.putAll(value);
 			PutOptions options = new PutOptions();
@@ -1736,6 +1737,7 @@ public class Project extends Processor {
 			} catch (Exception e) {
 				exception(e, "Cannot install %s into %s because %s", f, repo.getName(), e);
 			}
+			context.getInfo(p, f.getName() + ":");
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1727,7 +1727,7 @@ public class Project extends Processor {
 
 	private void install(RepositoryPlugin repo, Processor context, File f, Attrs value) throws Exception {
 		try (Processor p = new Processor(context)) {
-			p.use(context);
+			p.setBase(context.getBase());
 			p.getProperties()
 				.putAll(value);
 			PutOptions options = new PutOptions();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -418,6 +418,7 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		setTrace(reporter.isTrace());
 		setExceptions(reporter.isExceptions());
 		setFailOk(reporter.isFailOk());
+		setBase(reporter.getBase());
 	}
 
 	public static File getFile(File base, String file) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -418,7 +418,6 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		setTrace(reporter.isTrace());
 		setExceptions(reporter.isExceptions());
 		setFailOk(reporter.isFailOk());
-		setBase(reporter.getBase());
 	}
 
 	public static File getFile(File base, String file) {

--- a/docs/_instructions/maven-release.md
+++ b/docs/_instructions/maven-release.md
@@ -12,7 +12,7 @@ Though this instruction is not specific for a plugin, it was developed in conjun
 
     -maven-release ::= ( 'local'|'remote' ( ';' snapshot )? ) ( ',' option )*
     snapshot       ::= <value to be used for timestamp>
-    option         ::= sources | javadoc | pom | sign | extra*
+    option         ::= sources | javadoc | pom | sign | archive*
     archive          ::= 'archive' 
                        ( ';path=' ( PATH | '{' PATH '}' )?
                        ( ';classifier=' maven-classifier )?


### PR DESCRIPTION
The archive option used the context given in the RepositoryPlugin.put
as the base processor. This is true for the release process but
the `-buildrepo` option had a special install method in Project. This
method created a processor per file. This copied processor did 
not have the same file base nor did it collect the warnings and
errors.