### PR TITLE
Prefer the minus instruction over the header like variant

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -1214,24 +1214,24 @@ public class BndEditModel {
 			setEntries(resourceEntries2, Constants.INCLUDE_RESOURCE);
 		}
 
-		if (hasIncludeResourceInstruction()) {
-			resourceEntries1.addAll(addedEntries);
-			setEntries(resourceEntries1, Constants.INCLUDERESOURCE);
-		} else {
+		if (hasIncludeResourceHeaderLikeInstruction()) {
 			resourceEntries2.addAll(addedEntries);
 			setEntries(resourceEntries2, Constants.INCLUDE_RESOURCE);
+		} else {
+			resourceEntries1.addAll(addedEntries);
+			setEntries(resourceEntries1, Constants.INCLUDERESOURCE);
 		}
 	}
 
 	public void addIncludeResource(String resource) {
-		String key = hasIncludeResourceInstruction() ? Constants.INCLUDERESOURCE : Constants.INCLUDE_RESOURCE;
+		String key = hasIncludeResourceHeaderLikeInstruction() ? Constants.INCLUDE_RESOURCE : Constants.INCLUDERESOURCE;
 		List<String> entries = getEntries(key, listConverter);
 		entries.add(resource);
 		setEntries(entries, key);
 	}
 
-	private boolean hasIncludeResourceInstruction() {
-		return properties.containsKey(Constants.INCLUDERESOURCE);
+	private boolean hasIncludeResourceHeaderLikeInstruction() {
+		return properties.containsKey(Constants.INCLUDE_RESOURCE);
 	}
 
 	public void setProject(Project project) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -68,6 +68,7 @@ public interface Constants {
 
 	String		PRIVATE_PACKAGE								= "Private-Package";
 	String		IGNORE_PACKAGE								= "Ignore-Package";
+	@Deprecated
 	String		INCLUDE_RESOURCE							= "Include-Resource";
 	String		CONDITIONAL_PACKAGE							= "Conditional-Package";
 	String		BND_LASTMODIFIED							= "Bnd-LastModified";


### PR DESCRIPTION
Currently if one creates a model from scratch the BndEditModel prefer the header-like one over the minus instruction.

To not confuse users with the old variant, this one give precedence over the header-like and also deprecate the old header like variant.