### PR TITLE
Framework move to OSGi 1.10 & Felix 7.0.5

### DIFF
--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -17,10 +17,10 @@ jtwig.version: 5.86.1.RELEASE
 	org.apache.commons.lang3;version="[3.4,4.0)",\
 	com.google.guava;version="[18.0,19.0)",\
 	com.googlecode.concurrentlinkedhashmap.lru;version="[1.4.2,2.0.0)",\
-	org.objectweb.asm;version="[5.0.3,6.0.0)",\
-	org.objectweb.asm.analysis;version="[5.0.3,6.0.0)",\
-	org.objectweb.asm.tree;version="[5.0.3,6.0.0)",\
-	org.objectweb.asm.util;version="[5.0.3,6.0.0)",\
+	org.objectweb.asm,\
+	org.objectweb.asm.tree.analysis,\
+	org.objectweb.asm.tree,\
+	org.objectweb.asm.util,\
 	com.github.javaparser.javaparser-core;version=3.13
 	
 -testpath: \

--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -68,9 +68,9 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
 -maven-scope: provided
 
 -buildpath: \
+    org.osgi.framework;version='1.10',\
 	org.osgi.dto;version='1.0',\
 	org.osgi.resource;version='1.0',\
-	org.osgi.framework;version='1.8',\
 	org.osgi.util.tracker;version='1.5',\
 	org.osgi.service.coordinator;version=latest,\
 	org.osgi.service.log;version=latest,\
@@ -97,7 +97,7 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
 	biz.aQute.bnd.test;version=project,\
 	${junit},\
 	org.osgi.namespace.extender,\
-	org.apache.felix.framework, \
+	org.apache.felix.framework;version="[6.0.5,6.0.5]", \
 	biz.aQute.bnd.embedded-repo; version=snapshot
 
 # Dependencies needed by the inclusion of biz.aQute.bnd.reporter in the jar.
@@ -111,10 +111,10 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
     ${repo;org.apache.commons.lang3;[3.4,4.0)},\
     ${repo;com.google.guava;[18.0,19.0)},\
     ${repo;com.googlecode.concurrentlinkedhashmap.lru;[1.4.2,2.0.0)},\
-    ${repo;org.objectweb.asm;[5.0.3,6.0.0)},\
-    ${repo;org.objectweb.asm.analysis;[5.0.3,6.0.0)},\
-    ${repo;org.objectweb.asm.tree;[5.0.3,6.0.0)},\
-    ${repo;org.objectweb.asm.util;[5.0.3,6.0.0)},\
+    ${repo;org.objectweb.asm},\
+    ${repo;org.objectweb.asm.tree.analysis},\
+    ${repo;org.objectweb.asm.tree},\
+    ${repo;org.objectweb.asm.util},\
 	${repo;com.github.javaparser.javaparser-core;3.13}
 
 
@@ -126,10 +126,10 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
     org.apache.commons.lang3;version="[3.4,4.0)",\
     com.google.guava;version="[18.0,19.0)",\
     com.googlecode.concurrentlinkedhashmap.lru;version="[1.4.2,2.0.0)",\
-    org.objectweb.asm;version="[5.0.3,6.0.0)",\
-    org.objectweb.asm.analysis;version="[5.0.3,6.0.0)",\
-    org.objectweb.asm.tree;version="[5.0.3,6.0.0)",\
-    org.objectweb.asm.util;version="[5.0.3,6.0.0)",\
+    org.objectweb.asm,\
+    org.objectweb.asm.tree.analysis,\
+    org.objectweb.asm.tree,\
+    org.objectweb.asm.util,\
 	com.github.javaparser.javaparser-core;version=3.13
 
 

--- a/biz.aQute.launchpad.tests/bnd.bnd
+++ b/biz.aQute.launchpad.tests/bnd.bnd
@@ -4,13 +4,14 @@
 -dependson biz.aQute.bndlib,biz.aQute.repository,biz.aQute.resolve
 
 -buildpath: \
+    org.osgi.framework;version=1.10, \
     org.osgi.service.component.annotations;version='1.3.0', \
+    slf4j.api, \
     osgi.annotation,\
     osgi.core,\
     org.osgi.service.component;version='1.3.0'
 
 -testpath: \
