### PR TITLE
synchronize JAREditor.getFolder()

### DIFF
--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePage.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePage.java
@@ -132,7 +132,7 @@ public class JARTreePage extends FormPage {
 		update();
 	}
 
-	private IFolder getFolder(URI input, IProgressMonitor monitor) throws CoreException {
+	private synchronized IFolder getFolder(URI input, IProgressMonitor monitor) throws CoreException {
 
 		URI full = JarFileSystem.jarf(input, "/")
 			.orElseThrow(IllegalArgumentException::new);


### PR DESCRIPTION
Closes #5951 

With this I can no longer reproduce the racecondition and the java.lang.Exception: Resource '/.BndtoolsJAREditorTempFiles/temp/10000002' already exists