### PR TITLE
introduces resolve never option for bnd(run)

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
@@ -83,6 +83,12 @@ public interface ResolutionInstructions {
 		 */
 		@SyntaxAnnotation(lead = "Resolve when the runbundles are needed unless there is a cache file that is newer than the bndrun/project & workspace. The cache file has the same name as the project/bndrun file but starts with a '.'")
 		cache,
+
+		/**
+		 * Never resolve
+		 */
+		@SyntaxAnnotation(lead = "A Resolve will never take place. Manually resolve will result in error.")
+		never
 	}
 
 	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched, batchlaunch is like beforelaunch but only in batch mode", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch|batch)")

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.7.0")
+@org.osgi.annotation.versioning.Version("1.8.0")
 package aQute.bnd.help.instructions;

--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -184,6 +184,7 @@ public class Bndrun extends Run {
 		switch (resolve) {
 			case auto :
 			case manual :
+			case never :
 			default :
 				break;
 

--- a/biz.aQute.resolve/src/biz/aQute/resolve/RunResolution.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/RunResolution.java
@@ -30,6 +30,7 @@ import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.help.Syntax;
 import aQute.bnd.help.instructions.ResolutionInstructions;
+import aQute.bnd.help.instructions.ResolutionInstructions.ResolveMode;
 import aQute.bnd.help.instructions.ResolutionInstructions.RunStartLevel;
 import aQute.bnd.help.instructions.ResolutionInstructions.Runorder;
 import aQute.bnd.osgi.BundleId;
@@ -96,6 +97,13 @@ public class RunResolution {
 	 */
 	public static RunResolution resolve(Project project, Processor actualProperties,
 		Collection<ResolutionCallback> callbacks, ResolverLogger resolverLogger) {
+		if (ResolveMode.never.toString()
+			.equals(project.get(Constants.RESOLVE))) {
+			return new RunResolution(project, actualProperties, new UnsupportedOperationException(String
+				.format("Resolve is forbidden here, as %s is set to %s", Constants.RESOLVE,
+					ResolveMode.never.toString())),
+				null);
+		}
 		if (callbacks == null)
 			callbacks = Collections.emptyList();
 		ResolverLogger logger = resolverLogger == null ? ResolverLogger.newLogger(actualProperties, false)

--- a/docs/_instructions/resolve.md
+++ b/docs/_instructions/resolve.md
@@ -14,8 +14,9 @@ The values are:
 * `beforelaunch` – Calculate the `-runbundles` on demand. This ignores the value of the `-runbundles` and runs the resolver. The results of the resolver are cached. This cache works by creating a checksum over all the properties of the project.
 * `batch` – When running in batch mode, the run bundles will be resolved. In all other modes this will only resolve when the `-runbundles` are empty.
 * `cache` – Will use a cache file in the workspace cache. If that file is stale relative to the workspace or project or it does not exist, then the bnd(run) file will be resolved and the result is stored in the cache file.
+* `never` – If anybody tries to resolve , the process will throw an `UnsupportedOperationException`. This is intended for manually curated runbundles or where a base file is resolved and other files include them an add some additional instructions. The Excepetion is meant as a clear warning to any developer accidentally resolving the `-runbundles`.
 
- 
+
 ## Example
 
     -resolve beforelaunch


### PR DESCRIPTION
Sometimes you have e.g. a basic bnd(run) that can be resolved and others that include that file and add other instructions or bundles. In such a case developers may hit resolve on reflex and can result in diverging -rundbundes over time. Resolve never is an option to prevent developers from accidentally doing this.