### PR TITLE
handle drag/drop/adding to -runrequires

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
+++ b/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
@@ -47,6 +47,7 @@ import bndtools.editor.common.BndEditorPart;
 import bndtools.model.repo.DependencyPhase;
 import bndtools.model.repo.ProjectBundle;
 import bndtools.model.repo.RepositoryBundle;
+import bndtools.model.repo.RepositoryBundleUtils;
 import bndtools.model.repo.RepositoryBundleVersion;
 import bndtools.preferences.BndPreferences;
 import bndtools.wizards.repo.RepoBundleSelectionWizard;
@@ -166,7 +167,7 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 	private void doAddBundle() {
 		try {
 			RepoBundleSelectionWizard wizard = new RepoBundleSelectionWizard(new ArrayList<VersionedClause>(),
-				DependencyPhase.Run);
+				DependencyPhase.Req);
 			wizard.setSelectionPageTitle(getAddButtonLabel());
 			WizardDialog dialog = new WizardDialog(getSection().getShell(), wizard);
 
@@ -267,7 +268,7 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 		} else if (elem instanceof RepositoryBundleVersion) {
 			RepositoryBundleVersion rbv = (RepositoryBundleVersion) elem;
 			bsn = rbv.getBsn();
-			versionRange = rbv.getVersion()
+			versionRange = RepositoryBundleUtils.toVersionRangeUpToNextMajor(rbv.getVersion())
 				.toString();
 		} else if (elem instanceof ProjectBundle) {
 			bsn = ((ProjectBundle) elem).getBsn();

--- a/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
@@ -279,7 +279,8 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 				while (iterator.hasNext()) {
 					Object item = iterator.next();
 					if (item instanceof RepositoryBundle) {
-						VersionedClause newClause = RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item);
+						VersionedClause newClause = RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item,
+							phase);
 						adding.add(newClause);
 					} else if (item instanceof RepositoryBundleVersion) {
 						RepositoryBundleVersion bundleVersion = (RepositoryBundleVersion) item;

--- a/bndtools.core/src/bndtools/model/repo/DependencyPhase.java
+++ b/bndtools.core/src/bndtools/model/repo/DependencyPhase.java
@@ -1,6 +1,25 @@
 package bndtools.model.repo;
 
+/**
+ * This enum is used to describe the phase in which a dependency (e.g.
+ * repobundle, repobundleversion) is used. This is usually used to distinguish
+ * between wether a dependecy is added to -runrequires / -runbundles of a
+ * .bndrun or -buildpath of a bnd.bnd file.
+ */
 public enum DependencyPhase {
+	/**
+	 * e.g. adding a bundle / bundleversion to the -runrequires section of a
+	 * bnd.bnd file
+	 */
+	Req,
+	/**
+	 * e.g. adding a bundle / bundleversion to the -buildpath section of a
+	 * bnd.bnd file
+	 */
 	Build,
+	/**
+	 * e.g. adding a bundle / bundleversion to -runbundles section of a .bndrun
+	 * file
+	 */
 	Run
 }

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -22,12 +22,22 @@ public class RepositoryBundleUtils {
 	 * version is returned.
 	 *
 	 * @param bundle
+	 * @param phase
 	 * @return a version as described above
 	 */
-	public static VersionedClause convertRepoBundle(RepositoryBundle bundle) {
+	public static VersionedClause convertRepoBundle(RepositoryBundle bundle, DependencyPhase phase) {
 		Attrs attribs = new Attrs();
 		if (RepoUtils.isWorkspaceRepo(bundle.getRepo())) {
-			attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
+
+			if (phase == DependencyPhase.Req) {
+
+				// -runrequires: For the generic bsn name -> no version.
+				attribs.put(Constants.VERSION_ATTRIBUTE, null);
+			} else {
+				// for -runbundles and -buildpath we want 'snapshot'
+				attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
+			}
+
 		}
 		return new VersionedClause(bundle.getBsn(), attribs);
 	}
@@ -49,8 +59,18 @@ public class RepositoryBundleUtils {
 		DependencyPhase phase) {
 		Attrs attribs = new Attrs();
 		if (RepoUtils.isWorkspaceRepo(bundleVersion.getParentBundle()
-			.getRepo()))
-			attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
+			.getRepo())) {
+
+			if (phase == DependencyPhase.Req) {
+
+				// -runrequires: For the generic bsn name -> no version.
+				attribs.put(Constants.VERSION_ATTRIBUTE, null);
+			} else {
+				// for -runbundles and -buildpath we want 'snapshot'
+				attribs.put(Constants.VERSION_ATTRIBUTE, Constants.VERSION_ATTR_SNAPSHOT);
+			}
+
+		}
 		else {
 
 			if (phase == DependencyPhase.Build) {

--- a/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
+++ b/bndtools.core/src/bndtools/wizards/repo/RepoBundleSelectionWizardPage.java
@@ -288,7 +288,7 @@ public class RepoBundleSelectionWizardPage extends WizardPage {
 		for (Iterator<?> iter = selection.iterator(); iter.hasNext();) {
 			Object item = iter.next();
 			if (item instanceof RepositoryBundle) {
-				adding.add(RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item));
+				adding.add(RepositoryBundleUtils.convertRepoBundle((RepositoryBundle) item, phase));
 			} else if (item instanceof RepositoryBundleVersion) {
 				adding.add(RepositoryBundleUtils.convertRepoBundleVersion((RepositoryBundleVersion) item, phase));
 			} else if (item instanceof ProjectBundle) {

--- a/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
+++ b/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
@@ -1,0 +1,91 @@
+package bndtools.wizards.repo;
+
+import static aQute.bnd.version.VersionRange.parseVersionRange;
+import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundle;
+import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundleVersion;
+import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMajor;
+import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMicro;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import aQute.bnd.build.WorkspaceRepository;
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.version.Version;
+import bndtools.model.repo.DependencyPhase;
+import bndtools.model.repo.RepositoryBundle;
+import bndtools.model.repo.RepositoryBundleVersion;
+
+/**
+ * Tests behavior involved when dragging / dropping / adding repobundles to
+ * -runbundles, -runrequires in the UI e.g. .bndrun editor. In these cases a
+ * simple bsn or bsn+version needs to be converted to a range (or not). This
+ * test tests the different combinations. e.g.
+ * <ul>
+ * <li>foo.bundle.bar v1.2.3 -> foo.bundle.bar;version=[1.2.3,1.2.4] (micro
+ * version increment)</li>
+ * <li>foo.bundle.bar v1.2.3 -> foo.bundle.bar;version=[1.2.3,2.0.0] (major
+ * version increment)</li>
+ * </ul>
+ */
+public class RepoBundleVersionToRangeTest {
+
+	@Test
+	public void testVersionToVersionRanges() {
+		assertEquals(parseVersionRange("[1.2.3,1.2.4)").toString(),
+			toVersionRangeUpToNextMicro(Version.valueOf("1.2.3")).toString());
+
+		assertEquals(parseVersionRange("[1.2.3,2.0.0)").toString(),
+			toVersionRangeUpToNextMajor(Version.valueOf("1.2.3")).toString());
+
+	}
+
+	@Test
+	public void testVersionClauseConvertersWithNonWorkspaceRepo() {
+
+		RepositoryPlugin nonWorkspaceRepo = mock(RepositoryPlugin.class);
+		RepositoryBundle rb = new RepositoryBundle(nonWorkspaceRepo, "foo.bundle.bar");
+		RepositoryBundleVersion rbv = new RepositoryBundleVersion(rb, Version.valueOf("1.2.3"));
+
+		assertNull(convertRepoBundle(rb)
+			.getVersionRange());
+
+		// adding to -runrequires
+		assertEquals("[1.2.3,2.0.0)", convertRepoBundleVersion(rbv, DependencyPhase.Req)
+			.getVersionRange());
+
+		// adding to -runbundles
+		assertEquals("[1.2.3,1.2.4)", convertRepoBundleVersion(rbv, DependencyPhase.Run)
+			.getVersionRange());
+
+		assertEquals("1.2", convertRepoBundleVersion(rbv, DependencyPhase.Build)
+			.getVersionRange());
+
+	}
+
+	@Test
+	public void testVersionClauseConvertersWithWorkspaceRepo() {
+
+		RepositoryPlugin wsrepo = new WorkspaceRepository(null);
+		RepositoryBundle rb = new RepositoryBundle(wsrepo, "foo.bundle.bar");
+		RepositoryBundleVersion rbv = new RepositoryBundleVersion(rb, Version.valueOf("1.2.3"));
+
+		assertEquals("snapshot", convertRepoBundle(rb)
+			.getVersionRange());
+
+		// adding to -runrequires
+		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Req)
+			.getVersionRange());
+
+		// adding to -runbundles
+		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Run)
+			.getVersionRange());
+
+		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Build)
+			.getVersionRange());
+
+	}
+
+}

