### PR TITLE
Imports were lazily handed but the fixup required the original imports

### DIFF
--- a/bndtools.core/src/org/bndtools/refactor/util/RefactorAssistant.java
+++ b/bndtools.core/src/org/bndtools/refactor/util/RefactorAssistant.java
@@ -1082,6 +1082,7 @@ public class RefactorAssistant {
 		});
 		this.source = source;
 		this.iunit = null;
+		init();
 	}
 
 	public void add(ASTNode parent, Annotation newAnnotation) {

--- a/bndtools.core/test/org/bndtools/refactor/types/ComponentRefactorerTest.java
+++ b/bndtools.core/test/org/bndtools/refactor/types/ComponentRefactorerTest.java
@@ -19,153 +19,171 @@ class ComponentRefactorerTest {
 
 	static List<Scenario> scenarios() {
 		String empty = """
+			import com.example.Foo;
+			import com.example.Bar;
 			class F {
-			  String ref;
+			  Foo ref;
 			  F(  String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String emptyPublic = """
+			import com.example.Foo;
+			import com.example.Bar;
 			class F {
-			  String ref;
+			  Foo ref;
 			  public F(  String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String C = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  F(  String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String Cpublic = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  public F(  String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String CAc = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			import org.osgi.service.component.annotations.Activate;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  @Activate public F(  String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String CAcRp = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			import org.osgi.service.component.annotations.Activate;
 			import org.osgi.service.component.annotations.Reference;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  @Activate public F(  @Reference String service){
 			  }
 			  void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String CAm = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			import org.osgi.service.component.annotations.Activate;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  public F(  String service){
 			  }
 			  @Activate void activate(){
 			  }
 			  void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String CAmDm = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			import org.osgi.service.component.annotations.Activate;
 			import org.osgi.service.component.annotations.Deactivate;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  public F(  String service){
 			  }
 			  @Activate void activate(){
 			  }
 			  @Deactivate void deactivate(){
 			  }
-			  void setService(  String service){
+			  void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";
 		String CAmDmRm = """
+			import com.example.Foo;
+			import com.example.Bar;
 			import org.osgi.service.component.annotations.Component;
 			import org.osgi.service.component.annotations.Activate;
 			import org.osgi.service.component.annotations.Deactivate;
 			import org.osgi.service.component.annotations.Reference;
 			@Component class F {
-			  String ref;
+			  Foo ref;
 			  public F(  String service){
 			  }
 			  @Activate void activate(){
 			  }
 			  @Deactivate void deactivate(){
 			  }
-			  @Reference void setService(  String service){
+			  @Reference void setService(  Bar service){
 			  }
-			  void unsetService(  String service){
+			  void unsetService(  Bar service){
 			  }
 			}
 			""";


### PR DESCRIPTION
The RefactorAssistant lazily initialized the imports translation. However, the fixup() method that cleaned up any unused imports assumed it was initialized. So if there was a case without any resolved import, the fixup failed.