### PR TITLE
Fix empty bundle info

### DIFF
--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1161,6 +1161,13 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 						info.append(tooltipContent);
 						clipboard.copy(info.toString());
 					}
+			else {
+						// bundle does not seem to have a tooltip
+						// let's just add general bundle info
+						info.append(rb.toString());
+						clipboard.copy(info.toString());
+					}
+
 				} catch (Exception e) {
 					throw Exceptions.duck(e);
 				}


### PR DESCRIPTION
Fixes a small bug just found after https://github.com/bndtools/bnd/pull/5859 was merged.
It fixes the problem, that copy to clipboard on a RepoBundle did not copy anything to the clipboard.

<img width="387" alt="image" src="https://github.com/bndtools/bnd/assets/188422/08338eee-8464-40e3-aa1e-587dafbbd86d">

@pkriens could you merged that too please? 
