### PR TITLE
use VersionRange when adding bundle to Run Bundles

### DIFF
--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -9,19 +9,32 @@ import aQute.bnd.version.Version;
 import aQute.bnd.version.VersionRange;
 
 public class RepositoryBundleUtils {
-	private static final String VERSION_LATEST = "latest";
 
+	/**
+	 * Converts a RepositoryBundle into a versionioned clause. There are 2
+	 * cases: a) If the bundle comes from a workspace repository, then
+	 * bsn;version=snapshot is returned. b) Otherwise only the bsn without a
+	 * version is returned.
+	 *
+	 * @param bundle
+	 * @return a version as described above
+	 */
 	public static VersionedClause convertRepoBundle(RepositoryBundle bundle) {
 		Attrs attribs = new Attrs();
 		if (RepoUtils.isWorkspaceRepo(bundle.getRepo())) {
-			attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
+			attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
 		}
 		return new VersionedClause(bundle.getBsn(), attribs);
 	}
 
 	/**
 	 * Converts a RepositoryBundleVersion into a version or version range. e.g.
-	 * version='latest' or version='[1.2.3,1.2.4)'.
+	 * version='snapshot' or version='[1.2.3,1.2.4)'. version=snapshot means the
+	 * Version build in your workspace. We use version=snapshot instead of
+	 * version=latest, because version=latest is the highest version found.
+	 * Usually the workspace holds the latest Version. It is possible though,
+	 * that you may have a newer Version of one of the projects in your
+	 * workspace in one of your repositories.
 	 *
 	 * @param bundleVersion
 	 * @param phase
@@ -32,7 +45,7 @@ public class RepositoryBundleUtils {
 		Attrs attribs = new Attrs();
 		if (RepoUtils.isWorkspaceRepo(bundleVersion.getParentBundle()
 			.getRepo()))
-			attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
+			attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
 		else {
 
 			if (phase == DependencyPhase.Build) {

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -41,8 +41,10 @@ public class RepositoryBundleUtils {
 				// where only a Major.minor version should be inserted e.g.
 				// version='1.24'
 
-				String majorMinor = bundleVersion.getVersion() + "." + bundleVersion.getVersion()
-					.getMinor();
+				String majorMinor = bundleVersion.getVersion()
+					.getMajor() + "."
+					+ bundleVersion.getVersion()
+						.getMinor();
 				attribs.put(Constants.VERSION_ATTRIBUTE, majorMinor);
 
 			} else {

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -5,6 +5,8 @@ import org.bndtools.utils.repos.RepoUtils;
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.osgi.Constants;
+import aQute.bnd.version.Version;
+import aQute.bnd.version.VersionRange;
 
 public class RepositoryBundleUtils {
 	private static final String VERSION_LATEST = "latest";
@@ -17,6 +19,14 @@ public class RepositoryBundleUtils {
 		return new VersionedClause(bundle.getBsn(), attribs);
 	}
 
+	/**
+	 * Converts a RepositoryBundleVersion into a version or version range. e.g.
+	 * version='latest' or version='[1.2.3,2.0.0)'.
+	 *
+	 * @param bundleVersion
+	 * @param phase
+	 * @return a version or version range.
+	 */
 	public static VersionedClause convertRepoBundleVersion(RepositoryBundleVersion bundleVersion,
 		DependencyPhase phase) {
 		Attrs attribs = new Attrs();
@@ -24,6 +34,7 @@ public class RepositoryBundleUtils {
 			.getRepo()))
 			attribs.put(Constants.VERSION_ATTRIBUTE, VERSION_LATEST);
 		else {
+
 			StringBuilder builder = new StringBuilder();
 
 			builder.append(bundleVersion.getVersion()
@@ -31,12 +42,32 @@ public class RepositoryBundleUtils {
 			builder.append('.')
 				.append(bundleVersion.getVersion()
 					.getMinor());
+
+			// TODO why is this check?
 			if (phase != DependencyPhase.Build)
 				builder.append('.')
 					.append(bundleVersion.getVersion()
 						.getMicro());
 
-			attribs.put(Constants.VERSION_ATTRIBUTE, builder.toString());
+
+			// #5816 create a range from the given version up to the next major
+			// as in
+			// version='[1.2.3,2.0.0)'
+			// instead of version='1.2.3' because the latter is actually an open
+			// range meaning "1.2.3 and everything above" (see
+			// https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#d0e2221).
+			// This could surprise developers, as version='1.2.3' looks more
+			// like a exact version match.
+			// Thus we create a more limited range from the given version 1.2.3
+			// `up to the next major version
+			// this behavior is similar to what the resolver is inserting into
+			// the run bundles list.
+			Version l = new Version(builder.toString());
+			Version h = l.bumpMajor();
+			VersionRange vr = new VersionRange(true, l, h, false);
+			String range = vr.toString();
+
+			attribs.put(Constants.VERSION_ATTRIBUTE, range);
 		}
 		return new VersionedClause(bundleVersion.getParentBundle()
 			.getBsn(), attribs);

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -21,7 +21,7 @@ public class RepositoryBundleUtils {
 
 	/**
 	 * Converts a RepositoryBundleVersion into a version or version range. e.g.
-	 * version='latest' or version='[1.2.3,2.0.0)'.
+	 * version='latest' or version='[1.2.3,1.2.4)'.
 	 *
 	 * @param bundleVersion
 	 * @param phase
@@ -52,9 +52,9 @@ public class RepositoryBundleUtils {
 				// this code gets executed in the .bndrun editor
 				// when adding a version (e.g by drag&drop) to the -runbundles
 				// panel
-				// create a range from the given version up to the next major
+				// create a range from the given version up to the next micro
 				// as in
-				// version='[1.2.3,2.0.0)'
+				// version='[1.2.3,1.2.4)'
 				// instead of version='1.2.3' because the latter is actually an
 				// open
 				// range meaning "1.2.3 and everything above" (see
@@ -63,11 +63,11 @@ public class RepositoryBundleUtils {
 				// like a exact version match.
 				// Thus we create a more limited range from the given version
 				// 1.2.3
-				// `up to the next major version
+				// `up to the next micro version
 				// this behavior is similar to what the resolver is inserting
 				// into
 				// the run bundles list.
-				String range = toVersionRangeUpToNextMajor(bundleVersion.getVersion()).toString();
+				String range = toVersionRangeUpToNextMicro(bundleVersion.getVersion()).toString();
 				attribs.put(Constants.VERSION_ATTRIBUTE, range);
 			}
 
@@ -76,9 +76,10 @@ public class RepositoryBundleUtils {
 			.getBsn(), attribs);
 	}
 
-	private static VersionRange toVersionRangeUpToNextMajor(Version l) {
-		Version h = l.bumpMajor();
-		return new VersionRange(true, l, h, false);
+	private static VersionRange toVersionRangeUpToNextMicro(Version l) {
+		// bumpMicro
+		Version h = new Version(l.getMajor(), l.getMinor(), l.getMicro() + 1);
+		return new VersionRange(true, l.getWithoutQualifier(), h, false);
 	}
 
 }


### PR DESCRIPTION
Related to #5816 

This PR changes the behaviour of the .bndrun Editor when adding a bundle from a Repo to the Run Bundles panel,
a) via drag&drop
b) via the +-Button in the Run Bundles panel

The goal is that a version-range is used from the bundleVersion (inclusive) to the next major version (exclusive)

Before this change:
- bundle was added like `org.apache.felix.scr;version='2.2.2'` (which means "[2.2.2 and everything above](https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#d0e2221)", which could be surprising, as it looks like an exact version match if you don't know the spec)

After this change:
- bundle gets added like org.apache.felix.scr;version='[2.2.2,3.0.0)'

<img width="650" alt="image" src="https://github.com/bndtools/bnd/assets/188422/157bf109-aa2d-4e83-91e3-2fea198b05f3">

<img width="755" alt="image" src="https://github.com/bndtools/bnd/assets/188422/e9124ae7-098e-4863-9c08-a4a18641b6b3">

Gets added as this.
<img width="286" alt="image" src="https://github.com/bndtools/bnd/assets/188422/1c98fe44-01c4-4a28-a516-a04f34044a9f">



Now it looks similar to what happens in the Run Requirements:
`bnd.identity;id='org.apache.felix.gogo.runtime';version='[1.1.0,2.0.0)'`

<img width="656" alt="image" src="https://github.com/bndtools/bnd/assets/188422/e738eabf-e6ee-4795-ac1d-4c563194f694">
