### PR TITLE
[bndlib] Add mutator methods for -runbundles+ to BndEditModel

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -866,6 +866,15 @@ public class BndEditModel {
 		doSetObject(Constants.RUNBUNDLES, oldValue, paths, headerClauseListFormatter);
 	}
 
+	public List<VersionedClause> getRunBundlesDecorator() {
+		return doGetObject(aQute.bnd.osgi.Constants.RUNBUNDLES_DECORATOR, clauseListConverter);
+	}
+
+	public void setRunBundlesDecorator(List<? extends VersionedClause> paths) {
+		List<VersionedClause> oldValue = getRunBundlesDecorator();
+		doSetObject(aQute.bnd.osgi.Constants.RUNBUNDLES_DECORATOR, oldValue, paths, headerClauseListFormatter);
+	}
+
 	public boolean isIncludedPackage(String packageName) {
 		final Collection<String> privatePackages = getPrivatePackages();
 		if (privatePackages != null) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
@@ -1,4 +1,4 @@
-@Version("4.3.0")
+@Version("4.4.0")
 package aQute.bnd.build.model;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -241,6 +241,7 @@ public interface Constants {
 	String		RUNPROVIDEDCAPABILITIES						= "-runprovidedcapabilities";
 
 	String		RUNBUNDLES									= "-runbundles";
+	String		RUNBUNDLES_DECORATOR						= RUNBUNDLES + "+";
 	String		RUNBUNDLES_STARTLEVEL_ATTRIBUTE				= "startlevel";
 
 	String		RUNSTARTLEVEL								= "-runstartlevel";


### PR DESCRIPTION
For completeness, added missing mutator methods to the `BndEditModel` (I needed these for something else I'm working on).