-    slf4j.api, \
     slf4j.simple, \
 	${junit},\
 	biz.aQute.launchpad;version=latest, \

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/FO.java
@@ -23,7 +23,7 @@ public class FO {
 
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
 		.set("snapshot.dir", tmp.getAbsolutePath())
-		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
+		.runfw("org.apache.felix.framework;version='[7.0.5,7.0.5]'")
 		.bundles(
 			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, assertj-core, net.bytebuddy.byte-buddy, org.apache.servicemix.bundles.junit")
 		.debug();

--- a/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
+++ b/biz.aQute.launchpad.tests/test/aQute/xlaunchpad/LaunchpadRunnerBasicTest.java
@@ -25,7 +25,7 @@ public class LaunchpadRunnerBasicTest {
 	static LaunchpadBuilder builder = new LaunchpadBuilder().snapshot()
 		.set("snapshot.dir", tmp.getAbsolutePath())
 		.bndrun("runsystempackages.bndrun")
-		.runfw("jar/org.apache.felix.framework-6.0.2.jar;version=file")
+		.runfw("org.apache.felix.framework;version='[7.0.5,7.0.5]'")
 		.export("*")
 		.bundles(
 			"org.osgi.util.promise, org.osgi.util.function, jar/org.apache.felix.scr-2.1.16.jar;version=file, assertj-core, net.bytebuddy.byte-buddy")

--- a/biz.aQute.launchpad.tests/workspace.bndrun
+++ b/biz.aQute.launchpad.tests/workspace.bndrun
@@ -2,7 +2,7 @@
 	osgi.identity;filter:='(osgi.identity=biz.aQute.bndlib)',\
 	osgi.identity;filter:='(osgi.identity=biz.aQute.resolve)',\
 	osgi.identity;filter:='(osgi.identity=biz.aQute.repository)'
--runfw: org.apache.felix.framework;version='[6.0.5,6.0.5]'
+-runfw: org.apache.felix.framework;version='[7.0.5,7.0.5]'
 -runee: JavaSE-17
 -runpath: slf4j.api,slf4j.simple,aQute.libg
 -runbundles: \
@@ -16,7 +16,7 @@
 	biz.aQute.bndlib;version=snapshot,\
 	biz.aQute.repository;version=snapshot,\
 	biz.aQute.resolve;version=snapshot
--resolve: manual
+-resolve: cache
 -runtrace true
 -runrepos: \
 	Maven Central,\

--- a/biz.aQute.launchpad/bnd.bnd
+++ b/biz.aQute.launchpad/bnd.bnd
@@ -30,6 +30,7 @@ Import-Package: \
 
 -buildpath: \
     osgi.annotation,\
+    org.osgi.framework;version=1.10,\
     osgi.core,\
     org.osgi.service.component;version='[1.4,1.5)',\
     aQute.libg,\

--- a/biz.aQute.launchpad/missing.bndrun
+++ b/biz.aQute.launchpad/missing.bndrun
@@ -1,2 +1,2 @@
--runfw          org.apache.felix.framework
+-runfw          org.apache.felix.framework;version="[6.0.5,6.0.5]"
 -runbundles     org.apache.felix.cm;version='[1.2,1.21)'

--- a/biz.aQute.launchpad/runsystempackages.bndrun
+++ b/biz.aQute.launchpad/runsystempackages.bndrun
@@ -1,3 +1,3 @@
--runfw              org.apache.felix.framework
+-runfw          org.apache.felix.framework;version="[6.0.5,6.0.5]"
 -runbundles         org.osgi.service.cm
 -runsystempackages  sun.misc

--- a/biz.aQute.tester.test/base.bndrun
+++ b/biz.aQute.tester.test/base.bndrun
@@ -10,7 +10,7 @@
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)'
 
--runfw: org.apache.felix.framework
+-runfw: org.apache.felix.framework;version='[7.0.5,7.0.5]'
 -runee: JavaSE-1.8
 
 -runsystempackages: aQute.tester.testbase

--- a/biz.aQute.tester.test/biz.aQute.tester.bndrun
+++ b/biz.aQute.tester.test/biz.aQute.tester.bndrun
@@ -1,4 +1,4 @@
--runfw: org.apache.felix.framework;version='[6.0.5,6.0.5]'
+-runfw: org.apache.felix.framework;version='[7.0.5,7.0.5]'
 -runrequires: \
 	bnd.identity;id='biz.aQute.tester'
 -runee: JavaSE-1.8

--- a/biz.aQute.tester.test/bnd.bnd
+++ b/biz.aQute.tester.test/bnd.bnd
@@ -4,6 +4,7 @@
 -nobundles: true
 
 -buildpath: \
+    org.osgi.framework;version=1.10, \
 	org.apache.servicemix.bundles.junit;version=latest,\
 	junit-jupiter-api;version='${junit.jupiter.eclipse.version}',\
 	junit-jupiter-params;version='${junit.jupiter.eclipse.version}',\

--- a/biz.aQute.tester.test/bundleenginetest-noengines.bndrun
+++ b/biz.aQute.tester.test/bundleenginetest-noengines.bndrun
@@ -6,7 +6,7 @@
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)'
 	
--runfw: org.apache.felix.framework
+-runfw: org.apache.felix.framework;version='[7.0.5,7.0.5]'
 -runee: JavaSE-1.8
 
 -runsystempackages: \

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -56,6 +56,7 @@ org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:1.2.
 org.apache.felix:org.apache.felix.configadmin:1.9.10
 org.apache.felix:org.apache.felix.log:1.2.0
 org.apache.felix:org.apache.felix.framework:6.0.5
+org.apache.felix:org.apache.felix.framework:7.0.5
 org.apache.felix:org.apache.felix.gogo.command:1.0.2
 org.apache.felix:org.apache.felix.gogo.runtime:1.1.0
 org.apache.felix:org.apache.felix.gogo.shell:1.1.0
@@ -142,12 +143,12 @@ org.jtwig:jtwig-core:5.86.1.RELEASE
 org.jtwig:jtwig-reflection:5.86.1.RELEASE
 com.google.guava:guava:18.0
 com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2
-org.parboiled:parboiled-java:1.1.7
-org.parboiled:parboiled-core:jar:1.1.7
-org.ow2.asm:asm:jar:5.0.3
-org.ow2.asm:asm-tree:jar:5.0.3
-org.ow2.asm:asm-analysis:jar:5.0.3
-org.ow2.asm:asm-util:jar:5.0.3
+org.parboiled:parboiled-java:1.4.1
+org.parboiled:parboiled-core:jar:1.4.1
+
+org.ow2.asm:asm-analysis:jar:9.3
+org.ow2.asm:asm-util:jar:9.3
+
 com.github.javaparser:javaparser-core:3.13.10
 
 javax.json:javax.json-api:1.1.2


### PR DESCRIPTION
Needed a newer framework in a test.

- Added Felix 7.0.5 to the repo
- Updated launchpad projects to use proper org.osgi.framework on -testpath
- Updated a number of bndrun files

Somehow also the reporter needed an update

- Updated parboiled
- Updated asm