### PR TITLE
Still had NPEs in the null file system

### DIFF
--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JarFileSystem.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JarFileSystem.java
@@ -332,6 +332,6 @@ public class JarFileSystem extends FileSystem {
 
 	static IFileStore nullFileStore(IPath path) {
 		return EFS.getNullFileSystem()
-			.getStore(path);
+			.getStore(path.makeAbsolute());
 	}
 }


### PR DESCRIPTION
Turns out the path we gave it was not absolute.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>