### PR TITLE
Add double click handler resolutionview

### DIFF
--- a/biz.aQute.bndlib.tests/test/aQute/bnd/osgi/resource/CapReqBuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/aQute/bnd/osgi/resource/CapReqBuilderTest.java
@@ -7,8 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.osgi.resource.Capability;
 import org.osgi.resource.Requirement;
@@ -21,8 +19,6 @@ import aQute.lib.collections.ExtList;
 
 public class CapReqBuilderTest {
 
-	@InjectSoftAssertions
-	SoftAssertions softly;
 
 	@Test
 	public void testSimple() throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -30,6 +30,7 @@ import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.service.repository.ContentNamespace;
 
+import aQute.bnd.classindex.ClassIndexerAnalyzer;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
@@ -709,6 +710,16 @@ public class CapReqBuilder {
 	}
 
 	public static RequirementBuilder createRequirementFromCapability(Capability capability) {
+		return createRequirementFromCapability(capability, true);
+	}
+
+	/**
+	 * @param capability the capability to convert
+	 * @param includeBndHashes if <code>true</code> the requirement contains
+	 *            'bnd.hashes', otherwise not.
+	 * @return a RequirementBuilder from the capability
+	 */
+	public static RequirementBuilder createRequirementFromCapability(Capability capability, boolean includeBndHashes) {
 		final String namespace = capability.getNamespace();
 		RequirementBuilder builder = new RequirementBuilder(namespace);
 		final String versionAttrName = Optional.ofNullable(ResourceUtils.getVersionAttributeForNamespace(namespace))
@@ -720,6 +731,12 @@ public class CapReqBuilder {
 				.append('&');
 		}
 		capAttributes.forEach((name, v) -> {
+
+			if (!includeBndHashes && name.equals(ClassIndexerAnalyzer.BND_HASHES)) {
+				// skip bnd.hashes
+				return;
+			}
+
 			if (v instanceof Version || name.equals(versionAttrName)
 				|| (namespace.equals(PackageNamespace.PACKAGE_NAMESPACE)
 					&& name.equals(AbstractWiringNamespace.CAPABILITY_BUNDLE_VERSION_ATTRIBUTE))) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/CapReqBuilder.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.osgi.framework.Constants;
 import org.osgi.framework.Version;
@@ -30,7 +31,6 @@ import org.osgi.resource.Requirement;
 import org.osgi.resource.Resource;
 import org.osgi.service.repository.ContentNamespace;
 
-import aQute.bnd.classindex.ClassIndexerAnalyzer;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
@@ -710,16 +710,18 @@ public class CapReqBuilder {
 	}
 
 	public static RequirementBuilder createRequirementFromCapability(Capability capability) {
-		return createRequirementFromCapability(capability, true);
+		return createRequirementFromCapability(capability, null);
 	}
 
 	/**
 	 * @param capability the capability to convert
-	 * @param includeBndHashes if <code>true</code> the requirement contains
-	 *            'bnd.hashes', otherwise not.
+	 * @param includeAttributesFilter predicate to control from the caller which
+	 *            attributes to include. if <code>null</code> all attributes are
+	 *            included.
 	 * @return a RequirementBuilder from the capability
 	 */
-	public static RequirementBuilder createRequirementFromCapability(Capability capability, boolean includeBndHashes) {
+	public static RequirementBuilder createRequirementFromCapability(Capability capability,
+		Predicate<String> includeAttributesFilter) {
 		final String namespace = capability.getNamespace();
 		RequirementBuilder builder = new RequirementBuilder(namespace);
 		final String versionAttrName = Optional.ofNullable(ResourceUtils.getVersionAttributeForNamespace(namespace))
@@ -732,8 +734,8 @@ public class CapReqBuilder {
 		}
 		capAttributes.forEach((name, v) -> {
 
-			if (!includeBndHashes && name.equals(ClassIndexerAnalyzer.BND_HASHES)) {
-				// skip bnd.hashes
+			if (includeAttributesFilter != null && !includeAttributesFilter.test(name)) {
+				// skip this attribute
 				return;
 			}
 

--- a/bndtools.core/bnd.bnd
+++ b/bndtools.core/bnd.bnd
@@ -109,7 +109,9 @@ Export-Package: org.osgi.service.metatype.annotations
 	bndtools.utils;version=project;packages='*',\
 	slf4j.api,\
 	org.eclipse.ui.ide.application;version='1.3',\
-	org.eclipse.ui.console
+	org.eclipse.ui.console,\
+	org.eclipse.e4.core.services,\
+	org.osgi.service.event
 
 -testpath: \
 	slf4j.api,\

--- a/bndtools.core/src/bndtools/views/ViewEventTopics.java
+++ b/bndtools.core/src/bndtools/views/ViewEventTopics.java
@@ -1,0 +1,30 @@
+package bndtools.views;
+
+/**
+ * Topics for the EventBroker which is used for communication between different
+ * views. For example if View1 sends an event to View2 wants to open a dialog in
+ * the other view. .
+ */
+public enum ViewEventTopics {
+
+	/**
+	 * Event to open the advances search of the repositories view.
+	 */
+	REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH("EVENT/RepositoriesView/openAdvancedSearch");
+
+	private String eventtype;
+
+	ViewEventTopics(String eventtype) {
+		this.eventtype = eventtype;
+	}
+
+	public String topic() {
+		return eventtype;
+	}
+
+	@Override
+	public String toString() {
+		return eventtype;
+	}
+
+}

--- a/bndtools.core/src/bndtools/views/repository/AdvancedSearchDialog.java
+++ b/bndtools.core/src/bndtools/views/repository/AdvancedSearchDialog.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPersistable;
+import org.eclipse.ui.XMLMemento;
 import org.osgi.resource.Requirement;
 
 public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistable {
@@ -154,6 +155,21 @@ public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistabl
 			if (panel != null)
 				panel.restoreState(childMemento);
 		}
+	}
+
+	/**
+	 * @param req a requirement
+	 * @return a state object for the given requirement to open advancedSearch
+	 *         prefilled in the "Other" tab.
+	 */
+	public static IMemento toNamespaceSearchPanelMemento(Requirement req) {
+		XMLMemento memento = XMLMemento.createWriteRoot("search");
+		memento.putInteger("tabIndex", 2);
+		IMemento other = memento.createChild("tab", "Other");
+		other.putString("namespace", req.getNamespace());
+		other.putString("filter", req.getDirectives()
+			.get("filter"));
+		return memento;
 	}
 
 }

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -478,25 +478,6 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 			event -> handleOpenAdvancedSearch(event));
 	}
 
-	private void handleOpenAdvancedSearch(Event event) {
-
-		if (event == null) {
-			return;
-		}
-
-		// Handle the event, open the dialog
-		if (event.getProperty(IEventBroker.DATA) instanceof Requirement req) {
-
-			// fill and open advanced search
-			advancedSearchState = AdvancedSearchDialog.toNamespaceSearchPanelMemento(req)
-				.toString();
-			advancedSearchAction.setChecked(true);
-			advancedSearchAction.run();
-
-		}
-	}
-
-
 	private void configureOfflineAction() {
 		Workspace workspace = Central.getWorkspaceIfPresent();
 		if (workspace == null) {
@@ -1249,5 +1230,22 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 			}));
 	}
 
+	private void handleOpenAdvancedSearch(Event event) {
+
+		if (event == null) {
+			return;
+		}
+
+		// Handle the event, open the dialog
+		if (event.getProperty(IEventBroker.DATA) instanceof Requirement req) {
+
+			// fill and open advanced search
+			advancedSearchState = AdvancedSearchDialog.toNamespaceSearchPanelMemento(req)
+				.toString();
+			advancedSearchAction.setChecked(true);
+			advancedSearchAction.run();
+
+		}
+	}
 
 }

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -102,6 +102,7 @@ import bndtools.tasks.ResourceCapReqLoader;
 import bndtools.utils.PartAdapter;
 import bndtools.utils.SelectionUtils;
 import bndtools.views.ViewEventTopics;
+import bndtools.views.resolution.ResolutionView.LocalTransferDragListener;
 
 public class ResolutionView extends ViewPart implements ISelectionListener, IResourceChangeListener {
 
@@ -221,11 +222,6 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 					Requirement req = rw.requirement;
 					eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
 				}
-
-				// else if (element instanceof IAdaptable) {
-				// final URI uri = ((IAdaptable) element).getAdapter(URI.class);
-				//
-				// }
 
 			}
 		});

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -636,7 +636,13 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 
 				// convert the capability to a requirement (without
 				// bnd.hashes) for better results in the search