--- a/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
+++ b/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
@@ -1,11 +1,13 @@
 package bndtools.wizards.repo;
 
 import static aQute.bnd.version.VersionRange.parseVersionRange;
+import static bndtools.model.repo.DependencyPhase.Build;
+import static bndtools.model.repo.DependencyPhase.Req;
+import static bndtools.model.repo.DependencyPhase.Run;
 import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundle;
 import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundleVersion;
 import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMajor;
 import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMicro;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -14,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import aQute.bnd.build.WorkspaceRepository;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
-import bndtools.model.repo.DependencyPhase;
 import bndtools.model.repo.RepositoryBundle;
 import bndtools.model.repo.RepositoryBundleVersion;
 
@@ -49,19 +50,21 @@ public class RepoBundleVersionToRangeTest {
 		RepositoryBundle rb = new RepositoryBundle(nonWorkspaceRepo, "foo.bundle.bar");
 		RepositoryBundleVersion rbv = new RepositoryBundleVersion(rb, Version.valueOf("1.2.3"));
 
-		assertNull(convertRepoBundle(rb)
-			.getVersionRange());
+		// test repobundle (root node in the repo browser... just the bsn,
+		// without version)
+		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Req).toString());
+		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Run).toString());
+		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Build).toString());
+
 
 		// adding to -runrequires
