### PR TITLE
Improve error reporting for DS annotations

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -1022,7 +1022,8 @@ public class DSAnnotationReader extends ClassDataCollector {
 					} else { // def.fieldOption == FieldOption.REPLACE
 						if (member.isFinal()) {
 							analyzer
-								.error("In component '%s', field '%s' is final and fieldOption is not 'update'.",
+								.error(
+									"In component '%s', field '%s' has fieldOption 'replace' but the field is final.",
 									className,
 									def.field)
 								.details(getDetails(def, ErrorType.FINAL_FIELD_WITH_REPLACE));
@@ -1033,9 +1034,9 @@ public class DSAnnotationReader extends ClassDataCollector {
 									className, def.field)
 								.details(getDetails(def, ErrorType.DYNAMIC_FIELD_NOT_VOLATILE));
 						}
-						if (def.isCollectionSubClass) {
+						if (def.isNotDirectlyListOrCollection) {
 							analyzer.error(
-								"In component '%s', field '%s' is a subclass of Collection and fieldOption is not 'update'.",
+								"In component '%s', field '%s' is a collection type with fieldOption 'replace' but the type of the field is not declared as 'List' or 'Collection'.",
 								className, def.field)
 								.details(getDetails(def, ErrorType.COLLECTION_SUBCLASS_FIELD_WITH_REPLACE));
 						}
@@ -1104,9 +1105,9 @@ public class DSAnnotationReader extends ClassDataCollector {
 								className, def.parameter)
 								.details(getDetails(def, ErrorType.OPTIONAL_FIELD_WITH_MULTIPLE));
 						}
-						if (def.isCollectionSubClass) {
+						if (def.isNotDirectlyListOrCollection) {
 							analyzer.error(
-								"In component '%s', constructor argument %s is a subclass of Collection but this is not allowed for a constructor parameter",
+								"In component '%s', constructor argument %s is a subclass of Collection but it must be declared as either List or Collection",
 								className, def.parameter)
 								.details(getDetails(def, ErrorType.CONSTRUCTOR_SIGNATURE_ERROR));
 						}
@@ -1199,7 +1200,7 @@ public class DSAnnotationReader extends ClassDataCollector {
 					// check for subtype of Collection
 					if (analyzer.assignable(paramType, "java.util.Collection", false)) {
 						def.isCollection = true;
-						def.isCollectionSubClass = true;
+						def.isNotDirectlyListOrCollection = true;
 					}
 					break;
 				case "java.util.Optional" :

--- a/biz.aQute.bndlib/src/aQute/bnd/component/ReferenceDef.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/ReferenceDef.java
@@ -44,7 +44,11 @@ class ReferenceDef extends ExtensionDef {
 	CollectionType			collectionType;
 	boolean					isCollection;			// collection OR optional
 	boolean					isOptional;
-	boolean					isCollectionSubClass;
+	boolean					isNotDirectlyListOrCollection;	// The type extends
+															// java.util.Collection
+															// but is not
+															// java.util.List or
+															// java.util.Collection
 	Integer					parameter;
 	String					reasonForVersion;
 


### PR DESCRIPTION
The error messages when handling field/constructor injection with Collection types are somewhat confusing, in that they don't explain what the correct usage would be. This is particularly problematic with collection subclasses. This commit attempts to improve the error messages, and to improve the naming of an internal field which is used to track the fact that a DS reference is a collection type which is not `Collection` or `List`

See also #5994