### PR TITLE
open jar on dblclick on AdvancedSearch entry

### DIFF
--- a/bndtools.core/src/bndtools/model/repo/RepositoryResourceElement.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryResourceElement.java
@@ -3,12 +3,13 @@ package bndtools.model.repo;
 import java.util.Objects;
 
 import org.bndtools.utils.resources.ResourceUtils;
+import org.eclipse.core.runtime.IAdaptable;
 import org.osgi.framework.Version;
 import org.osgi.resource.Resource;
 
 import aQute.bnd.service.RepositoryPlugin;
 
-public class RepositoryResourceElement implements ResourceProvider {
+public class RepositoryResourceElement implements ResourceProvider, IAdaptable {
 
 	private final Resource					resource;
 	private final String					name;
@@ -39,6 +40,20 @@ public class RepositoryResourceElement implements ResourceProvider {
 	@Override
 	public Resource getResource() {
 		return resource;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+
+		// this is triggered e.g. when you doubleclick on an
+		// Advanved-Search result entry in the RepositoryBrowser
+		// see
+		// bndtools.views.repository.RepositoriesView.createPartControl(Composite)
+		// and scroll down to "viewer.addDoubleClickListener(..."
+		// but since repositoryBundleVersion already implements IAdaptable
+		// we just forward to it
+		return repositoryBundleVersion.getAdapter(adapter);
 	}
 
 	@Override


### PR DESCRIPTION
* before this change: double clicking on a result entry  of an Advanced search (e.g. by package name) nothing happened
* after this change: the jar of the bundle opens. this is now same behavior as double clicking on a bundleVersion in the repo browser without advanced search filtering


## Testing

* filter the RepoBrowser e.g. by a specific package name
* then double click on one of the search results
* Expected Result: The Jar Viewer should open this entry. 

<img width="421" alt="image" src="https://github.com/bndtools/bnd/assets/188422/e3b5f659-0768-4a5a-bf4f-ab72bf4e7fde">


<img width="769" alt="image" src="https://github.com/bndtools/bnd/assets/188422/af682b83-0b14-4154-98d2-4c5686644fac">
