### PR TITLE
upgrade SWT to 3.126 to fix MacOS / JDK bug

### DIFF
--- a/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
@@ -259,8 +259,8 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.121.0,3.121.1)',\
-	org.eclipse.swt.cocoa.macosx.aarch64;version='[3.121.0,3.121.1)',\
+	org.eclipse.swt;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt.cocoa.macosx.aarch64;version='[3.126.0,3.126.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
 	org.eclipse.text;version='[3.12.200,3.12.201)',\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -259,8 +259,8 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.121.0,3.121.1)',\
-	org.eclipse.swt.cocoa.macosx.x86_64;version='[3.121.0,3.121.1)',\
+	org.eclipse.swt;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt.cocoa.macosx.x86_64;version='[3.126.0,3.126.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
 	org.eclipse.text;version='[3.12.200,3.12.201)',\

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -168,4 +168,5 @@ org.codehaus.plexus:plexus-classworlds:2.5.2
 
 ## higher SWT version required because of SWT bug with MacOS Sonoma 
 org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:jar:3.126.0
+org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:jar:3.126.0
 org.eclipse.platform:org.eclipse.swt:jar:3.126.0

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -165,3 +165,7 @@ org.eclipse.aether:aether-api:${aether.version}
 org.sonatype.plexus:plexus-build-api:0.0.7
 org.codehaus.plexus:plexus-utils:3.0.22
 org.codehaus.plexus:plexus-classworlds:2.5.2
+
+## higher SWT version required because of SWT bug with MacOS Sonoma 
+org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:jar:3.126.0
+org.eclipse.platform:org.eclipse.swt:jar:3.126.0


### PR DESCRIPTION
Closes #6185 

It seems we can stay on older Eclipse 4.25 but use a higher SWT version which has fixed the SWT bug (see https://github.com/eclipse-platform/eclipse.platform.swt/issues/1012).

With this fix I was able to use Eclipse with latest Temurin JDKs like

- OpenJDK Runtime Environment Temurin-17.0.11+9
- OpenJDK Runtime Environment Temurin-21.0.3+9

and it looks as usual again: 

<img width="904" alt="Bildschirmfoto 2024-07-17 um 16 36 23" src="https://github.com/user-attachments/assets/ac838cfe-9757-45fb-969f-d85e2b71c4ac">

<img width="1468" alt="Bildschirmfoto 2024-07-17 um 16 36 56" src="https://github.com/user-attachments/assets/9ad87ad9-9db7-4c8c-8788-d05cc1b8700a">