-				Requirement req = CapReqBuilder.createRequirementFromCapability(cap, false)
+				Requirement req = CapReqBuilder.createRequirementFromCapability(cap, (name) -> {
+					if (name.equals("bnd.hashes")) {
+						return false;
+					}
+
+					return true;
+				})
 					.buildSyntheticRequirement();
 				// Open AdvanvedSearch of RepositoriesView
 				eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -635,9 +635,12 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 			if (element instanceof Capability cap) {
 
 				// convert the capability to a requirement (without
-				// bnd.hashes) for better results in the search
+				// bundle-attributes and bnd.hashes) for better results in the
+				// advanced search e.g.
+				// (&(osgi.wiring.package=my.package.foo)(version>=1.7.23))
 				Requirement req = CapReqBuilder.createRequirementFromCapability(cap, (name) -> {
-					if (name.equals("bnd.hashes")) {
+					if (name.equals("bundle-symbolic-name") || name.equals("bundle-version")
+						|| name.equals("bnd.hashes")) {
 						return false;
 					}
 

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.OpenEvent;
@@ -208,22 +209,7 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 		ColumnViewerToolTipSupport.enableFor(reqsViewer);
 		reqsViewer.setLabelProvider(new RequirementWrapperLabelProvider(true));
 		reqsViewer.setContentProvider(new CapReqMapContentProvider());
-
-		reqsViewer.addDoubleClickListener(event -> {
-			if (!event.getSelection()
-				.isEmpty()) {
-				IStructuredSelection selection = (IStructuredSelection) event.getSelection();
-				final Object element = selection.getFirstElement();
-
-				if (element instanceof RequirementWrapper rw) {
-
-					// Open AdvanvedSearch of RepositoriesView
-					Requirement req = rw.requirement;
-					eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
-				}
-
-			}
-		});
+		reqsViewer.addDoubleClickListener(event -> handleReqsViewerDoubleClickEvent(event));
 
 		Composite capsPanel = new Composite(splitPanel, SWT.NONE);
 		capsPanel.setBackground(parent.getBackground());
@@ -250,24 +236,7 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 			}
 		});
 
-		capsViewer.addDoubleClickListener(event -> {
-			if (!event.getSelection()
-				.isEmpty()) {
-				IStructuredSelection selection = (IStructuredSelection) event.getSelection();
-				final Object element = selection.getFirstElement();
-
-				if (element instanceof Capability cap) {
-
-					// convert the capability to a requirement (stop the
-					// bnd.hashes) for better results in the search
-					Requirement req = CapReqBuilder.createRequirementFromCapability(cap, false)
-						.buildSyntheticRequirement();
-					// Open AdvanvedSearch of RepositoriesView
-					eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
-				}
-
-			}
-		});
+		capsViewer.addDoubleClickListener(event -> handleCapsViewerDoubleClickEvent(event));
 
 		hideSelfImportsFilter = new ViewerFilter() {
 
@@ -310,6 +279,7 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 			.getSelection();
 		selectionChanged(activePart, activeSelection);
 	}
+
 
 	private void openEditor(OpenEvent event) {
 		IStructuredSelection selection = (IStructuredSelection) event.getSelection();
@@ -638,6 +608,41 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 
 		@Override
 		public void dragFinished(DragSourceEvent event) {}
+	}
+
+	private void handleReqsViewerDoubleClickEvent(DoubleClickEvent event) {
+		if (!event.getSelection()
+			.isEmpty()) {
+			IStructuredSelection selection = (IStructuredSelection) event.getSelection();
+			final Object element = selection.getFirstElement();
+
+			if (element instanceof RequirementWrapper rw) {
+
+				// Open AdvanvedSearch of RepositoriesView
+				Requirement req = rw.requirement;
+				eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
+			}
+
+		}
+	}
+
+	private void handleCapsViewerDoubleClickEvent(DoubleClickEvent event) {
+		if (!event.getSelection()
+			.isEmpty()) {
+			IStructuredSelection selection = (IStructuredSelection) event.getSelection();
+			final Object element = selection.getFirstElement();
+
+			if (element instanceof Capability cap) {
+
+				// convert the capability to a requirement (without
+				// bnd.hashes) for better results in the search
+				Requirement req = CapReqBuilder.createRequirementFromCapability(cap, false)
+					.buildSyntheticRequirement();
+				// Open AdvanvedSearch of RepositoriesView
+				eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
+			}
+
+		}
 	}
 
 }

