### PR TITLE
Repository Browser: Add context menu action "Update Revisions :: To higher MICRO / MINOR / MAJOR revision"

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -153,7 +153,7 @@ public class MbrCommand extends Processor {
 			bnd.trace("repo %s", repo.getName());
 
 			MbrUpdater mbr = new MbrUpdater(repo, bnd::trace);
-			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates, bnd.out);
+			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates);
 
 			if (!options.dry()) {
 				if (mbr.update(content)) {

--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -238,7 +238,7 @@ public class MbrCommand extends Processor {
 
 				if (versionResult.mavenVersionAvailable()) {
 					bnd.out.format(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
-						versionResult);
+						versionResult.mavenVersion());
 				}
 
 			});

--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -152,11 +152,11 @@ public class MbrCommand extends Processor {
 		for (MavenBndRepository repo : repos) {
 			bnd.trace("repo %s", repo.getName());
 
-			MbrUpdater mbr = new MbrUpdater(repo);
+			MbrUpdater mbr = new MbrUpdater(repo, bnd::trace);
 			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates, bnd.out);
 
 			if (!options.dry()) {
-				if (mbr.update(repo, content)) {
+				if (mbr.update(content)) {
 					repo.refresh();
 				}
 			}

--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -1,15 +1,11 @@
 package aQute.bnd.main;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -19,13 +15,13 @@ import aQute.bnd.osgi.Instruction;
 import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.repository.maven.provider.MavenBndRepository;
+import aQute.bnd.repository.maven.provider.MbrUpdater;
+import aQute.bnd.repository.maven.provider.MbrUpdater.Scope;
 import aQute.bnd.version.MavenVersion;
-import aQute.bnd.version.Version;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.getopt.Arguments;
 import aQute.lib.getopt.Description;
 import aQute.lib.getopt.Options;
-import aQute.lib.io.IO;
 import aQute.lib.json.JSONCodec;
 import aQute.lib.justif.Justif;
 import aQute.maven.api.Archive;
@@ -114,13 +110,6 @@ public class MbrCommand extends Processor {
 		format("Multiple archives for a single program", revisions);
 	}
 
-	enum Scope {
-		micro,
-		minor,
-		major,
-		all
-	}
-
 	@Description("For each archive in the index, show the available higher versions")
 	@Arguments(arg = {
 		"archive-glob..."
@@ -139,8 +128,8 @@ public class MbrCommand extends Processor {
 		List<MavenBndRepository> repos = getRepositories(options.repo());
 		List<Archive> archives = getArchives(repos, options._arguments());
 
-		MultiMap<Archive, MavenVersion> overlap = getUpdates(options.scope(Scope.all), repos, archives,
-			options.snapshotlike());
+		MultiMap<Archive, MavenVersion> overlap = MbrUpdater.getUpdates(options.scope(Scope.all), repos,
+			archives, options.snapshotlike());
 		format("Updates available", overlap);
 	}
 
@@ -157,79 +146,23 @@ public class MbrCommand extends Processor {
 		List<MavenBndRepository> repos = getRepositories(options.repo());
 		List<Archive> archives = getArchives(repos, options._arguments());
 
-		MultiMap<Archive, MavenVersion> updates = getUpdates(options.scope(Scope.all), repos, archives,
-			options.snapshotlike());
+		MultiMap<Archive, MavenVersion> updates = MbrUpdater.getUpdates(options.scope(Scope.all), repos,
+			archives, options.snapshotlike());
 
 		for (MavenBndRepository repo : repos) {
 			bnd.trace("repo %s", repo.getName());
-			Map<Archive, MavenVersion> content = new HashMap<>();
 
-			for (Archive archive : new TreeSet<>(repo.getArchives())) {
-				List<MavenVersion> list = updates.get(archive);
-				if (list == null || list.isEmpty()) {
-					content.put(archive, archive.revision.version);
-				} else {
-					MavenVersion version = list.get(list.size() - 1);
-					bnd.out.format("  %-70s   %20s -> %s%n", archive.getRevision().program,
-						archive.getRevision().version, version);
-					content.put(archive, version);
-				}
-			}
+			MbrUpdater mbr = new MbrUpdater(repo);
+			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates, bnd.out);
 
 			if (!options.dry()) {
-				if (update(repo, content)) {
+				if (mbr.update(repo, content)) {
 					repo.refresh();
 				}
 			}
 		}
 	}
 
-	private boolean update(MavenBndRepository repo, Map<Archive, MavenVersion> translations) throws IOException {
-		boolean changes = false;
-		StringBuilder sb = new StringBuilder();
-		Iterator<String> lc;
-		if (repo.getIndexFile()
-			.isFile()) {
-			lc = IO.reader(repo.getIndexFile())
-				.lines()
-				.iterator();
-			bnd.trace("reading %s", repo.getIndexFile());
-		} else {
-			lc = Collections.emptyIterator();
-		}
-
-		for (Iterator<String> i = lc; i.hasNext();) {
-			String line = i.next()
-				.trim();
-			if (!line.startsWith("#") && !line.isEmpty()) {
-
-				Archive archive = Archive.valueOf(line);
-				if (archive != null) {
-					MavenVersion version = translations.get(archive);
-					if (version != null) {
-						if (!archive.revision.version.equals(version)) {
-							Archive updated = archive.update(version);
-							sb.append(updated)
-								.append("\n");
-							changes = true;
-							continue;
-						}
-					}
-				}
-			}
-			sb.append(line)
-				.append("\n");
-		}
-		if (!changes)
-			return false;
-
-		repo.getIndexFile()
-			.getParentFile()
-			.mkdirs();
-		bnd.trace("writing %s", repo.getIndexFile());
-		IO.store(sb.toString(), repo.getIndexFile());
-		return changes;
-	}
 
 	private List<MavenBndRepository> getRepositories(int[] repo) {
 		if (repo == null)
@@ -289,76 +222,5 @@ public class MbrCommand extends Processor {
 			.collect(Collectors.toList());
 	}
 
-	private MultiMap<Archive, MavenVersion> getUpdates(Scope scope, List<MavenBndRepository> repos,
-		List<Archive> archives, boolean snapshotlike) throws Exception {
-		MultiMap<Archive, MavenVersion> overlap = new MultiMap<>();
-
-		for (Archive archive : archives) {
-			for (MavenBndRepository r : repos) {
-				if (r.getArchives()
-					.contains(archive)) {
-					MavenVersion version = archive.revision.version;
-					r.getRevisions(archive.revision.program)
-						.stream()
-						.map(revision -> revision.version)
-						.filter(snapshotlike ? x -> true : notSnapshotlikePredicate)
-						.filter(v -> v.compareTo(version) > 0)
-						.forEach(v -> {
-							overlap.add(archive, v);
-						});
-				}
-			}
-		}
-		overlap.entrySet()
-			.forEach(e -> {
-				List<MavenVersion> filtered = filter(e.getValue(), e.getKey().revision.version.getOSGiVersion(), scope);
-				e.setValue(filtered);
-			});
-		return overlap;
-	}
-
-	private List<MavenVersion> filter(List<MavenVersion> versions, Version current, Scope show) {
-
-		if (versions.isEmpty())
-			return versions;
-
-		MavenVersion major = null;
-		MavenVersion minor = null;
-		MavenVersion micro = null;
-
-		for (MavenVersion v : versions) {
-			major = v;
-			if (v.getOSGiVersion()
-				.getMajor() == current.getMajor()) {
-				minor = v;
-				if (v.getOSGiVersion()
-					.getMinor() == current.getMinor()) {
-					micro = v;
-				}
-			}
-		}
-
-		switch (show) {
-			default :
-			case all :
-				return versions;
-
-			case major :
-				return Collections.singletonList(major);
-
-			case minor :
-				if (minor == null)
-					return Collections.emptyList();
-				else
-					return Collections.singletonList(minor);
-
-			case micro :
-				if (micro == null)
-					return Collections.emptyList();
-				else
-					return Collections.singletonList(micro);
-
-		}
-	}
 
 }

--- a/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java
@@ -16,6 +16,7 @@ import aQute.bnd.osgi.Instructions;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.repository.maven.provider.MavenBndRepository;
 import aQute.bnd.repository.maven.provider.MbrUpdater;
+import aQute.bnd.repository.maven.provider.MbrUpdater.MavenVersionResult;
 import aQute.bnd.repository.maven.provider.MbrUpdater.Scope;
 import aQute.bnd.version.MavenVersion;
 import aQute.lib.collections.MultiMap;
@@ -153,19 +154,8 @@ public class MbrCommand extends Processor {
 			bnd.trace("repo %s", repo.getName());
 
 			MbrUpdater mbr = new MbrUpdater(repo);
-			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates);
-			content.entrySet()
-				.forEach(e -> {
-					Archive archive = e.getKey();
-					MavenVersion version = e.getValue();
-
-					if (version.compareTo(archive.getRevision().version) > 0) {
-						// log only updates
-						bnd.trace(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
-							version);
-					}
-
-				});
+			Map<Archive, MavenVersionResult> content = mbr.calculateUpdateRevisions(updates);
+			logMavenUpdates(content);
 
 			if (!options.dry()) {
 				if (repo.getIndexFile()
@@ -240,4 +230,17 @@ public class MbrCommand extends Processor {
 	}
 
 
+	private void logMavenUpdates(Map<Archive, MavenVersionResult> content) {
+		content.entrySet()
+			.forEach(e -> {
+				Archive archive = e.getKey();
+				MavenVersionResult versionResult = e.getValue();
+
+				if (versionResult.mavenVersionAvailable()) {
+					bnd.out.format(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
+						versionResult);
+				}
+
+			});
+	}
 }

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -56,7 +56,7 @@ Export-Package: \
 -builderignore: testresources, testdata
 
 -fixupmessages.tag: "Export aQute.maven.provider,* private references \\[aQute.lib.tag\\]"
--fixupmessages.getopts: "Export aQute.bnd.repository.maven.provider,* private references \\[aQute.lib.getopt\\]"
+-fixupmessages.lib: "Export aQute.bnd.repository.maven.provider,* private references \\[aQute.lib.collections, aQute.lib.getopt, aQute.lib.startlevel\\]"
 -fixupmessages.configurable: "Export aQute.bnd.repository.osgi,* private references \\[aQute.configurable\\]"
 
 -baseline: *

--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -56,7 +56,7 @@ Export-Package: \
 -builderignore: testresources, testdata
 
 -fixupmessages.tag: "Export aQute.maven.provider,* private references \\[aQute.lib.tag\\]"
--fixupmessages.lib: "Export aQute.bnd.repository.maven.provider,* private references \\[aQute.lib.collections, aQute.lib.getopt, aQute.lib.startlevel\\]"
+-fixupmessages.lib: "Export aQute.bnd.repository.maven.provider,* private references \\[aQute.lib.collections, aQute.lib.getopt\\]"
 -fixupmessages.configurable: "Export aQute.bnd.repository.osgi,* private references \\[aQute.configurable\\]"
 
 -baseline: *

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -827,7 +827,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 		switch (target.length) {
 			case 0 :
-				return null;
+				return actions.getRepoActions(registry.getPlugin(Clipboard.class));
 			case 1 :
 				return actions.getProgramActions((String) target[0]);
 			case 2 :

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenVersionResult.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenVersionResult.java
@@ -1,0 +1,1 @@
+package aQute.bnd.repository.maven.provider;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Mbr.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Mbr.java
@@ -131,7 +131,7 @@ class Mbr {
 
 	public boolean update(MavenBndRepository repo, Map<Archive, MavenVersion> translations) throws IOException {
 		StringBuilder sb = new StringBuilder();
-		boolean changes = buildMvnFileString(sb, repo, translations);
+		boolean changes = buildGAVString(sb, repo, translations);
 		if (!changes)
 			return false;
 
@@ -151,7 +151,7 @@ class Mbr {
 	 *         <code>false</code>
 	 * @throws IOException
 	 */
-	public boolean buildMvnFileString(StringBuilder sb, MavenBndRepository repo, Map<Archive, MavenVersion> translations)
+	public boolean buildGAVString(StringBuilder sb, MavenBndRepository repo, Map<Archive, MavenVersion> translations)
 		throws IOException {
 		boolean changes = false;
 		Iterator<String> lc;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Mbr.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Mbr.java
@@ -1,0 +1,188 @@
+package aQute.bnd.repository.maven.provider;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import aQute.bnd.version.MavenVersion;
+import aQute.bnd.version.Version;
+import aQute.lib.collections.MultiMap;
+import aQute.lib.io.IO;
+import aQute.maven.api.Archive;
+
+/**
+ * Functionality copied from MbrCommand used by RepoActions. Maybe more
+ * refactoring, re-use could be done.
+ */
+class Mbr {
+
+	private MavenBndRepository repo;
+
+	public Mbr(MavenBndRepository repo) {
+		this.repo = repo;
+	}
+
+	public Map<Archive, MavenVersion> updateRevisions(Scope scope, boolean onlyUpdates) throws Exception {
+		Map<Archive, MavenVersion> content = new HashMap<>();
+
+		List<Archive> archives = repo.getArchives()
+			.stream()
+			.toList();
+
+		MultiMap<Archive, MavenVersion> updates = getUpdates(scope, repo, archives, false);
+
+		for (Archive archive : new TreeSet<>(repo.getArchives())) {
+			List<MavenVersion> list = updates.get(archive);
+			if (list == null || list.isEmpty()) {
+				if (!onlyUpdates) {
+					content.put(archive, archive.revision.version);
+				}
+			} else {
+				MavenVersion version = list.get(list.size() - 1);
+				// bnd.out.format(" %-70s %20s -> %s%n",
+				// archive.getRevision().program,
+				// archive.getRevision().version, version);
+				content.put(archive, version);
+			}
+		}
+		return content;
+	}
+
+	enum Scope {
+		micro,
+		minor,
+		major,
+		all
+	}
+
+	final static Pattern					SNAPSHOTLIKE_P				= Pattern
+		.compile("(-[^.]+)|(.*(beta|alfa|alpha|rc).?\\d+$)", Pattern.CASE_INSENSITIVE);
+	final static Predicate<MavenVersion>	notSnapshotlikePredicate	= v -> !SNAPSHOTLIKE_P.matcher(v.toString())
+		.find();
+
+	private MultiMap<Archive, MavenVersion> getUpdates(Scope scope, MavenBndRepository repo, List<Archive> archives,
+		boolean snapshotlike) throws Exception {
+		MultiMap<Archive, MavenVersion> overlap = new MultiMap<>();
+
+		for (Archive archive : archives) {
+			MavenVersion version = archive.revision.version;
+			repo.getRevisions(archive.revision.program)
+				.stream()
+				.map(revision -> revision.version)
+				.filter(snapshotlike ? x -> true : notSnapshotlikePredicate)
+				.filter(v -> v.compareTo(version) > 0)
+				.forEach(v -> {
+					overlap.add(archive, v);
+				});
+		}
+		overlap.entrySet()
+			.forEach(e -> {
+				List<MavenVersion> filtered = filter(e.getValue(), e.getKey().revision.version.getOSGiVersion(), scope);
+				e.setValue(filtered);
+			});
+		return overlap;
+	}
+
+	private List<MavenVersion> filter(List<MavenVersion> versions, Version current, Scope show) {
+
+		if (versions.isEmpty())
+			return versions;
+
+		MavenVersion major = null;
+		MavenVersion minor = null;
+		MavenVersion micro = null;
+
+		for (MavenVersion v : versions) {
+			major = v;
+			if (v.getOSGiVersion()
+				.getMajor() == current.getMajor()) {
+				minor = v;
+				if (v.getOSGiVersion()
+					.getMinor() == current.getMinor()) {
+					micro = v;
+				}
+			}
+		}
+
+		switch (show) {
+			default :
+			case all :
+				return versions;
+
+			case major :
+				return Collections.singletonList(major);
+
+			case minor :
+				if (minor == null)
+					return Collections.emptyList();
+				else
+					return Collections.singletonList(minor);
+
+			case micro :
+				if (micro == null)
+					return Collections.emptyList();
+				else
+					return Collections.singletonList(micro);
+
+		}
+	}
+
+	public boolean update(MavenBndRepository repo, Map<Archive, MavenVersion> translations) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		boolean changes = buildUpdates(sb, repo, translations);
+		if (!changes)
+			return false;
+
+		repo.getIndexFile()
+			.getParentFile()
+			.mkdirs();
+		// bnd.trace("writing %s", repo.getIndexFile());
+		IO.store(sb.toString(), repo.getIndexFile());
+		return changes;
+	}
+
+	public boolean buildUpdates(StringBuilder sb, MavenBndRepository repo, Map<Archive, MavenVersion> translations)
+		throws IOException {
+		boolean changes = false;
+		Iterator<String> lc;
+		if (repo.getIndexFile()
+			.isFile()) {
+			lc = IO.reader(repo.getIndexFile())
+				.lines()
+				.iterator();
+			// bnd.trace("reading %s", repo.getIndexFile());
+		} else {
+			lc = Collections.emptyIterator();
+		}
+
+		for (Iterator<String> i = lc; i.hasNext();) {
+			String line = i.next()
+				.trim();
+			if (!line.startsWith("#") && !line.isEmpty()) {
+
+				Archive archive = Archive.valueOf(line);
+				if (archive != null) {
+					MavenVersion version = translations.get(archive);
+					if (version != null) {
+						if (!archive.revision.version.equals(version)) {
+							Archive updated = archive.update(version);
+							sb.append(updated)
+								.append("\n");
+							changes = true;
+							continue;
+						}
+					}
+				}
+			}
+			sb.append(line)
+				.append("\n");
+		}
+		return changes;
+	}
+}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -17,6 +17,7 @@ import aQute.bnd.version.Version;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.io.IO;
 import aQute.lib.justif.Justif;
+import aQute.lib.startlevel.Trace;
 import aQute.maven.api.Archive;
 
 /**
@@ -25,12 +26,62 @@ import aQute.maven.api.Archive;
  */
 public class MbrUpdater {
 
-	private MavenBndRepository repo;
+	private final static Pattern					SNAPSHOTLIKE_P				= Pattern
+		.compile("(-[^.]+)|(.*(beta|alfa|alpha|rc).?\\d+$)", Pattern.CASE_INSENSITIVE);
+	private final static Predicate<MavenVersion>	notSnapshotlikePredicate	= v -> !SNAPSHOTLIKE_P
+		.matcher(v.toString())
+		.find();
 
-	public MbrUpdater(MavenBndRepository repo) {
+	private MavenBndRepository						repo;
+	private Trace									logger;
+
+	public MbrUpdater(MavenBndRepository repo, Trace logger) {
 		this.repo = repo;
+		this.logger = logger != null ? logger : (format, args) -> {};
 	}
 
+	public enum Scope {
+		micro,
+		minor,
+		major,
+		all
+	}
+
+	public static MultiMap<Archive, MavenVersion> getUpdates(Scope scope, Collection<MavenBndRepository> repos,
+		Collection<Archive> archives, boolean snapshotlike) throws Exception {
+		MultiMap<Archive, MavenVersion> overlap = new MultiMap<>();
+
+		for (Archive archive : archives) {
+			for (MavenBndRepository r : repos) {
+				if (r.getArchives()
+					.contains(archive)) {
+					MavenVersion version = archive.revision.version;
+					r.getRevisions(archive.revision.program)
+						.stream()
+						.map(revision -> revision.version)
+						.filter(snapshotlike ? x -> true : notSnapshotlikePredicate)
+						.filter(v -> v.compareTo(version) > 0)
+						.forEach(v -> {
+							overlap.add(archive, v);
+						});
+				}
+			}
+		}
+		overlap.entrySet()
+			.forEach(e -> {
+				List<MavenVersion> filtered = filter(e.getValue(), e.getKey().revision.version.getOSGiVersion(), scope);
+				e.setValue(filtered);
+			});
+		return overlap;
+	}
+
+	/**
+	 * Calculates the new revisions for each archive.
+	 *
+	 * @param updates
+	 * @param out optional logger
+	 * @return a map the revision for each archive.
+	 */
 	public Map<Archive, MavenVersion> calculateUpdateRevisions(MultiMap<Archive, MavenVersion> updates,
 		PrintStream out) {
 		Map<Archive, MavenVersion> content = new HashMap<>();
@@ -52,42 +103,52 @@ public class MbrUpdater {
 		return content;
 	}
 
-	public enum Scope {
-		micro,
-		minor,
-		major,
-		all
+	/**
+	 * For each archive in the index, show the available higher versions. The
+	 * result is similar to MbrCommand#_check
+	 *
+	 * @param scope
+	 * @param archives
+	 * @return a formatted string with the available updates for each archive.
+	 * @throws Exception
+	 */
+	String preview(Scope scope, Collection<Archive> archives) throws Exception {
+		MultiMap<Archive, MavenVersion> overlap = getUpdates(scope, Collections.singletonList(repo), archives, false);
+		return format(overlap);
 	}
 
-	final static Pattern					SNAPSHOTLIKE_P				= Pattern
-		.compile("(-[^.]+)|(.*(beta|alfa|alpha|rc).?\\d+$)", Pattern.CASE_INSENSITIVE);
-	final static Predicate<MavenVersion>	notSnapshotlikePredicate	= v -> !SNAPSHOTLIKE_P.matcher(v.toString())
-		.find();
-
-	public boolean update(MavenBndRepository repo, Map<Archive, MavenVersion> translations) throws IOException {
+	/**
+	 * Updates the repo with the new revisions from the map.
+	 *
+	 * @param map
+	 * @return <code>true</code> if there were changes. <code>false</code>
+	 *         otherwise.
+	 * @throws IOException
+	 */
+	public boolean update(Map<Archive, MavenVersion> map) throws IOException {
 		StringBuilder sb = new StringBuilder();
-		boolean changes = buildGAVString(sb, repo, translations);
+		boolean changes = buildGAVString(sb, map);
 		if (!changes)
 			return false;
 
 		repo.getIndexFile()
 			.getParentFile()
 			.mkdirs();
-		// bnd.trace("writing %s", repo.getIndexFile());
+		logger.trace("writing %s", repo.getIndexFile());
 		IO.store(sb.toString(), repo.getIndexFile());
 		return changes;
 	}
 
 	/**
-	 * @param sb contains a list of Maven GAVs like in a central.mvn file
+	 * @param sb will be written with a list of Maven GAVs like in a central.mvn
+	 *            file
 	 * @param repo
 	 * @param translations
 	 * @return <code>true</code> when there were changes / updates, otherwise
 	 *         <code>false</code>
 	 * @throws IOException
 	 */
-	public boolean buildGAVString(StringBuilder sb, MavenBndRepository repo, Map<Archive, MavenVersion> translations)
-		throws IOException {
+	private boolean buildGAVString(StringBuilder sb, Map<Archive, MavenVersion> translations) throws IOException {
 		boolean changes = false;
 		Iterator<String> lc;
 		if (repo.getIndexFile()
@@ -95,7 +156,7 @@ public class MbrUpdater {
 			lc = IO.reader(repo.getIndexFile())
 				.lines()
 				.iterator();
-			// bnd.trace("reading %s", repo.getIndexFile());
+			logger.trace("reading %s", repo.getIndexFile());
 		} else {
 			lc = Collections.emptyIterator();
 		}
@@ -125,55 +186,12 @@ public class MbrUpdater {
 		return changes;
 	}
 
-	/**
-	 * For each archive in the index, show the available higher versions. The
-	 * result is similar to MbrCommand#_check
-	 *
-	 * @param scope
-	 * @param archives
-	 * @return a formatted string with the available updates for each archive.
-	 * @throws Exception
-	 */
-	public String preview(Scope scope, Collection<Archive> archives) throws Exception {
-		MultiMap<Archive, MavenVersion> overlap = getUpdates(scope, Collections.singletonList(repo), archives, false);
-
-		return format(overlap);
-	}
-
 	private String format(MultiMap<Archive, MavenVersion> overlap) {
 		Justif j = new Justif(140, 50, 60, 70, 80, 90, 100, 110);
 		j.formatter()
 			.format("%n## %60s%n", "Updates available");
 		j.table(overlap, "");
 		return j.wrap();
-	}
-
-	public static MultiMap<Archive, MavenVersion> getUpdates(Scope scope, Collection<MavenBndRepository> repos,
-		Collection<Archive> archives, boolean snapshotlike) throws Exception {
-		MultiMap<Archive, MavenVersion> overlap = new MultiMap<>();
-
-		for (Archive archive : archives) {
-			for (MavenBndRepository r : repos) {
-				if (r.getArchives()
-					.contains(archive)) {
-					MavenVersion version = archive.revision.version;
-					r.getRevisions(archive.revision.program)
-						.stream()
-						.map(revision -> revision.version)
-						.filter(snapshotlike ? x -> true : notSnapshotlikePredicate)
-						.filter(v -> v.compareTo(version) > 0)
-						.forEach(v -> {
-							overlap.add(archive, v);
-						});
-				}
-			}
-		}
-		overlap.entrySet()
-			.forEach(e -> {
-				List<MavenVersion> filtered = filter(e.getValue(), e.getKey().revision.version.getOSGiVersion(), scope);
-				e.setValue(filtered);
-			});
-		return overlap;
 	}
 
 	private static List<MavenVersion> filter(List<MavenVersion> versions, Version current, Scope show) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -1,7 +1,6 @@
 package aQute.bnd.repository.maven.provider;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -82,8 +81,7 @@ public class MbrUpdater {
 	 * @param out optional logger
 	 * @return a map the revision for each archive.
 	 */
-	public Map<Archive, MavenVersion> calculateUpdateRevisions(MultiMap<Archive, MavenVersion> updates,
-		PrintStream out) {
+	public Map<Archive, MavenVersion> calculateUpdateRevisions(MultiMap<Archive, MavenVersion> updates) {
 		Map<Archive, MavenVersion> content = new HashMap<>();
 
 		for (Archive archive : new TreeSet<>(repo.getArchives())) {
@@ -93,10 +91,8 @@ public class MbrUpdater {
 			} else {
 				MavenVersion version = list.get(list.size() - 1);
 
-				if (out != null) {
-					out.format(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
+				logger.trace(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
 						version);
-				}
 				content.put(archive, version);
 			}
 		}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -3,8 +3,8 @@ package aQute.bnd.repository.maven.provider;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -16,7 +16,6 @@ import aQute.bnd.version.Version;
 import aQute.lib.collections.MultiMap;
 import aQute.lib.io.IO;
 import aQute.lib.justif.Justif;
-import aQute.lib.startlevel.Trace;
 import aQute.maven.api.Archive;
 
 /**
@@ -32,11 +31,9 @@ public class MbrUpdater {
 		.find();
 
 	private final MavenBndRepository				repo;
-	private final Trace								logger;
 
-	public MbrUpdater(MavenBndRepository repo, Trace logger) {
+	public MbrUpdater(MavenBndRepository repo) {
 		this.repo = repo;
-		this.logger = logger != null ? logger : (format, args) -> {};
 	}
 
 	public enum Scope {
@@ -78,11 +75,10 @@ public class MbrUpdater {
 	 * Calculates the new revisions for each archive.
 	 *
 	 * @param updates
-	 * @param out optional logger
 	 * @return a map the revision for each archive.
 	 */
 	public Map<Archive, MavenVersion> calculateUpdateRevisions(MultiMap<Archive, MavenVersion> updates) {
-		Map<Archive, MavenVersion> content = new HashMap<>();
+		Map<Archive, MavenVersion> content = new LinkedHashMap<>();
 
 		for (Archive archive : new TreeSet<>(repo.getArchives())) {
 			List<MavenVersion> list = updates.get(archive);
@@ -90,9 +86,6 @@ public class MbrUpdater {
 				content.put(archive, archive.revision.version);
 			} else {
 				MavenVersion version = list.get(list.size() - 1);
-
-				logger.trace(" %-70s %20s -> %s%n", archive.getRevision().program, archive.getRevision().version,
-						version);
 				content.put(archive, version);
 			}
 		}
@@ -130,7 +123,6 @@ public class MbrUpdater {
 		repo.getIndexFile()
 			.getParentFile()
 			.mkdirs();
-		logger.trace("writing %s", repo.getIndexFile());
 		IO.store(sb.toString(), repo.getIndexFile());
 		return changes;
 	}
@@ -152,7 +144,6 @@ public class MbrUpdater {
 			lc = IO.reader(repo.getIndexFile())
 				.lines()
 				.iterator();
-			logger.trace("reading %s", repo.getIndexFile());
 		} else {
 			lc = Collections.emptyIterator();
 		}

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -32,8 +32,8 @@ public class MbrUpdater {
 		.matcher(v.toString())
 		.find();
 
-	private MavenBndRepository						repo;
-	private Trace									logger;
+	private final MavenBndRepository				repo;
+	private final Trace								logger;
 
 	public MbrUpdater(MavenBndRepository repo, Trace logger) {
 		this.repo = repo;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -33,9 +33,11 @@ import aQute.maven.api.Revision;
 class RepoActions {
 
 	private MavenBndRepository repo;
+	private MbrUpdater			mbr;
 
 	RepoActions(MavenBndRepository mavenBndRepository) {
 		this.repo = mavenBndRepository;
+		this.mbr = new MbrUpdater(repo);
 	}
 
 	Map<String, Runnable> getRepoActions(final Clipboard clipboard) throws Exception {
@@ -250,7 +252,6 @@ class RepoActions {
 
 	private String preview(Scope scope) {
 		try {
-			MbrUpdater mbr = new MbrUpdater(repo, null);
 			return mbr.preview(scope, repo.getArchives());
 
 		} catch (Exception e) {
@@ -260,7 +261,6 @@ class RepoActions {
 
 	private void upgradeRevisions(Scope scope) {
 		try {
-			MbrUpdater mbr = new MbrUpdater(repo, null);
 
 			MultiMap<Archive, MavenVersion> updates = MbrUpdater.getUpdates(scope, Collections.singleton(repo),
 				repo.getArchives(), false);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -1,11 +1,13 @@
 package aQute.bnd.repository.maven.provider;
 
+import static aQute.bnd.repository.maven.provider.Mbr.Scope.major;
+import static aQute.bnd.repository.maven.provider.Mbr.Scope.micro;
+import static aQute.bnd.repository.maven.provider.Mbr.Scope.minor;
 import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.maxBy;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -37,72 +39,29 @@ class RepoActions {
 	Map<String, Runnable> getRepoActions(final Clipboard clipboard) throws Exception {
 		Map<String, Runnable> map = new LinkedHashMap<>();
 
-		map.put("Update Revisions :: To higher MICRO revision if available", () -> {
-			try {
-				upgradeRevisions(Scope.micro);
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+		map.put("Update Revisions :: To higher MICRO revision", () -> {
+			upgradeRevisions(micro);
 		});
-		map.put("Update Revisions :: To higher MINOR revision if available", () -> {
-			try {
-				upgradeRevisions(Scope.minor);
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+		map.put("Update Revisions :: To higher MINOR revision", () -> {
+			upgradeRevisions(minor);
 		});
-		map.put("Update Revisions :: To higher MAJOR revision if available", () -> {
-			try {
-				upgradeRevisions(Scope.major);
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+		map.put("Update Revisions :: To higher MAJOR revision", () -> {
+			upgradeRevisions(major);
 		});
 
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MICRO revision", () -> {
-			try {
-				clipboard.copy(buildMvnFileString(Scope.micro).toString());
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+			clipboard.copy(buildMvnFileString(micro));
 		});
-
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MINOR revision", () -> {
-			try {
-				clipboard.copy(buildMvnFileString(Scope.minor).toString());
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+			clipboard.copy(buildMvnFileString(minor));
 		});
-
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MAJOR revision", () -> {
-			try {
-				clipboard.copy(buildMvnFileString(Scope.major).toString());
-			} catch (Exception e) {
-				throw Exceptions.duck(e);
-			}
+			clipboard.copy(buildMvnFileString(major));
 		});
 
 		return map;
 	}
 
-	private StringBuilder buildMvnFileString(Scope scope) throws Exception, IOException {
-		Mbr mbr = new Mbr(repo);
-		Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(scope, repo.getArchives());
-
-		StringBuilder sb = new StringBuilder();
-		mbr.buildMvnFileString(sb, repo, content);
-		return sb;
-	}
-
-	private void upgradeRevisions(Scope scope) throws Exception, IOException {
-		Mbr mbr = new Mbr(repo);
-		Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(scope, repo.getArchives());
-
-		if (mbr.update(repo, content)) {
-			repo.refresh();
-		}
-	}
 
 	Map<String, Runnable> getProgramActions(final String bsn) throws Exception {
 		Map<String, Runnable> map = new LinkedHashMap<>();
@@ -286,6 +245,34 @@ class RepoActions {
 			}
 
 		});
+	}
+
+	private String buildMvnFileString(Scope scope) {
+		try {
+			Mbr mbr = new Mbr(repo);
+			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(scope, repo.getArchives());
+
+			StringBuilder sb = new StringBuilder();
+			mbr.buildGAVString(sb, repo, content);
+			return sb.toString();
+
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	private void upgradeRevisions(Scope scope) {
+		try {
+			Mbr mbr = new Mbr(repo);
+			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(scope, repo.getArchives());
+
+			if (mbr.update(repo, content)) {
+				repo.refresh();
+			}
+
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
 	}
 
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -250,7 +250,7 @@ class RepoActions {
 
 	private String preview(Scope scope) {
 		try {
-			MbrUpdater mbr = new MbrUpdater(repo);
+			MbrUpdater mbr = new MbrUpdater(repo, null);
 			return mbr.preview(scope, repo.getArchives());
 
 		} catch (Exception e) {
@@ -260,14 +260,14 @@ class RepoActions {
 
 	private void upgradeRevisions(Scope scope) {
 		try {
-			MbrUpdater mbr = new MbrUpdater(repo);
+			MbrUpdater mbr = new MbrUpdater(repo, null);
 
 			MultiMap<Archive, MavenVersion> updates = MbrUpdater.getUpdates(scope, Collections.singleton(repo),
 				repo.getArchives(), false);
 
 			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates, null);
 
-			if (mbr.update(repo, content)) {
+			if (mbr.update(content)) {
 				repo.refresh();
 			}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -17,6 +17,7 @@ import org.osgi.util.promise.Promise;
 
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Jar;
+import aQute.bnd.repository.maven.provider.MbrUpdater.MavenVersionResult;
 import aQute.bnd.repository.maven.provider.MbrUpdater.Scope;
 import aQute.bnd.service.clipboard.Clipboard;
 import aQute.bnd.version.MavenVersion;
@@ -265,7 +266,7 @@ class RepoActions {
 			MultiMap<Archive, MavenVersion> updates = MbrUpdater.getUpdates(scope, Collections.singleton(repo),
 				repo.getArchives(), false);
 
-			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates);
+			Map<Archive, MavenVersionResult> content = mbr.calculateUpdateRevisions(updates);
 
 			if (mbr.update(content)) {
 				repo.refresh();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -265,7 +265,7 @@ class RepoActions {
 			MultiMap<Archive, MavenVersion> updates = MbrUpdater.getUpdates(scope, Collections.singleton(repo),
 				repo.getArchives(), false);
 
-			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates, null);
+			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(updates);
 
 			if (mbr.update(content)) {
 				repo.refresh();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -50,13 +50,13 @@ class RepoActions {
 		});
 
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MICRO revision", () -> {
-			clipboard.copy(buildMvnFileString(micro));
+			clipboard.copy(preview(micro));
 		});
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MINOR revision", () -> {
-			clipboard.copy(buildMvnFileString(minor));
+			clipboard.copy(preview(minor));
 		});
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MAJOR revision", () -> {
-			clipboard.copy(buildMvnFileString(major));
+			clipboard.copy(preview(major));
 		});
 
 		return map;
@@ -247,14 +247,10 @@ class RepoActions {
 		});
 	}
 
-	private String buildMvnFileString(Scope scope) {
+	private String preview(Scope scope) {
 		try {
 			Mbr mbr = new Mbr(repo);
-			Map<Archive, MavenVersion> content = mbr.calculateUpdateRevisions(scope, repo.getArchives());
-
-			StringBuilder sb = new StringBuilder();
-			mbr.buildGAVString(sb, repo, content);
-			return sb.toString();
+			return mbr.preview(scope, repo.getArchives());
 
 		} catch (Exception e) {
 			throw Exceptions.duck(e);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.repository.maven.provider;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
This PR is a suggestion for bnd's [MbrCommand](https://github.com/bndtools/bnd/blob/master/biz.aQute.bnd/src/aQute/bnd/main/MbrCommand.java) e.g. `bnd mbr update -s micro` but making it available in bndtools' UI. 

This adds a context menu when you Right-Click on a _MavenBndRepo_ like this:

<img width="578" alt="image" src="https://github.com/bndtools/bnd/assets/188422/c38b9b97-ac58-4a11-96ea-fb63a2785f65">

This allows to increase versions of a full `central.mvn` maven index file. 

Similar functionality already exists if you right-click on a **single** RepoBundle-**Revision**. This suggestion here basically does it for the whole repository. 

I added a Dry-Run-Option which does _not_ modify the .mvn file, but instead copies the result to the Clipboard.
I am not sure if this is a good idea, since it can take some time depending on the size of the repo and the user might not notice it... UX isn't great. I kept it for now, since it helped during debugging, but I am fine with removal too... or suggestions how it could be improved. Better wording suggestions welcome too.

Also: I basically copy pasted and adjusted the code from MbrCommand. There is room for better re-use, but I just wanted to prototype this first. 


## Dry-Run

The output of the Dry-Run is similar to `MbrCommand#_check` e.g.:

```
## Updates available
com.fasterxml.jackson.core:jackson-core:2.16.1 2.16.2
etc.
```