### PR TITLE
setIncludeResource used removeAll

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -1190,8 +1190,10 @@ public class BndEditModel {
 			.collect(toList());
 	}
 
+	@Deprecated
 	public void setIncludeResource(List<String> newEntries) {
-		List<String> resourceEntries1 = getEntries(Constants.INCLUDERESOURCE, listConverter);
+		List<String> resourceEntries1 = getEntries(Constants.INCLUDERESOURCE, listConverter).stream()
+			.toList();
 		List<String> resourceEntries2 = getEntries(Constants.INCLUDE_RESOURCE, listConverter);
 
 		Set<String> resourceEntries = Stream.concat(resourceEntries1.stream(), resourceEntries2.stream())


### PR DESCRIPTION
Somehow the author got an immutable list in the BndEditModel. The BndEditoModel was not designed for this and this will generally cause problems. The method is not used anywhere in the code base so I've deprecated it. I also made a copy of the list used in removeAll to prevent this.
This code sucks but so are many things. If you start to use the API, the onus on you is to just provide a PR and get it over with.

Fixes #5919
---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>