### PR TITLE
Issue/5967 concurrent error handling

### DIFF
--- a/aQute.libg/src/aQute/service/reporter/Report.java
+++ b/aQute.libg/src/aQute/service/reporter/Report.java
@@ -35,6 +35,17 @@ public interface Report {
 			l.length = length;
 			return l;
 		}
+
+		public void to(Location l) {
+			l.message = message;
+			l.line = line;
+			l.file = file;
+			l.context = context;
+			l.reference = reference;
+			l.methodName = methodName;
+			l.details = details;
+			l.length = length;
+		}
 	}
 
 	/**

--- a/aQute.libg/src/aQute/service/reporter/Report.java
+++ b/aQute.libg/src/aQute/service/reporter/Report.java
@@ -36,15 +36,20 @@ public interface Report {
 			return l;
 		}
 
-		public void to(Location l) {
-			l.message = message;
-			l.line = line;
-			l.file = file;
-			l.context = context;
-			l.reference = reference;
-			l.methodName = methodName;
-			l.details = details;
-			l.length = length;
+		/**
+		 * Copies the location details to the destination. This will not include
+		 * the message.
+		 *
+		 * @param destination the other location.
+		 */
+		public void to(Location destination) {
+			destination.line = line;
+			destination.file = file;
+			destination.context = context;
+			destination.reference = reference;
+			destination.methodName = methodName;
+			destination.details = details;
+			destination.length = length;
 		}
 	}
 

--- a/aQute.libg/src/aQute/service/reporter/packageinfo
+++ b/aQute.libg/src/aQute/service/reporter/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/biz.aQute.bndlib.tests/test/test/MacroTest.java
+++ b/biz.aQute.bndlib.tests/test/test/MacroTest.java
@@ -1276,7 +1276,7 @@ public class MacroTest {
 	@Test
 	public void testSuper() {
 		try (Processor top = new Processor();
-		Processor middle = new Processor(top);
+			Processor middle = new Processor(top);
 			Processor bottom = new Processor(middle)) {
 
 			top.setProperty("a", "top.a");
@@ -1770,35 +1770,13 @@ public class MacroTest {
 			p.setProperty("real", "true");
 			Macro m = new Macro(p);
 
-			m.process("    ${warning;xw;1;2;3 ${three}}");
-			m.process("    ${error;xe;1;2;3 ${three}}");
+			m.process("    ${warning;xw;w1;w2;w3 w${three}}");
+			m.process("    ${error;xe;e1;e2;e3 e${three}}");
 			m.process("    ${if;1;$<a>}");
 
-			assertTrue(p.getWarnings()
-				.get(0)
-				.endsWith("xw"), "xw");
-			assertTrue(p.getWarnings()
-				.get(1)
-				.endsWith("1"), "1");
-			assertTrue(p.getWarnings()
-				.get(2)
-				.endsWith("2"), "2");
-			assertTrue(p.getWarnings()
-				.get(3)
-				.endsWith("3 333"), "3 333");
-
-			assertTrue(p.getErrors()
-				.get(0)
-				.endsWith("xe"), "xw");
-			assertTrue(p.getErrors()
-				.get(1)
-				.endsWith("1"), "1");
-			assertTrue(p.getErrors()
-				.get(2)
-				.endsWith("2"), "2");
-			assertTrue(p.getErrors()
-				.get(3)
-				.endsWith("3 333"), "3 333");
+			assertThat(p.getWarnings()).containsExactly("xw", "w1", "w2", "w3 w333",
+				"No translation found for macro: a");
+			assertThat(p.getErrors()).containsExactly("xe", "e1", "e2", "e3 e333");
 		} catch (IOException e) {
 			fail(e);
 		}
@@ -1919,7 +1897,7 @@ public class MacroTest {
 			assertEquals("aa\nbb\ncc\ndd\nee\nff", m.process("${unescape;${sjoin;\\n;aa,bb,cc;dd,ee,ff}}"));
 		} catch (IOException e) {
 			fail(e);
-	}
+		}
 	}
 
 	@Test

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -149,7 +149,6 @@ public class MessageReporter {
 			}
 		}
 
