### PR TITLE
#5908 Split package problems in eclipse

### DIFF
--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -12,6 +12,9 @@ Import-Package: \
  org.apache.felix.shell;resolution:=optional,\
  ${eclipse.importpackage},\
  *
+# Alas, we're forced to use this because Eclipse has split packages :-(
+Require-Bundle \
+    org.eclipse.jdt.ui
 
 Export-Package: org.osgi.service.metatype.annotations 
 


### PR DESCRIPTION
Finally had to give in, is adding the org.eclipse.jdt.ui bundle as Require-Bundle because it is sooooooo difficult to keep package packages, it is much better split :-(
Fixes #5908 I hope.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>