### PR TITLE
Add support for PropertyKeys, where these records pair the Processor/key

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ProcessorTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ProcessorTest.java
@@ -22,6 +22,7 @@ import aQute.bnd.osgi.AttributeClasses;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.OSInformation;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Processor.PropertyKey;
 import aQute.bnd.osgi.resource.RequirementBuilder;
 import aQute.bnd.osgi.resource.ResourceBuilder;
 import aQute.bnd.osgi.resource.ResourceUtils;
@@ -619,6 +620,27 @@ public class ProcessorTest {
 
 			String plusplus = p.mergeProperties("foo++");
 			assertThat(plusplus).isEqualTo("d,e,f");
+		}
+
+	}
+
+	@Test
+	public void testPropertyKeys() throws IOException {
+		try (Processor top = new Processor()) {
+			top.setProperty("foo+.1", "x,y,z");
+			top.setProperty("foo+.2", "x,y,z");
+			top.setProperty("foo++", "d,e,f");
+			try (Processor bottom = new Processor(top)) {
+				bottom.setProperty("foo+", "a,b,c");
+				bottom.setProperty("foo+.2", "x,y,z");
+				List<PropertyKey> keys = bottom.getMergePropertyKeys("foo+");
+				assertThat(keys).hasSize(4);
+				assertThat(keys).containsExactly(//
+					new PropertyKey(bottom, "foo+", 0), //
+					new PropertyKey(top, "foo+.1", 1), //
+					new PropertyKey(bottom, "foo+.2", 0), //
+					new PropertyKey(top, "foo+.2", 1));
+			}
 		}
 
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -2011,6 +2011,7 @@ public class Workspace extends Processor {
 		}
 	}
 
