### PR TITLE
Avoid NPE in AnsiHandler.java

### DIFF
--- a/bndtools.core/src/bndtools/core/console/AnsiHandler.java
+++ b/bndtools.core/src/bndtools/core/console/AnsiHandler.java
@@ -29,6 +29,10 @@ public class AnsiHandler implements IPatternMatchListener {
 		Display.getDefault()
 			.asyncExec(() -> {
 				try {
+					if (console == null) {
+						// ignore
+						return;
+					}
 					console.getDocument()
 						.replace(0, event.getOffset() + event.getLength(), "");
 				} catch (BadLocationException e) {


### PR DESCRIPTION
fixes #5884
Not sure why console is null, but since it is passed from outside Eclipse framework it is not under our control. we should just handle the null case.