### PR TITLE
NewWorkspace Wizzard: fix switch workspace after finish

### DIFF
--- a/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
@@ -14,7 +14,10 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.ide.ChooseWorkspaceData;
+import org.eclipse.ui.internal.ide.actions.OpenWorkspaceAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +119,16 @@ public class Model implements Runnable {
 						System.setProperty("osgi.instance.area", location.getAbsolutePath());
 						System.setProperty("osgi.instance.area.default", location.getAbsolutePath());
 
-						PlatformUI.getWorkbench()
-							.restart();
+						// show Eclipse Switch Workspace dialog with the new
+						// workspace location pre-filled
+						ChooseWorkspaceData launchData = new ChooseWorkspaceData(location.getAbsolutePath());
+						launchData.workspaceSelected(location.getAbsolutePath());
+						launchData.writePersistedData();
+
+						IWorkbenchWindow window = PlatformUI.getWorkbench()
+							.getActiveWorkbenchWindow();
+						new OpenWorkspaceAction(window).run();
+
 					});
 				}
 			} catch (Exception e) {

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -129,7 +129,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			clean.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 8, 1));
 
 			Button switchWorkspace = new Button(container, SWT.CHECK);
-			switchWorkspace.setText("Switch to new workspace after finish");
+			switchWorkspace.setText("Show workspace select dialog to switch to new workspace after finish");
 			switchWorkspace.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 8, 1));
 
 			CheckboxTableViewer selectedTemplates = CheckboxTableViewer.newCheckList(container,


### PR DESCRIPTION
Closes #6252 

Now instead of doing an instant restart (which did not switch to the new workspace) we show the existing Eclipse Switch Workspace dialog but have the new workspace location pre-filled. Since this reuses existing Eclipse feature of OpenWorkspaceAction all the switch workspace logic can be reused.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/9553969a-9e5c-4dda-acde-8a43fe30dc36">

<img width="604" alt="image" src="https://github.com/user-attachments/assets/a01fa867-dfbb-44be-b966-54d71f61694f">

Note: It seems the Switch Workspace feature already does not work in a Development instance of Eclipse (when launched from within Eclipse), because I get the following error:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/c9f216b2-a813-462c-b0fa-8ce7d19ecf67">

Thus I would need to merge this once to master, test and see if it works with the next snapshot build in a real Eclipse instance. 

@pkriens what do you think? It is a slight change from previous UI workflow (showing switch workspace dialog instead of restarting directly), but since the switch did not work, maybe this is an ok compromise?

