### PR TITLE
[bndtools] Update boot delegation directive to find missing SAX parsers

### DIFF
--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -124,7 +124,7 @@
     osgi.console.enable.builtin=false,\
     tester.separatethread=true,\
     osgi.instance.area=${.}/generated/workspace,\
-	org.osgi.framework.bootdelegation='javax.net,javax.management',\
+	org.osgi.framework.bootdelegation='javax.net,javax.management,org.xml.sax,org.xml.sax.helpers,javax.xml,javax.xml.parsers',\
 	bndtools.core.test.dir=${.},\
 	logback.configurationFile=${fileuri;${.}/logback.xml}
 

--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -22,7 +22,7 @@
 	eclipse.product=org.eclipse.sdk.ide,\
 	osgi.console=,\
 	osgi.instance.area.default=../bndtools.test/workspace,\
-	org.osgi.framework.bootdelegation='javax.net,javax.management,javax.net.ssl',\
+	org.osgi.framework.bootdelegation='javax.net,javax.management,org.xml.sax,org.xml.sax.helpers,javax.xml,javax.xml.parsers',\
 	logback.configurationFile=${fileuri;${.}/logback.xml}
 
 # Keep sorted so that we can diff


### PR DESCRIPTION
Noticed some errors when running the test Eclipse instances that were related to being unable to find SAX parsers. Adding the packages to boot delegation seems to fix the problem.