### PR TITLE
Update dependabot.yml to ignore test dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     directory: "/maven-plugins"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+        # This version is used in the resolver tests and should not be updated
+        versions: ["2.11.1"]
 
   # Maintain dependencies for gradle
   - package-ecosystem: "gradle"


### PR DESCRIPTION
I believe this will stop dependabot complaining about the version of Jackson used in the resolver verification tests.