### PR TITLE
Add a verify goal to the bnd-resolver-maven-plugin

### DIFF
--- a/maven-plugins/bnd-resolver-maven-plugin/README.md
+++ b/maven-plugins/bnd-resolver-maven-plugin/README.md
@@ -1,10 +1,10 @@
 # bnd-resolver-maven-plugin
 
-The `bnd-resolver-maven-plugin` is a bnd based plugin to resolve bundles from bndrun files.
+The `bnd-resolver-maven-plugin` is a bnd based plugin to resolve and validate bundles in bndrun files.
 
 ## What does the `bnd-resolver-maven-plugin` do?
 
-Point the plugin to one or more bndrun files in the same project. It will resolve the -runbundles value.
+Point the plugin to one or more bndrun files in the same project. It can `resolve` or `verify` the -runbundles value for that bndrun file.
 
 ```
     <plugin>
@@ -27,6 +27,19 @@ Point the plugin to one or more bndrun files in the same project. It will resolv
     </plugin>
 ```
 
+### What's the difference between "resolve" and "verify"
+
+A `resolve` operation uses the `-runrequires` from your bndrun file to *generate* the content of the `-runbundles`. This is usually saved back to the bnrun file so that you can use it with another plugin such as `bnd-testing-maven-plugin` or `bnd-export-maven-plugin`. The `resolve` goal is normally executed directly from the command line, or bound to a profile, so that a developer can regenerate the list of bundles after making changes to the code.
+
+The `verify` goal is fundamentally different from `resolve` as it will never create a list of `-runbundles` for you - it only works with bndrun files that are already resolved. A `verify` operation *checks* the `-runbundles` from your bndrun file to make sure that they:
+
+ 1. Are a valid resolution
+ 2. Satisfy the `-runrequires` requirements
+
+The `verify` goal is normally bound to a lifecycle phase and executed as part of the build. This may only be enabled in CI, for example by using a profile, or it may be run as part of every build. A failure from the `verify` goal indicates that the bndrun needs to be updated, either by hand, or by using the `resolve` goal.
+
+### Using bundles from the file system
+
 Here's an example setting the `bundles` used for resolution.
 
 ```
@@ -43,11 +56,20 @@ Here's an example setting the `bundles` used for resolution.
 
 ## Executing the resolve operation
 
-Since the resolve operation is not associated with any maven build phase, it must in invoked manually.
+Since the resolve operation is not associated with any maven build phase, it must be invoked manually, or bound to a lifecycle phase in configuration.
 
 Here's an example invocation:
 ```
 mvn bnd-resolver:resolve