-		assertEquals("[1.2.3,2.0.0)", convertRepoBundleVersion(rbv, DependencyPhase.Req)
-			.getVersionRange());
+		assertEquals("foo.bundle.bar;version='[1.2.3,2.0.0)'", convertRepoBundleVersion(rbv, Req).toString());
 
 		// adding to -runbundles
-		assertEquals("[1.2.3,1.2.4)", convertRepoBundleVersion(rbv, DependencyPhase.Run)
-			.getVersionRange());
+		assertEquals("foo.bundle.bar;version='[1.2.3,1.2.4)'", convertRepoBundleVersion(rbv, Run).toString());
 
-		assertEquals("1.2", convertRepoBundleVersion(rbv, DependencyPhase.Build)
-			.getVersionRange());
+		// adding to -buildpath
+		assertEquals("foo.bundle.bar;version='1.2'", convertRepoBundleVersion(rbv, Build).toString());
 
 	}
 
@@ -72,19 +75,18 @@ public class RepoBundleVersionToRangeTest {
 		RepositoryBundle rb = new RepositoryBundle(wsrepo, "foo.bundle.bar");
 		RepositoryBundleVersion rbv = new RepositoryBundleVersion(rb, Version.valueOf("1.2.3"));
 
-		assertEquals("snapshot", convertRepoBundle(rb)
-			.getVersionRange());
+		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Req).toString());
+		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundle(rb, Run).toString());
+		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundle(rb, Build).toString());
 
 		// adding to -runrequires
-		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Req)
-			.getVersionRange());
+		assertEquals("foo.bundle.bar", convertRepoBundleVersion(rbv, Req).toString());
 
 		// adding to -runbundles
-		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Run)
-			.getVersionRange());
+		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundleVersion(rbv, Run).toString());
 
