### PR TITLE
Fix MojoExecutionException in m2e plugin when using maven-jar-plugin 3.x

### DIFF
--- a/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
@@ -304,6 +304,7 @@ public class BndConfigurator extends ServiceAwareM2EConfigurator {
 		projectRegistry.execute(projectFacade, (context1, monitor1) -> {
 			SubMonitor progress = SubMonitor.convert(monitor1);
 			MavenProject mavenProject = getMavenProject(projectFacade, progress.split(1));
+			mavenProject.getArtifact().setFile(null);
 
 			List<MojoExecution> mojoExecutions = null;
 			if (!isTest) {


### PR DESCRIPTION
This PR prevents MojoExecutionExceptions when using the bndtools m2e plugin and maven-jar-plugin 3.x.

The exception occurs when saving files when "Build Automatically" is enabled. The first automatic build after saving the file works fine. On subsequent builds the artifact is set which causes the following exception to be thrown:

```
!SUBENTRY 1 org.eclipse.m2e.core 4 0 2023-09-09 13:30:47.366
!MESSAGE Failed to execute mojo org.apache.maven.plugins:maven-jar-plugin:3.3.0:jar {execution: default-jar}
!STACK 0
org.apache.maven.plugin.MojoExecutionException: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them.
	at org.apache.maven.plugins.jar.AbstractJarMojo.execute(AbstractJarMojo.java:315)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:126)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeMojo(MavenExecutionContext.java:338)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.lambda$0(MavenExecutionContext.java:291)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:394)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:228)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:290)
	at bndtools.m2e.BndConfigurator.lambda$execJarMojo$2(BndConfigurator.java:323)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:394)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:228)
	at org.eclipse.m2e.core.internal.project.registry.MavenProjectManager.lambda$0(MavenProjectManager.java:141)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:394)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:275)
	at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:214)
	at org.eclipse.m2e.core.internal.project.registry.MavenProjectManager.execute(MavenProjectManager.java:140)
	at bndtools.m2e.BndConfigurator.execJarMojo(BndConfigurator.java:304)
	at bndtools.m2e.BndConfigurator$1$1.runInWorkspace(BndConfigurator.java:188)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:43)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

See also:

* MJAR-198: https://issues.apache.org/jira/browse/MJAR-198
* AbstractJarMojo: https://github.com/apache/maven-jar-plugin/blob/2860c8b4b745a2f211b69df4c225fd7081ce9d61/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java#L298-L301