### PR TITLE
Conflict handling when having multiple Resolve-results open and changes happen in resolve window(s) vs main window

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -14,6 +14,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -269,6 +270,9 @@ public class BndEditModel {
 	private Workspace															workspace;
 	private IDocument															document;
 
+	// for change detection when multiple wizards look at the same model
+	private Date																lastChangedAt;
+
 	// Converter<String, ResolveMode> resolveModeFormatter =
 	// EnumFormatter.create(ResolveMode.class, ResolveMode.manual);
 
@@ -453,6 +457,7 @@ public class BndEditModel {
 	}
 
 	public void saveChangesTo(IDocument document) {
+		this.lastChangedAt = new Date();
 		for (Iterator<Entry<String, String>> iter = changesToSave.entrySet()
 			.iterator(); iter.hasNext();) {
 			Entry<String, String> entry = iter.next();
@@ -1445,6 +1450,10 @@ public class BndEditModel {
 		} catch (IllegalArgumentException | InstantiationException | IllegalAccessException e) {
 			throw Exceptions.duck(e);
 		}
+	}
+
+	public Date getLastChangedAt() {
+		return lastChangedAt;
 	}
 
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -14,7 +14,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -271,7 +270,7 @@ public class BndEditModel {
 	private IDocument															document;
 
 	// for change detection when multiple wizards look at the same model
-	private Date																lastChangedAt;
+	private long																lastChangedAt;
 
 	// Converter<String, ResolveMode> resolveModeFormatter =
 	// EnumFormatter.create(ResolveMode.class, ResolveMode.manual);
@@ -457,7 +456,7 @@ public class BndEditModel {
 	}
 
 	public void saveChangesTo(IDocument document) {
-		this.lastChangedAt = new Date();
+		this.lastChangedAt = System.currentTimeMillis();
 		for (Iterator<Entry<String, String>> iter = changesToSave.entrySet()
 			.iterator(); iter.hasNext();) {
 			Entry<String, String> entry = iter.next();
@@ -1452,7 +1451,7 @@ public class BndEditModel {
 		}
 	}
 
-	public Date getLastChangedAt() {
+	public long getLastChangedAt() {
 		return lastChangedAt;
 	}
 

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
@@ -3,6 +3,7 @@ package org.bndtools.core.resolve.ui;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -60,10 +61,12 @@ public class ResolutionSuccessPanel {
 	private Button								btnAddResolveOptional;
 	private ResolutionResult					result;
 	private Section								sectOptional;
+	private Date								lastModelChangedAtOpening;
 
 	public ResolutionSuccessPanel(BndEditModel model, ResolutionResultPresenter presenter) {
 		this.model = model;
 		this.presenter = presenter;
+		this.lastModelChangedAtOpening = model.getLastChangedAt();
 	}
 
 	public void createControl(Composite parent) {
@@ -222,6 +225,13 @@ public class ResolutionSuccessPanel {
 	}
 
 	private void doAddResolve() {
+
+		if (!model.getLastChangedAt()
+			.equals(lastModelChangedAtOpening)) {
+			throw new IllegalStateException("Model has changed on " + model.getLastChangedAt()
+				+ " since we opened it at " + lastModelChangedAtOpening);
+		}
+
 		List<Requirement> oldRequires = model.getRunRequires();
 		if (oldRequires == null)
 			oldRequires = Collections.emptyList();

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
@@ -227,8 +227,13 @@ public class ResolutionSuccessPanel {
 	private void doAddResolve() {
 
 		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
-			throw new IllegalStateException("Model has changed on " + new Date(model.getLastChangedAt())
-				+ " since we opened it at " + new Date(lastModelChangedAtOpening));
+			String message = "Could update. The model has changed on " + new Date(model.getLastChangedAt())
+				+ " since we opened it at " + new Date(lastModelChangedAtOpening)
+				+ ". Please close and click on 'Resolve' again.";
+
+			presenter.setMessage(message, IMessageProvider.ERROR);
+
+			throw new IllegalStateException(message);
 		}
 
 		List<Requirement> oldRequires = model.getRunRequires();

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
@@ -61,7 +61,7 @@ public class ResolutionSuccessPanel {
 	private Button								btnAddResolveOptional;
 	private ResolutionResult					result;
 	private Section								sectOptional;
-	private Date								lastModelChangedAtOpening;
+	private long								lastModelChangedAtOpening;
 
 	public ResolutionSuccessPanel(BndEditModel model, ResolutionResultPresenter presenter) {
 		this.model = model;
@@ -226,10 +226,9 @@ public class ResolutionSuccessPanel {
 
 	private void doAddResolve() {
 
-		if (!model.getLastChangedAt()
-			.equals(lastModelChangedAtOpening)) {
-			throw new IllegalStateException("Model has changed on " + model.getLastChangedAt()
-				+ " since we opened it at " + lastModelChangedAtOpening);
+		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
+			throw new IllegalStateException("Model has changed on " + new Date(model.getLastChangedAt())
+				+ " since we opened it at " + new Date(lastModelChangedAtOpening));
 		}
 
 		List<Requirement> oldRequires = model.getRunRequires();

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -5,7 +5,7 @@ import java.util.Date;
 
 import org.bndtools.core.resolve.ResolutionResult;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.wizard.Wizard;
 
 import aQute.bnd.build.model.BndEditModel;
@@ -37,12 +37,21 @@ public class ResolutionWizard extends Wizard {
 		ResolutionResult result = resultsPage.getResult();
 
 		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
-			MessageDialog.openError(getShell(), "Error",
-				"Wizard cannot continue and will now exit: Model has changed on " + new Date(model.getLastChangedAt())
-					+ " since we opened it at " + new Date(lastModelChangedAtOpening)
-					+ ". Please close and click on 'Resolve' again.");
-			getContainer().getShell()
-				.close();
+
+			String message = "Could update. The model has changed on " + new Date(model.getLastChangedAt())
+				+ " since we opened it at " + new Date(lastModelChangedAtOpening)
+				+ ". Please close and click on 'Resolve' again.";
+
+			resultsPage.setMessage(message, IMessageProvider.ERROR);
+
+			// alternative:
+			// MessageDialog.openError(getShell(), "Error",
+			// "Wizard cannot continue and will now exit: Model has changed on "
+			// + new Date(model.getLastChangedAt())
+			// + " since we opened it at " + new Date(lastModelChangedAtOpening)
+			// + ". Please close and click on 'Resolve' again.");
+			// getContainer().getShell()
+			// .close();
 			return false;
 		}
 

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -1,9 +1,11 @@
 package org.bndtools.core.resolve.ui;
 
 import java.util.Collections;
+import java.util.Date;
 
 import org.bndtools.core.resolve.ResolutionResult;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.wizard.Wizard;
 
 import aQute.bnd.build.model.BndEditModel;
@@ -14,10 +16,12 @@ public class ResolutionWizard extends Wizard {
 	private final ResolutionResultsWizardPage	resultsPage;
 	private final BndEditModel					model;
 	private boolean								preserveRunBundleUnresolved;
+	private Date								lastModelChangedAtOpening;
 
 	@SuppressWarnings("unused")
 	public ResolutionWizard(BndEditModel model, IFile file, ResolutionResult result) {
 		this.model = model;
+		this.lastModelChangedAtOpening = model.getLastChangedAt();
 
 		resultsPage = new ResolutionResultsWizardPage(model);
 		resultsPage.setResult(result);
@@ -31,6 +35,19 @@ public class ResolutionWizard extends Wizard {
 	@Override
 	public boolean performFinish() {
 		ResolutionResult result = resultsPage.getResult();
+
+		if (!model.getLastChangedAt()
+			.equals(lastModelChangedAtOpening)) {
+			MessageDialog.openError(getShell(), "Error",
+				"Wizard cannot continue and will now exit: Model has changed on " + model.getLastChangedAt()
+					+ " since we opened it at " + lastModelChangedAtOpening);
+			getContainer().getShell()
+				.close();
+			return false;
+			// throw new IllegalStateException("Model has changed on " +
+			// model.getLastChangedAt()
+			// + " since we opened it at " + lastModelChangedAtOpening);
+		}
 
 		if (result != null && result.getOutcome() == ResolutionResult.Outcome.Resolved) {
 			RunResolution resolution = result.getResolution();

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -39,13 +39,11 @@ public class ResolutionWizard extends Wizard {
 		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
 			MessageDialog.openError(getShell(), "Error",
 				"Wizard cannot continue and will now exit: Model has changed on " + new Date(model.getLastChangedAt())
-					+ " since we opened it at " + new Date(lastModelChangedAtOpening));
+					+ " since we opened it at " + new Date(lastModelChangedAtOpening)
+					+ ". Please close and click on 'Resolve' again.");
 			getContainer().getShell()
 				.close();
 			return false;
-			// throw new IllegalStateException("Model has changed on " +
-			// model.getLastChangedAt()
-			// + " since we opened it at " + lastModelChangedAtOpening);
 		}
 
 		if (result != null && result.getOutcome() == ResolutionResult.Outcome.Resolved) {

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -16,7 +16,7 @@ public class ResolutionWizard extends Wizard {
 	private final ResolutionResultsWizardPage	resultsPage;
 	private final BndEditModel					model;
 	private boolean								preserveRunBundleUnresolved;
-	private Date								lastModelChangedAtOpening;
+	private long								lastModelChangedAtOpening;
 
 	@SuppressWarnings("unused")
 	public ResolutionWizard(BndEditModel model, IFile file, ResolutionResult result) {
@@ -36,11 +36,10 @@ public class ResolutionWizard extends Wizard {
 	public boolean performFinish() {
 		ResolutionResult result = resultsPage.getResult();
 
-		if (!model.getLastChangedAt()
-			.equals(lastModelChangedAtOpening)) {
+		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
 			MessageDialog.openError(getShell(), "Error",
-				"Wizard cannot continue and will now exit: Model has changed on " + model.getLastChangedAt()
-					+ " since we opened it at " + lastModelChangedAtOpening);
+				"Wizard cannot continue and will now exit: Model has changed on " + new Date(model.getLastChangedAt())
+					+ " since we opened it at " + new Date(lastModelChangedAtOpening));
 			getContainer().getShell()
 				.close();
 			return false;


### PR DESCRIPTION
Based on https://github.com/bndtools/bnd/pull/5863#issuecomment-1792931273

> I think you need to probably look what happens if you include the optional requirements. This will I think edit the BndEditModel but this can of course be edited from the main editor window as well now.
> 
> You need to make sure that if it can only be updated from one window. There is properties support in this class but optimistic locking is fine with me as well. If it has changed, you refuse to update.

## Preview

When any other UI part / view changes something to the underlying BndEditModel (e.g. in the main window I edit and save the `.bndrun` file or I update optional requirements in one of the resolve windows then this change is detected and further updates fail.

<img width="1592" alt="image" src="https://github.com/bndtools/bnd/assets/188422/09b5b36d-de78-482c-8847-3a98ce9b0e96">

The same behavior applies when clicking the "Update" Button when the model has changed.
