### PR TITLE
Fix typo error message, add help to Resolution Wizard, Method renaming

### DIFF
--- a/bndtools.core/src/bndtools/editor/common/HelpButtons.java
+++ b/bndtools.core/src/bndtools/editor/common/HelpButtons.java
@@ -36,5 +36,7 @@ public final class HelpButtons {
 		"https://bndtools.org/manual/bndeditor.html#run", "Help",
 		"The bnd editor for .bndrun files facilitates dependency management, automated resolution of required bundles, configuration of JVM and framework properties, direct launching of OSGi instances for testing, and the export of run configurations as executable JARs. Click to open manual in the browser.");
 
+	public static final String					HELP_URL_RESOLUTIONRESULTSWIZARDPAGE	= "https://bnd.bndtools.org/chapters/250-resolving.html#resolving-1";
+
 	private HelpButtons() {}
 }

--- a/bndtools.core/src/bndtools/editor/common/HelpButtons.java
+++ b/bndtools.core/src/bndtools/editor/common/HelpButtons.java
@@ -1,7 +1,7 @@
 package bndtools.editor.common;
 
-import static bndtools.utils.EditorUtils.createButton;
-import static bndtools.utils.EditorUtils.createButtonWithText;
+import static bndtools.utils.EditorUtils.createHelpButton;
+import static bndtools.utils.EditorUtils.createHelpButtonWithText;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
@@ -12,27 +12,27 @@ import org.eclipse.jface.action.ActionContributionItem;
  */
 public final class HelpButtons {
 
-	public static final Action					HELP_BTN_REPOSITORIES			= createButton(
+	public static final Action					HELP_BTN_REPOSITORIES			= createHelpButton(
 		"https://bndtools.org/manual/repositories-view.html",
 		"The Repositories View provides a user-friendly interface to inspect and manage the bundle repositories that are available to your Bndtools projects. Click to open manual in the browser.");
 
-	public static final Action					HELP_BTN_BNDTOOLS_EXPLORER		= createButton(
+	public static final Action					HELP_BTN_BNDTOOLS_EXPLORER		= createHelpButton(
 		"https://bndtools.org/manual/packageexplorer.html",
 		"The explorer provides an overview of the projects and their contents and allows advanced filtering. Click to open manual in the browser.");
 
-	public static final Action					HELP_BTN_RESOLUTION_VIEW		= createButton(
+	public static final Action					HELP_BTN_RESOLUTION_VIEW		= createHelpButton(
 		"https://bndtools.org/manual/resolution-view.html",
 		"The Resolution view shows the requirements and capabilities of one or multiple selected items, be they bnd.bnd files, JAR files, or entries in the Repositories view. This is useful for understanding dependencies as it provides information about what requirements are matched with what capabilities from the included resources. Click to open manual in the browser.");
 
-	public static final Action					HELP_BTN_BND_EDITOR				= createButton(
+	public static final Action					HELP_BTN_BND_EDITOR				= createHelpButton(
 		"https://bndtools.org/manual/bndeditor.html",
 		"This editor allows to edit bnd.bnd files, which define OSGi bundle metadata and build instructions for Java projects, encompassing sections for builtpath, imports, exports, bundle headers, and instructions to control the generation of the resulting OSGi bundle. Click to open manual in the browser.");
 
-	public static final Action					HELP_BTN_BND_EDITOR_WORKSPACE	= createButton(
+	public static final Action					HELP_BTN_BND_EDITOR_WORKSPACE	= createHelpButton(
 		"https://bndtools.org/manual/bndeditor.html",
 		"This editor allows to edit global .bnd files such as the main cnf/build.bnd, which serves as the central configuration hub for the entire bndtools workspace, allowing users to define and manage global build settings, plugins, repository references, and other overarching workspace properties. Click to open manual in the browser.");
 
-	public static final ActionContributionItem	HELP_BTN_BND_EDITOR_RUN			= createButtonWithText(
+	public static final ActionContributionItem	HELP_BTN_BND_EDITOR_RUN			= createHelpButtonWithText(
 		"https://bndtools.org/manual/bndeditor.html#run", "Help",
 		"The bnd editor for .bndrun files facilitates dependency management, automated resolution of required bundles, configuration of JVM and framework properties, direct launching of OSGi instances for testing, and the export of run configurations as executable JARs. Click to open manual in the browser.");
 

--- a/bndtools.core/src/bndtools/utils/EditorUtils.java
+++ b/bndtools.core/src/bndtools/utils/EditorUtils.java
@@ -43,13 +43,13 @@ public class EditorUtils {
 	}
 
 	/**
-	 * Creates a button with icon and tooltip.
+	 * Creates a help button with icon and tool-tip.
 	 *
 	 * @param url
 	 * @param tooltipText
 	 * @return
 	 */
-	public static final Action createButton(String url, String tooltipText) {
+	public static final Action createHelpButton(String url, String tooltipText) {
 		Action btn = new Action("Help", IAction.AS_PUSH_BUTTON) {
 			@Override
 			public void run() {
@@ -64,15 +64,15 @@ public class EditorUtils {
 	}
 
 	/**
-	 * Creates a button with icon, text and tooltip.
+	 * Creates a help button with help-icon, text and tool-tip.
 	 *
 	 * @param url
 	 * @param buttonText
 	 * @param tooltipText
 	 * @return
 	 */
-	public static final ActionContributionItem createButtonWithText(String url, String buttonText, String tooltipText) {
-		Action btn = createButton(url, tooltipText);
+	public static final ActionContributionItem createHelpButtonWithText(String url, String buttonText, String tooltipText) {
+		Action btn = createHelpButton(url, tooltipText);
 		btn.setText(buttonText);
 
 		// the ActionContributionItem is required to display text below the icon

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionResultsWizardPage.java
@@ -12,11 +12,13 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Composite;
 
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.exceptions.Exceptions;
 import bndtools.Plugin;
+import bndtools.editor.common.HelpButtons;
 
 public class ResolutionResultsWizardPage extends WizardPage implements ResolutionResultPresenter {
 
@@ -162,6 +164,11 @@ public class ResolutionResultsWizardPage extends WizardPage implements Resolutio
 
 	public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
 		propertySupport.removePropertyChangeListener(propertyName, listener);
+	}
+
+	@Override
+	public void performHelp() {
+		Program.launch(HelpButtons.HELP_URL_RESOLUTIONRESULTSWIZARDPAGE);
 	}
 
 	@Override

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionSuccessPanel.java
@@ -227,7 +227,7 @@ public class ResolutionSuccessPanel {
 	private void doAddResolve() {
 
 		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
-			String message = "Could update. The model has changed on " + new Date(model.getLastChangedAt())
+			String message = "Could not update. The model has changed on " + new Date(model.getLastChangedAt())
 				+ " since we opened it at " + new Date(lastModelChangedAtOpening)
 				+ ". Please close and click on 'Resolve' again.";
 

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionWizard.java
@@ -38,7 +38,7 @@ public class ResolutionWizard extends Wizard {
 
 		if (model.getLastChangedAt() > lastModelChangedAtOpening) {
 
-			String message = "Could update. The model has changed on " + new Date(model.getLastChangedAt())
+			String message = "Could not update. The model has changed on " + new Date(model.getLastChangedAt())
 				+ " since we opened it at " + new Date(lastModelChangedAtOpening)
 				+ ". Please close and click on 'Resolve' again.";
 


### PR DESCRIPTION
A few tweaks. See commit messages for details.
- added the word "not" in error message
- the ResolutionWizzard had a Help-Button (lower left) which was without function. I think it was there by default ,but nobody added functionality. I now linked to the manual (Resolving section)
- give two button methods from earlier  more appropriate names

Can be merged if no objections.