### PR TITLE
Add search bar to Unresolved requirements in ResolutionFailedPanel

### DIFF
--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionFailurePanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionFailurePanel.java
@@ -58,6 +58,7 @@ public class ResolutionFailurePanel {
 	private static final String						SEARCHSTRING_HINT		= "Enter search string to filter unresolved requirements (Space to separate terms; '*' for partial matches)";
 
 	private static final boolean	failureTreeMode	= true;
+	private RequirementWithResourceLabelProvider	requirementWithResourceLabelProvider;
 
 	public void createControl(final Composite parent) {
 		FormToolkit toolkit = new FormToolkit(parent.getDisplay());
@@ -95,9 +96,11 @@ public class ResolutionFailurePanel {
 
 		unresolvedViewer = new TreeViewer(treeUnresolved);
 
-		unresolvedRequirementsContentProvider = new UnresolvedRequirementsContentProvider();
+		requirementWithResourceLabelProvider = new RequirementWithResourceLabelProvider();
+		unresolvedViewer.setLabelProvider(requirementWithResourceLabelProvider);
+		unresolvedRequirementsContentProvider = new UnresolvedRequirementsContentProvider(
+			requirementWithResourceLabelProvider);
 		unresolvedViewer.setContentProvider(unresolvedRequirementsContentProvider);
-		unresolvedViewer.setLabelProvider(new RequirementWithResourceLabelProvider());
 		setFailureViewMode();
 
 		addSearchbarForUnresolved();

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionFailurePanel.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/ResolutionFailurePanel.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import org.bndtools.core.resolve.ResolutionResult;
 import org.bndtools.core.ui.icons.Icons;
 import org.bndtools.core.ui.resource.RequirementWithResourceLabelProvider;
+import org.bndtools.utils.swt.FilterPanelPart;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.TreeViewer;
@@ -35,6 +36,7 @@ import org.osgi.resource.Requirement;
 import org.osgi.service.resolver.ResolutionException;
 
 import biz.aQute.resolve.ResolveProcess;
+import bndtools.Plugin;
 import bndtools.model.obr.SorterComparatorAdapter;
 
 public class ResolutionFailurePanel {
@@ -49,6 +51,11 @@ public class ResolutionFailurePanel {
 	private TreeViewer				unresolvedViewer;
 	private Section					sectProcessingErrors;
 	private Section					sectUnresolved;
+
+	private UnresolvedRequirementsContentProvider	unresolvedRequirementsContentProvider;
+	private final FilterPanelPart					unresolvedFilterPart	= new FilterPanelPart(Plugin.getDefault()
+		.getScheduler());
+	private static final String						SEARCHSTRING_HINT		= "Enter search string to filter unresolved requirements (Space to separate terms; '*' for partial matches)";
 
 	private static final boolean	failureTreeMode	= true;
 
@@ -85,10 +92,16 @@ public class ResolutionFailurePanel {
 		gd.heightHint = 300;
 		sectUnresolved.setLayoutData(gd);
 
+
 		unresolvedViewer = new TreeViewer(treeUnresolved);
-		unresolvedViewer.setContentProvider(new UnresolvedRequirementsContentProvider());
+
+		unresolvedRequirementsContentProvider = new UnresolvedRequirementsContentProvider();
+		unresolvedViewer.setContentProvider(unresolvedRequirementsContentProvider);
 		unresolvedViewer.setLabelProvider(new RequirementWithResourceLabelProvider());
 		setFailureViewMode();
+
+		addSearchbarForUnresolved();
+
 	}
 
 	public Control getControl() {
@@ -300,5 +313,16 @@ public class ResolutionFailurePanel {
 	}
 
 	void dispose() {}
+
+	private void addSearchbarForUnresolved() {
+		Control reqsFilterPanel = unresolvedFilterPart.createControl(composite, 5, 5);
+		unresolvedFilterPart.setHint(SEARCHSTRING_HINT);
+		unresolvedFilterPart.addPropertyChangeListener(event -> {
+			String filter = (String) event.getNewValue();
+
+			unresolvedRequirementsContentProvider.setFilter(filter);
+			unresolvedViewer.refresh();
+		});
+	}
 
 }

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/UnresolvedRequirementsContentProvider.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/UnresolvedRequirementsContentProvider.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.bndtools.core.ui.resource.RequirementWithResourceLabelProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.osgi.resource.Requirement;
@@ -15,6 +16,11 @@ import aQute.libg.glob.Glob;
 public class UnresolvedRequirementsContentProvider implements ITreeContentProvider {
 
 	private String wildcardFilter = null;
+	private RequirementWithResourceLabelProvider	labelProvider;
+
+	public UnresolvedRequirementsContentProvider(RequirementWithResourceLabelProvider labelProvider) {
+		this.labelProvider = labelProvider;
+	}
 
 	@Override
 	public Object[] getElements(Object inputElement) {
@@ -96,7 +102,8 @@ public class UnresolvedRequirementsContentProvider implements ITreeContentProvid
 					if (obj instanceof Requirement rw) {
 
 						for (Glob g : globs) {
-							if (g.matcher(rw.toString()
+							if (g.matcher(labelProvider.getLabel(rw)
+								.toString()
 								.toLowerCase())
 								.find()) {
 								filteredResults.add(obj);

--- a/bndtools.core/src/org/bndtools/core/resolve/ui/UnresolvedRequirementsContentProvider.java
+++ b/bndtools.core/src/org/bndtools/core/resolve/ui/UnresolvedRequirementsContentProvider.java
@@ -1,23 +1,52 @@
 package org.bndtools.core.resolve.ui;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
+import org.osgi.resource.Requirement;
+
+import aQute.libg.glob.Glob;
 
 public class UnresolvedRequirementsContentProvider implements ITreeContentProvider {
 
+	private String wildcardFilter = null;
+
 	@Override
 	public Object[] getElements(Object inputElement) {
+
+		List<Object[]> arrays = new LinkedList<>();
+
 		if (inputElement instanceof Object[])
-			return (Object[]) inputElement;
+			arrays.add((Object[]) inputElement);
 
 		if (inputElement instanceof Collection<?>) {
 			Collection<?> coll = (Collection<?>) inputElement;
-			return coll.toArray();
+			arrays.add(coll.toArray());
 		}
 
-		return null;
+		return filter(flatten(arrays));
+	}
+
+	private Object[] flatten(List<Object[]> arrays) {
+		// Iterate over once to count the lengths
+		int length = 0;
+		for (Object[] array : arrays) {
+			length += array.length;
+		}
+		Object[] result = new Object[length];
+
+		// Iterate again to flatten out the arrays
+		int position = 0;
+		for (Object[] array : arrays) {
+			System.arraycopy(array, 0, result, position, array.length);
+			position += array.length;
+		}
+		return result;
 	}
 
 	@Override
@@ -48,6 +77,43 @@ public class UnresolvedRequirementsContentProvider implements ITreeContentProvid
 	public boolean hasChildren(Object element) {
 		// TODO Auto-generated method stub
 		return false;
+	}
+
+	private Object[] filter(Object[] array) {
+		List<Object> filteredResults = new ArrayList<>();
+		if (wildcardFilter == null || wildcardFilter.equals("*") || wildcardFilter.equals("")) {
+			return array;
+		} else {
+			String[] split = wildcardFilter.split("\\s+");
+			Glob globs[] = new Glob[split.length];
+			for (int i = 0; i < split.length; i++) {
+				globs[i] = new Glob(split[i].toLowerCase());
+			}
+
+			Arrays.stream(array)
+				.forEach(obj -> {
+
+					if (obj instanceof Requirement rw) {
+
+						for (Glob g : globs) {
+							if (g.matcher(rw.toString()
+								.toLowerCase())
+								.find()) {
+								filteredResults.add(obj);
+								return;
+							}
+						}
+					}
+
+				});
+
+		}
+
+		return filteredResults.toArray();
+	}
+
+	public void setFilter(String filter) {
+		this.wildcardFilter = filter;
 	}
 
 }


### PR DESCRIPTION
This PR adds a search bar to this view:

<img width="890" alt="image" src="https://github.com/bndtools/bnd/assets/188422/92b95ea7-ae4e-4cb8-923c-a05c49d979b6">

I found that helpful, because before I could never make sense of that list, because I couldn't "see" / or "find" anything (can't see the forest for the trees). 

Now the search bar at least allows to search for anything from the error message above, and maybe find what is of interest for you. 

Note on search bar positioning: The search bar currently is at the bottom, because I could't find a way to add it below the "Unresolved requirements" header. I managed to add it right _above_ the "Unresolved requirements" header, but there I did not like it because it does not look like it belongs to the "Unresolved requirements".

Maybe because it is a collapsible tree or some view panel which does not allow this. I don't know.
I personally don't find that bad, but it is a bit different than other views where the search bar is at the top. 
