### PR TITLE
Eclipse hack boot delegation

### DIFF
--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -22,7 +22,7 @@
 	eclipse.product=org.eclipse.sdk.ide,\
 	osgi.console=,\
 	osgi.instance.area.default=../bndtools.test/workspace,\
-	org.osgi.framework.bootdelegation='javax.net,javax.management,org.xml.sax,org.xml.sax.helpers,javax.xml,javax.xml.parsers',\
+	org.osgi.framework.bootdelegation='javax.*,org.xml.*',\
 	logback.configurationFile=${fileuri;${.}/logback.xml}
 
 # Keep sorted so that we can diff


### PR DESCRIPTION
Eclipse seems to use boot delegation for javax.*. Since we're not doing this in our debug setup, we get errors. This patch just does the same brain damaged thing
Eclipse is doing to mitigate even brain deader
bundles. Yes, I am frustrated, bnd fixed this problem 20 years ago!
Fixes #5911

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>