-		assertEquals("snapshot", convertRepoBundleVersion(rbv, DependencyPhase.Build)
-			.getVersionRange());
+		// adding to -buildpath
+		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundleVersion(rbv, Build).toString());
 
 	}
 

--- a/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
+++ b/bndtools.core/test/bndtools/wizards/repo/RepoBundleVersionToRangeTest.java
@@ -8,10 +8,13 @@ import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundle;
 import static bndtools.model.repo.RepositoryBundleUtils.convertRepoBundleVersion;
 import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMajor;
 import static bndtools.model.repo.RepositoryBundleUtils.toVersionRangeUpToNextMicro;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import aQute.bnd.build.WorkspaceRepository;
 import aQute.bnd.service.RepositoryPlugin;
@@ -31,15 +34,25 @@ import bndtools.model.repo.RepositoryBundleVersion;
  * version increment)</li>
  * </ul>
  */
+@ExtendWith(SoftAssertionsExtension.class)
 public class RepoBundleVersionToRangeTest {
+
+	@InjectSoftAssertions
+	SoftAssertions softly;
 
 	@Test
 	public void testVersionToVersionRanges() {
-		assertEquals(parseVersionRange("[1.2.3,1.2.4)").toString(),
-			toVersionRangeUpToNextMicro(Version.valueOf("1.2.3")).toString());
+		softly.assertThat(toVersionRangeUpToNextMicro(Version.valueOf("1.2.3")).toString())
+			.isEqualTo("[1.2.3,1.2.4)");
 
-		assertEquals(parseVersionRange("[1.2.3,2.0.0)").toString(),
-			toVersionRangeUpToNextMajor(Version.valueOf("1.2.3")).toString());
+		softly.assertThat(toVersionRangeUpToNextMajor(Version.valueOf("1.2.3")).toString())
+			.isEqualTo("[1.2.3,2.0.0)");
+
+		softly.assertThat(toVersionRangeUpToNextMicro(Version.valueOf("1.2.3")).toString())
+			.isEqualTo(parseVersionRange("[1.2.3,1.2.4)").toString());
+
+		softly.assertThat(toVersionRangeUpToNextMajor(Version.valueOf("1.2.3")).toString())
+			.isEqualTo(parseVersionRange("[1.2.3,2.0.0)").toString());
 
 	}
 
@@ -52,19 +65,25 @@ public class RepoBundleVersionToRangeTest {
 
 		// test repobundle (root node in the repo browser... just the bsn,
 		// without version)
-		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Req).toString());
-		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Run).toString());
-		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Build).toString());
+		softly.assertThat(convertRepoBundle(rb, Req).toString())
+			.isEqualTo("foo.bundle.bar");
+		softly.assertThat(convertRepoBundle(rb, Run).toString())
+			.isEqualTo("foo.bundle.bar");
+		softly.assertThat(convertRepoBundle(rb, Build).toString())
+			.isEqualTo("foo.bundle.bar");
 
 
 		// adding to -runrequires
-		assertEquals("foo.bundle.bar;version='[1.2.3,2.0.0)'", convertRepoBundleVersion(rbv, Req).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Req).toString())
+			.isEqualTo("foo.bundle.bar;version='[1.2.3,2.0.0)'");
 
 		// adding to -runbundles
-		assertEquals("foo.bundle.bar;version='[1.2.3,1.2.4)'", convertRepoBundleVersion(rbv, Run).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Run).toString())
+			.isEqualTo("foo.bundle.bar;version='[1.2.3,1.2.4)'");
 
 		// adding to -buildpath
-		assertEquals("foo.bundle.bar;version='1.2'", convertRepoBundleVersion(rbv, Build).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Build).toString())
+			.isEqualTo("foo.bundle.bar;version='1.2'");
 
 	}
 
