### PR TITLE
Repositories View: MavenRepo: Add more copy to clipboard action menu entries on right click

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/Actionable.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/Actionable.java
@@ -14,7 +14,22 @@ import java.util.Map;
 public interface Actionable {
 	/**
 	 * Return a map with command names (potentially localized) and a Runnable.
-	 * The caller can execute the caller at will.
+	 * The caller can execute the caller at will. Note: The command names can be
+	 * hierarchical using
+	 *
+	 * <pre>
+	 *  ::
+	 * </pre>
+	 *
+	 * (space, double-colon, space) as the delimiter. This can be used by
+	 * callers to build hierarchical menues. The last part of such a
+	 * hierarchical label can be used as the actual label e.g. of a button.
+	 * <h2>Examples</h2>
+	 * <ul>
+	 * <li>Label 1</li>
+	 * <li>Sub Menu :: Label 1 in Submenu</li>
+	 * <li>Sub Menu :: Label 2 in Submenu</li>
+	 * </ul>
 	 *
 	 * @param target the target object, null if commands for the encompassing
 	 *            entity is sought (e.g. the repo itself).

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -832,9 +832,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				return actions.getProgramActions((String) target[0]);
 			case 2 :
 				Archive archive = getArchive(target);
-				String bsn = (String) target[0];
-				Version version = (Version) target[1];
-				return actions.getRevisionActions(archive, bsn, version, registry.getPlugin(Clipboard.class));
+				return actions.getRevisionActions(archive, registry.getPlugin(Clipboard.class));
 			default :
 		}
 		return null;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -68,6 +68,7 @@ import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.Registry;
 import aQute.bnd.service.RegistryPlugin;
 import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.service.clipboard.Clipboard;
 import aQute.bnd.service.maven.PomOptions;
 import aQute.bnd.service.maven.ToDependencyPom;
 import aQute.bnd.service.release.ReleaseBracketingPlugin;
@@ -831,7 +832,9 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				return actions.getProgramActions((String) target[0]);
 			case 2 :
 				Archive archive = getArchive(target);
-				return actions.getRevisionActions(archive);
+				String bsn = (String) target[0];
+				Version version = (Version) target[1];
+				return actions.getRevisionActions(archive, bsn, version, registry.getPlugin(Clipboard.class));
 			default :
 		}
 		return null;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -13,7 +13,6 @@ import org.osgi.util.promise.Promise;
 
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Jar;
-import aQute.bnd.service.Actionable;
 import aQute.bnd.service.clipboard.Clipboard;
 import aQute.bnd.version.Version;
 import aQute.lib.io.IO;
@@ -191,21 +190,6 @@ class RepoActions {
 			clipboard.copy(rev);
 		});
 
-		map.put("Copy tooltip to clipboard", () -> {
-			if (repo instanceof Actionable) {
-				Actionable arepo = repo;
-				try {
-
-					String tooltipContent = arepo.tooltip(bsn, version);
-					if (tooltipContent != null) {
-						clipboard.copy(tooltipContent);
-					}
-				} catch (Exception e) {
-					throw Exceptions.duck(e);
-				}
-			}
-		});
-
 		map.put("Copy Compile Dependecies to clipboard", () -> {
 
 			try {
@@ -220,7 +204,12 @@ class RepoActions {
 					sb.append("\n");
 				}
 
-				clipboard.copy(sb.toString());
+				String content = sb.toString();
+				if (content.isEmpty()) {
+					clipboard.copy("-- No Compile Dependencies found --");
+				} else {
+					clipboard.copy(content);
+				}
 
 			} catch (Exception e) {
 				throw Exceptions.duck(e);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -184,13 +184,13 @@ class RepoActions {
 	private static final void addCopyToClipboardActions(MavenBndRepository repo, final Archive archive,
 		Clipboard clipboard, Map<String, Runnable> map) {
 
-		map.put("Copy GAV to clipboard", () -> {
+		map.put("Copy to clipboard :: Copy GAV to clipboard", () -> {
 			String rev = archive.getRevision()
 				.toString();
 			clipboard.copy(rev);
 		});
 
-		map.put("Copy Compile Dependecies to clipboard", () -> {
+		map.put("Copy to clipboard :: Copy Compile Dependecies to clipboard", () -> {
 
 			try {
 				StringBuilder sb = new StringBuilder();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -47,7 +47,7 @@ class RepoActions {
 		return map;
 	}
 
-	Map<String, Runnable> getRevisionActions(final Archive archive, String bsn, Version version, Clipboard cb)
+	Map<String, Runnable> getRevisionActions(final Archive archive, String bsn, Version version, Clipboard clipboard)
 		throws Exception {
 		Map<String, Runnable> map = new LinkedHashMap<>();
 		map.put("Clear from Cache", () -> {
@@ -92,12 +92,13 @@ class RepoActions {
 
 		addSources(archive, map);
 
-		if (cb != null) {
+		// Some "Copy to Clipboard" actions, if clipboard is available
+		if (clipboard != null) {
 
-			map.put("Copy revision to clipboard", () -> {
+			map.put("Copy GAV to clipboard", () -> {
 				String rev = archive.getRevision()
 					.toString();
-				cb.copy(rev);
+				clipboard.copy(rev);
 			});
 
 			map.put("Copy tooltip to clipboard", () -> {
@@ -106,7 +107,7 @@ class RepoActions {
 
 						String tooltipContent = arepo.tooltip(bsn, version);
 						if (tooltipContent != null) {
-							cb.copy(tooltipContent);
+							clipboard.copy(tooltipContent);
 						}
 					} catch (Exception e) {
 						throw Exceptions.duck(e);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -95,30 +95,14 @@ class RepoActions {
 		// Some "Copy to Clipboard" actions, if clipboard is available
 		if (clipboard != null) {
 
-			map.put("Copy GAV to clipboard", () -> {
-				String rev = archive.getRevision()
-					.toString();
-				clipboard.copy(rev);
-			});
-
-			map.put("Copy tooltip to clipboard", () -> {
-				if (repo instanceof Actionable arepo) {
-					try {
-
-						String tooltipContent = arepo.tooltip(bsn, version);
-						if (tooltipContent != null) {
-							clipboard.copy(tooltipContent);
-						}
-					} catch (Exception e) {
-						throw Exceptions.duck(e);
-					}
-				}
-			});
+			addCopyToClipboardActions(repo, archive, bsn, version, clipboard, map);
 
 		}
 
 		return map;
 	}
+
+
 
 	void addSources(final Archive archive, Map<String, Runnable> map) throws Exception {
 		Promise<File> pBinary = repo.storage.get(archive);
@@ -196,5 +180,51 @@ class RepoActions {
 			repo.index.add(d.program.version(d.version)
 				.archive("jar", null));
 		}
+	}
+
+	private static final void addCopyToClipboardActions(MavenBndRepository repo, final Archive archive, String bsn,
+		Version version, Clipboard clipboard, Map<String, Runnable> map) {
+
+		map.put("Copy GAV to clipboard", () -> {
+			String rev = archive.getRevision()
+				.toString();
+			clipboard.copy(rev);
+		});
+
+		map.put("Copy tooltip to clipboard", () -> {
+			if (repo instanceof Actionable arepo) {
+				try {
+
+					String tooltipContent = arepo.tooltip(bsn, version);
+					if (tooltipContent != null) {
+						clipboard.copy(tooltipContent);
+					}
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+			}
+		});
+
+		map.put("Copy Compile Dependecies to clipboard", () -> {
+
+			try {
+				StringBuilder sb = new StringBuilder();
+
+				IPom pom = repo.storage.getPom(archive.revision);
+				Map<Program, Dependency> dependencies = pom.getDependencies(MavenScope.compile, false);
+				for (Dependency d : dependencies.values()) {
+
+					sb.append(d.program.version(d.version)
+						.archive("jar", null));
+					sb.append("\n");
+				}
+
+				clipboard.copy(sb.toString());
+
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+
+		});
 	}
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -192,7 +192,8 @@ class RepoActions {
 		});
 
 		map.put("Copy tooltip to clipboard", () -> {
-			if (repo instanceof Actionable arepo) {
+			if (repo instanceof Actionable) {
+				Actionable arepo = repo;
 				try {
 
 					String tooltipContent = arepo.tooltip(bsn, version);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -46,7 +46,7 @@ class RepoActions {
 		return map;
 	}
 
-	Map<String, Runnable> getRevisionActions(final Archive archive, String bsn, Version version, Clipboard clipboard)
+	Map<String, Runnable> getRevisionActions(final Archive archive, final Clipboard clipboard)
 		throws Exception {
 		Map<String, Runnable> map = new LinkedHashMap<>();
 		map.put("Clear from Cache", () -> {
@@ -94,7 +94,7 @@ class RepoActions {
 		// Some "Copy to Clipboard" actions, if clipboard is available
 		if (clipboard != null) {
 
-			addCopyToClipboardActions(repo, archive, bsn, version, clipboard, map);
+			addCopyToClipboardActions(repo, archive, clipboard, map);
 
 		}
 
@@ -181,8 +181,8 @@ class RepoActions {
 		}
 	}
 
-	private static final void addCopyToClipboardActions(MavenBndRepository repo, final Archive archive, String bsn,
-		Version version, Clipboard clipboard, Map<String, Runnable> map) {
+	private static final void addCopyToClipboardActions(MavenBndRepository repo, final Archive archive,
+		Clipboard clipboard, Map<String, Runnable> map) {
 
 		map.put("Copy GAV to clipboard", () -> {
 			String rev = archive.getRevision()

--- a/bndtools.core/src/bndtools/utils/HierarchicalLabel.java
+++ b/bndtools.core/src/bndtools/utils/HierarchicalLabel.java
@@ -1,0 +1,298 @@
+package bndtools.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+
+/**
+ * This class uses a list labels to internally store the different hierarchical
+ * labels. It provides methods to get the number of layers, retrieve a label by
+ * position, retrieve the first and last labels to e.g. build a menu with
+ * submenues.
+ *
+ * <pre>
+ * public static void main(String[] args) {
+ * 	HierarchicalLabel label = new HierarchicalLabel("layer1/layer2/layer3/layer4", (l) -> new Action(l.getLast()));
+ *
+ * 	System.out.println("Number of layers: " + label.getNumLevels());
+ * 	System.out.println("Label at position 2: " + label.getByPosition(2));
+ * 	System.out.println("First label: " + label.getFirst());
+ * 	System.out.println("Last label: " + label.getLast());
+ *
+ * }
+ * </pre>
+ */
+public class HierarchicalLabel {
+
+	private static final String					DELIMITER_FOR_HIERARCHY	= " :: ";
+
+	/**
+	 * <p>
+	 * Regex for parsing the compoundLabelExpression in the constructor:
+	 * </p>
+	 * <ol>
+	 * <li>
+	 * <p>
+	 * <strong>Group 1 <code>(-)?</code></strong>: Represents an optional minus
+	 * sign <code>-</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This is used to determine if something is <code>enabled</code>. If
+	 * this group is present, then <code>enabled</code> is set to
+	 * <code>false</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 2 <code>(!)?</code></strong>: Represents an optional
+	 * exclamation mark <code>!</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This is used to determine if something is <code>checked</code>. If
+	 * this group is present, then <code>checked</code> is set to
+	 * <code>true</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 3 <code>([^{}]+)</code></strong>: Matches one or more
+	 * characters that are not curly braces <code>{</code> or <code>}</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This captures the actual <code>labeltext</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 4 <code>(?:\\{([^}]+)\\})?</code></strong>: This is an
+	 * optional group that captures text inside curly braces.
+	 * </p>
+	 * <ul>
+	 * <li><code>(?: ... )</code> is a non-capturing group.</li>
+	 * <li><code>\\{([^}]+)\\}</code> captures characters between <code>{</code>
+	 * and <code>}</code>.</li>
+	 * <li>This captures the <code>description</code>.</li>
+	 * </ul>
+	 * </li> See Constructor for Example Strings
+	 * </ol>
+	 * </p>
+	 */
+	final static Pattern						LABEL_PATTERN			= Pattern
+		.compile("(-)?(!)?([^{}]+)(?:\\{([^}]+)\\})?");
+
+	private final List<String>					labels;
+	private Function<HierarchicalLabel, Action>	leafActionCallback;
+
+	boolean										enabled					= true;
+	boolean										checked					= false;
+	String										description				= null;
+
+	/**
+	 * @param compoundLabel a string consisting of multiple parts which is parse
+	 *            by a regex into 4 parts. E.g.
+	 *            <h3 id="example-strings-">Example Strings:</h3>
+	 *            <ol>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;-!MyLabel{This is a description}&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: <code>-</code> =&gt; <code>enabled</code> is
+	 *            <code>false</code>.</li>
+	 *            <li>Group 2: <code>!</code> =&gt; <code>checked</code> is
+	 *            <code>true</code>.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: <code>This is a description</code> =&gt;
+	 *            Description is &quot;This is a description&quot;.</li>
+	 *            </ul>
+	 *            </li>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;!MyLabel&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: Not present =&gt; <code>enabled</code> is not
+	 *            affected (remains whatever value it previously had).</li>
+	 *            <li>Group 2: <code>!</code> =&gt; <code>checked</code> is
+	 *            <code>true</code>.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: Not present =&gt; Description is
+	 *            <code>null</code>.</li>
+	 *            </ul>
+	 *            </li>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;MyLabel{Description here}&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: Not present =&gt; <code>enabled</code> is not
+	 *            affected.</li>
+	 *            <li>Group 2: Not present =&gt; <code>checked</code> is not
+	 *            affected.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: <code>Description here</code> =&gt; Description
+	 *            is &quot;Description here&quot;.</li>
+	 *            </ul>
+	 *            </li>
+	 *            </ol>
+	 *            <p>
+	 *            These example strings illustrate how the regex pattern breaks
+	 *            down and captures each part of the input string.
+	 *            </p>
+	 * @param leafNodeAction a callback to create an Action from the outside
+	 */
+	public HierarchicalLabel(String compoundLabel, Function<HierarchicalLabel, Action> leafNodeAction) {
+		this.leafActionCallback = leafNodeAction;
+		if (compoundLabel == null || compoundLabel.trim()
+			.isEmpty()) {
+			throw new IllegalArgumentException("Label string cannot be null or empty.");
+		}
+
+		String label = compoundLabel;
+		Matcher m = LABEL_PATTERN.matcher(compoundLabel);
+		if (m.matches()) {
+			if (m.group(1) != null)
+				enabled = false;
+
+			if (m.group(2) != null)
+				checked = true;
+
+			label = m.group(3);
+
+			description = m.group(4);
+		}
+
+		this.labels = new ArrayList<>(Arrays.asList(label.split(DELIMITER_FOR_HIERARCHY)));
+
+	}
+
+	public Action getLeafAction() {
+		return leafActionCallback.apply(this);
+	}
+
+	public int getNumLLevels() {
+		return labels.size();
+	}
+
+	public String getByPosition(int position) {
+		if (position < 0 || position >= labels.size()) {
+			throw new IllegalArgumentException("Position out of bounds.");
+		}
+		return labels.get(position);
+	}
+
+	public String getFirst() {
+		return labels.get(0);
+	}
+
+	public String getLast() {
+		return labels.get(labels.size() - 1);
+	}
+
+	public List<String> getLabels() {
+		return labels;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public boolean isChecked() {
+		return checked;
+	}
+
+	@Override
+	public String toString() {
+		return String.join("/", labels);
+	}
+
+	public MenuManager createMenuItems() {
+		return createSubMenu(0);
+	}
+
+	private MenuManager createSubMenu(int position) {
+		if (position >= labels.size()) {
+			return null;
+		}
+
+		MenuManager current = new MenuManager(labels.get(position), null);
+		if (position == labels.size() - 1) {
+			current.add(leafActionCallback.apply(this));
+		} else {
+			MenuManager childMenu = createSubMenu(position + 1);
+			if (childMenu != null) {
+				current.add(childMenu);
+			}
+		}
+		return current;
+	}
+
+	public static class HierarchicalMenu {
+
+		private final List<HierarchicalLabel> labels = new ArrayList<>();
+
+		public HierarchicalMenu() {
+
+		}
+
+		public HierarchicalMenu add(HierarchicalLabel label) {
+			labels.add(label);
+			return this;
+		}
+
+		public void build(IMenuManager root) {
+			createMenu(labels, root);
+		}
+
+	}
+
+	public static void createMenu(List<HierarchicalLabel> labels, IMenuManager rootMenu) {
+
+		Map<String, IMenuManager> menus = new LinkedHashMap<>();
+
+		for (HierarchicalLabel hl : labels) {
+			IMenuManager current = rootMenu;
+			List<String> hlLabels = hl.getLabels();
+			for (int i = 0; i < hlLabels.size(); i++) {
+				String currentLabel = hlLabels.get(i);
+				if (i == hlLabels.size() - 1) {
+					// currentMenu = getOrCreateSubMenu(menuMap, currentMenu,
+					// currentLabel);
+					current.add(hl.getLeafAction());
+				} else {
+					current = getOrCreateSubMenu(menus, current, currentLabel);
+				}
+			}
+		}
+
+	}
+
+	private static IMenuManager getOrCreateSubMenu(Map<String, IMenuManager> menus, IMenuManager parent,
+		String label) {
+		String key = parent.toString() + " -> " + label;
+
+		if (!menus.containsKey(key)) {
+			IMenuManager newMenu = new MenuManager(label, null);
+			parent.add(newMenu);
+			menus.put(key, newMenu);
+		}
+
+		return menus.get(key);
+	}
+}

--- a/bndtools.core/src/bndtools/utils/HierarchicalMenu.java
+++ b/bndtools.core/src/bndtools/utils/HierarchicalMenu.java
@@ -1,0 +1,66 @@
+package bndtools.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+
+/**
+ * Helper to create menus with submenus from a list of
+ * {@link HierarchicalLabel}s.
+ */
+public class HierarchicalMenu {
+
+	private final List<HierarchicalLabel<Action>> labels = new ArrayList<>();
+
+	public HierarchicalMenu() {
+
+	}
+
+	public HierarchicalMenu add(HierarchicalLabel<Action> label) {
+		labels.add(label);
+		return this;
+	}
+
+	public void build(IMenuManager root) {
+		createMenu(labels, root);
+	}
+
+
+	public static void createMenu(List<HierarchicalLabel<Action>> labels, IMenuManager rootMenu) {
+
+		Map<String, IMenuManager> menus = new LinkedHashMap<>();
+
+		for (HierarchicalLabel<Action> hl : labels) {
+			IMenuManager current = rootMenu;
+			List<String> hlLabels = hl.getLabels();
+			for (int i = 0; i < hlLabels.size(); i++) {
+				String currentLabel = hlLabels.get(i);
+				if (i == hlLabels.size() - 1) {
+					// currentMenu = getOrCreateSubMenu(menuMap, currentMenu,
+					// currentLabel);
+					current.add(hl.getLeafAction());
+				} else {
+					current = getOrCreateSubMenu(menus, current, currentLabel);
+				}
+			}
+		}
+
+	}
+
+	private static IMenuManager getOrCreateSubMenu(Map<String, IMenuManager> menus, IMenuManager parent, String label) {
+		String key = parent.toString() + " -> " + label;
+
+		if (!menus.containsKey(key)) {
+			IMenuManager newMenu = new MenuManager(label, null);
+			parent.add(newMenu);
+			menus.put(key, newMenu);
+		}
+
+		return menus.get(key);
+	}
+}

--- a/bndtools.core/src/bndtools/utils/LabelParser.java
+++ b/bndtools.core/src/bndtools/utils/LabelParser.java
@@ -1,0 +1,157 @@
+package bndtools.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses a label-string into various parts.
+ */
+public class LabelParser {
+
+	/**
+	 * <p>
+	 * Regex for parsing the compoundLabelExpression in the constructor:
+	 * </p>
+	 * <ol>
+	 * <li>
+	 * <p>
+	 * <strong>Group 1 <code>(-)?</code></strong>: Represents an optional minus
+	 * sign <code>-</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This is used to determine if something is <code>enabled</code>. If
+	 * this group is present, then <code>enabled</code> is set to
+	 * <code>false</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 2 <code>(!)?</code></strong>: Represents an optional
+	 * exclamation mark <code>!</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This is used to determine if something is <code>checked</code>. If
+	 * this group is present, then <code>checked</code> is set to
+	 * <code>true</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 3 <code>([^{}]+)</code></strong>: Matches one or more
+	 * characters that are not curly braces <code>{</code> or <code>}</code>.
+	 * </p>
+	 * <ul>
+	 * <li>This captures the actual <code>labeltext</code>.</li>
+	 * </ul>
+	 * </li>
+	 * <li>
+	 * <p>
+	 * <strong>Group 4 <code>(?:\\{([^}]+)\\})?</code></strong>: This is an
+	 * optional group that captures text inside curly braces.
+	 * </p>
+	 * <ul>
+	 * <li><code>(?: ... )</code> is a non-capturing group.</li>
+	 * <li><code>\\{([^}]+)\\}</code> captures characters between <code>{</code>
+	 * and <code>}</code>.</li>
+	 * <li>This captures the <code>description</code>.</li>
+	 * </ul>
+	 * </li> See Constructor for Example Strings
+	 * </ol>
+	 * </p>
+	 */
+	final static Pattern	LABEL_PATTERN	= Pattern.compile("(-)?(!)?([^{}]+)(?:\\{([^}]+)\\})?");
+
+	String					label;
+	boolean					enabled			= true;
+	boolean					checked			= false;
+	String					description		= null;
+
+	/**
+	 * @param labelExpression a string consisting of multiple parts which is
+	 *            parse by a regex into 4 parts. E.g.
+	 *            <h3 id="example-strings-">Example Strings:</h3>
+	 *            <ol>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;-!MyLabel{This is a description}&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: <code>-</code> =&gt; <code>enabled</code> is
+	 *            <code>false</code>.</li>
+	 *            <li>Group 2: <code>!</code> =&gt; <code>checked</code> is
+	 *            <code>true</code>.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: <code>This is a description</code> =&gt;
+	 *            Description is &quot;This is a description&quot;.</li>
+	 *            </ul>
+	 *            </li>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;!MyLabel&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: Not present =&gt; <code>enabled</code> is not
+	 *            affected (remains whatever value it previously had).</li>
+	 *            <li>Group 2: <code>!</code> =&gt; <code>checked</code> is
+	 *            <code>true</code>.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: Not present =&gt; Description is
+	 *            <code>null</code>.</li>
+	 *            </ul>
+	 *            </li>
+	 *            <li>
+	 *            <p>
+	 *            <strong>&quot;MyLabel{Description here}&quot;</strong>
+	 *            </p>
+	 *            <ul>
+	 *            <li>Group 1: Not present =&gt; <code>enabled</code> is not
+	 *            affected.</li>
+	 *            <li>Group 2: Not present =&gt; <code>checked</code> is not
+	 *            affected.</li>
+	 *            <li>Group 3: <code>MyLabel</code> =&gt; Label text is
+	 *            &quot;MyLabel&quot;.</li>
+	 *            <li>Group 4: <code>Description here</code> =&gt; Description
+	 *            is &quot;Description here&quot;.</li>
+	 *            </ul>
+	 *            </li>
+	 *            </ol>
+	 *            <p>
+	 *            These example strings illustrate how the regex pattern breaks
+	 *            down and captures each part of the input string.
+	 *            </p>
+	 */
+	public LabelParser(String labelExpression) {
+
+		Matcher m = LABEL_PATTERN.matcher(labelExpression);
+		if (m.matches()) {
+			if (m.group(1) != null)
+				enabled = false;
+
+			if (m.group(2) != null)
+				checked = true;
+
+			label = m.group(3);
+
+			description = m.group(4);
+		}
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public boolean isChecked() {
+		return checked;
+	}
+
+}

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -810,62 +810,9 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 								hmenu.add(new HierarchicalLabel<Action>(label.replace("&", "&&"), l -> {
 
-									Action a = new Action(l.getLast()) {
-										@Override
-										public void run() {
-											Job backgroundJob = new Job("Repository Action '" + getText() + "'") {
-
-												@Override
-												protected IStatus run(IProgressMonitor monitor) {
-													try {
-														e1.getValue()
-															.run();
-														if (rp != null && rp instanceof Refreshable)
-															Central.refreshPlugin((Refreshable) rp, true);
-													} catch (final Exception e) {
-														IStatus status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID,
-															"Error executing: " + getName(), e);
-														Plugin.getDefault()
-															.getLog()
-															.log(status);
-													}
-													monitor.done();
-													return Status.OK_STATUS;
-												}
-											};
-
-											backgroundJob.addJobChangeListener(new JobChangeAdapter() {
-												@Override
-												public void done(IJobChangeEvent event) {
-													if (event.getResult()
-														.isOK()) {
-														viewer.getTree()
-															.getDisplay()
-															.asyncExec(() -> viewer.refresh());
-													}
-												}
-											});
-
-											backgroundJob.setUser(true);
-											backgroundJob.setPriority(Job.SHORT);
-											backgroundJob.schedule();
-										}
-									};
-									a.setEnabled(l.isEnabled());
-									if (l.getDescription() != null)
-										a.setDescription(l.getDescription());
-									a.setChecked(l.isChecked());
-
-									return a;
+									return createAction(l.getLast(), l.getDescription(), l.isEnabled(), l.isChecked(),
+										rp, e1.getValue());
 								}));
-
-								// // Actions for the sub menu
-								// if (label.startsWith("Copy")) {
-								// // add the action to the submenu
-								// copyToClipboardSubMenu.add(a);
-								// } else {
-								// manager.add(a);
-								// }
 
 							}
 
@@ -1169,9 +1116,8 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 	private HierarchicalLabel<Action> createContextMenueCopyInfo(Actionable act, final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundleVersion rbr) {
 
-		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info",
-			(label) -> createAction(label.getLast(), "Add general info about this entry to clipboard.", true,
-				false, rp, () -> {
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+			"Add general info about this entry to clipboard.", true, false, rp, () -> {
 
 				final StringBuilder info = new StringBuilder();
 
@@ -1203,8 +1149,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		RepositoryBundleVersion rbr) {
 
 		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy bsn+version",
-			(label) -> createAction(label.getLast(), "Copy bsn;version=version to clipboard.", true, false, rp,
-				() -> {
+			(label) -> createAction(label.getLast(), "Copy bsn;version=version to clipboard.", true, false, rp, () -> {
 
 				String rev = rbr.getBsn() + ";version=" + rbr.getVersion()
 					.toString();

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -770,8 +770,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		});
 	}
 
-
-
 	void createContextMenu() {
 		MenuManager mgr = new MenuManager();
 		Menu menu = mgr.createContextMenu(viewer.getControl());
@@ -805,9 +803,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 						// add the other actions
 						Map<String, Runnable> actions = act.actions();
 
-
 						if (actions != null) {
-
 
 							for (final Entry<String, Runnable> e1 : actions.entrySet()) {
 								String label = e1.getKey();
@@ -872,7 +868,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 									a.setDescription(description);
 								a.setChecked(checked);
 
-
 								// Actions for the sub menu
 								if (label.startsWith("Copy")) {
 									// add the action to the submenu
@@ -892,7 +887,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 			}
 		});
 	}
-
 
 	private void fillToolBar(IToolBarManager toolBar) {
 		toolBar.add(advancedSearchAction);
@@ -1174,51 +1168,55 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 		if (act instanceof RepositoryBundleVersion rbr) {
 
-			Action copyBsnAction = createAction("Copy bsn+version", "Copy bsn;version=version to clipboard.", true,
-				false, rp, () -> {
-
-
-				if (registry != null) {
-						String rev = rbr.getBsn() + ";version=" + rbr.getVersion()
-							.toString();
-						clipboard.copy(rev);
-
-				}
-
-			});
-			copyToSubMenu.add(copyBsnAction);
-
-			Action copyInfoAction = createAction("Copy info", "Add general info about this entry to clipboard.", true,
-				false, rp, () -> {
-
-				if (registry != null) {
-						String info = rbr.toString();
-						clipboard.copy(info);
-				}
-
-			});
-			copyToSubMenu.add(copyInfoAction);
-
-			Action copyTooltipAction = createAction("Copy tooltip", "Add tooltip content to clipboard.", true,
-				false, rp, () -> {
-
-						String tooltipContent;
-						try {
-							tooltipContent = act.tooltip(rbr.getBsn(), rbr.getVersion()
-								.toString());
-
-							if (tooltipContent != null) {
-								clipboard.copy(tooltipContent);
-							}
-						} catch (Exception e) {
-							throw Exceptions.duck(e);
-						}
-
-					}
-			);
-			copyToSubMenu.add(copyTooltipAction);
+			copyToSubMenu.add(createContextMenueBsn(rp, clipboard, rbr));
+			copyToSubMenu.add(createContextMenueCopyInfo(act, rp, clipboard, rbr));
 
 		}
+	}
+
+	private Action createContextMenueCopyInfo(Actionable act, final RepositoryPlugin rp, final Clipboard clipboard,
+		RepositoryBundleVersion rbr) {
+		Action copyInfoAction = createAction("Copy info", "Add general info about this entry to clipboard.", true,
+			false, rp, () -> {
+
+				final StringBuilder info = new StringBuilder();
+
+				// append the tooltip content +
+				// RepositoryBundleVersion.toString() general info
+				try {
+					String tooltipContent = act.tooltip(rbr.getBsn(), rbr.getVersion()
+						.toString());
+
+					if (tooltipContent != null && !tooltipContent.isBlank()) {
+						info.append(tooltipContent);
+					}
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+
+				if (!info.isEmpty()) {
+					info.append('\n');
+				}
+
+				info.append(rbr.toString());
+
+				clipboard.copy(info.toString());
+
+			});
+		return copyInfoAction;
+	}
+
+	private Action createContextMenueBsn(final RepositoryPlugin rp, final Clipboard clipboard,
+		RepositoryBundleVersion rbr) {
+		Action copyBsnAction = createAction("Copy bsn+version", "Copy bsn;version=version to clipboard.", true, false,
+			rp, () -> {
+
+				String rev = rbr.getBsn() + ";version=" + rbr.getVersion()
+					.toString();
+				clipboard.copy(rev);
+
+			});
+		return copyBsnAction;
 	}
 
 }

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1101,7 +1101,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		}
 	}
 
-	public Action createAction(String label, String description, boolean enabled, boolean checked, RepositoryPlugin rp,
+	private Action createAction(String label, String description, boolean enabled, boolean checked, RepositoryPlugin rp,
 		Runnable r) {
 
 		Action a = new Action(label) {

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -816,9 +816,11 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 							}
 
-							hmenu.build(manager);
 
 						}
+
+						// build the final menue
+						hmenu.build(manager);
 
 					}
 				}

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1116,7 +1116,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 			hmenu.add(createContextMenueCopyInfoRepoBundle(act, rp, clipboard, rb));
 		}
 
-		if (act instanceof Repository r || act instanceof RepositoryPlugin r) {
+		if ((act instanceof Repository) || (act instanceof RepositoryPlugin)) {
 			hmenu.add(createContextMenueCopyInfoRepo(act, rp, clipboard));
 		}
 

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -811,7 +811,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 								hmenu.add(new HierarchicalLabel<Action>(label.replace("&", "&&"), l -> {
 
-									return createAction(l.getLast(), l.getDescription(), l.isEnabled(), l.isChecked(),
+									return createAction(l.getLeaf(), l.getDescription(), l.isEnabled(), l.isChecked(),
 										rp, e1.getValue());
 								}));
 
@@ -1124,7 +1124,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 	private HierarchicalLabel<Action> createContextMenueCopyInfoRepo(Actionable act, final RepositoryPlugin rp,
 		final Clipboard clipboard) {
-		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLeaf(),
 			"Add general info about this entry to clipboard.", true, false, rp, () -> {
 
 				final StringBuilder info = new StringBuilder();
@@ -1147,7 +1147,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 	private HierarchicalLabel<Action> createContextMenueCopyInfoRepoBundle(Actionable act, final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundle rb) {
-		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLeaf(),
 			"Add general info about this entry to clipboard.", true, false, rp, () -> {
 
 				final StringBuilder info = new StringBuilder();
@@ -1172,7 +1172,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundleVersion rbr) {
 
-		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLeaf(),
 			"Add general info about this entry to clipboard.", true, false, rp, () -> {
 
 				final StringBuilder info = new StringBuilder();
@@ -1205,7 +1205,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		RepositoryBundleVersion rbr) {
 
 		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy bsn+version",
-			(label) -> createAction(label.getLast(), "Copy bsn;version=version to clipboard.", true, false, rp, () -> {
+			(label) -> createAction(label.getLeaf(), "Copy bsn;version=version to clipboard.", true, false, rp, () -> {
 
 				String rev = rbr.getBsn() + ";version=" + rbr.getVersion()
 					.toString();

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -89,6 +89,7 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.ResourceTransfer;
 import org.eclipse.ui.part.ViewPart;
 import org.osgi.resource.Requirement;
+import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.Workspace;
 import aQute.bnd.exceptions.Exceptions;
@@ -816,7 +817,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 							}
 
-
 						}
 
 						// build the final menue
@@ -1108,14 +1108,68 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		}
 
 		if (act instanceof RepositoryBundleVersion rbr) {
-
 			hmenu.add(createContextMenueBsn(rp, clipboard, rbr));
-			hmenu.add(createContextMenueCopyInfo(act, rp, clipboard, rbr));
-
+			hmenu.add(createContextMenueCopyInfoRepoBundleVersion(act, rp, clipboard, rbr));
 		}
+
+		if (act instanceof RepositoryBundle rb) {
+			hmenu.add(createContextMenueCopyInfoRepoBundle(act, rp, clipboard, rb));
+		}
+
+		if (act instanceof Repository r || act instanceof RepositoryPlugin r) {
+			hmenu.add(createContextMenueCopyInfoRepo(act, rp, clipboard));
+		}
+
 	}
 
-	private HierarchicalLabel<Action> createContextMenueCopyInfo(Actionable act, final RepositoryPlugin rp,
+	private HierarchicalLabel<Action> createContextMenueCopyInfoRepo(Actionable act, final RepositoryPlugin rp,
+		final Clipboard clipboard) {
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+			"Add general info about this entry to clipboard.", true, false, rp, () -> {
+
+				final StringBuilder info = new StringBuilder();
+
+				// append the tooltip content
+				try {
+
+					String tooltipContent = act.tooltip();
+
+					if (tooltipContent != null && !tooltipContent.isBlank()) {
+						info.append(tooltipContent);
+						clipboard.copy(info.toString());
+					}
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+
+			}));
+	}
+
+	private HierarchicalLabel<Action> createContextMenueCopyInfoRepoBundle(Actionable act, final RepositoryPlugin rp,
+		final Clipboard clipboard, RepositoryBundle rb) {
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),
+			"Add general info about this entry to clipboard.", true, false, rp, () -> {
+
+				final StringBuilder info = new StringBuilder();
+
+				// append the tooltip content
+				try {
+
+					String tooltipContent = act.tooltip(rb.getBsn());
+
+					if (tooltipContent != null && !tooltipContent.isBlank()) {
+						info.append(tooltipContent);
+						clipboard.copy(info.toString());
+					}
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+
+			}));
+	}
+
+	private HierarchicalLabel<Action> createContextMenueCopyInfoRepoBundleVersion(Actionable act,
+		final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundleVersion rbr) {
 
 		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info", (label) -> createAction(label.getLast(),

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -115,7 +115,7 @@ import bndtools.model.repo.SearchableRepositoryTreeContentProvider;
 import bndtools.preferences.BndPreferences;
 import bndtools.preferences.WorkspaceOfflineChangeAdapter;
 import bndtools.utils.HierarchicalLabel;
-import bndtools.utils.HierarchicalLabel.HierarchicalMenu;
+import bndtools.utils.HierarchicalMenu;
 import bndtools.utils.SelectionDragAdapter;
 import bndtools.wizards.workspace.AddFilesToRepositoryWizard;
 import bndtools.wizards.workspace.WorkspaceSetupWizard;
@@ -794,7 +794,8 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 						//
 						final Actionable act = (Actionable) firstElement;
 
-						// add general copyToClipboard SubMenu entries
+						// use HierarchicalMenu to build up a menue with SubMenu
+						// entries
 						HierarchicalMenu hmenu = new HierarchicalMenu();
 						addCopyToClipboardSubMenueEntries(act, rp, hmenu);
 
@@ -807,7 +808,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 								String label = e1.getKey();
 
-								hmenu.add(new HierarchicalLabel(label.replace("&", "&&"), l -> {
+								hmenu.add(new HierarchicalLabel<Action>(label.replace("&", "&&"), l -> {
 
 									Action a = new Action(l.getLast()) {
 										@Override
@@ -1165,10 +1166,10 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 		}
 	}
 
-	private HierarchicalLabel createContextMenueCopyInfo(Actionable act, final RepositoryPlugin rp,
+	private HierarchicalLabel<Action> createContextMenueCopyInfo(Actionable act, final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundleVersion rbr) {
 
-		return new HierarchicalLabel("Copy to clipboard :: Copy info",
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy info",
 			(label) -> createAction(label.getLast(), "Add general info about this entry to clipboard.", true,
 				false, rp, () -> {
 
@@ -1198,10 +1199,10 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 			}));
 	}
 
-	private HierarchicalLabel createContextMenueBsn(final RepositoryPlugin rp, final Clipboard clipboard,
+	private HierarchicalLabel<Action> createContextMenueBsn(final RepositoryPlugin rp, final Clipboard clipboard,
 		RepositoryBundleVersion rbr) {
 
-		return new HierarchicalLabel("Copy to clipboard :: Copy bsn+version",
+		return new HierarchicalLabel<Action>("Copy to clipboard :: Copy bsn+version",
 			(label) -> createAction(label.getLast(), "Copy bsn;version=version to clipboard.", true, false, rp,
 				() -> {
 

--- a/bndtools.core/test/bndtools/wizards/repo/HierarchicalLabelTest.java
+++ b/bndtools.core/test/bndtools/wizards/repo/HierarchicalLabelTest.java
@@ -1,0 +1,96 @@
+package bndtools.wizards.repo;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import bndtools.utils.HierarchicalLabel;
+import bndtools.utils.LabelParser;
+
+/**
+ * TODO
+ */
+@ExtendWith(SoftAssertionsExtension.class)
+public class HierarchicalLabelTest {
+
+	@InjectSoftAssertions
+	SoftAssertions softly;
+
+	@Test
+	public void testHierarchicalLabel() {
+
+		HierarchicalLabel<String> one = new HierarchicalLabel<>("Foo", l -> l.getLeaf());
+		softly.assertThat(one.getFirst())
+			.isEqualTo("Foo");
+		softly.assertThat(one.getLeaf())
+			.isEqualTo("Foo");
+		softly.assertThat(one.getNumLLevels())
+			.isEqualTo(1);
+		softly.assertThat(one.getByPosition(0))
+			.isEqualTo("Foo");
+
+		HierarchicalLabel<String> two = new HierarchicalLabel<>("Foo :: Bar", l -> l.getLeaf());
+		softly.assertThat(two.getFirst())
+			.isEqualTo("Foo");
+		softly.assertThat(two.getLeaf())
+			.isEqualTo("Bar");
+		softly.assertThat(two.getNumLLevels())
+			.isEqualTo(2);
+		softly.assertThat(two.getByPosition(0))
+			.isEqualTo("Foo");
+		softly.assertThat(two.getByPosition(1))
+			.isEqualTo("Bar");
+		softly.assertThatException()
+			.isThrownBy(() -> two.getByPosition(2))
+			.withMessageContaining("Position out of bounds.");
+
+		HierarchicalLabel<String> disabled = new HierarchicalLabel<>("-!Foo :: Bar{This is a description}",
+			l -> l.getLeaf());
+		softly.assertThat(disabled.getLeaf())
+			.isEqualTo("Bar");
+		softly.assertThat(disabled.getDescription())
+			.isEqualTo("This is a description");
+		softly.assertThat(disabled.isEnabled())
+			.isFalse();
+		softly.assertThat(disabled.isChecked())
+			.isTrue();
+
+	}
+
+	@Test
+	public void testLabelParser() {
+		LabelParser a = new LabelParser("-!MyLabel{This is a description}");
+		softly.assertThat(a.getLabel())
+			.isEqualTo("MyLabel");
+		softly.assertThat(a.getDescription())
+			.isEqualTo("This is a description");
+		softly.assertThat(a.isEnabled())
+			.isFalse();
+		softly.assertThat(a.isChecked())
+			.isTrue();
+
+		LabelParser b = new LabelParser("MyLabel{This is a description}");
+		softly.assertThat(b.getLabel())
+			.isEqualTo("MyLabel");
+		softly.assertThat(b.getDescription())
+			.isEqualTo("This is a description");
+		softly.assertThat(b.isEnabled())
+			.isTrue();
+		softly.assertThat(b.isChecked())
+			.isFalse();
+
+		LabelParser c = new LabelParser("!MyLabel");
+		softly.assertThat(c.getLabel())
+			.isEqualTo("MyLabel");
+		softly.assertThat(c.getDescription())
+			.isNull();
+		softly.assertThat(c.isEnabled())
+			.isTrue();
+		softly.assertThat(c.isChecked())
+			.isTrue();
+	}
+
+
+}


### PR DESCRIPTION
This PR adds more Copy to Clipboard actions to a revision of a leaf entry of a Repository item:

<img width="510" alt="image" src="https://github.com/bndtools/bnd/assets/188422/084cfb90-2311-49d4-a550-cc37489f63fa">

For example for an entry of `com.fasterxml.jackson.core.jackson-databind` : 

## Add GAV to Clipboard

`com.fasterxml.jackson.core:jackson-databind:2.13.4` is added to clipboard

## Add tooltip to Clipboard

The content of this tooltip when you hover over a leaf-entry is added:

<img width="580" alt="image" src="https://github.com/bndtools/bnd/assets/188422/063a3b3f-be63-4217-98c8-b7dd84c0aa75">


```
com.fasterxml.jackson.core.jackson-databind
General data-binding functionality for Jackson: works on core streaming API
com.fasterxml.jackson.core.jackson-databind
SHA-256: C9FAFF420D9E2C7E1E4711DBEEBEC2506A32C9942027211C5C293D8D87807EB6
Coordinates: com.fasterxml.jackson.core:jackson-databind:2.13.4
```

is added to the clipboard.

I found this helpful because the tooltip currently cannot be copy pasted and the tooltip contains useful information.

## Add Compile Dependencies to Clipboard

```
com.fasterxml.jackson.core:jackson-annotations:2.13.4
com.fasterxml.jackson.core:jackson-core:2.13.4
```

is added to the clipboard.
It is basically similar to **Add Compile Dependencies**

I wanted to add "Runtime Dependencies" too, but always got an empty result. Didn't have time to investigate. 
If you find it useful too, it's easy to add too.


## Feedback

Consider this PR just a suggestion. My main goal was to have **Add GAV to Clipboard** because this is handy when researching a dependency on google. The idea for the other two entries just came by playing around with it. 
We can remove them if they are too much. Ideally I would like to have a sub-menu "Copy to Clipboard" with those entries,  but didn't know how to do that.

I can also add testcases, when we know what to keep and what not.