### PR TITLE
build.bnd: avoid resolving default containing ${.} to absolute path

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -908,7 +908,7 @@
 		    <property name="snapshotUrl" type="string" description="The urls to the remote snapshot repository." default="https://repository.apache.org/snapshots/" />
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="readOnly" type="boolean" description="" default="false" />
-		    <property name="index" type="string" description="The path to the index file" default="\${.}/central.maven" />
+		    <property name="index" type="string" description="The path to the index file (relative to build.bnd, or an absolute path)" default="./central.maven" />
 		    <property name="source" type="string" description="Content added to the index file. Content maybe one line without CR/LF as long as there is a comma or whitespace separating the GAVs. Further same format as the index file." />
 		    <property name="noupdateOnRelease" type="boolean" description="Do not update the index when a file is released" />
 		    <property name="poll_time" type="int" description="Sets the time in seconds when to check for changes in the pom-files" default="5" />
@@ -938,7 +938,7 @@
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="revision" type="string" description="Coordinates of a maven revision. I.e. group:artifactid[:c]:version. Can be a comma separated list of GAVs." />
 		    <property name="location" type="string" description="Points to a file that is used as the cache. It will be in OSGi format." />
-		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files." default="\${.}/pom.xml" />
+		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files. (relative to build.bnd, or an absolute path)" default="./pom.xml" />
 		    <property name="query" type="string" description="The query used to search Maven Central Search." />
 		    <property name="queryUrl" type="string" description="The url of the Maven Central Search."  />
 		    <property name="transitive" type="boolean" description="Allow transitive dependencies" />

--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -908,7 +908,7 @@
 		    <property name="snapshotUrl" type="string" description="The urls to the remote snapshot repository." default="https://repository.apache.org/snapshots/" />
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="readOnly" type="boolean" description="" default="false" />
-		    <property name="index" type="string" description="The path to the index file (relative to build.bnd, or an absolute path)" default="./central.maven" />
+		    <property name="index" type="string" description="The path to the index file (relative to build.bnd, or an absolute path)" default="${.}/central.maven" />
 		    <property name="source" type="string" description="Content added to the index file. Content maybe one line without CR/LF as long as there is a comma or whitespace separating the GAVs. Further same format as the index file." />
 		    <property name="noupdateOnRelease" type="boolean" description="Do not update the index when a file is released" />
 		    <property name="poll_time" type="int" description="Sets the time in seconds when to check for changes in the pom-files" default="5" />
@@ -938,7 +938,7 @@
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="revision" type="string" description="Coordinates of a maven revision. I.e. group:artifactid[:c]:version. Can be a comma separated list of GAVs." />
 		    <property name="location" type="string" description="Points to a file that is used as the cache. It will be in OSGi format." />
-		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files. (relative to build.bnd, or an absolute path)" default="./pom.xml" />
+		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files. (relative to build.bnd, or an absolute path)" default="${.}/pom.xml" />
 		    <property name="query" type="string" description="The query used to search Maven Central Search." />
 		    <property name="queryUrl" type="string" description="The url of the Maven Central Search."  />
 		    <property name="transitive" type="boolean" description="Allow transitive dependencies" />

--- a/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
+++ b/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
@@ -1,2 +1,1 @@
-bndtools/workspace;branch=origin/${version;==;${base.version}},
 bndtools/bndtools.workspace.min 

--- a/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
+++ b/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
@@ -1,1 +1,2 @@
+bndtools/workspace;branch=origin/${version;==;${base.version}},
 bndtools/bndtools.workspace.min 


### PR DESCRIPTION
This PR basically changes the default value for a repo index file when adding / editing repos via plugin editor. The previous default was not good, because it contained the `${.}` which causes some surprising behavior.

Not sure if this is related to https://github.com/bndtools/bnd/commit/f37f8574b7e887644c036cea073d19d853072159

the ${.} in the default-value caused to expand the value always to an absolute path on the harddrive of the developer editing and saving the file. if you accidentally commit this, then it wil fail on other machines. Let's just define the name, relative to the build.bnd . it can still be changed manually

**Steps to reproduce:**

1. Add a  MavenBndRepository to the `build.bnd` a config like below

Notice an `index=${.}/central.maven; \` is added (because this was the default value of the index property). 

```
-plugin.6.Centralstaging: \
	aQute.bnd.repository.maven.provider.MavenBndRepository; \
		releaseUrl          ='https://repository.apache.org/content/repositories/staging/';\
		readOnly=true; \
		index=${.}/central.maven; \
		name="Maven Central Staging"
```

2. Then save, close build.bnd and reopen again. (in the source view there is still `index=${.}/central-staging.maven;`)
3. Click on "Edit" (or double click) on the created  MavenBndRepo

**Actual result:** 
`index=${.}/central-staging.maven;` is now expanded to `/some/absolute/local/path/central-staging.maven`

<img width="707" alt="image" src="https://github.com/bndtools/bnd/assets/188422/47f38858-dd24-41c5-8e61-19cc908d9934">

(Sorry the screenshot contains a `central-staging.maven`, but it is actually a `central.maven`... I just don't have another screenshot of it).

**Expected result**
I did not want to see the expanded path, but just the value from the source editor. 
