### PR TITLE
bnd-maven plugin: delete existing MANIFEST.MF from previous build

### DIFF
--- a/maven-plugins/README.md
+++ b/maven-plugins/README.md
@@ -65,8 +65,10 @@ A plugin to generate sources and resources.
 
 # Building the Maven Plugins
 
-You must first run `./gradlew :build` to build the Bnd artifacts and install them in your local maven repo.
-You can then run `./mvnw install` to build the Bnd Maven plugins.
+You must first run `./gradlew :build` (or `./gradlew build -x test` skip tests for faster local builds) to build the Bnd artifacts and install them in your local maven repo.
+You can then run `./mvnw install` to build the Bnd Maven plugins (or `mvn install -Dinvoker.skip=true` to skip tests for faster local builds).
+
+
 
 ---
 

--- a/maven-plugins/bnd-maven-plugin/README.md
+++ b/maven-plugins/bnd-maven-plugin/README.md
@@ -92,6 +92,28 @@ The `bnd-process` is not executed by default, therefore at least one explicit ex
 </plugin>
 ```
 
+**Deleting existing MANIFEST.MF of previous builds:** 
+Note that `process-classes` uses content in the `classesDir` as input which could also contain a `META-INF/MANIFEST.MF` file (e.g. from a previous build). In some cases this could lead to surprising results when `process-classes` is executed multiple times. You can set the `deleteExistingManifest` configuration to `true` to delete an existing MANIFEST.MF at `manifestPath` prior to execution to avoid that it is used as input to the bnd process.
+
+```xml
+<plugin>
+    <groupId>biz.aQute.bnd</groupId>
+    <artifactId>bnd-maven-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>bnd-process</id>
+            <goals>
+                <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+            	<deleteExistingManifest>true</deleteExistingManifest>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+
 ### Configuration Parameters
 
 | Configuration Parameter | Description                                                                                                                                                                                                                                                                       |
@@ -99,6 +121,8 @@ The `bnd-process` is not executed by default, therefore at least one explicit ex
 | `bndfile`               | File path to a bnd file containing bnd instructions for this project. The file path can be either absolute or relative to the project directory. _Defaults to `bnd.bnd`_.                                                                                                         |
 | `bnd`                   | Bnd instructions for this project specified directly in the pom file. This is generally be done using a `<![CDATA[  ]]>` section. If the projects has a `bndfile` configuration property or a file in the default location `bnd.bnd`, then this configuration element is ignored. |
 | `manifestPath`          | Specify the path to store the generated manifest file. _Defaults to `${project.build.outputDirectory}/META-INF/MANIFEST.MF`._                                                                                                                                                     |
+| `deleteExistingManifest`          | Whether to delete an existing file at `manifestPath` before execution. _Defaults to `false`._
+|
 | `classesDir`            | The directory where the `maven-compiler-plugin` places its output. _Defaults to `${project.build.outputDirectory}`._                                                                                                                                                              |
 | `includeClassesDir`     | Include the entire contents of `classesDir` in the bundle. *Defaults to `true`*.                                                                                                                                                                                                  |
 | `outputDir`             | The directory where this goal will store its output. _Defaults to `${project.build.outputDirectory}`._                                                                                                                                                                            |
@@ -429,6 +453,8 @@ The `bnd-process-tests` is not executed by default, therefore at least one expli
 | `skip`                  | Skip the goal. _Defaults to `false`._ Override with property `bnd-tests.skip` or `maven.test.skip`.                                                                                                                                                                               |
 | `skipIfEmpty`           | Skip processing if `includeClassesDir` is `true` and the `classesDir` is empty. _Defaults to `false`._ Override with property `bnd.skipIfEmpty`.                                                                                                                                  |
 | `manifestPath`          | Specify the path to store the generated manifest file. _Defaults to `${project.build.testOutputDirectory}/META-INF/MANIFEST.MF`._                                                                                                                                                 |
+| `deleteExistingManifest`          | Whether to delete an existing file at `manifestPath` before execution. _Defaults to `false`._
+|
 | `outputDir`             | The directory where this goal will store its output. _Defaults to `${project.build.testOutputDirectory}`._                                                                                                                                                                        |
 | `packagingTypes`        | The list of maven packaging types for which the plugin will execute. *Defaults to `jar,war`*. Override with property `bnd.packagingTypes`.                                                                                                                                        |
 | `outputTimestamp`       | Timestamp for [reproducible][1] output archive entries, either formatted as ISO 8601 `yyyy-MM-dd'T'HH:mm:ssXXX` or as an int representing seconds since the epoch. _Defaults to `${project.build.outputTimestamp}`_.                                                              |

--- a/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -96,6 +96,12 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 	boolean					includeClassesDir;
 
 	/**
+	 * Whether to delete an existing {@link #getManifestPath()} before execution.
+	 */
+	@Parameter(defaultValue = "false")
+	boolean					deleteExistingManifest;
+
+	/**
 	 * The directory where the webapp is built when packaging is {@code war}.
 	 */
 	@Parameter(alias = "warOutputDir", defaultValue = "${project.build.directory}/${project.build.finalName}")
@@ -252,6 +258,16 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 			List<Builder> subs = builder.getSubBuilders();
 			if ((subs.size() != 1) || !builder.equals(subs.get(0))) {
 				throw new MojoExecutionException("Sub-bundles not permitted in a maven build");
+			}
+
+			if (deleteExistingManifest) {
+				// delete existing MANIFEST.MF
+				// e.g. from previous build to avoid that this MANIFEST.MF
+				// becomes input to the bnd process (which could lead to
+				// suprising results in some cases)
+				File existingMetaInf = getManifestPath();
+				logger.info("Delete existing manifest: {}", existingMetaInf);
+				IO.delete(existingMetaInf);
 			}
 
 			// always add the outputDirectory to the classpath, but


### PR DESCRIPTION
Based on comment https://github.com/bndtools/bnd/issues/6221#issuecomment-2296567709

This fixes a problem where a 'mvn process-classes' picked up `target/classes/META-INF/MANIFEST.MF` from a previous build and produced a new MANIFEST.MF based on the results of the previous build... which should not happen.

We now delete the existing `target/classes/META-INF/MANIFEST.MF` if it exists.

Now this gives consistent results for the following case:

```
mvn clean process-classes
mvn clean process-classes
```
or 

`mvn clean process-classes`
followed by a
`mvn process-classes`


@pkriens I wonder how this PR affects the statement in 

https://github.com/bndtools/bnd/blob/c1bb1658ee3cdd4d7052a3722af3afb107f96828/maven-plugins/bnd-maven-plugin/README.md?plain=1#L111
