### PR TITLE
Dependency bot does not get the action/upload version bumped

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -102,7 +102,7 @@ jobs:
         JFROG_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
     - name: Upload Test Reports
       if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
       with:
         name: Build_JDK${{ matrix.java }}_${{ matrix.os }}-test-reports
         path: |

--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -102,7 +102,7 @@ jobs:
         JFROG_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
     - name: Upload Test Reports
       if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       with:
         name: Build_JDK${{ matrix.java }}_${{ matrix.os }}-test-reports
         path: |

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         ./.github/scripts/rebuild-build.sh
     - name: Upload dist/bundles
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
       with:
         name: Dist_Bundles_JDK${{ matrix.java }}_${{ matrix.os }}
         if-no-files-found: error
@@ -110,7 +110,7 @@ jobs:
     - name: Set up Gradle
       uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2
     - name: Download dist/bundles
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff
       with:
         name: ${{ needs.build.outputs.dist-bundles }}
         path: dist/bundles
@@ -120,7 +120,7 @@ jobs:
         ${{ format(matrix.runner, './.github/scripts/rebuild-test.sh') }}
     - name: Upload Test Reports
       if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
       with:
         name: Rebuild_JDK${{ matrix.java }}_${{ matrix.os }}-test-reports
         path: |

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         ./.github/scripts/rebuild-build.sh
     - name: Upload dist/bundles
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       with:
         name: Dist_Bundles_JDK${{ matrix.java }}_${{ matrix.os }}
         if-no-files-found: error
@@ -110,7 +110,7 @@ jobs:
     - name: Set up Gradle
       uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2
     - name: Download dist/bundles
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.build.outputs.dist-bundles }}
         path: dist/bundles
@@ -120,7 +120,7 @@ jobs:
         ${{ format(matrix.runner, './.github/scripts/rebuild-test.sh') }}
     - name: Upload Test Reports
       if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       with:
         name: Rebuild_JDK${{ matrix.java }}_${{ matrix.os }}-test-reports
         path: |


### PR DESCRIPTION
The Dependabot #5988 fails to rebuild. I suspect this is caused by asymmetry in the upload/download actions. So lets try with readable versions.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>