### PR TITLE
Remove usage of internal class RenamePackageProcessor

### DIFF
--- a/bndtools.core/src/bndtools/refactor/PkgRenameParticipant.java
+++ b/bndtools.core/src/bndtools/refactor/PkgRenameParticipant.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.IPackageFragment;
-import org.eclipse.jdt.internal.corext.refactoring.rename.RenamePackageProcessor;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -66,8 +65,6 @@ public class PkgRenameParticipant extends RenameParticipant implements ISharable
 		sb.append("Bndtools: rename package '");
 		sb.append(pkgFragment.getElementName());
 		sb.append("' ");
-		if (((RenamePackageProcessor) this.getProcessor()).getRenameSubpackages())
-			sb.append("and subpackages ");
 		sb.append("to '");
 		sb.append(args.getNewName());
 		sb.append("'");


### PR DESCRIPTION
* fixes #5891
* this fixes the NoClassDefFoundError: org/eclipse/jdt/internal/corext/refactoring/rename/RenamePackageProcessor because RenamePackageProcessor seems to be internal
* we loose a tiny bit of detail in the Rename dialog method but renaming works again

This sentence

<img width="610" alt="image" src="https://github.com/bndtools/bnd/assets/188422/efcc9076-43cd-454b-9e0f-bcdedce860e9">

was created by the touched code:

<img width="829" alt="image" src="https://github.com/bndtools/bnd/assets/188422/35df016e-3a06-436d-88d7-4f93dae051f3">

We loose the part of the sentence when the "Rename subpackages" checkbox was checked.
The checkbox is still working. It is just the sentence in the UI which does not mention this anymore.
I think that is a negligible compromise.

Edit:
I found that that package is marked as internal: `org.eclipse.jdt.internal.corext.refactoring.rename;x-internal:=true`

<img width="1012" alt="image" src="https://github.com/bndtools/bnd/assets/188422/22c85750-7978-415a-b475-58bc12e19cde">


> The x-internal Directive
> The x-internal directive can be used in an Export-Package header to specify whether the package is an internal package. The Plug-in Development Environment will discourage other bundles from using an internal package. If the x-internal directive is not specified then a default value of 'false' is used. The x-internal directive must use the following syntax:
> 
> x-internal ::= ( 'true' | 'false' )
> 

Source: https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fbundle_manifest.html

So I guess in the past it was not internal. Now it is.


Thoughts?

