### PR TITLE
Add a MakeJar to create a plain-old-jar file as a resource

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/make/MakeJar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/make/MakeJar.java
@@ -1,0 +1,61 @@
+package aQute.bnd.make;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import aQute.bnd.osgi.About;
+import aQute.bnd.osgi.AbstractResource;
+import aQute.bnd.osgi.Builder;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Jar;
+import aQute.bnd.osgi.Resource;
+import aQute.bnd.service.MakePlugin;
+
+public class MakeJar implements MakePlugin {
+
+	@Override
+	public Resource make(Builder builder, String destination, Map<String, String> argumentsOnMake) throws Exception {
+		String type = argumentsOnMake.get("type"); //$NON-NLS-1$
+		if (!"jar".equals(type)) { //$NON-NLS-1$
+			return null;
+		}
+		String input = argumentsOnMake.get("input"); //$NON-NLS-1$
+		if (input == null) {
+			builder.error("No input specified on a make instruction for %s, args=%s", destination, argumentsOnMake); //$NON-NLS-1$
+			return null;
+		}
+		File folder = builder.getFile(input);
+		if (!folder.isDirectory()) {
+			return null;
+		}
+		boolean noExtra = Boolean.parseBoolean(argumentsOnMake.get("noExtra")); //$NON-NLS-1$
+		boolean reproducible = Boolean.parseBoolean(argumentsOnMake.get("reproducible")); //$NON-NLS-1$
+		return new AbstractResource(System.currentTimeMillis()) {
+
+			@Override
+			protected byte[] getBytes() throws Exception {
+				try (Jar jar = new Jar(folder)) {
+					Manifest manifest = new Manifest();
+					Attributes mainAttributes = manifest.getMainAttributes();
+					mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0"); //$NON-NLS-1$
+					if (!noExtra) {
+						mainAttributes.putValue(Constants.CREATED_BY, String.format("%s (%s)", //$NON-NLS-1$
+							System.getProperty("java.version"), System.getProperty("java.vendor"))); //$NON-NLS-1$ //$NON-NLS-2$
+						mainAttributes.putValue(Constants.TOOL, "Bnd-" + About.getBndVersion()); //$NON-NLS-1$
+						if (!reproducible) {
+							mainAttributes.putValue(Constants.BND_LASTMODIFIED, Long.toString(lastModified()));
+						}
+					}
+					jar.setManifest(manifest);
+					ByteArrayOutputStream stream = new ByteArrayOutputStream();
+					jar.write(stream);
+					return stream.toByteArray();
+				}
+			}
+		};
+	}
+
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -44,6 +44,7 @@ import aQute.bnd.help.instructions.BuilderInstructions;
 import aQute.bnd.make.Make;
 import aQute.bnd.make.MakeBnd;
 import aQute.bnd.make.MakeCopy;
+import aQute.bnd.make.MakeJar;
 import aQute.bnd.make.component.ServiceComponent;
 import aQute.bnd.maven.PomPropertiesResource;
 import aQute.bnd.maven.PomResource;
@@ -1733,6 +1734,7 @@ public class Builder extends Analyzer {
 	 */
 
 	static MakeBnd					makeBnd					= new MakeBnd();
+	static MakeJar					makeJar					= new MakeJar();
 	static MakeCopy					makeCopy				= new MakeCopy();
 	static ServiceComponent			serviceComponent		= new ServiceComponent();
 	static CDIAnnotations			cdiAnnotations			= new CDIAnnotations();
@@ -1747,6 +1749,7 @@ public class Builder extends Analyzer {
 	@Override
 	protected void setTypeSpecificPlugins(PluginsContainer pluginsContainer) {
 		pluginsContainer.add(makeBnd);
+		pluginsContainer.add(makeJar);
 		pluginsContainer.add(makeCopy);
 		pluginsContainer.add(serviceComponent);
 		pluginsContainer.add(cdiAnnotations);


### PR DESCRIPTION
Currently one can already create a new bundle using additional bnd instructions file but this has some caveats when one only wants to package some stuff into a jar and also some processing overhead.

This adds a new MakeJar that do what the name suggest and create a dumb jar from an input directory.