### PR TITLE
Workspace templates: remove old bndtools/workspace

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/TemplateID.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/TemplateID.java
@@ -26,7 +26,7 @@ public record TemplateID(String organisation, String repository, String path, St
 			g("path", set(lit("/"), SEGMENT_P)), opt(lit("/"))),
 		opt(lit("#"), g("branch", REF_P)) //
 	);
-	final static URI ROOT = URI.create("https://github.com/bndtools/workspace#master");
+	final static URI ROOT = URI.create("https://github.com/bndtools/bndtools.workspace.min#master");
 
 	@Override
 	public int compareTo(TemplateID o) {
@@ -58,8 +58,9 @@ public record TemplateID(String organisation, String repository, String path, St
 
 	/**
 	 * Parse the id into a Template ID. The default is
-	 * `bndtools/workspace#master`. The missing fields are taken from this
-	 * default. If the id does not match the pattern, it is assumed to be a URI.
+	 * `bndtools/bndtools.workspace.min#master`. The missing fields are taken
+	 * from this default. If the id does not match the pattern, it is assumed to
+	 * be a URI.
 	 *
 	 * @param id id or uri
 	 * @return a TemplateId

--- a/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
@@ -29,7 +29,7 @@ public class Model implements Runnable {
 	static final IWorkspace		ECLIPSE_WORKSPACE	= ResourcesPlugin.getWorkspace();
 	static final IWorkspaceRoot	ROOT				= ECLIPSE_WORKSPACE.getRoot();
 	static final IPath			ROOT_LOCATION		= ROOT.getLocation();
-	static final URI			TEMPLATE_HOME		= URI.create("https:://github.com/bndtools/workspace");
+	static final URI			TEMPLATE_HOME		= URI.create("https:://github.com/bndtools/bndtools.workspace.min");
 
 	final static File			current				= ROOT_LOCATION.toFile();
 

--- a/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
+++ b/org.bndtools.templating.gitrepo/resources/processed/org/bndtools/templating/jgit/initialrepos.txt
@@ -1,2 +1,1 @@
-bndtools/workspace;branch=origin/${version;==;${base.version}},
 bndtools/bndtools.workspace.min 


### PR DESCRIPTION
Closes #5955

 from initialrepos.txt, because in https://github.com/bndtools/bnd/issues/5955 we kind of agreed to remove https://github.com/bndtools/workspace workspace template and just keep the bndtools/bndtools.workspace.min , because workspace templates will most likely be superseded by Template Fragments

After this the Create Workspace dialog looks like this for new users.

<img width="586" alt="image" src="https://github.com/bndtools/bnd/assets/188422/93887827-0268-440f-8473-b08c45def5f0">
