### PR TITLE
Add vertical scrollbar to Jar viewer

### DIFF
--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePart.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePart.java
@@ -58,7 +58,7 @@ public class JARTreePart extends AbstractFormPart {
 		Section section = toolkit.createSection(parent, ExpandableComposite.TITLE_BAR | ExpandableComposite.EXPANDED);
 
 		section.setText("Content Tree");
-		tree = toolkit.createTree(section, SWT.FULL_SELECTION | SWT.SINGLE);
+		tree = toolkit.createTree(section, SWT.FULL_SELECTION | SWT.SINGLE | SWT.V_SCROLL);
 		tree.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TREE_BORDER);
 
 		section.setClient(tree);


### PR DESCRIPTION
* the fixes the problem that for large jars with many classes in a package you could not scroll to the bottom e.g. to the last class... Now you can.

Before:

<img width="716" alt="image" src="https://github.com/bndtools/bnd/assets/188422/63a3ce49-8d88-420c-a425-c7be25a5cd91">


After:

<img width="426" alt="image" src="https://github.com/bndtools/bnd/assets/188422/2feae97f-f3cb-4129-9eb3-819196805189">
