### PR TITLE
Refresh the EclipseWorkspaceRepository in RepositoriesViewRefresher

### DIFF
--- a/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
+++ b/bndtools.core/src/bndtools/central/RepositoriesViewRefresher.java
@@ -29,6 +29,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.build.WorkspaceRepository;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.service.RepositoryListenerPlugin;
 import aQute.bnd.service.RepositoryPlugin;
@@ -115,6 +116,23 @@ public class RepositoriesViewRefresher implements RepositoryListenerPlugin {
 							});
 
 					}
+
+					if (target instanceof WorkspaceRepository) {
+						// e.g. new project / project template project was
+						// added.
+						// refresh the EclipseWorkspaceRepository so that new
+						// added project templates show up
+						// in the "New Project" wizard (see
+						// AbstractNewBndProjectWizard)
+						try {
+							monitor.subTask("Refresh EclipseWorkspaceRepository to detect new or changed projects");
+							Central.getEclipseWorkspaceRepository()
+								.refresh();
+						} catch (Exception e) {
+							// swallow to not interrupt the rest
+						}
+					}
+
 					if (state.getAndSet(State.IDLE) == State.REDO) {
 						refreshRepositories(null);
 					}


### PR DESCRIPTION
Closes #6213 

This is an improvement of commit 0e1fac345 in PR #6191

We now hook into the RepositoriesViewRefresher which already gets triggered after projects have been built to update the Repositories list. The only thing which is missing here is a Refresh of the EclipseWorkspaceRepository, which is needed so that new "Project template projects" show up immediately in the "New Project" wizard.

The advantage over PR is than no manual user action is needed (e.g. no click on "Refresh button in Repositories browser")


## Testing

1. Open **File / New / Bnd OSGi Project** and create a Template project e.g. mustache

<img width="650" alt="image" src="https://github.com/user-attachments/assets/4f1014ab-28c0-49db-abd8-751cefa65638">

<img width="395" alt="image" src="https://github.com/user-attachments/assets/b597bd2a-dc7c-4ce3-9138-413d7fe23979">

Give it a name and click finish.

2. quickly Open **File / New / Bnd OSGi Project** again and check if the new template appears. 

<img width="661" alt="image" src="https://github.com/user-attachments/assets/65fa0e7a-d085-4ddd-82ad-9f93e39f1332">

