### PR TITLE
Ensure bnd-resolver-maven-plugin verify handles multi-release jars

### DIFF
--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/invoker.properties
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/invoker.properties
@@ -1,0 +1,7 @@
+invoker.goals=--no-transfer-progress package
+
+# Run mvn with --debug for debug logging
+#invoker.debug=true
+
+# Run mvn in debugging mode and wait for a debugger to attach
+#invoker.environmentVariables.MAVEN_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/pom.xml
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>biz.aQute.bnd-test</groupId>
+		<artifactId>resolver-test</artifactId>
+		<version>0.0.1</version>
+		<relativePath>../parent</relativePath>
+	</parent>
+
+	<artifactId>verify-multirelease</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<it.resolve.skip>true</it.resolve.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.16.1</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-resolver-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+							<skip>false</skip>
+						</configuration>
+                    </execution>
+                </executions>
+            </plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/test.bndrun
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/it/verify-multirelease/test.bndrun
@@ -1,0 +1,7 @@
+-runfw: org.apache.felix.framework
+-runrequires: osgi.identity;filter:='(osgi.identity=com.fasterxml.jackson.core.jackson-databind)'
+
+-runbundles: com.fasterxml.jackson.core.jackson-databind;version='[2.16.1,2.16.2)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.16.1,2.16.2)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.16.1,2.16.2)'
+	


### PR DESCRIPTION
Multi-Release Jars are modelled in bnd using SupportingResource children. When verifying we only care about the *real* resources which end up in the run bundles so we must

1. Permit SupportingResource children to pass through the ResolveCallback
2. Remove SupportingResource children from the resolve result before comparing it