+```
+
+## Executing the verify operation
+
+Since the verify operation is not associated with any maven build phase, it must be invoked manually, or bound to a lifecycle phase in configuration.
+
+Here's an example invocation:
+```
+mvn bnd-resolver:verify
 ```
 
 ## Bndrun Details Inferred from Maven
@@ -61,18 +83,27 @@ The `-runee` and `-runrequires` values can be inferred from the maven project as
 
 An *implicit repository* containing the project artifact and project dependencies (as defined through the configuration of `bundles`, `scopes`, `useMavenDependencies` and `includeDependencyManagement`) is created and added when this plugin is executed.
 
-## Configuration Properties
+## Common Configuration Properties
+
+The following configuration properties are common to both the `resolve` and `verify` goals
 
 | Configuration Property        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `bndruns`                     | Can contain `bndrun` child elements specifying a bndrun file to resolve. These are relative to the `${project.basedir}` directory. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bndrun files in the `bndrunDir` directory.  _Defaults to `<include>*.bndrun</include>`._                                                                                                                                                               |
 | `bndrunDir`                   | This directory will be used when locating bndrun files using `include` and `exclude`. _Defaults to `${project.basedir}`_.                                                                                                                                                                                                                                                                                                                                                              |
-| `outputBndrunDir`             | The bndrun files will be written to the specified directory. If the specified directory is the same as `bndrunDir`, then any changes to a bndrun files will cause the bndrun file to be overwritten. _Defaults to `${project.basedir}`_.                                                                                                                                                                                                                                               |
-| `failOnChanges`               | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                                                             |
-| `writeOnChanges`              | Whether to write the resolved run bundles back to the `-runbundles` property of the `bndrun` file. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                                               |
 | `bundles`                     | A collection of files to include in the *implicit repository*. Can contain `bundle` child elements specifying the path to a bundle. These can be absolute paths. You can also specify `include` and `exclude` child elements using Ant-style globs to specify bundles. These are relative to the `${project.basedir}` directory. _Defaults to dependencies in the scopes specified by the `scopes` property, plus the current artifact (if any and `useMavenDependencies` is `true`)._ |
 | `useMavenDependencies`        | If `true`, adds the project dependencies subject to `scopes` to the collection of files to include in the *implicit repository*. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                 |
 | `reportOptional`              | If `true`, resolution failure reports will include optional requirements. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                                                                        |
 | `scopes`                      | Specify from which scopes to collect dependencies. _Defaults to `compile, runtime`._ Override with property `bnd.resolve.scopes`.                                                                                                                                                                                                                                                                                                                                                      |
 | `includeDependencyManagement` | Include `<dependencyManagement>` subject to `scopes` when collecting files to include in the *implicit repository*. _Defaults to `false`._ Override with property `bnd.resolve.include.dependency.management`.                                                                                                                                                                                                                                                                         |
 | `skip`                        | Skip the project. _Defaults to `false`._ Override with property `bnd.resolve.skip`.                                                                                                                                                                                                                                                                                                                                                                                                    |
+
+### Additional Configuration Properties for the resolve goal
+
+The following properties apply only to the `resolve` goal
+
+| Configuration Property        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `outputBndrunDir`             | The bndrun files will be written to the specified directory. If the specified directory is the same as `bndrunDir`, then any changes to a bndrun files will cause the bndrun file to be overwritten. _Defaults to `${project.basedir}`_.                                                                                                                                                                                                                                               |
+| `failOnChanges`               | Whether to fail the build if any change in the resolved `-runbundles` is discovered. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                                                             |
+| `writeOnChanges`              | Whether to write the resolved run bundles back to the `-runbundles` property of the `bndrun` file. _Defaults to `true`._                                                                                                                                                                                                                                                                                                                                                               |

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/parent/pom.xml
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/parent/pom.xml
@@ -7,6 +7,10 @@
 	<version>0.0.1</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<it.resolve.skip>false</it.resolve.skip>
+	</properties>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -55,6 +59,9 @@
 							<goals>
 								<goal>resolve</goal>
 							</goals>
+							<configuration>
+								<skip>${it.resolve.skip}</skip>
+							</configuration>
 						</execution>
 					</executions>
 				</plugin>

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/invoker.properties
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/invoker.properties
@@ -1,0 +1,7 @@
+invoker.goals=--no-transfer-progress package
+
+# Run mvn with --debug for debug logging
+#invoker.debug=true
+
+# Run mvn in debugging mode and wait for a debugger to attach
+#invoker.environmentVariables.MAVEN_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/pom.xml
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>resolver-test</artifactId>
+		<version>0.0.1</version>
+		<relativePath>../parent</relativePath>
+	</parent>
+
+	<artifactId>verify</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<it.resolve.skip>true</it.resolve.skip>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-resolver-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/test.bndrun
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/test.bndrun
@@ -1,0 +1,5 @@
+-standalone: ${projectsDirectory}/index/index.xml.gz
+-runfw: org.apache.felix.framework
+-runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.eventadmin)'
+
+-runbundles: org.apache.felix.eventadmin;version="[1.4.6,1.4.7)"

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
@@ -1,0 +1,287 @@
+package aQute.bnd.maven.resolver.plugin;
+
+import static aQute.bnd.maven.lib.resolve.BndrunContainer.report;
+import static java.util.stream.Collectors.toList;
+
+import java.io.File;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import aQute.bnd.build.Container;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.maven.lib.configuration.Bndruns;
+import aQute.bnd.maven.lib.configuration.Bundles;
+import aQute.bnd.maven.lib.resolve.BndrunContainer;
+import aQute.bnd.maven.lib.resolve.Operation;
+import aQute.bnd.maven.lib.resolve.Scope;
+import aQute.bnd.osgi.BundleId;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.resource.CapReqBuilder;
+import aQute.bnd.osgi.resource.ResourceUtils;
+import aQute.bnd.unmodifiable.Sets;
+import aQute.bnd.version.VersionRange;
+import aQute.lib.io.IO;
+import aQute.lib.utf8properties.UTF8Properties;
+import biz.aQute.resolve.ResolutionCallback;
+import biz.aQute.resolve.ResolveProcess;
+import biz.aQute.resolve.RunResolution;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.osgi.resource.Capability;
+import org.osgi.resource.Requirement;
+import org.osgi.resource.Resource;
+import org.osgi.service.resolver.ResolutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies the <code>-runbundles</code> for the given bndrun file(s).
+ */
+@Mojo(name = "verify", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, threadSafe = true)
+public class VerifierMojo extends AbstractMojo {
+	private static final Logger									logger	= LoggerFactory.getLogger(VerifierMojo.class);
+
+	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	private MavenProject										project;
+
+	@Parameter(defaultValue = "${settings}", readonly = true)
+	private Settings											settings;
+
+	@Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+	private RepositorySystemSession								repositorySession;
+
+	@Parameter
+	private Bndruns												bndruns	= new Bndruns();
+
+	@Parameter
+	private Bundles												bundles	= new Bundles();
+
+	@Parameter(defaultValue = "true")
+	private boolean												useMavenDependencies;
+
+	@Parameter(defaultValue = "${project.build.directory}", readonly = true)
+	private File												targetDir;
+
+	@Parameter(defaultValue = "${session}", readonly = true)
+	private MavenSession										session;
+
+	@Parameter(property = "bnd.resolve.include.dependency.management", defaultValue = "false")
+	private boolean												includeDependencyManagement;
+
+	@Parameter(defaultValue = "true")
+	private boolean												reportOptional;
+
+	@Parameter(property = "bnd.resolve.scopes", defaultValue = "compile,runtime")
+	private Set<Scope>											scopes	= Sets.of(Scope.compile, Scope.runtime);
+
+	@Parameter(property = "bnd.resolve.skip", defaultValue = "false")
+	private boolean												skip;
+
+	/**
+	 * The bndrun files will be read from this directory.
+	 */
+	@Parameter(defaultValue = "${project.basedir}")
+	private File 												bndrunDir;
+
+	/**
+	 * The bndrun files will be written to this directory. If the
+	 * specified directory is the same as {@link #bndrunDir}, then
+	 * any changes to a bndrun file will cause the bndrun file to be overwritten.
+	 */
+	@Parameter(defaultValue = "${project.basedir}")
+	private File 												outputBndrunDir;
+
+	@Component
+	private RepositorySystem									system;
+
+	@Component
+	private ProjectDependenciesResolver							resolver;
+
+	@Component
+	@SuppressWarnings("deprecation")
+	private org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skip) {
+			logger.debug("skip project as configured");
+			return;
+		}
+
+		int errors = 0;
+
+		try {
+			List<File> bndrunFiles = bndruns.getFiles(bndrunDir, "*.bndrun");
+
+			if (bndrunFiles.isEmpty()) {
+				logger.warn(
+					"No bndrun files were specified with <bndrun> or found as *.bndrun in the project. This is unexpected.");
+				return;
+			}
+
+			BndrunContainer container = new BndrunContainer.Builder(project, session, repositorySession, resolver,
+				artifactFactory, system).setBundles(bundles.getFiles(project.getBasedir()))
+					.setIncludeDependencyManagement(includeDependencyManagement)
+					.setScopes(scopes)
+					.setUseMavenDependencies(useMavenDependencies)
+					.build();
+
+			Operation operation = getOperation();
+
+			for (File runFile : bndrunFiles) {
+				logger.info("Verifying {}:", runFile);
+				if (!Objects.equals(outputBndrunDir, bndrunDir)) {
+					IO.mkdirs(outputBndrunDir);
+					File outputRunFile = new File(outputBndrunDir, runFile.getName());
+					try (Writer writer = IO.writer(outputRunFile)) {
+						UTF8Properties props = new UTF8Properties();
+						props.setProperty(Constants.INCLUDE, String.format("\"~%s\"", escape(IO.absolutePath(runFile))));
+						props.store(writer, null);
+					}
+					runFile = outputRunFile;
+				}
+				errors += container.execute(runFile, "resolve", targetDir, operation);
+			}
+		} catch (Exception e) {
+			throw new MojoExecutionException(e.getMessage(), e);
+		}
+
+		if (errors > 0)
+			throw new MojoFailureException(errors + " errors found");
+	}
+
+	private Operation getOperation() {
+		return (file, runName, run) -> {
+			try {
+				String originalRunRequires = run.mergeProperties(Constants.RUNREQUIRES);
+
+				Collection<BundleId> expectedRunbundles = run.getRunbundles()
+					.stream()
+					.map(Container::getBundleId)
+					.collect(toList());
+
+				List<Requirement> runBundleReqs = expectedRunbundles.stream()
+					.map(c -> CapReqBuilder
+						.createBundleRequirement(c.getBsn(),
+							new VersionRange(c.getVersion(), c.getVersion()).toString())
+						.buildSyntheticRequirement())
+					.collect(toList());
+
+				run.setRunRequires(runBundleReqs.stream()
+					.map(Requirement::toString)
+					.collect(Collectors.joining(", ")));
+
+				RunResolution result = run.resolve(new BundleFilter(runBundleReqs));
+
+				if (result.isOK()) {
+					List<BundleId> resolved = result.getContainers()
+						.stream()
+						.map(Container::getBundleId)
+						.collect(toList());
+
+					List<BundleId> missing = expectedRunbundles.stream()
+						.filter(c -> !resolved.contains(c))
+						.collect(toList());
+					List<BundleId> extra = resolved.stream()
+						.filter(c -> !expectedRunbundles.contains(c))
+						.collect(toList());
+
+					if (missing.isEmpty() && extra.isEmpty()) {
+
+						Parameters inputRequirements = new Parameters(originalRunRequires, run);
+						List<Resource> resolvedResources = result.getOrderedResources();
+
+						List<Requirement> unmatchedInitialRequirements = CapReqBuilder
+							.getRequirementsFrom(inputRequirements)
+							.stream()
+							.filter(req -> resolvedResources.stream()
+								.noneMatch(res -> ResourceUtils.matches(req, res)))
+							.collect(toList());
+
+						if (unmatchedInitialRequirements.isEmpty()) {
+							logger.info("The bndrun file {} validated successfully", file);
+						} else {
+							logger.error("The bndrun file {} failed validation with {} unmatched initial requirements",
+								file, unmatchedInitialRequirements);
+							run.error(
+								"Bndrun resolution verification failed for file %s.\nThe following initial requirements were not satisfied: %s",
+								file, unmatchedInitialRequirements);
+						}
+					} else {
+						logger.error(
+							"The bndrun file {} failed validation with {} missing bundles and {} extra bundles", file,
+							missing, extra);
+						run.error(
+							"Bndrun resolution verification failed for file %s.\nThe missing results were: %s\nThe extra bundles were: %s",
+							file, missing, extra);
+					}
+				} else {
+					if (result.exception instanceof ResolutionException) {
+						String msg = ResolveProcess.format((ResolutionException) result.exception, reportOptional);
+						logger.error(msg);
+						run.error(msg);
+					} else {
+						logger.error("An unknown error ocurred verifying bndrun file {}", file, result.exception);
+						run.error("An unknown error ocurred verifying bndrun file %s", result.exception, file);
+					}
+				}
+			} finally {
+				int errors = report(run);
+				if (errors > 0) {
+					return errors;
+				}
+			}
+			return 0;
+		};
+	}
+
+	private static class BundleFilter implements ResolutionCallback {
+		private final List<Requirement> bundleRequirements;
+
+		public BundleFilter(List<Requirement> bundleRequirements) {
+			this.bundleRequirements = bundleRequirements;
+		}
+
+		@Override
+		public void processCandidates(Requirement requirement, Set<Capability> wired, List<Capability> candidates) {
+			Iterator<Capability> it = candidates.iterator();
+			while (it.hasNext()) {
+				Capability id = ResourceUtils.getIdentityCapability(it.next()
+					.getResource());
+				if (bundleRequirements.stream()
+					.noneMatch(r -> ResourceUtils.matches(requirement, id))) {
+					it.remove();
+				}
+			}
+		}
+	}
+
+	private String escape(String input) {
+		final int length = input.length();
+		StringBuilder sb = new StringBuilder(length);
+		for (int i = 0; i < length;i++) {
+			char c = input.charAt(i);
+			if (c == '"') {
+				sb.append('\\');
+			}
+			sb.append(c);
+		}
+		return sb.length() == length ? input : sb.toString();
+	}
+}


### PR DESCRIPTION
The  goal provides a way to validate that a set of run bundles is a valid resolution. It does this by creating a set of run requirements requiring each run bundle by identity and performing a resolve operation. This resolve operation forbids any capabilities that come from bundles not in the list of run requirements. If the resolution succeeds then it is further checked against the orginal run requirements.

If these checks pass then we know that:

 * The resolution is valid
 * The resolution satisfies the original run requirements

This is useful for CI when we want to test that a checked-in bndrun file has been correctly resolved.

Fixes #5984