### PR TITLE
Add adapter for IProject > (bnd) Project

### DIFF
--- a/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/quickfix/BuildpathQuickFixProcessor.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
@@ -64,7 +65,6 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Descriptors;
 import aQute.bnd.osgi.Descriptors.TypeRef;
 import aQute.bnd.result.Result;
-import bndtools.central.Central;
 
 @Component
 public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
@@ -365,7 +365,7 @@ public class BuildpathQuickFixProcessor implements IQuickFixProcessor {
 			if (java == null)
 				return null;
 
-			project = Central.getProject(java.getProject());
+			project = Adapters.adapt(java.getProject(), Project.class);
 			if (project == null)
 				return null;
 

--- a/bndtools.core/src/bndtools/command/BndExportJarHandler.java
+++ b/bndtools.core/src/bndtools/command/BndExportJarHandler.java
@@ -13,6 +13,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -24,7 +25,6 @@ import aQute.bnd.osgi.Resource;
 import aQute.lib.io.IO;
 import biz.aQute.resolve.Bndrun;
 import bndtools.Plugin;
-import bndtools.central.Central;
 import bndtools.launch.util.LaunchUtils;
 
 public class BndExportJarHandler extends AbstractHandler {
@@ -47,8 +47,8 @@ public class BndExportJarHandler extends AbstractHandler {
 
 					File exportDir = bndrun.getBase();
 
-					if (Central.isBndProject(project)) {
-						Project bndProject = Central.getProject(project);
+					Project bndProject = Adapters.adapt(project, Project.class);
+					if (bndProject != null) {
 						bndrun.setBase(bndProject.getBase());
 						exportDir = IO.getBasedFile(bndProject.getTargetDir(), "export");
 						exportDir.mkdirs();
@@ -61,7 +61,7 @@ public class BndExportJarHandler extends AbstractHandler {
 							File exported = IO.getBasedFile(exportDir, export.getKey());
 							resource.write(exported);
 							exported.setLastModified(resource.lastModified());
-							if (Central.isBndProject(project)) {
+							if (bndProject != null) {
 								project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 							}
 						}

--- a/bndtools.core/src/bndtools/internal/BndAdapter.java
+++ b/bndtools.core/src/bndtools/internal/BndAdapter.java
@@ -1,0 +1,42 @@
+package bndtools.internal;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.osgi.service.component.annotations.Component;
+
+import aQute.bnd.build.Project;
+import bndtools.Plugin;
+import bndtools.central.Central;
+
+@Component(service = IAdapterFactory.class, property = {
+	IAdapterFactory.SERVICE_PROPERTY_ADAPTABLE_CLASS + "=org.eclipse.core.resources.IProject",
+	IAdapterFactory.SERVICE_PROPERTY_ADAPTER_NAMES + "=aQute.bnd.build.Project"
+})
+public class BndAdapter implements IAdapterFactory {
+
+	@Override
+	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		if (adapterType == Project.class) {
+			if (adaptableObject instanceof IProject project) {
+				try {
+					if (project.hasNature(Plugin.BNDTOOLS_NATURE)) {
+						// this project is for sure a bndtools project ...
+						Project bndproject = Central.getProject(project);
+						return adapterType.cast(project);
+					}
+				} catch (Exception e) {
+					// can't adapt that project then...
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+		return new Class<?>[] {
+			Project.class
+		};
+	}
+
+}

--- a/bndtools.core/src/bndtools/internal/BndAdapter.java
+++ b/bndtools.core/src/bndtools/internal/BndAdapter.java
@@ -1,14 +1,16 @@
 package bndtools.internal;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.osgi.service.component.annotations.Component;
 
 import aQute.bnd.build.Project;
+import bndtools.Activator;
 import bndtools.Plugin;
 import bndtools.central.Central;
 
-@Component(service = IAdapterFactory.class, property = {
+@Component(property = {
 	IAdapterFactory.SERVICE_PROPERTY_ADAPTABLE_CLASS + "=org.eclipse.core.resources.IProject",
 	IAdapterFactory.SERVICE_PROPERTY_ADAPTER_NAMES + "=aQute.bnd.build.Project"
 })
@@ -22,10 +24,19 @@ public class BndAdapter implements IAdapterFactory {
 					if (project.hasNature(Plugin.BNDTOOLS_NATURE)) {
 						// this project is for sure a bndtools project ...
 						Project bndproject = Central.getProject(project);
-						return adapterType.cast(project);
+						return adapterType.cast(bndproject);
 					}
 				} catch (Exception e) {
-					// can't adapt that project then...
+					if (e instanceof CoreException core) {
+						Activator.getDefault()
+							.getLog()
+							.log(core.getStatus());
+
+					} else {
+						Activator.getDefault()
+						.getLog()
+							.error("Adaption of " + adaptableObject + " as a bndtools project failed", e);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If one wants to write generic UI components then there is often the question to answer to what (bnd) project an Eclipse IProject belongs (if any).

This adds an Adapter that can adapt from IProject > (bnd) Project if the IProject is a PDE Bnd backed project.

See also
- https://bnd.discourse.group/t/announcement-bnd-and-pde-cooperation/372
- Corresponding PDE change https://github.com/eclipse-pde/eclipse.pde/pull/918