### PR TITLE
Fix Gradle plugin version refs in README

### DIFF
--- a/gradle-plugins/.gitignore
+++ b/gradle-plugins/.gitignore
@@ -1,3 +1,7 @@
-build/
-/.gradle/
-bin/
+.gradle
+bin
+build
+
+.idea
+*.iml
+.vscode

--- a/gradle-plugins/README.md
+++ b/gradle-plugins/README.md
@@ -1,5 +1,8 @@
 # Gradle Plugins
 
+[![Maven Central](https://img.shields.io/maven-central/v/biz.aQute.bnd.builder/biz.aQute.bnd.builder.gradle.plugin)](https://central.sonatype.com/artifact/biz.aQute.bnd.builder/biz.aQute.bnd.builder.gradle.plugin)
+[![Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/biz.aQute.bnd.builder)](https://plugins.gradle.org/plugin/biz.aQute.bnd.builder)
+
 Bnd includes Gradle plugins for [Gradle][1] users to build Bnd projects in [Bnd Workspace builds][20] as well as in [non-Bnd Workspace builds][21].
 A typical Gradle build is a non-Bnd workspace build.
 A Bnd Workspace build uses the information specified in the Bnd Workspace's `cnf/build.bnd` file and each project's `bnd.bnd` file to configure the Gradle projects and tasks.

--- a/gradle-plugins/README.md
+++ b/gradle-plugins/README.md
@@ -35,7 +35,7 @@ To make the Bnd Builder Gradle Plugin available to your build, use the following
 ```groovy
 pluginManagement {
   plugins {
-    id "biz.aQute.bnd.builder" version "7.1.0"
+    id "biz.aQute.bnd.builder" version "7.0.0"
   }
 }
 ```
@@ -652,7 +652,7 @@ The main approach is to edit `settings.gradle` as follows:
 
 ```groovy
 plugins {
-  id "biz.aQute.bnd.workspace" version "7.1.0"
+  id "biz.aQute.bnd.workspace" version "7.0.0"
 }
 ```
 The Gradle marker plugins for the Bnd Gradle plugins are also in Maven Central.
@@ -675,7 +675,7 @@ The second approach, for when you already have a `settings.gradle` file which in
 
 ```groovy
 plugins {
-  id "biz.aQute.bnd.workspace" version "7.1.0"
+  id "biz.aQute.bnd.workspace" version "7.0.0"
 }
 ```
 


### PR DESCRIPTION
The version of 7.1.0 hasn't been released, we shouldn't ref to it in docs.