### PR TITLE
fix new project templates not showing up

### DIFF
--- a/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
+++ b/bndtools.core/src/bndtools/central/EclipseWorkspaceRepository.java
@@ -19,10 +19,11 @@ import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.repository.AbstractIndexingRepository;
 import aQute.bnd.osgi.repository.WorkspaceRepositoryMarker;
 import aQute.bnd.osgi.resource.ResourceBuilder;
+import aQute.bnd.service.Refreshable;
 import aQute.lib.io.IO;
 
 public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProject, File>
-	implements WorkspaceRepositoryMarker {
+	implements WorkspaceRepositoryMarker, Refreshable {
 	EclipseWorkspaceRepository() {
 		super();
 		Central.onCnfWorkspace(this::initialize);
@@ -78,5 +79,16 @@ public class EclipseWorkspaceRepository extends AbstractIndexingRepository<IProj
 	@Override
 	public String toString() {
 		return NAME;
+	}
+
+	@Override
+	public boolean refresh() throws Exception {
+		initialize(null);
+		return true;
+	}
+
+	@Override
+	public File getRoot() throws Exception {
+		return null;
 	}
 }

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -34,7 +34,9 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.IWorkbench;
 
 import aQute.bnd.build.Project;
+import aQute.bnd.exceptions.Exceptions;
 import bndtools.Plugin;
+import bndtools.central.Central;
 
 class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippingWizard {
 
@@ -52,6 +54,13 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippi
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection currentSelection) {
 		super.init(workbench, currentSelection);
+
+		try {
+			// refresh, to not miss recently created project templates.
+			Central.refreshPlugins();
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
 
 		BuiltInTemplate baseTemplate = new BuiltInTemplate(EMPTY_TEMPLATE_NAME, DEFAULT_TEMPLATE_ENGINE);
 		baseTemplate.addInputResource(Project.BNDFILE, new StringResource("")); //$NON-NLS-1$

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -34,7 +34,6 @@ import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.IWorkbench;
 
 import aQute.bnd.build.Project;
-import aQute.bnd.exceptions.Exceptions;
 import bndtools.Plugin;
 import bndtools.central.Central;
 
@@ -59,7 +58,10 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippi
 			// refresh, to not miss recently created project templates.
 			Central.refreshPlugins();
 		} catch (Exception e) {
-			throw Exceptions.duck(e);
+			Plugin.getDefault()
+				.getLog()
+				.log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,
+					String.format("Unable to refresh Plugins in NewBndProjectWizard"), e));
 		}
 
 		BuiltInTemplate baseTemplate = new BuiltInTemplate(EMPTY_TEMPLATE_NAME, DEFAULT_TEMPLATE_ENGINE);

--- a/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
+++ b/bndtools.core/src/bndtools/wizards/project/NewBndProjectWizard.java
@@ -35,7 +35,6 @@ import org.eclipse.ui.IWorkbench;
 
 import aQute.bnd.build.Project;
 import bndtools.Plugin;
-import bndtools.central.Central;
 
 class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippingWizard {
 
@@ -53,16 +52,6 @@ class NewBndProjectWizard extends AbstractNewBndProjectWizard implements ISkippi
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection currentSelection) {
 		super.init(workbench, currentSelection);
-
-		try {
-			// refresh, to not miss recently created project templates.
-			Central.refreshPlugins();
-		} catch (Exception e) {
-			Plugin.getDefault()
-				.getLog()
-				.log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,
-					String.format("Unable to refresh Plugins in NewBndProjectWizard"), e));
-		}
 
 		BuiltInTemplate baseTemplate = new BuiltInTemplate(EMPTY_TEMPLATE_NAME, DEFAULT_TEMPLATE_ENGINE);
 		baseTemplate.addInputResource(Project.BNDFILE, new StringResource("")); //$NON-NLS-1$

--- a/org.bndtools.templates.template/resources/bndrun.help.xml
+++ b/org.bndtools.templates.template/resources/bndrun.help.xml
@@ -1,1 +1,1 @@
-<form>Generates a template project for creating new Run Descriptor (bndrun) files.</form>
+<form>Generates a template project for creating new Run Descriptor (bndrun) files. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates.</form>

--- a/org.bndtools.templates.template/resources/bndrun.help.xml
+++ b/org.bndtools.templates.template/resources/bndrun.help.xml
@@ -1,1 +1,1 @@
-<form>Generates a template project for creating new Run Descriptor (bndrun) files. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates.</form>
+<form>Generates a template project for creating new Run Descriptor (bndrun) files. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates in the 'New Bnd OSGi Project' dialog.</form>

--- a/org.bndtools.templates.template/resources/project.help.xml
+++ b/org.bndtools.templates.template/resources/project.help.xml
@@ -1,1 +1,1 @@
-<form>Generates a template project for creating new Bndtools/OSGi projects. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates.</form>
+<form>Generates a template project for creating new Bndtools/OSGi projects. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates in the 'New Bnd OSGi Project' dialog.</form>

--- a/org.bndtools.templates.template/resources/project.help.xml
+++ b/org.bndtools.templates.template/resources/project.help.xml
@@ -1,1 +1,1 @@
-<form>Generates a template project for creating new Bndtools/OSGi projects.</form>
+<form>Generates a template project for creating new Bndtools/OSGi projects. Please refresh the Repositories in the Repository Browser after creating this Project Template project, to make it show up in the list of available templates.</form>


### PR DESCRIPTION
This fixes the problem, that newly created "project template"-projects required a Eclipse restart to show up in the **New Bnd Project** wizard.

See https://bnd.discourse.group/t/enabling-template-repositories-by-default/460/5

This PR makes sure that new Project templates always / immediately show up in the "New Bnd OSGi Project" wizard, after creation.

<img width="596" alt="image" src="https://github.com/user-attachments/assets/c6119746-17df-48f0-b42f-49fa8725937d">

