### PR TITLE
Fix NPE

### DIFF
--- a/bndtools.core/src/bndtools/javasearch/JavaSearchStartupParticipant.java
+++ b/bndtools.core/src/bndtools/javasearch/JavaSearchStartupParticipant.java
@@ -51,7 +51,13 @@ public class JavaSearchStartupParticipant implements IStartupParticipant, IQuery
 
 	@Override
 	public void stop() {
-		NewSearchUI.removeQueryListener(this);
+		Display current = Display.getCurrent();
+		if (current != null) {
+			current.syncExec(() -> {
+				NewSearchUI.removeQueryListener(this);
+			});
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
Related to https://github.com/bndtools/bnd/issues/6199#issuecomment-2323434448


Display.getCurrent() is null already when stop is called. So check for null and only execute if not null. Since it was called when quitting Eclipse, it is probably very late in the process where most things are already shutdown.

This is a similar fix as to the one in https://github.com/bndtools/bnd/pull/6223