### PR TITLE
make Resolve Window non-modal

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -386,6 +386,11 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 									return button;
 								}
 							};
+
+							// non-modal means, that we can open multi resolve
+							// result windows and e.g. compare results
+							dialog.setModal(false);
+
 							if (dialog.open() == Window.OK && !dirtyBeforeResolve) {
 								// save changes immediately if there were no
 								// unsaved changes before the resolve


### PR DESCRIPTION
now you can click on Resolve multiple times which opens a new window everytime, so you can e.g. compare different results

Based on comment in https://github.com/bndtools/bnd/pull/5862#issuecomment-1792268413