+	/**
 	 * Find the Processor that has the give file as properties.
 	 *
 	 * @param file the file that should match the Project or Workspace

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
@@ -123,6 +124,7 @@ public class Workspace extends Processor {
 	public static final String	EXT						= "ext";
 	public static final String	BUILDFILE				= "build.bnd";
 	public static final String	CNFDIR					= "cnf";
+	public static final String	CNF_BUILD_BND			= CNFDIR + "/" + BUILDFILE;
 	public static final String	CACHEDIR				= "cache/" + About.CURRENT;
 	public static final String	STANDALONE_REPO_CLASS	= "aQute.bnd.repository.osgi.OSGiRepository";
 
@@ -2009,4 +2011,26 @@ public class Workspace extends Processor {
 		}
 	}
 
+	 * Find the Processor that has the give file as properties.
+	 *
+	 * @param file the file that should match the Project or Workspace
+	 * @return an optional Processor
+	 */
+	public Optional<Processor> findProcessor(File file) {
+		File cnf = getFile(CNF_BUILD_BND);
+		if (cnf.equals(file))
+			return Optional.of(this);
+
+		File projectDir = file.getParentFile();
+		if (projectDir.isDirectory()) {
+			File wsDir = projectDir.getParentFile();
+			if (wsDir.equals(getBase())) {
+				Project project = getProject(projectDir.getName());
+				if (project != null) {
+					return project.findProcessor(file);
+				}
+			}
+		}
+		return Optional.empty();
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -77,8 +77,6 @@ import aQute.lib.utf8properties.UTF8Properties;
 @SuppressWarnings("deprecation")
 public class BndEditModel {
 
-	private static final String													BUILDFILE							= Workspace.CNFDIR
-		+ "/" + Workspace.BUILDFILE;
 	public static final String													NEWLINE_LINE_SEPARATOR				= "\\n\\\n\t";
 	public static final String													LIST_SEPARATOR						= ",\\\n\t";
 
@@ -273,13 +271,6 @@ public class BndEditModel {
 
 	// for change detection when multiple wizards look at the same model
 	private long																lastChangedAt;
-	/**
-	 * Is either the workspace (when cnf/build.bnd) or a project (when its
-	 * bnd.bnd) or a random bndrun linked to workspace (event if it isn't a
-	 * bndrun). Primary purpose is to walk the inheritance chain implied in the
-	 * Workspace/Project/sub bnd files/bndrun files
-	 */
-	Processor																	owner;
 
 	// Converter<String, ResolveMode> resolveModeFormatter =
 	// EnumFormatter.create(ResolveMode.class, ResolveMode.manual);
@@ -395,14 +386,27 @@ public class BndEditModel {
 		this(bndrun.getWorkspace());
 		this.project = bndrun;
 		File propertiesFile = bndrun.getPropertiesFile();
-		this.owner = workspace.findProcessor(propertiesFile)
-			.orElse(bndrun);
-
 		if (propertiesFile.isFile())
 			this.document = new Document(IO.collect(propertiesFile));
 		else
 			this.document = new Document("");
 		loadFrom(this.document);
+	}
+
+	/**
+	 * Is either the workspace (when cnf/build.bnd) or a project (when its
+	 * bnd.bnd) or a random bndrun linked to workspace (event if it isn't a
+	 * bndrun). Primary purpose is to walk the inheritance chain implied in the
+	 * Workspace/Project/sub bnd files files
+	 */
+	Processor getOwner() {
+		File propertiesFile = project.getPropertiesFile();
+		if (!propertiesFile.getName()
+			.endsWith(".bnd"))
+			return project;
+
+		return workspace.findProcessor(propertiesFile)
+			.orElse(project);
 	}
 
 	public void loadFrom(IDocument document) throws IOException {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -77,6 +77,8 @@ import aQute.lib.utf8properties.UTF8Properties;
 @SuppressWarnings("deprecation")
 public class BndEditModel {
 
+	private static final String													BUILDFILE							= Workspace.CNFDIR
+		+ "/" + Workspace.BUILDFILE;
 	public static final String													NEWLINE_LINE_SEPARATOR				= "\\n\\\n\t";
 	public static final String													LIST_SEPARATOR						= ",\\\n\t";
 
@@ -271,6 +273,13 @@ public class BndEditModel {
 
 	// for change detection when multiple wizards look at the same model
 	private long																lastChangedAt;
+	/**
+	 * Is either the workspace (when cnf/build.bnd) or a project (when its
+	 * bnd.bnd) or a random bndrun linked to workspace (event if it isn't a
+	 * bndrun). Primary purpose is to walk the inheritance chain implied in the
+	 * Workspace/Project/sub bnd files/bndrun files
+	 */
+	Processor																	owner;
 
 	// Converter<String, ResolveMode> resolveModeFormatter =
 	// EnumFormatter.create(ResolveMode.class, ResolveMode.manual);
@@ -382,10 +391,13 @@ public class BndEditModel {
 		loadFrom(document);
 	}
 
-	public BndEditModel(Project project) throws IOException {
-		this(project.getWorkspace());
-		this.project = project;
-		File propertiesFile = project.getPropertiesFile();
+	public BndEditModel(Project bndrun) throws IOException {
+		this(bndrun.getWorkspace());
+		this.project = bndrun;
+		File propertiesFile = bndrun.getPropertiesFile();
+		this.owner = workspace.findProcessor(propertiesFile)
+			.orElse(bndrun);
+
 		if (propertiesFile.isFile())
 			this.document = new Document(IO.collect(propertiesFile));
 		else
@@ -1456,5 +1468,4 @@ public class BndEditModel {
 	public long getLastChangedAt() {
 		return lastChangedAt;
 	}
-
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -112,7 +112,7 @@ public class BndEditModel {
 	private Properties															properties							= new UTF8Properties();
 	private final Map<String, Object>											objectProperties					= new HashMap<>();
 	private final Map<String, String>											changesToSave						= new TreeMap<>();
-	private Project																project;
+	private Project																bndrun;
 
 	private volatile boolean													dirty;
 
@@ -384,7 +384,7 @@ public class BndEditModel {
 
 	public BndEditModel(Project bndrun) throws IOException {
 		this(bndrun.getWorkspace());
-		this.project = bndrun;
+		this.bndrun = bndrun;
 		File propertiesFile = bndrun.getPropertiesFile();
 		if (propertiesFile.isFile())
 			this.document = new Document(IO.collect(propertiesFile));
@@ -400,13 +400,13 @@ public class BndEditModel {
 	 * Workspace/Project/sub bnd files files
 	 */
 	Processor getOwner() {
-		File propertiesFile = project.getPropertiesFile();
+		File propertiesFile = bndrun.getPropertiesFile();
 		if (!propertiesFile.getName()
 			.endsWith(".bnd"))
-			return project;
+			return bndrun;
 
 		return workspace.findProcessor(propertiesFile)
-			.orElse(project);
+			.orElse(bndrun);
 	}
 
 	public void loadFrom(IDocument document) throws IOException {
@@ -1253,11 +1253,11 @@ public class BndEditModel {
 	}
 
 	public void setProject(Project project) {
-		this.project = project;
+		this.bndrun = project;
 	}
 
 	public Project getProject() {
-		return project;
+		return bndrun;
 	}
 
 	public Workspace getWorkspace() {
@@ -1290,10 +1290,10 @@ public class BndEditModel {
 		File source = getBndResource();
 		Processor parent;
 
-		if (project != null) {
-			parent = project;
+		if (bndrun != null) {
+			parent = bndrun;
 			if (source == null) {
-				source = project.getPropertiesFile();
+				source = bndrun.getPropertiesFile();
 			}
 		} else if (workspace != null && isCnf()) {
 			parent = workspace;
@@ -1366,7 +1366,7 @@ public class BndEditModel {
 	 */
 	public void saveChanges() throws IOException {
 		assert document != null
-			&& project != null : "you can only call saveChanges when you created this edit model with a project";
+			&& bndrun != null : "you can only call saveChanges when you created this edit model with a project";
 
 		saveChangesTo(document);
 		store(document, getProject().getPropertiesFile());
@@ -1383,7 +1383,7 @@ public class BndEditModel {
 			try {
 				return aQute.lib.converter.Converter.cnv(ResolutionInstructions.ResolveMode.class, resolve);
 			} catch (Exception e) {
-				project.error("Invalid value for %s: %s. Allowed values are %s", Constants.RESOLVE, resolve,
+				bndrun.error("Invalid value for %s: %s. Allowed values are %s", Constants.RESOLVE, resolve,
 					ResolutionInstructions.ResolveMode.class.getEnumConstants());
 			}
 		}
@@ -1407,7 +1407,7 @@ public class BndEditModel {
 	}
 
 	public void load() throws IOException {
-		loadFrom(project.getPropertiesFile());
+		loadFrom(bndrun.getPropertiesFile());
 	}
 
 	/**


### PR DESCRIPTION
@chrisrueger is working on editing the plugins. Since merged properties, the edit panes in the build.bnd 
editor and the bnd.bnd editor are a bit of a mess. 

This change in processor adds the concept of a PropertyKey, where the Property Key links the Processor that defines the property and the actual key. So a merged property is translated to a properly sorted set of ProperyKeys and can then be edited with the BndEditModel.

Unfortunately, the BndEditModel had no proper knowledge of the Processor. For this reason, a findProcessor method was added to Workspace and Project to find the a Processor that is properly linked with inheritance.

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>