### PR TITLE
Resolution view: allow reqs/caps filtering on the tooltip text

### DIFF
--- a/bndtools.core/src/bndtools/model/resolution/CapReqMapContentProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapReqMapContentProvider.java
@@ -142,7 +142,7 @@ public class CapReqMapContentProvider implements ITreeContentProvider {
 				if (obj instanceof RequirementWrapper rw) {
 
 					for (Glob g : globs) {
-						if (g.matcher(rw.requirement.toString())
+							if (g.matcher(RequirementWrapperLabelProvider.tooltipText(rw))
 							.find()) {
 							filteredResults.add(obj);
 							return;
@@ -152,7 +152,7 @@ public class CapReqMapContentProvider implements ITreeContentProvider {
 				else if (obj instanceof Capability cap) {
 
 					for (Glob g : globs) {
-						if (g.matcher(cap.toString())
+							if (g.matcher(CapabilityLabelProvider.tooltipText(cap))
 							.find()) {
 							filteredResults.add(obj);
 							return;

--- a/bndtools.core/src/bndtools/model/resolution/CapReqMapContentProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapReqMapContentProvider.java
@@ -133,7 +133,7 @@ public class CapReqMapContentProvider implements ITreeContentProvider {
 			String[] split = wildcardFilter.split("\\s+");
 			Glob globs[] = new Glob[split.length];
 			for (int i = 0; i < split.length; i++) {
-				globs[i] = new Glob(split[i]);
+				globs[i] = new Glob(split[i].toLowerCase());
 			}
 
 			// parallel search
@@ -142,7 +142,8 @@ public class CapReqMapContentProvider implements ITreeContentProvider {
 				if (obj instanceof RequirementWrapper rw) {
 
 					for (Glob g : globs) {
-							if (g.matcher(RequirementWrapperLabelProvider.tooltipText(rw))
+							if (g.matcher(RequirementWrapperLabelProvider.tooltipText(rw)
+								.toLowerCase())
 							.find()) {
 							filteredResults.add(obj);
 							return;
@@ -152,7 +153,8 @@ public class CapReqMapContentProvider implements ITreeContentProvider {
 				else if (obj instanceof Capability cap) {
 
 					for (Glob g : globs) {
-							if (g.matcher(CapabilityLabelProvider.tooltipText(cap))
+							if (g.matcher(CapabilityLabelProvider.tooltipText(cap)
+								.toLowerCase())
 							.find()) {
 							filteredResults.add(obj);
 							return;

--- a/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
@@ -41,9 +41,7 @@ public class CapabilityLabelProvider extends StyledCellLabelProvider {
 
 	@Override
 	public String getToolTipText(Object element) {
-		if (element instanceof Capability) {
-			Capability cap = (Capability) element;
-
+		if (element instanceof Capability cap) {
 			return tooltipText(cap);
 		}
 
@@ -51,11 +49,17 @@ public class CapabilityLabelProvider extends StyledCellLabelProvider {
 	}
 
 	static String tooltipText(Capability cap) {
-		StringBuilder buf = new StringBuilder();
+		// caps tooltips become quite large because of the bnd.hashes and uses
+		StringBuilder buf = new StringBuilder(400);
+
+		Resource r = cap.getResource();
+
+		buf.append("FROM: ")
+			.append(r)
+			.append("\n");
 
 		buf.append(cap.getNamespace());
 
-		Resource r = cap.getResource();
 		if (r instanceof SupportingResource sr) {
 			int index = sr.getSupportingIndex();
 			if (index >= 0) {

--- a/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/CapabilityLabelProvider.java
@@ -44,40 +44,44 @@ public class CapabilityLabelProvider extends StyledCellLabelProvider {
 		if (element instanceof Capability) {
 			Capability cap = (Capability) element;
 
-			StringBuilder buf = new StringBuilder();
-
-			buf.append(cap.getNamespace());
-
-			Resource r = cap.getResource();
-			if (r instanceof SupportingResource sr) {
-				int index = sr.getSupportingIndex();
-				if (index >= 0) {
-					buf.append("Capability from a supporting resource ")
-						.append(index)
-						.append(" part of ")
-						.append(sr.getParent())
-						.append("\n");
-				}
-			}
-
-			for (Entry<String, Object> attribute : cap.getAttributes()
-				.entrySet())
-				buf.append(";\n\t")
-					.append(attribute.getKey())
-					.append(" = ")
-					.append(attribute.getValue());
-
-			for (Entry<String, String> directive : cap.getDirectives()
-				.entrySet())
-				buf.append(";\n\t")
-					.append(directive.getKey())
-					.append(" := ")
-					.append(directive.getValue());
-
-			return buf.toString();
+			return tooltipText(cap);
 		}
 
 		return null;
+	}
+
+	static String tooltipText(Capability cap) {
+		StringBuilder buf = new StringBuilder();
+
+		buf.append(cap.getNamespace());
+
+		Resource r = cap.getResource();
+		if (r instanceof SupportingResource sr) {
+			int index = sr.getSupportingIndex();
+			if (index >= 0) {
+				buf.append("Capability from a supporting resource ")
+					.append(index)
+					.append(" part of ")
+					.append(sr.getParent())
+					.append("\n");
+			}
+		}
+
+		for (Entry<String, Object> attribute : cap.getAttributes()
+			.entrySet())
+			buf.append(";\n\t")
+				.append(attribute.getKey())
+				.append(" = ")
+				.append(attribute.getValue());
+
+		for (Entry<String, String> directive : cap.getDirectives()
+			.entrySet())
+			buf.append(";\n\t")
+				.append(directive.getKey())
+				.append(" := ")
+				.append(directive.getValue());
+
+		return buf.toString();
 	}
 
 }

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
@@ -15,6 +15,11 @@ public class RequirementWrapper {
 	public Collection<? extends Object>	requirers;
 
 	public boolean isOptional() {
+
+		if (requirement == null) {
+			return false;
+		}
+
 		String resolution = requirement.getDirectives()
 			.get(Constants.RESOLUTION);
 

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
@@ -5,12 +5,25 @@ import java.util.Objects;
 
 import org.osgi.resource.Requirement;
 
+import aQute.bnd.osgi.Constants;
+
 public class RequirementWrapper {
 
 	public Requirement					requirement;
 	public boolean						resolved;
 	public boolean						java;
 	public Collection<? extends Object>	requirers;
+
+	public boolean isOptional() {
+		String resolution = requirement.getDirectives()
+			.get(Constants.RESOLUTION);
+
+		if (resolution == null) {
+			return false;
+		}
+
+		return Constants.OPTIONAL.equals(resolution);
+	}
 
 	@Override
 	public int hashCode() {

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapper.java
@@ -9,16 +9,16 @@ import aQute.bnd.osgi.Constants;
 
 public class RequirementWrapper {
 
-	public Requirement					requirement;
+	public final Requirement			requirement;
 	public boolean						resolved;
 	public boolean						java;
 	public Collection<? extends Object>	requirers;
 
-	public boolean isOptional() {
+	public RequirementWrapper(Requirement requirement) {
+		this.requirement = requirement;
+	}
 
-		if (requirement == null) {
-			return false;
-		}
+	public boolean isOptional() {
 
 		String resolution = requirement.getDirectives()
 			.get(Constants.RESOLUTION);

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
@@ -75,17 +75,18 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
 	static String tooltipText(RequirementWrapper rw) {
 		Requirement req = rw.requirement;
 
-		StringBuilder buf = new StringBuilder();
+		StringBuilder buf = new StringBuilder(300);
 		if (rw.resolved)
 			buf.append("RESOLVED:\n");
 		if (rw.java)
 			buf.append("JAVA:\n");
 
+		Resource r = req.getResource();
+
 		buf.append("FROM: ")
-			.append(req.getResource())
+			.append(r)
 			.append("\n");
 
-		Resource r = req.getResource();
 		if (r instanceof SupportingResource sr) {
 			int index = sr.getSupportingIndex();
 			if (index >= 0) {
@@ -111,8 +112,6 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
 				.append(directive.getKey())
 				.append(" := ")
 				.append(directive.getValue());
-
-		Resource resource = req.getResource();
 
 		return buf.toString();
 	}

--- a/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
+++ b/bndtools.core/src/bndtools/model/resolution/RequirementWrapperLabelProvider.java
@@ -64,54 +64,57 @@ public class RequirementWrapperLabelProvider extends RequirementLabelProvider {
 
 	@Override
 	public String getToolTipText(Object element) {
-		if (element instanceof RequirementWrapper) {
-			RequirementWrapper rw = (RequirementWrapper) element;
-			Requirement req = rw.requirement;
-
-			StringBuilder buf = new StringBuilder();
-			if (rw.resolved)
-				buf.append("RESOLVED:\n");
-			if (rw.java)
-				buf.append("JAVA:\n");
-
-			buf.append("FROM: ")
-				.append(req.getResource())
-				.append("\n");
-
-			Resource r = rw.requirement.getResource();
-			if (r instanceof SupportingResource sr) {
-				int index = sr.getSupportingIndex();
-				if (index >= 0) {
-					buf.append("Requirement from a supporting resource ")
-						.append(index)
-						.append(" part of ")
-						.append(sr.getParent())
-						.append("\n");
-				}
-			}
-			buf.append(req.getNamespace());
-
-
-			for (Entry<String, Object> attr : req.getAttributes()
-				.entrySet())
-				buf.append(";\n\t")
-					.append(attr.getKey())
-					.append(" = ")
-					.append(attr.getValue());
-
-			for (Entry<String, String> directive : req.getDirectives()
-				.entrySet())
-				buf.append(";\n\t")
-					.append(directive.getKey())
-					.append(" := ")
-					.append(directive.getValue());
-
-			Resource resource = req.getResource();
-
-			return buf.toString();
+		if (element instanceof RequirementWrapper rw) {
+			return tooltipText(rw);
 		}
 
 		return null;
+	}
+
+
+	static String tooltipText(RequirementWrapper rw) {
+		Requirement req = rw.requirement;
+
+		StringBuilder buf = new StringBuilder();
+		if (rw.resolved)
+			buf.append("RESOLVED:\n");
+		if (rw.java)
+			buf.append("JAVA:\n");
+
+		buf.append("FROM: ")
+			.append(req.getResource())
+			.append("\n");
+
+		Resource r = req.getResource();
+		if (r instanceof SupportingResource sr) {
+			int index = sr.getSupportingIndex();
+			if (index >= 0) {
+				buf.append("Requirement from a supporting resource ")
+					.append(index)
+					.append(" part of ")
+					.append(sr.getParent())
+					.append("\n");
+			}
+		}
+		buf.append(req.getNamespace());
+
+		for (Entry<String, Object> attr : req.getAttributes()
+			.entrySet())
+			buf.append(";\n\t")
+				.append(attr.getKey())
+				.append(" = ")
+				.append(attr.getValue());
+
+		for (Entry<String, String> directive : req.getDirectives()
+			.entrySet())
+			buf.append(";\n\t")
+				.append(directive.getKey())
+				.append(" := ")
+				.append(directive.getValue());
+
+		Resource resource = req.getResource();
+
+		return buf.toString();
 	}
 
 }

--- a/bndtools.core/src/bndtools/tasks/BndBuilderCapReqLoader.java
+++ b/bndtools.core/src/bndtools/tasks/BndBuilderCapReqLoader.java
@@ -97,8 +97,7 @@ public abstract class BndBuilderCapReqLoader implements CapReqLoader {
 	}
 
 	private RequirementWrapper toRequirementWrapper(Requirement req) {
-		RequirementWrapper rw = new RequirementWrapper();
-		rw.requirement = req;
+		RequirementWrapper rw = new RequirementWrapper(req);
 		if (req.getNamespace()
 			.equals(PackageNamespace.PACKAGE_NAMESPACE)) {
 			String pkgName = (String) req.getAttributes()

--- a/bndtools.core/src/bndtools/tasks/ResourceCapReqLoader.java
+++ b/bndtools.core/src/bndtools/tasks/ResourceCapReqLoader.java
@@ -85,8 +85,7 @@ public class ResourceCapReqLoader implements CapReqLoader {
 				listForNamespace = new LinkedList<>();
 				result.put(ns, listForNamespace);
 			}
-			RequirementWrapper wrapper = new RequirementWrapper();
-			wrapper.requirement = req;
+			RequirementWrapper wrapper = new RequirementWrapper(req);
 			listForNamespace.add(wrapper);
 		}
 


### PR DESCRIPTION
this allows more fine grained Glob filtering e.g. on the resource name e.g. using "FROM:*mypackage" which allows to filter reqs and caps based on their underlying resources

## Example

In the example below I have selected
- a bundle
- and the complete Maven Central repo in the repo browser
- the requirements I have filtered so that I only see requirements coming from my bundle which contains the letters "obs" in the resource name

<img width="1029" alt="image" src="https://github.com/bndtools/bnd/assets/188422/1c906adb-c3e5-4368-8434-1a0463ff4220">

This is very handy in the use case where I am particularly interested in e.g. requirements of a particular resource. 
E.g. in my case I wanted to find out all reqs of my bundle which are not satisfied by Maven Central so that I can drag them into .bnd Editor "Customize Imports" and mark them as _optional_


