### PR TITLE
Synchronizer Eclipse/Bnd was activated

### DIFF
--- a/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
+++ b/bndtools.core/src/bndtools/central/sync/SynchronizeWorkspaceWithEclipse.java
@@ -42,7 +42,7 @@ import bndtools.central.Central;
  * with the file system. Any deltas are processed by creating or deleting the
  * project.
  */
-@Component(enabled = true)
+@Component(enabled = false)
 public class SynchronizeWorkspaceWithEclipse {
 	static IWorkspace			eclipse			= ResourcesPlugin.getWorkspace();
 	final static IWorkspaceRoot	root			= eclipse.getRoot();


### PR DESCRIPTION
Fixes #6077. Stupid mistake. I activated a watcher and that deleted the project before the wizard was finished because it did not exist in the bnd workspace. I would like to remove the Java Wizard since we have all our details in the cnf/build.bnd

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>