### PR TITLE
Finish button enabled during template selection

### DIFF
--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -231,4 +231,9 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippi
 		return ISkippingWizard.super.getNextPage(page);
 	}
 
+	@Override
+	public boolean canFinish() {
+		return getContainer().getCurrentPage() != templatePage;
+	}
+
 }


### PR DESCRIPTION
During the template selection the finish button was enabled but this can't happen because we miss the name. This is a mess because it is based on the Java Wizard but we do not need most of the information. Should be rewritten but not on my list right now.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>