### PR TITLE
Fixes for the bnd-resolver-maven-plugin verification

### DIFF
--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/pom.xml
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/pom.xml
@@ -18,6 +18,14 @@
 		<it.resolve.skip>true</it.resolve.skip>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.11.1</version>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -29,6 +37,9 @@
                         <goals>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+							<skip>false</skip>
+						</configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/test.bndrun
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify/test.bndrun
@@ -1,5 +1,7 @@
--standalone: ${projectsDirectory}/index/index.xml.gz
 -runfw: org.apache.felix.framework
--runrequires: osgi.identity;filter:='(osgi.identity=org.apache.felix.eventadmin)'
+-runrequires: osgi.identity;filter:='(osgi.identity=com.fasterxml.jackson.core.jackson-databind)'
 
--runbundles: org.apache.felix.eventadmin;version="[1.4.6,1.4.7)"
+-runbundles: com.fasterxml.jackson.core.jackson-databind;version='[2.11.1,2.11.2)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.11.1,2.11.2)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.11.1,2.11.2)'
+	

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
@@ -243,7 +243,7 @@ public class VerifierMojo extends AbstractMojo {
 				Capability id = ResourceUtils.getIdentityCapability(it.next()
 					.getResource());
 				if (bundleRequirements.stream()
-					.noneMatch(r -> ResourceUtils.matches(requirement, id))) {
+					.noneMatch(r -> ResourceUtils.matches(r, id))) {
 					it.remove();
 				}
 			}


### PR DESCRIPTION
The test case used to test the verifier was too simple, and failed to identify that the wrong requirement was being tested in the ResolutionCallback. This commit makes the test more extensive, and fixes the bug.