-
 	}
 
 	class Cache {
@@ -200,17 +199,25 @@ public class MessageReporter {
 			}
 			String s = Processor.formatArrays(format, args);
 			Message m = new Message(counter.getAndIncrement(), s, true);
-			messages.putIfAbsent(s, m);
+			putMessage(s, m);
 			return m;
 		} finally {
 			processor().signal();
 		}
 	}
 
+	void putMessage(String s, Message m) {
+		ConcurrentHashMap<String, Message> current;
+		do {
+			current = messages;
+			current.putIfAbsent(s, m);
+		} while (current != messages);
+	}
+
 	SetLocation warning(String format, Object... args) {
 		String s = Processor.formatArrays(format, args);
 		Message m = new Message(counter.getAndIncrement(), s, false);
-		messages.putIfAbsent(s, m);
+		putMessage(s, m);
 		return m;
 	}
 
@@ -239,7 +246,7 @@ public class MessageReporter {
 			.sorted()
 			.map(m -> new Message(counter.getAndIncrement(), m, actualPrefix))
 			.forEach(m -> {
-				messages.putIfAbsent(m.message, m);
+				putMessage(m.message, m);
 			});
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -30,7 +30,6 @@ public class MessageReporter {
 
 		final boolean	error;
 		final int		sequence;
-		final String	message;
 
 		Message(int sequence, String message, boolean error) {
 			this.sequence = sequence;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -1,0 +1,272 @@
+package aQute.bnd.osgi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.header.Attrs;
+import aQute.bnd.header.Parameters;
+import aQute.service.reporter.Report.Location;
+import aQute.service.reporter.Reporter;
+import aQute.service.reporter.Reporter.SetLocation;
+
+/**
+ * This is the error and warning messages collected. It implements a concurrent
+ * message handling system.
+ */
+public class MessageReporter {
+
+	final Processor								processor;
+	final AtomicInteger							counter		= new AtomicInteger(1000);
+	volatile ConcurrentHashMap<String, Message>	messages	= new ConcurrentHashMap<>();
+
+	class Message extends Location implements SetLocation, Comparable<Message> {
+		@Override
+		public String toString() {
+			return "Message [error=" + error + ", sequence=" + sequence + ", message=" + message + "]";
+		}
+
+		final boolean	error;
+		final int		sequence;
+		final String	message;
+
+		Message(int sequence, String message, boolean error) {
+			this.sequence = sequence;
+			this.message = message;
+			this.error = error;
+		}
+
+		Message(int sequence, Message m, String actualPrefix) {
+			this.sequence = sequence;
+			this.message = actualPrefix.concat(m.message);
+			this.error = m.error;
+			m.to(this);
+		}
+
+		@Override
+		public SetLocation file(String file) {
+			this.file = file;
+			return this;
+		}
+
+		@Override
+		public SetLocation header(String header) {
+			this.header = header;
+			return this;
+		}
+
+		@Override
+		public SetLocation context(String context) {
+			this.context = context;
+			return this;
+		}
+
+		@Override
+		public SetLocation method(String methodName) {
+			this.methodName = methodName;
+			return this;
+		}
+
+		@Override
+		public SetLocation line(int n) {
+			this.line = n;
+			return this;
+		}
+
+		@Override
+		public SetLocation reference(String reference) {
+			this.reference = reference;
+			return this;
+		}
+
+		@Override
+		public SetLocation details(Object details) {
+			this.details = details;
+			return null;
+		}
+
+		@Override
+		public Location location() {
+			return this;
+		}
+
+		@Override
+		public SetLocation length(int length) {
+			this.length = length;
+			return this;
+		}
+
+		@Override
+		public int compareTo(Message o) {
+			return Integer.compare(sequence, o.sequence);
+		}
+
+		void fixup(Instructions fixupInstrs, List<String> errors, List<String> warnings) {
+
+			boolean error = this.error;
+
+			Instruction matcher = fixupInstrs.finder(message);
+			String type = error ? Constants.FIXUPMESSAGES_IS_ERROR : Constants.FIXUPMESSAGES_IS_WARNING;
+			String message = this.message;
+
+			if (matcher != null && !matcher.isNegated()) {
+
+				Attrs attrs = fixupInstrs.get(matcher);
+				String restrict = attrs.get(Constants.FIXUPMESSAGES_RESTRICT_DIRECTIVE);
+				String replace = attrs.get(Constants.FIXUPMESSAGES_REPLACE_DIRECTIVE);
+				String is = attrs.get(Constants.FIXUPMESSAGES_IS_DIRECTIVE);
+
+				if (restrict == null || restrict.equals(type)) {
+
+					if (is != null && !is.equals(type)) {
+						error = !error;
+					}
+
+					if (replace != null) {
+						try (Processor replacer = new Processor(processor())) {
+							replacer.setProperty("@", message);
+							processor().getLogger()
+								.debug("replacing {} with {}", message, replace);
+							message = replacer.getReplacer()
+								.process(replace);
+						} catch (Exception e) {
+							throw Exceptions.duck(e);
+						}
+					}
+
+					if (attrs.isEmpty() || Constants.FIXUPMESSAGES_IS_IGNORE.equals(is)) {
+						message = null;
+					}
+				}
+			}
+			if (message != null) {
+				if (error)
+					errors.add(message);
+				else
+					warnings.add(message);
+			}
+		}
+
+
+	}
+
+	class Cache {
+		final List<String>	errors		= new ArrayList<>();
+		final List<String>	warnings	= new ArrayList<>();
+
+		Cache() {
+			boolean failOk = processor().isFailOk();
+			Instructions fixupInstrs = new Instructions();
+			Parameters fixup = processor().getMergedParameters(Constants.FIXUPMESSAGES);
+			fixup.forEach((k, v) -> fixupInstrs.put(Instruction.legacy(k), v));
+
+			messages.values()
+				.stream()
+				.sorted()
+				.forEach(m -> {
+					m.fixup(fixupInstrs, failOk ? warnings : errors, warnings);
+				});
+		}
+	}
+
+	MessageReporter(Processor processor) {
+		this.processor = processor;
+	}
+
+	List<String> getWarnings() {
+		return fixup().warnings;
+	}
+
+	List<String> getErrors() {
+		return fixup().errors;
+	}
+
+	Cache fixup() {
+		return new Cache();
+	}
+
+	Location getLocation(String msg) {
+		return messages.get(msg);
+	}
+
+	public SetLocation error(String format, Object... args) {
+		try {
+			for (int i = 0; i < args.length; i++) {
+				if (args[i] instanceof Throwable t) {
+					args[i] = Exceptions.causes(t);
+				}
+			}
+			String s = Processor.formatArrays(format, args);
+			Message m = new Message(counter.getAndIncrement(), s, true);
+			messages.putIfAbsent(s, m);
+			return m;
+		} finally {
+			processor().signal();
+		}
+	}
+
+	SetLocation warning(String format, Object... args) {
+		String s = Processor.formatArrays(format, args);
+		Message m = new Message(counter.getAndIncrement(), s, false);
+		messages.putIfAbsent(s, m);
+		return m;
+	}
+
+	void getInfo(Reporter from, String prefix) {
+		String actualPrefix = prefix == null ? prefix = processor().getBase() + " :" : prefix;
+
+		MessageReporter other;
+		if (from instanceof Processor processor) {
+			other = processor.reporter;
+		} else if (from instanceof MessageReporter mr) {
+			other = mr;
+		} else {
+			// backward compatible reporters
+			addAll(true, prefix, from);
+			addAll(false, prefix, from);
+			from.getErrors()
+				.clear();
+			from.getWarnings()
+				.clear();
+			return;
+		}
+
+		ConcurrentHashMap<String, Message> older = other.clear();
+		older.values()
+			.stream()
+			.sorted()
+			.map(m -> new Message(counter.getAndIncrement(), m, actualPrefix))
+			.forEach(m -> {
+				messages.putIfAbsent(m.message, m);
+			});
+	}
+
+	/*
+	 * for backward compatible reporters
+	 */
+	void addAll(boolean error, String prefix, Reporter reporter) {
+		for (String message : new ArrayList<>(error ? reporter.getErrors() : reporter.getWarnings())) {
+			String newMessage = prefix.isEmpty() ? message : prefix.concat(message);
+			Message m = new Message(counter.getAndIncrement(), newMessage, error);
+			Location location = reporter.getLocation(message);
+			if (location != null)
+				location.to(m);
+		}
+	}
+
+	ConcurrentHashMap<String, Message> clear() {
+		ConcurrentHashMap<String, Message> previous = messages;
+		messages = new ConcurrentHashMap<>();
+		return previous;
+	}
+
+	Processor processor() {
+		return this.processor.current();
+	}
+
+	Message remove(String message) {
+		return messages.remove(message);
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -38,10 +38,10 @@ public class MessageReporter {
 		}
 
 		Message(int sequence, Message m, String actualPrefix) {
+			m.to(this);
 			this.sequence = sequence;
 			this.message = actualPrefix.concat(m.message);
 			this.error = m.error;
-			m.to(this);
 		}
 
 		@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -222,7 +222,7 @@ public class MessageReporter {
 	}
 
 	void getInfo(Reporter from, String prefix) {
-		String actualPrefix = prefix == null ? prefix = processor().getBase() + " :" : prefix;
+		String actualPrefix = prefix == null ? processor().getBase() + " :" : prefix;
 
 		MessageReporter other;
 		if (from instanceof Processor processor) {
@@ -231,8 +231,8 @@ public class MessageReporter {
 			other = mr;
 		} else {
 			// backward compatible reporters
-			addAll(true, prefix, from);
-			addAll(false, prefix, from);
+			addAll(true, actualPrefix, from);
+			addAll(false, actualPrefix, from);
 			from.getErrors()
 				.clear();
 			from.getWarnings()
@@ -260,6 +260,7 @@ public class MessageReporter {
 			Location location = reporter.getLocation(message);
 			if (location != null)
 				location.to(m);
+			putMessage(newMessage, m);
 		}
 	}
 

--- a/bndtools.core/src/org/bndtools/build/api/DefaultBuildErrorDetailsHandler.java
+++ b/bndtools.core/src/org/bndtools/build/api/DefaultBuildErrorDetailsHandler.java
@@ -14,6 +14,7 @@ import aQute.bnd.build.Project;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.Processor.FileLine;
+import aQute.lib.strings.Strings;
 import aQute.service.reporter.Report.Location;
 import bndtools.central.Central;
 
@@ -87,7 +88,7 @@ public final class DefaultBuildErrorDetailsHandler extends AbstractBuildErrorDet
 		}
 
 		Map<String, Object> attribs = new HashMap<>();
-		attribs.put(IMarker.MESSAGE, location.message.trim() + extra);
+		attribs.put(IMarker.MESSAGE, Strings.trim(location.message) + extra);
 		attribs.put(IMarker.LINE_NUMBER, line + 1);
 		if (end != -1 && start != -1) {
 			attribs.put(IMarker.CHAR_START, start);


### PR DESCRIPTION
#5967 indicated that in Gradle and maybe also in Maven the error/warning message handling was not properly handling concurrent access in getInfo. 

This PR has put the core message handling of Processor in a new class MessageReporter. This class should be concurrent safe for normal usage. It should at least not throw ConcurrentModificationExceptions ...

The behavior is slightly changed. The previous code handled out modifiable versions of its own error/warnings. This was used in several places to change these lists from the outside. One place was `Processor.check(patterns)`. A lot of tests depended on this behavior so that was explicitly coupled.