### PR TITLE
checks Project validity and handles projects without bnd.bnd file

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1,6 +1,7 @@
 package aQute.bnd.build;
 
 import static aQute.bnd.build.Container.toPaths;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -234,7 +235,7 @@ public class Project extends Processor {
 		if (getBase() == null || !getBase().isDirectory())
 			return false;
 
-		return getPropertiesFile() == null || getPropertiesFile().isFile();
+		return getPropertiesFile() == null || (!mustFileExist() || getPropertiesFile().isFile());
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -1381,8 +1381,15 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 		return propertiesFile;
 	}
 
+	/**
+	 * Marks if the given Properties File really must exist.
+	 */
 	public void setFileMustExist(boolean mustexist) {
 		fileMustExist = mustexist;
+	}
+
+	public boolean mustFileExist() {
+		return fileMustExist;
 	}
 
 	static public String read(InputStream in) throws Exception {


### PR DESCRIPTION
Fixes a Bug, where the created project for the code generator in maven is invalid, if no bnd file exists.