### PR TITLE
Fix NPE by executing JavaSearchStartupParticipant.start() in Display.getCurrent()

### DIFF
--- a/bndtools.core/src/bndtools/javasearch/JavaSearchStartupParticipant.java
+++ b/bndtools.core/src/bndtools/javasearch/JavaSearchStartupParticipant.java
@@ -14,6 +14,7 @@ import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.ISearchResult;
 import org.eclipse.search.ui.NewSearchUI;
 import org.eclipse.search.ui.text.AbstractTextSearchResult;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetManager;
 import org.eclipse.ui.PlatformUI;
@@ -24,8 +25,11 @@ public class JavaSearchStartupParticipant implements IStartupParticipant, IQuery
 
 	@Override
 	public void start() {
-		NewSearchUI.addQueryListener(this);
-		createBndtoolsJavaWorkingSet();
+		Display.getCurrent()
+			.syncExec(() -> {
+				NewSearchUI.addQueryListener(this);
+				createBndtoolsJavaWorkingSet();
+			});
 	}
 
 	private void createBndtoolsJavaWorkingSet() {


### PR DESCRIPTION
Closes #6199

This hopefully fixes the NPE in `org.eclipse.jface.resource.JFaceResources.getResources(Display)` which expects the current display

**For the record:** I did not do the same in `JavaSearchStartupParticipant.stop()` because then I got the following when exiting the Debug Eclipse instance:

```
g! 2024-08-17 13:06:01,117 [Framework stop - Equinox Container: 08c6cf07-37df-4845-b378-a729e987b66a] ERROR org.eclipse.equinox.logger - Error stopping startup participant
java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.widgets.Display.syncExec(java.lang.Runnable)" because the return value of "org.eclipse.swt.widgets.Display.getCurrent()" is null
	at bndtools.javasearch.JavaSearchStartupParticipant.stop(JavaSearchStartupParticipant.java:51)
	at bndtools.Plugin.stopStartupParticipants(Plugin.java:124)
	at bndtools.Plugin.stop(Plugin.java:139)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:875)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:867)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.stopWorker0(EquinoxBundle.java:1046)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.stopWorker(EquinoxBundle.java:376)
	at org.eclipse.osgi.container.Module.doStop(Module.java:660)
	at org.eclipse.osgi.container.Module.stop(Module.java:521)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:1893)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1768)
	at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:275)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:208)
	at org.eclipse.osgi.container.Module.doStop(Module.java:660)
	at org.eclipse.osgi.container.Module.stop(Module.java:521)
	at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:207)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:226)
	at java.base/java.lang.Thread.run(Thread.java:1583)

```

So I left `JavaSearchStartupParticipant.stop()` unchanged.