@@ -75,18 +94,24 @@ public class RepoBundleVersionToRangeTest {
 		RepositoryBundle rb = new RepositoryBundle(wsrepo, "foo.bundle.bar");
 		RepositoryBundleVersion rbv = new RepositoryBundleVersion(rb, Version.valueOf("1.2.3"));
 
-		assertEquals("foo.bundle.bar", convertRepoBundle(rb, Req).toString());
-		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundle(rb, Run).toString());
-		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundle(rb, Build).toString());
+		softly.assertThat(convertRepoBundle(rb, Req).toString())
+			.isEqualTo("foo.bundle.bar");
+		softly.assertThat(convertRepoBundle(rb, Run).toString())
+			.isEqualTo("foo.bundle.bar;version=snapshot");
+		softly.assertThat(convertRepoBundle(rb, Build).toString())
+			.isEqualTo("foo.bundle.bar;version=snapshot");
 
 		// adding to -runrequires
-		assertEquals("foo.bundle.bar", convertRepoBundleVersion(rbv, Req).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Req).toString())
+			.isEqualTo("foo.bundle.bar");
 
 		// adding to -runbundles
-		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundleVersion(rbv, Run).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Run).toString())
+			.isEqualTo("foo.bundle.bar;version=snapshot");
 
 		// adding to -buildpath
-		assertEquals("foo.bundle.bar;version=snapshot", convertRepoBundleVersion(rbv, Build).toString());
+		softly.assertThat(convertRepoBundleVersion(rbv, Build).toString())
+			.isEqualTo("foo.bundle.bar;version=snapshot");
 
 	}
 


### PR DESCRIPTION
Part 2 of #5816 handling the `-runrequires` part.

The following behavior is handled: Adding a bundle / bundleversion to the `-runrequires` section via Drag&Drop or the `+`-Button Wizard.

1. Adding / dragging a Workspace Bundle
Expected Result: bnd.identity;id='com.my.bundle'

2. Adding / dragging a repo bundle-version (leaf node)
Expected Result: bnd.identity;id='org.apache.felix.logback';version:Version='[1.0.2,2.0.0)'

3. Adding / dragging a repo bundle (root node without version)
Expected Result: bnd.identity;id='org.apache.felix.logback'


## How it looks in the UI

### Run Requirements (version,major) range

**-runrequires drag & drop**

- 1 & 2 are workspace bundles 
- 3 & 4 are Maven repo bundles

<img width="652" alt="image" src="https://github.com/bndtools/bnd/assets/188422/2ec12b37-83c0-4835-a48c-898149415fcf">

**-runrequires via + button**

<img width="841" alt="image" src="https://github.com/bndtools/bnd/assets/188422/81c2cc04-94af-47b8-8bc4-29318ceb056c">

<img width="655" alt="image" src="https://github.com/bndtools/bnd/assets/188422/1174744a-cffd-45ed-96d0-fcf9f9c46854">

```
-runrequires: \
	bnd.identity;id='my.workspacebundle.core',\
	bnd.identity;id='my.workspacebundle.core.apiservices',\
	bnd.identity;id='com.fasterxml.jackson.core.jackson-annotations',\
	bnd.identity;id='com.fasterxml.jackson.core.jackson-core';version='[2.13.4,3.0.0)'
```

### Run Bundles (version,micro) range and 'snapshot' for workspace bundles

and in comparison with -runbundles:

**-runbundles drag & drop**

<img width="549" alt="image" src="https://github.com/bndtools/bnd/assets/188422/61fceef1-3b68-43e3-b8a4-6c767ce1382d">

**-runbundles + Button**

<img width="890" alt="image" src="https://github.com/bndtools/bnd/assets/188422/52de277e-3ef4-40ce-b632-0f9ccb4b42e0">

<img width="654" alt="image" src="https://github.com/bndtools/bnd/assets/188422/a40f98e3-15a5-449c-a3d8-adad320cea0e">

```
-runbundles: \
	my.workspacebundle.core;version=snapshot,\
	my.workspacebundle.core.apiservices;version=snapshot,\
	com.fasterxml.jackson.core.jackson-annotations,\
	com.fasterxml.jackson.core.jackson-core;version='[2.13.4,2.13.5)'

```