### PR TITLE
Show blacklisted req/caps on resolve failure

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/AbstractResolveContext.java
@@ -100,6 +100,7 @@ public abstract class AbstractResolveContext extends ResolveContext {
 	private Resource								systemResource;
 	private Resource								inputResource;
 	private Set<Resource>							blacklistedResources					= new HashSet<>();
+	private final Set<Capability>					blacklistedCapabilities					= new HashSet<>();
 	private int										level									= 0;
 	private Resource								framework;
 	private final AtomicBoolean						reported								= new AtomicBoolean();
@@ -285,8 +286,18 @@ public abstract class AbstractResolveContext extends ResolveContext {
 	protected Collection<Capability> findProviders(Repository repo, Requirement requirement) {
 		Map<Requirement, Collection<Capability>> map = repo.findProviders(Collections.singleton(requirement));
 		Collection<Capability> caps = map.get(requirement);
-		caps.removeIf(capability -> blacklistedResources.contains(capability.getResource()));
+		caps.removeIf(capability -> isBlacklisted(capability));
 		return caps;
+	}
+
+	private boolean isBlacklisted(Capability capability) {
+
+		boolean contains = blacklistedResources.contains(capability.getResource());
+		if (contains) {
+			blacklistedCapabilities.add(capability);
+		}
+
+		return contains;
 	}
 
 	private void setResourcePriority(int priority, Resource resource) {
@@ -693,6 +704,10 @@ public abstract class AbstractResolveContext extends ResolveContext {
 
 	public Set<Resource> getBlackList() {
 		return blacklistedResources;
+	}
+
+	public Set<Capability> getBlacklistedCapabilities() {
+		return blacklistedCapabilities;
 	}
 
 	public void setLevel(int n) {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/BndResolutionException.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/BndResolutionException.java
@@ -12,14 +12,14 @@ import org.osgi.service.resolver.ResolutionException;
  * A {@link ResolutionException} providing more details about why resolution has
  * failed.
  */
-public class ResolutionExceptionWithDetails extends ResolutionException {
+public class BndResolutionException extends ResolutionException {
 
 	private static final long	serialVersionUID	= 1L;
 
 	private Set<Resource>		blackList;
 	private Set<Capability>		blacklistedCapabilities;
 
-	public ResolutionExceptionWithDetails(String message, Throwable cause,
+	public BndResolutionException(String message, Throwable cause,
 		Collection<Requirement> unresolvedRequirements, Set<Resource> blackList,
 		Set<Capability> blacklistedCapabilities) {
 		super(message, cause, unresolvedRequirements);

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolutionExceptionWithDetails.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolutionExceptionWithDetails.java
@@ -1,0 +1,38 @@
+package biz.aQute.resolve;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.resolver.ResolutionException;
+
+/**
+ * A {@link ResolutionException} providing more details about why resolution has
+ * failed.
+ */
+public class ResolutionExceptionWithDetails extends ResolutionException {
+
+	private static final long	serialVersionUID	= 1L;
+
+	private Set<Resource>		blackList;
+	private Set<Capability>		blacklistedCapabilities;
+
+	public ResolutionExceptionWithDetails(String message, Throwable cause,
+		Collection<Requirement> unresolvedRequirements, Set<Resource> blackList,
+		Set<Capability> blacklistedCapabilities) {
+		super(message, cause, unresolvedRequirements);
+		this.blackList = blackList;
+		this.blacklistedCapabilities = blacklistedCapabilities;
+
+	}
+
+	public Set<Resource> getBlackList() {
+		return blackList;
+	}
+
+	public Set<Capability> getBlacklistedCapabilities() {
+		return blacklistedCapabilities;
+	}
+}

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -241,7 +241,6 @@ public class ResolveProcess {
 	 *            output
 	 * @return the report
 	 */
-	@SuppressWarnings("unlikely-arg-type")
 	public static String format(ResolutionException re, boolean reportOptional) {
 		List<Requirement> chain = getCausalChain(re);
 
@@ -290,11 +289,11 @@ public class ResolveProcess {
 
 			// 4. Check Blacklist
 
-			if (re instanceof ResolutionExceptionWithDetails detailedExc) {
+			if (re instanceof BndResolutionException detailedExc) {
 				Set<Resource> blackList = detailedExc.getBlackList();
 				Set<Capability> blacklistedCapabilities = detailedExc.getBlacklistedCapabilities();
 
-				if (!blacklistedCapabilities.isEmpty()) {
+				if (blacklistedCapabilities != null && !blacklistedCapabilities.isEmpty()) {
 
 					f.format(
 						"%n%nBlacklisted Capabilities: Some requirements could not be satisfied because of blacklisted capabilities in -runblacklist:%n");
@@ -491,7 +490,7 @@ public class ResolveProcess {
 			Set<Capability> blacklistedCapabilities = arctx.getBlacklistedCapabilities();
 
 			if (!blacklistedCapabilities.isEmpty()) {
-				return new ResolutionExceptionWithDetails(re.getMessage(), re, list, blackList,
+				return new BndResolutionException(re.getMessage(), re, list, blackList,
 					blacklistedCapabilities);
 			} else {
 				return new ResolutionException(re.getMessage(), re, list);

--- a/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/ResolveProcess.java
@@ -290,53 +290,76 @@ public class ResolveProcess {
 			// 4. Check Blacklist
 
 			if (re instanceof BndResolutionException detailedExc) {
-				Set<Resource> blackList = detailedExc.getBlackList();
-				Set<Capability> blacklistedCapabilities = detailedExc.getBlacklistedCapabilities();
-
-				if (blacklistedCapabilities != null && !blacklistedCapabilities.isEmpty()) {
-
-					f.format(
-						"%n%nBlacklisted Capabilities: Some requirements could not be satisfied because of blacklisted capabilities in -runblacklist:%n");
-
-					for (Requirement req : chain) {
-
-						String namespace = req.getNamespace();
-						String filter = req.getDirectives()
-							.get("filter");
-
-						for (Resource blacklistedRes : blackList) {
-
-							List<Capability> findCapability = ResourceUtils.findCapability(blacklistedRes, namespace,
-								filter);
-							if (!findCapability.isEmpty()) {
-								f.format(
-									"%s is ignored because it is blacklisted although providing required capability %s%s%n",
-									blacklistedRes, namespace, filter);
-							}
-
-						}
-
-					}
-
-					f.format("%n%nAll Blacklisted Capabilities:%n");
-
-					for (Capability cap : blacklistedCapabilities) {
-						f.format("%s providing capability %s:%s ignored%n", cap.getResource(), cap.getNamespace(),
-							cap.getAttributes()
-							.get(cap.getNamespace()));
-					}
-
-					f.format("%n%nAll Blacklisted Resources%n");
-
-					for (Resource res : blackList) {
-						f.format("%s%n", res);
-					}
-				}
-
-
+				printBlacklistDebugLog(chain, f, detailedExc);
 			}
 
 			return f.toString();
+		}
+	}
+
+	/**
+	 * Print -runblacklist related debug output if exists.
+	 *
+	 * @param unresolvedRequirements
+	 * @param f
+	 * @param detailedExc
+	 */
+	private static void printBlacklistDebugLog(List<Requirement> unresolvedRequirements, Formatter f,
+		BndResolutionException detailedExc) {
+		Set<Resource> blackList = detailedExc.getBlackList();
+		Set<Capability> blacklistedCapabilities = detailedExc.getBlacklistedCapabilities();
+
+		if (blacklistedCapabilities != null && !blacklistedCapabilities.isEmpty()) {
+
+			f.format(
+				"%n%nBlacklisted Capabilities: Some requirements could not be satisfied because of blacklisted capabilities in -runblacklist:%n");
+
+			printBlacklistSummary(unresolvedRequirements, f, blackList);
+
+			f.format("%n%nAll blacklisted Capabilities:%n");
+
+			for (Capability cap : blacklistedCapabilities) {
+				f.format("'%s' providing capability '%s: %s' ignored%n", cap.getResource(), cap.getNamespace(),
+					cap.getAttributes()
+						.get(cap.getNamespace()));
+			}
+
+			f.format("%n%nAll blacklisted Resources:%n");
+
+			for (Resource res : blackList) {
+				f.format("%s%n", res);
+			}
+		}
+	}
+
+	/**
+	 * Tries to determine which of the blacklisted capability (resource) is
+	 * responsible for an unresolved requirement.
+	 *
+	 * @param unresolvedRequirements
+	 * @param f
+	 * @param blackList
+	 */
+	private static void printBlacklistSummary(List<Requirement> unresolvedRequirements, Formatter f,
+		Set<Resource> blackList) {
+		for (Requirement req : unresolvedRequirements) {
+
+			String namespace = req.getNamespace();
+			String filter = req.getDirectives()
+				.get("filter");
+
+			for (Resource blacklistedRes : blackList) {
+
+				List<Capability> findCapability = ResourceUtils.findCapability(blacklistedRes, namespace,
+					filter);
+				if (!findCapability.isEmpty()) {
+					f.format(
+						"'%s' is ignored because it is blacklisted although providing required capability '%s: %s'%n",
+						blacklistedRes, namespace, filter);
+				}
+
+			}
+
 		}
 	}
 


### PR DESCRIPTION
## What is it

1st draft of an attempt to improve and enrich the Resolution failure output with information about blacklisted items which were not considered for resolution. The goal is to make it easier to spot resolution failure because of a too broad blacklist. This is based on a real use case (see https://github.com/bndtools/bndtools.workspace.min/pull/11#issuecomment-1827377986 ) where the blacklist was the reason for failed resolving, but the current tooling gave no indication about this.

Although it was an OSI-layer 8 problem, it would have made the chase easier, if there was some kind of pointer to the `-runblacklist`


## Example output

<img width="890" alt="image" src="https://github.com/bndtools/bnd/assets/188422/ae30510c-91e1-42a0-b805-42f96de73de0">


```
Resolution failed. Summary:
      ⇒ Bundle: servicetest.consumer cannot be resolved
              ⇒ Extender: &(osgi.extender=osgi.component)(version=[1.5.0,2.0.0)) cannot be resolved
                      ⇒ because Import-Package requirement for: org.osgi.service.component; version=[1.5.0,1.6.0) could not be provided by any available bundle or dependency

Note: The summary above may be incomplete. Please check the full output below for more hints.
Resolution failed. Capabilities satisfying the following requirements could not be found:

    [<<INITIAL>>]
      ⇒ osgi.identity: (osgi.identity=servicetest.consumer)
          ⇒ [servicetest.consumer version=1.0.0.202311271939]
              ⇒ osgi.extender: (&(osgi.extender=osgi.component)(version>=1.5.0)(!(version>=2.0.0)))
                  ⇒ [org.apache.felix.scr version=2.2.6]
                      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.osgi.service.component)(version>=1.5.0)(!(version>=1.6.0)))

Blacklisted Capabilities: Some requirements could not be satisfied because of blacklisted capabilities in -runblacklist:
org.osgi.service.component version=1.5.1.202212101352 is ignored because it is blacklisted although providing required capability osgi.wiring.package(&(osgi.wiring.package=org.osgi.service.component)(version>=1.5.0)(!(version>=1.6.0)))


All Blacklisted Capabilities:
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.framework.startlevel ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.dto ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.framework ignored
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.framework.dto ignored
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.util.tracker ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.util.tracker ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.resource ignored
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.framework ignored
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.framework.wiring ignored
osgi.core version=6.0.0.201403061837 providing capability osgi.wiring.package:org.osgi.resource ignored
org.osgi.service.component version=1.5.1.202212101352 providing capability osgi.wiring.package:org.osgi.service.component ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.framework.startlevel ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.framework.wiring ignored
osgi.core version=8.0.0.202007221806 providing capability osgi.wiring.package:org.osgi.framework.dto ignored


All Blacklisted Resources
slf4j.api__8 version=2.0.9 type=bnd.synthetic
slf4j.api__9 version=2.0.9 type=bnd.synthetic
slf4j.simple__8 version=2.0.9 type=bnd.synthetic
slf4j.simple__9 version=2.0.9 type=bnd.synthetic
slf4j.nop__8 version=2.0.9 type=bnd.synthetic
slf4j.nop__9 version=2.0.9 type=bnd.synthetic
org.osgi.service.metatype.annotations version=1.4.1.202109301733
org.osgi.service.transaction.control version=1.0.0.201802012107
org.osgi.service.component.annotations version=1.5.1.202212101352
org.osgi.service.networkadapter version=1.0.1.202109301733
org.osgi.service.repository version=1.1.0.201505202024
org.osgi.service.zigbee version=1.0.1.202109301733
org.osgi.service.packageadmin version=1.2.1.202007221806
org.osgi.service.application version=1.1.0.201505202023
org.osgi.service.log version=1.5.0.202007221806
org.osgi.service.clusterinfo version=1.0.0.201802012106
org.osgi.service.blueprint version=1.0.2.201505202024
org.osgi.service.feature version=1.0.0.202109301733
org.osgi.service.permissionadmin version=1.2.1.202007221806
org.osgi.service.condpermadmin version=1.1.2.202007221806
org.osgi.service.configurator version=1.0.1.202109301733
org.osgi.service.onem2m version=1.0.0.202109301733
slf4j.osgi version=2.0.0
org.osgi.service.enocean version=1.0.1.202109301733
org.osgi.service.http.whiteboard version=1.1.1.202109301733
org.osgi.service.rest version=1.0.0.201505202024
org.osgi.service.serviceloader version=1.0.0.201505202024
org.osgi.service.servlet version=2.0.0.202212101352
org.osgi.service.startlevel version=1.1.1.202007221806
org.osgi.service.dmt version=2.0.2.201802012106
org.osgi.service.monitor version=1.0.0.201505202023
org.osgi.service.jndi version=1.0.1.202109301733
org.osgi.service.typedevent version=1.0.0.202109301733
slf4j.api version=2.0.9
org.osgi.service.usbinfo version=1.0.1.202109301733
org.osgi.service.condition version=1.0.0.202007221806
org.osgi.service.subsystem version=1.1.0.201505202024
org.osgi.service.device version=1.1.1.202109301733
org.osgi.service.metatype version=1.4.1.202109301733
org.osgi.service.resourcemonitoring version=1.0.1.202109301733
org.osgi.service.async version=1.0.0.201505202023
slf4j.simple version=2.0.9
org.osgi.service.deploymentadmin version=1.1.0.201505202023
osgi.core version=6.0.0.201403061837
org.osgi.service.prefs version=1.1.2.202109301733
org.osgi.service.dal version=1.0.2.202109301733
org.osgi.service.remoteserviceadmin version=1.1.0.201505202024
org.osgi.service.http version=1.2.2.202109301733
org.osgi.service.coordinator version=1.0.2.201505202024
org.osgi.service.jdbc version=1.1.0.202212101352
org.osgi.service.cm version=1.6.1.202109301733
org.osgi.service.wireadmin version=1.0.2.202109301733
org.osgi.service.url version=1.0.1.202007221806
org.osgi.service.cdi version=1.0.1.202109301733
org.osgi.service.dal.functions version=1.0.1.202109301733
slf4j.nop version=2.0.9
org.osgi.service.tr069todmt version=1.0.2.202109301733
osgi.cmpn version=5.0.0.201305092017
org.osgi.service.provisioning version=1.2.0.201505202024
org.osgi.service.component version=1.5.1.202212101352
org.osgi.service.event version=1.4.1.202109301733
org.osgi.service.useradmin version=1.1.1.202109301733
org.osgi.service.jakartars version=2.0.0.202212101352
org.osgi.service.log.stream version=1.0.0.202109301733
org.osgi.service.jaxrs version=1.0.1.202109301733
org.osgi.service.jpa version=1.1.1.202109301733
org.osgi.service.serial version=1.0.1.202109301733
org.osgi.service.upnp version=1.2.1.202109301733
org.osgi.service.io version=1.0.0.201505202023
osgi.core version=8.0.0.202007221806
org.osgi.service.resolver version=1.1.1.202007221806

```

## TODO discussion and cleanup needed. 

This is only a base for discussion. 
We could build up on this to make the output more precise or use the information also in other places for more subtle UI-indicators. E.g. @pkriens suggested on slack:

> black listing is on resource level. Maybe we should gray out the resource in the Repositories list in the Resolution window?
...
> I like the greying out + tooltip: I am in the blacklist!




