### PR TITLE
Improve Resolve failed message and make it more helpful

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -251,23 +251,16 @@ public class ResolveProcess {
 
 		try (Formatter f = new Formatter()) {
 
-			FilterParser p = new FilterParser();
-
 			f.format("Resolution failed. Summary:");
 
-			// 1. pretty print requirements chain using FilterParser which is
-			// easier to read
+			// 1. Print a shorter "human" readable summary
+			printSummary(chain, f);
 
-			prettyPrintSummary(chain, f, p);
-
-			// 2. do the original which still has more details
-			f.format("\n\n");
-			f.format(
-				"Note: The summary above may be incomplete. Please check the full output below for more hints.\n");
+			// 2. Still print the original which has more details
 
 			// this line is required by
 			// /gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestResolveTask.groovy
-			f.format("Resolution failed. Capabilities satisfying the following requirements could not be found:\n");
+			f.format("Resolution failed. Capabilities satisfying the following requirements could not be found:%n");
 
 			String prefix = "    ";
 			for (Requirement req : chain) {
@@ -298,10 +291,21 @@ public class ResolveProcess {
 		}
 	}
 
-	private static void prettyPrintSummary(List<Requirement> chain, Formatter f, FilterParser p) {
+	/**
+	 * Prints a summary by transforming the requirements chain using
+	 * FilterParser which removes visual noise from the output and tries to make
+	 * the output read like a sentence. It is hopefully easier to digest as a
+	 * user. We still print the full resolution output below to.
+	 *
+	 * @param chain
+	 * @param f
+	 */
+	private static void printSummary(List<Requirement> chain, Formatter f) {
+
+		FilterParser p = new FilterParser();
+
 		String prefix = "    ";
 		for (Requirement req : chain) {
-			// f.format("%n%s[%s]", prefix, req.getResource());
 			if ("    ".equals(prefix))
 				prefix = ARROW;
 			else
@@ -309,6 +313,9 @@ public class ResolveProcess {
 			formatPrettyPrinted(f, prefix, req, p);
 			prefix = "    " + prefix;
 		}
+
+		f.format("%n%n");
+		f.format("Note: The summary above may be incomplete. Please check the full output below for more hints.%n");
 	}
 
 	private static List<Requirement> getCausalChain(ResolutionException re) {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -238,17 +238,7 @@ public class ResolveProcess {
 	 * @return the report
 	 */
 	public static String format(ResolutionException re, boolean reportOptional) {
-		List<Requirement> chain = new ArrayList<>();
-
-		Throwable cause = re;
-		while (cause != null) {
-			if (cause instanceof ReasonException mre) {
-				// there will only be one entry here
-				chain.addAll(mre.getUnresolvedRequirements());
-			}
-
-			cause = cause.getCause();
-		}
+		List<Requirement> chain = getCausalChain(re);
 
 		Map<Boolean, List<Requirement>> requirements = re.getUnresolvedRequirements()
 			.stream()
@@ -284,6 +274,21 @@ public class ResolveProcess {
 
 			return f.toString();
 		}
+	}
+
+	public static List<Requirement> getCausalChain(ResolutionException re) {
+		List<Requirement> chain = new ArrayList<>();
+
+		Throwable cause = re;
+		while (cause != null) {
+			if (cause instanceof ReasonException mre) {
+				// there will only be one entry here
+				chain.addAll(mre.getUnresolvedRequirements());
+			}
+
+			cause = cause.getCause();
+		}
+		return chain;
 	}
 
 	static BiConsumer<? super Resource, ? super List<Requirement>> formatGroup(Formatter f) {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -351,21 +351,38 @@ public class ResolveProcess {
 		f.format("%n%s%s: %s", prefix, req.getNamespace(), filter);
 	}
 
+	/**
+	 * Tries to transform a Requirement into a sentence.
+	 *
+	 * @param f
+	 * @param prefix
+	 * @param req
+	 * @param p
+	 */
 	private static void formatPrettyPrinted(Formatter f, String prefix, Requirement req, FilterParser p) {
 		String filter = req.getDirectives()
 			.get("filter");
 
-		Expression prettyFilter = p.parse(req);
+		Expression prettyExp = p.parse(req);
 
-		if (prettyFilter instanceof IdentityExpression iexp) {
-			f.format("%n%s%s: %s %s", prefix, "Bundle", prettyFilter.toString(), "cannot be resolved");
-		} else if (prettyFilter instanceof PackageExpression pck) {
-			f.format("%n%s%s: %s %s", prefix, "because package", prettyFilter.toString(),
-				"is not provided by any other bundle or dependency");
+		if (prettyExp instanceof IdentityExpression iexp) {
+			// e.g. "Bundle: biz.aQute.bnd cannot be resolved"
+			f.format("%n%s%s: %s %s", prefix, "Bundle", prettyExp.toString(), "cannot be resolved");
+		} else if (prettyExp instanceof PackageExpression pck) {
+			// e.g. "because Import-Package requirement for :
+			// org.apache.tools.ant.types could not be provided by any
+			// available bundle or dependency"
+			String category = FilterParser.namespaceToCategory(req.getNamespace());
+			f.format("%n%s%s%s%s: %s %s", prefix, "because ", category, " requirement for", prettyExp.toString(),
+				"could not be provided by any available bundle or dependency");
 		}
 		else {
+			// any other case
+			// e.g. "osgi.enroute.endpoint:
+			// &(osgi.enroute.endpoint=/sse/1)(version=[1.1.0,2.0.0)) cannot be
+			// resolved"
 			String category = FilterParser.namespaceToCategory(req.getNamespace());
-			f.format("%n%s%s: %s %s", prefix, category, prettyFilter.toString(), "cannot be resolved");
+			f.format("%n%s%s: %s %s", prefix, category, prettyExp.toString(), "cannot be resolved");
 		}
 	}
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -264,7 +264,10 @@ public class ResolveProcess {
 			f.format("\n\n");
 			f.format(
 				"Note: The summary above may be incomplete. Please check the full output below for more hints.\n");
-			f.format("Capabilities satisfying the following requirements could not be found:\n");
+
+			// this line is required by
+			// /gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestResolveTask.groovy
+			f.format("Resolution failed. Capabilities satisfying the following requirements could not be found:\n");
 
 			String prefix = "    ";
 			for (Requirement req : chain) {

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
@@ -3,9 +3,6 @@ package org.bndtools.core.resolve.ui;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.bndtools.core.resolve.ResolutionResult;
 import org.bndtools.core.resolve.ResolveOperation;
@@ -16,13 +13,9 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.osgi.resource.Requirement;
-import org.osgi.service.resolver.ResolutionException;
 
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.exceptions.Exceptions;
-import aQute.bnd.version.VersionRange;
-import biz.aQute.resolve.ResolveProcess;
 import bndtools.Plugin;
 
 public class ResolutionResultsWizardPage extends WizardPage implements ResolutionResultPresenter {
@@ -126,9 +119,11 @@ public class ResolutionResultsWizardPage extends WizardPage implements Resolutio
 			default :
 				resolutionFailurePanel.setInput(result);
 
-				String message = createHelpfulResolutionFailedMessage(result);
-
-				setErrorMessage("Resolution failed! " + message);
+				setErrorMessage(
+					"Resolution failed! The error message below is structured like a tree. "
+						+ "The trunk is the first line with the initial error,\n"
+						+ "and the most indented lines are the leaves, "
+						+ "detailing specific requirements that have not been met (usually missing dependencies (bundles, jars).");
 
 				stack.topControl = resolutionFailurePanel.getControl();
 				break;
@@ -139,92 +134,6 @@ public class ResolutionResultsWizardPage extends WizardPage implements Resolutio
 		updateButtons();
 	}
 
-	/**
-	 * Try to produce a more human readable message which provides a hint which
-	 * dependency might be missing.
-	 *
-	 * @param result2
-	 * @return
-	 */
-	private static String createHelpfulResolutionFailedMessage(ResolutionResult result) {
-		String message = "";
-		ResolutionException resolutionException = result.getResolutionException();
-		if (resolutionException != null && resolutionException.getUnresolvedRequirements() != null
-			&& !resolutionException.getUnresolvedRequirements()
-				.isEmpty()) {
-
-			// last entry contains the info which could be most useful
-			// to create an error message
-			List<Requirement> causalChain = ResolveProcess.getCausalChain(resolutionException);
-			if (!causalChain.isEmpty()) {
-				Requirement lastEntry = causalChain.get(causalChain.size() - 1);
-				String pck = (String) lastEntry.getAttributes()
-					.get("osgi.wiring.package");
-
-				if (pck != null) {
-					String resourceName = lastEntry.getResource()
-						.toString();
-
-					String filter = lastEntry.getDirectives()
-						.get("filter");
-					VersionRange versionRange = filterToVersionRange(filter);
-
-					String messagePartVersion = versionRange != null ? versionRange.toString() : "";
-
-					// best effort to come up with a useful message
-					message = "You are missing a dependency containing the package / capability: \"" + pck
-						+ "\"";
-
-					if (messagePartVersion != null) {
-						message += " (in version " + messagePartVersion + ")";
-					}
-
-					message += ". This is required by " + resourceName + ").";
-				}
-
-				// TODO handle other cases / heuristics
-
-			}
-		}
-		return message;
-	}
-
-	/**
-	 * Extracts version strings from an ldap filter expression e.g.
-	 *
-	 * <pre>
-	 * osgi.wiring.package: (&(osgi.wiring.package=some.package.foo)(version>=2.3.0)(!(version>=3.0.0)))
-	 * </pre>
-	 *
-	 * TODO maybe there is a better place for this helper
-	 *
-	 * @param text The input string containing version information.
-	 * @return An array of strings containing the extracted version conditions.
-	 */
-	public static VersionRange filterToVersionRange(String text) {
-
-		if (text == null) {
-			return null;
-		}
-
-		// Define the regex pattern with capturing groups
-		Pattern pattern = Pattern.compile("\\(!?(version>=([^)]+))\\)");
-		Matcher matcher = pattern.matcher(text);
-
-		// Array to hold the matches
-		String[] versions = new String[2];
-		int count = 0;
-
-		// Find the matches and extract the captured groups
-		while (matcher.find() && count < 2) {
-			versions[count] = matcher.group(2); // Captured group 2 contains the
-												// version number
-			count++;
-		}
-
-		// Return the extracted versions if two were found
-		return count == 2 ? new VersionRange(versions[0], versions[1]) : null;
-	}
 
 	@Override
 	public void updateButtons() {

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
@@ -119,11 +119,8 @@ public class ResolutionResultsWizardPage extends WizardPage implements Resolutio
 			default :
 				resolutionFailurePanel.setInput(result);
 
-				setErrorMessage(
-					"Resolution failed! The error message below is structured like a tree. "
-						+ "The trunk is the first line with the initial error,\n"
-						+ "and the most indented lines are the leaves, "
-						+ "detailing specific requirements that have not been met (usually missing dependencies (bundles, jars).");
+				setErrorMessage("Resolution failed! The tree-like error message below "
+						+ "contain details about unmet requirements and dependencies (most indended lines).");
 
 				stack.topControl = resolutionFailurePanel.getControl();
 				break;


### PR DESCRIPTION
Attempt to produce a more readable message from a failed Resolution instead of just "Resolution failed!"

New sentence reads:

> Resolution failed! You are missing a dependency containing the package / capability: "some.other.missing.package" (in version [2.3.0,3.0.0)). This is required by my.package.foo version=1.0.0).

Feel free to suggest better / different wording. But my goal was to make it an english sentence. 
I even thought about adding something like "e.g. search on google for `'some.other.missing.package jar'` and add that to your repository).

## Examples:

I tested it by removing some libraries on purpose from `central.maven` (then click on refresh Repositories) and then click "Resolve". This caused a previously successful resolution to fail.

<img width="1277" alt="image" src="https://github.com/bndtools/bnd/assets/188422/e7c0fbac-2626-4e7f-95ce-89644b0e576d">

<img width="1125" alt="image" src="https://github.com/bndtools/bnd/assets/188422/1b8b8963-c2c8-4154-b4c3-0490feccc029">


This is just a first draft. If there is an agreement that this is helpful there is cleanup needed.
Feedback welcome. 
