### PR TITLE
refreshFromModel() before resolving

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
@@ -159,6 +159,7 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 	private void doResolve() {
 		IFormPage formPage = (IFormPage) getManagedForm().getContainer();
 		BndEditor editor = (BndEditor) formPage.getEditor();
+		refreshFromModel();
 		commit(false);
 		editor.resolveRunBundles(new NullProgressMonitor(), false);
 	}


### PR DESCRIPTION
This fixes the problem that the runrequirements get deleted if you click the resolve button too fast when the runrequirements part has not been loaded yet.

Closes #6028