--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -102,7 +102,6 @@ import bndtools.tasks.ResourceCapReqLoader;
 import bndtools.utils.PartAdapter;
 import bndtools.utils.SelectionUtils;
 import bndtools.views.ViewEventTopics;
-import bndtools.views.resolution.ResolutionView.LocalTransferDragListener;
 
 public class ResolutionView extends ViewPart implements ISelectionListener, IResourceChangeListener {
 
@@ -259,9 +258,11 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 
 				if (element instanceof Capability cap) {
 
-					// Open AdvanvedSearch of RepositoriesView
-					Requirement req = CapReqBuilder.createRequirementFromCapability(cap)
+					// convert the capability to a requirement (stop the
+					// bnd.hashes) for better results in the search
+					Requirement req = CapReqBuilder.createRequirementFromCapability(cap, false)
 						.buildSyntheticRequirement();
+					// Open AdvanvedSearch of RepositoriesView
 					eventBroker.post(ViewEventTopics.REPOSITORIESVIEW_OPEN_ADVANCED_SEARCH.topic(), req);
 				}
 


### PR DESCRIPTION
## What problem does it solve?

During debugging some dependency issues the ResolutionView is a valueable tool to see who requires and provides what. I wished it would be possible to e.g. "click" on a package and do an advanced search for it in the Repositories Browser to see which bundle(s) provide(s) this capability

## In this PR

Suggestion for the problem above.

- Double Clicking on an entry of the ResolutionsView (Requirements and Capabilities) now opens the AdvancedSearch of Repository Browser in the "Other" tab and prefills the fields for namespace and filter.
- Existing behavior is kept ( Clicking on a Java Class in Requirements still opens the java file in the editor) (TODO Although I noticed some flaky behavior where the loaders are sometimes cleared so that the class does not open.  )

- this speeds up workflows where you are debugging and you want to research in the Respositories based on output of the resolutions view

- experimental: I used Eclipse's IEventBroker here. This is something which is not done in bndtools so far. If there are other mechanisms we can use them. I just needed something so that 2 views can interact with eachother

- added support for Copy to Clipboard using Keyboard `Crtl + C / Cmd + C` for Resolution View entries

## Example: Click on a Requirement

- click on Requirement `(&(osgi.wiring.package=org.example.foo)(version>=1.0.0)(!(version>=2.0.0)))`
- results in a Repo-Search for the requirement

<img width="586" alt="image" src="https://github.com/bndtools/bnd/assets/188422/1f393a5f-250c-4410-b619-927acda5d855">


## Example: Click on a Capability


- Click on a Capability  `osgi.wiring.package;bnd.hashes='123, 456, 789';bundle-symbolic-name='org.example';bundle-version='1.7.23';osgi.wiring.package='org.example.foo';version:Version='1.7.23'`
- results in a Repo-Search for the requirement
`(&(osgi.wiring.package=org.example.foo)(version>=1.7.23))`

or

<img width="946" alt="image" src="https://github.com/bndtools/bnd/assets/188422/a7df67d3-54ec-4d6c-929d-5f60e8b82267">

<img width="586" alt="image" src="https://github.com/bndtools/bnd/assets/188422/8f59611d-00a1-483c-b547-b04fcc4a2667">

<img width="867" alt="image" src="https://github.com/bndtools/bnd/assets/188422/b409482a-4ede-4d72-87d3-246ecb9aa5b3">
