### PR TITLE
refs #6033 - Add EXPORT to MavenRunProvider

### DIFF
--- a/bndtools.m2e/src/bndtools/m2e/MavenRunProvider.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenRunProvider.java
@@ -121,6 +121,7 @@ public class MavenRunProvider implements RunProvider {
 		switch (mode) {
 			case LAUNCH :
 			case EDIT :
+			case EXPORT :
 			case SOURCES :
 				if ((mojoExecution = getBndResolverMojoExecution(maven, projectFacade, bndrunMatchs,
 					monitor)) != null) {


### PR DESCRIPTION
possible fix for #6033

- added EXPORT to MavenRunPOrovider
- without the UI export exports an empty jar with just the launcher
- with EXPORT switch, the bundles from the bndrun will be exported as well