### PR TITLE
BndPomRepository should support both bsn and gav like MavenBndRepository

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/BridgeRepository.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/BridgeRepository.java
@@ -262,6 +262,11 @@ public class BridgeRepository {
 
 			gavIndex.computeIfAbsent(bsn, k -> new HashMap<>())
 				.put(version, new ResourceInfo(r));
+
+			if (bc == null) {
+				bsnIndex.computeIfAbsent(bsn, k -> new HashMap<>())
+					.put(version, new ResourceInfo(r));
+			}
 		}
 		else {
 			// No way to index this

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -302,50 +302,17 @@ public class BndPomRepository extends BaseRepository
 		}
 
 		Archive archive;
-		
-
-		//
-		// First try if this is a BSN, not a GAV
-		//
-
-		if (bsn.indexOf(':') < 0) {
-
-			ResourceInfo resource = bridge.getInfo(bsn, version);
-			if (resource == null) {
-				archive = trySources(bsn, version);
-				if (archive == null)
-					return null;
-			} else {
-
-				String from = resource.getInfo()
-					.from();
-				archive = Archive.valueOf(from);
-			}
-
+		ResourceInfo resource = bridge.getInfo(bsn, version);
+		if (resource == null) {
+			archive = trySources(bsn, version);
+			if (archive == null)
+				return null;
 		} else {
 
-			//
-			// Handle the GAV. This "hack" is borrowed from  
-			// aQute.bnd.repository.maven.provider.IndexFile.find(String, Version)
-			// because MavenBndRepository can handle both bsn and GAV too
-			// TODO Notice that the GAV can also contain extension +
-			// classifier
-			//
-			
-			ResourceInfo resource = bridge.getInfoByGAV(bsn, version);
-			if (resource == null) {
-				archive = trySourcesByGAV(bsn, version);
-				if (archive == null)
-					return null;
-			} else {
-
-				String from = resource.getInfo()
-					.from();
-				archive = Archive.valueOf(from);
-			}
-
+			String from = resource.getInfo()
+				.from();
+			archive = Archive.valueOf(from);
 		}
-
 
 		Promise<File> p = repoImpl.getMavenRepository()
 			.get(archive);
@@ -468,24 +435,6 @@ public class BndPomRepository extends BaseRepository
 
 		String rawBsn = bsn.substring(0, bsn.length() - BSN_SOURCE_SUFFIX.length());
 		ResourceInfo resource = bridge.getInfo(rawBsn, version);
-		if (resource == null)
-			return null;
-
-		String from = resource.getInfo()
-			.from();
-		return Archive.valueOf(from)
-			.getOther(Archive.JAR_EXTENSION, Archive.SOURCES_CLASSIFIER);
-	}
-
-	/*
-	 * Try to fetch sources by GAV (instead of bsn)
-	 */
-	private Archive trySourcesByGAV(String gav, Version version) throws Exception {
-		if (!gav.endsWith(BSN_SOURCE_SUFFIX))
-			return null;
-
-		String rawBsn = gav.substring(0, gav.length() - BSN_SOURCE_SUFFIX.length());
-		ResourceInfo resource = bridge.getInfoByGAV(rawBsn, version);
 		if (resource == null)
 			return null;
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
@@ -90,21 +90,19 @@ class PomRepository extends InnerRepository {
 
 	void save(Traverser traverser) throws Exception {
 		Promise<Map<Archive, Resource>> p = traverser.getResources();
+
 		Map<Archive, Resource> map = p.getValue();
+		setArchives(map.keySet());
 
-		Set<Archive> keySet = map.keySet();
-		set(keySet);
-
-		Collection<Resource> resources = map
-			.values();
-
+		Collection<Resource> resources = map.values();
 		set(resources);
+
 		save(getMavenRepository().getName(), resources, getLocation());
 	}
 
-	private void set(Set<Archive> keySet) {
+	private void setArchives(Set<Archive> archives) {
 		this.archives.clear();
-		this.archives.addAll(keySet);
+		this.archives.addAll(archives);
 	}
 
 	void save(String name, Collection<? extends Resource> resources, File location) throws Exception, IOException {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
@@ -89,8 +89,12 @@ class PomRepository extends InnerRepository {
 
 	void save(Traverser traverser) throws Exception {
 		Promise<Map<Archive, Resource>> p = traverser.getResources();
-		Collection<Resource> resources = p.getValue()
+		Map<Archive, Resource> map = p.getValue();
+
+		this.archives.addAll(map.keySet());
+		Collection<Resource> resources = map
 			.values();
+
 		set(resources);
 		save(getMavenRepository().getName(), resources, getLocation());
 	}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomRepository.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.osgi.resource.Resource;
@@ -91,12 +92,19 @@ class PomRepository extends InnerRepository {
 		Promise<Map<Archive, Resource>> p = traverser.getResources();
 		Map<Archive, Resource> map = p.getValue();
 
-		this.archives.addAll(map.keySet());
+		Set<Archive> keySet = map.keySet();
+		set(keySet);
+
 		Collection<Resource> resources = map
 			.values();
 
 		set(resources);
 		save(getMavenRepository().getName(), resources, getLocation());
+	}
+
+	private void set(Set<Archive> keySet) {
+		this.archives.clear();
+		this.archives.addAll(keySet);
 	}
 
 	void save(String name, Collection<? extends Resource> resources, File location) throws Exception, IOException {

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
@@ -28,6 +28,13 @@ public class MavenRepoTestHelper {
 		assertEquals("commons-cli-1.2.jar", f12maven.getName());
 		assertEquals(f12maven, f12osgi);
 
+		// check if 1.2 instead of 1.2.0 works too
+		File f12maven2DigitsVer = repo.get("commons-cli:commons-cli", new Version("1.2"), null);
+		File f12osgi2DigitsVer = repo.get("org.apache.commons.cli", new Version("1.2"), null);
+
+		assertEquals("commons-cli-1.2.jar", f12maven2DigitsVer.getName());
+		assertEquals(f12maven2DigitsVer, f12osgi2DigitsVer);
+
 	}
 
 }

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
@@ -1,6 +1,7 @@
 package aQute.bnd.repository.maven.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -22,8 +23,12 @@ public class MavenRepoTestHelper {
 			.size());
 		System.out.println(repo.list("org.apache.commons.cli"));
 		System.out.println(repo.versions("org.apache.commons.cli"));
+
 		File f12maven = repo.get("commons-cli:commons-cli", new Version("1.2.0"), null);
 		File f12osgi = repo.get("org.apache.commons.cli", new Version("1.2.0"), null);
+
+		assertTrue(f12maven.exists());
+		assertTrue(f12osgi.exists());
 
 		assertEquals("commons-cli-1.2.jar", f12maven.getName());
 		assertEquals(f12maven, f12osgi);
@@ -32,8 +37,12 @@ public class MavenRepoTestHelper {
 		File f12maven2DigitsVer = repo.get("commons-cli:commons-cli", new Version("1.2"), null);
 		File f12osgi2DigitsVer = repo.get("org.apache.commons.cli", new Version("1.2"), null);
 
+		assertTrue(f12maven2DigitsVer.exists());
+		assertTrue(f12osgi2DigitsVer.exists());
+
 		assertEquals("commons-cli-1.2.jar", f12maven2DigitsVer.getName());
 		assertEquals(f12maven2DigitsVer, f12osgi2DigitsVer);
+
 
 	}
 

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
@@ -1,0 +1,33 @@
+package aQute.bnd.repository.maven.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import aQute.bnd.service.RepositoryPlugin;
+import aQute.bnd.version.Version;
+
+public class MavenRepoTestHelper {
+
+	/**
+	 * This method is called by two maven repo tests to ensure that both repos
+	 * behave the same and can get a resource by bns and gav in case both are
+	 * available.
+	 *
+	 * @param repo
+	 * @throws Exception
+	 */
+	public static void assertMavenReposGetViaBSNAndGAV(RepositoryPlugin repo) throws Exception {
+		assertEquals(1, repo.list("org.apache.commons.cli")
+			.size());
+		System.out.println(repo.list("org.apache.commons.cli"));
+		System.out.println(repo.versions("org.apache.commons.cli"));
+		File f12maven = repo.get("commons-cli:commons-cli", new Version("1.2.0"), null);
+		File f12osgi = repo.get("org.apache.commons.cli", new Version("1.2.0"), null);
+
+		assertEquals("commons-cli-1.2.jar", f12maven.getName());
+		assertEquals(f12maven, f12osgi);
+
+	}
+
+}

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/helpers/MavenRepoTestHelper.java
@@ -1,9 +1,11 @@
 package aQute.bnd.repository.maven.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.util.SortedSet;
 
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
@@ -42,6 +44,17 @@ public class MavenRepoTestHelper {
 
 		assertEquals("commons-cli-1.2.jar", f12maven2DigitsVer.getName());
 		assertEquals(f12maven2DigitsVer, f12osgi2DigitsVer);
+
+		// version should accept both too
+		SortedSet<Version> versionsMaven = repo.versions("commons-cli:commons-cli");
+		SortedSet<Version> versionsOsgi = repo.versions("org.apache.commons.cli");
+
+		assertNotNull(versionsMaven);
+		assertNotNull(versionsOsgi);
+		assertTrue(versionsMaven.stream()
+			.anyMatch(v -> "1.2.0".equals(v.toString())));
+		assertTrue(versionsOsgi.stream()
+			.anyMatch(v -> "1.2.0".equals(v.toString())));
 
 
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -40,6 +40,8 @@ import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.repository.XMLResourceParser;
+import aQute.bnd.repository.maven.helpers.MavenRepoTestHelper;
+import aQute.bnd.repository.maven.provider.MavenBndRepoTest;
 import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
@@ -265,6 +267,31 @@ public class PomRepositoryTest {
 			assertNotNull(list);
 			assertEquals(1, list.size());
 		}
+	}
+
+
+	/**
+	 * Commons CLI 1.2 is in there as GAV & as BSN Note: This test should be
+	 * kept in sync with {@link MavenBndRepoTest#testGetViaBSNAndGAV()}
+	 */
+	@Test
+	public void testGetViaBSNAndGAV() throws Exception {
+		try (BndPomRepository repo = new BndPomRepository()) {
+			Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			w.setBase(tmp);
+			repo.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("pom", "testdata/pomrepo/simpleGetViaBSNAndGAV.xml");
+			config.put("transitive", "false");
+			config.put("snapshotUrl", "https://repo.maven.apache.org/maven2/");
+			config.put("releaseUrl", "https://repo.maven.apache.org/maven2/");
+			config.put("name", "test2");
+			repo.setProperties(config);
+
+			MavenRepoTestHelper.assertMavenReposGetViaBSNAndGAV(repo);
+		}
+
 	}
 
 	@Test

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -44,6 +44,8 @@ import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.osgi.resource.ResourceUtils.IdentityCapability;
+import aQute.bnd.repository.maven.helpers.MavenRepoTestHelper;
+import aQute.bnd.repository.maven.pom.provider.PomRepositoryTest;
 import aQute.bnd.service.RepositoryPlugin.PutOptions;
 import aQute.bnd.service.RepositoryPlugin.PutResult;
 import aQute.bnd.service.maven.PomOptions;
@@ -619,23 +621,17 @@ public class MavenBndRepoTest {
 		assertTrue(file.isFile());
 	}
 
-	/*
-	 * Commons CLI 1.2 is in there as GAV & as BSN
+	/**
+	 * Commons CLI 1.2 is in there as GAV & as BSN Note: This test should be
+	 * kept in sync with {@link PomRepositoryTest#testGetViaBSNAndGAV()}
 	 */
 	@Test
 	public void testGetViaBSNAndGAV() throws Exception {
 		config(null);
 
-		assertEquals(1, repo.list("org.apache.commons.cli")
-			.size());
-		System.out.println(repo.list("org.apache.commons.cli"));
-		System.out.println(repo.versions("org.apache.commons.cli"));
-		File f12maven = repo.get("commons-cli:commons-cli", new Version("1.2.0"), null);
-		File f12osgi = repo.get("org.apache.commons.cli", new Version("1.2.0"), null);
-
-		assertEquals("commons-cli-1.2.jar", f12maven.getName());
-		assertEquals(f12maven, f12osgi);
+		MavenRepoTestHelper.assertMavenReposGetViaBSNAndGAV(repo);
 	}
+
 
 	@Test
 	public void testList() throws Exception {

--- a/biz.aQute.repository/testdata/pomrepo/simpleGetViaBSNAndGAV.xml
+++ b/biz.aQute.repository/testdata/pomrepo/simpleGetViaBSNAndGAV.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>test</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+
+	<dependencies>
+		<dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>
+		
+	</dependencies>
+	
+ </project>


### PR DESCRIPTION
Closes #5961 

This PR should fix the problem that for a valid OSGi bundle MavenBndRepository.get(bsnOrGav) can be used with bsn or gav and returns something. 
BndPomRepostory.get() instead only works with the bsn for a valid OSGi bundle. (Non OSGi bundles which do not have a bsn meta data can only be looked up by gav wich works as expected)

This PR's goal is to make both repos behave the same and support bsn or gav for OSGi bundles.

