### PR TITLE
RepoView: Add to Clipboard: Bundles with substitution packages / self-imports

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -961,13 +961,14 @@ public abstract class ResourceUtils {
 	}
 
 	/**
-	 * Calculates a list of package names which are exported and also imported.
-	 * This can be handy for debugging and identify unwanted self-imports.
+	 * Calculates a list of packages which are exported and also imported. This
+	 * can be handy for debugging and identify unwanted substitution packages /
+	 * self-imports.
 	 *
 	 * @param r the resource
-	 * @return a non-null list of self-import package names.
+	 * @return a non-null list of packages.
 	 */
-	public static Collection<PackageExpression> getSelfImportPackages(Resource r) {
+	public static Collection<PackageExpression> getSubstitutionPackages(Resource r) {
 		List<Capability> caps = r.getCapabilities(PackageNamespace.PACKAGE_NAMESPACE);
 		List<Requirement> requirements = r.getRequirements(PackageNamespace.PACKAGE_NAMESPACE);
 
@@ -993,10 +994,10 @@ public abstract class ResourceUtils {
 			}
 		}
 
-		Set<String> selfImports = new LinkedHashSet<>(exportedPackages);
-		selfImports.retainAll(importedPackages);
+		Set<String> substitutions = new LinkedHashSet<>(exportedPackages);
+		substitutions.retainAll(importedPackages);
 
-		return selfImports.stream()
+		return substitutions.stream()
 			.map(pck -> pckVersionMap.get(pck))
 			.collect(Collectors.toCollection(LinkedHashSet::new));
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceUtils.java
@@ -102,7 +102,6 @@ public abstract class ResourceUtils {
 	private static final Converter						cnv							= new Converter()
 		.hook(Version.class, (dest, o) -> toVersion(o));
 
-	private static final FilterParser					fp							= new FilterParser();
 
 	public interface IdentityCapability extends Capability {
 		public enum Type {
@@ -986,8 +985,10 @@ public abstract class ResourceUtils {
 
 		// Populate imported packages
 		Map<String, PackageExpression> pckVersionMap = new LinkedHashMap<>();
+		FilterParser fp = new FilterParser(); // new instance required to avoid
+												// invorrect caching
 		for (Requirement req : requirements) {
-			PackageExpression pckExp = getRequirementPackage(req);
+			PackageExpression pckExp = getRequirementPackage(req, fp);
 			if (pckExp != null) {
 				importedPackages.add(pckExp.getPackageName());
 				pckVersionMap.put(pckExp.getPackageName(), pckExp);
@@ -1002,7 +1003,7 @@ public abstract class ResourceUtils {
 			.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
-	private static PackageExpression getRequirementPackage(Requirement req) {
+	private static PackageExpression getRequirementPackage(Requirement req, FilterParser fp) {
 
 		Expression exp = fp.parse(req);
 		if (exp instanceof PackageExpression pckExp) {

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
@@ -89,7 +89,7 @@ public class RepositoryBundleVersion extends RepositoryEntry implements Actionab
 
 	@Override
 	public Resource getResource() {
-		return bundle.getResource();
+		return super.getResource();
 	}
 
 }

--- a/bndtools.core/src/bndtools/model/repo/SearchableRepositoryTreeContentProvider.java
+++ b/bndtools.core/src/bndtools/model/repo/SearchableRepositoryTreeContentProvider.java
@@ -51,6 +51,9 @@ public class SearchableRepositoryTreeContentProvider extends RepositoryTreeConte
 			if (currentChild instanceof RepositoryBundleVersion rpv) {
 				allChildren.add(rpv);
 			}
+			else if (currentChild instanceof RepositoryResourceElement rre) {
+				allChildren.add(rre.getRepositoryBundleVersion());
+			}
 
 			Object[] childrenOfChild = getChildren(currentChild);
 			if (childrenOfChild != null) {

--- a/bndtools.core/src/bndtools/model/repo/SearchableRepositoryTreeContentProvider.java
+++ b/bndtools.core/src/bndtools/model/repo/SearchableRepositoryTreeContentProvider.java
@@ -1,5 +1,11 @@
 package bndtools.model.repo;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.repository.SearchableRepository;
 
@@ -27,5 +33,30 @@ public class SearchableRepositoryTreeContentProvider extends RepositoryTreeConte
 		}
 
 		return result;
+	}
+
+	public List<RepositoryBundleVersion> allRepoBundleVersions(final RepositoryPlugin rp) {
+		Object[] result = getChildren(rp);
+
+		List<RepositoryBundleVersion> allChildren = new ArrayList<>();
+		Queue<Object> queue = new LinkedList<>();
+
+		if (result != null) {
+			queue.addAll(Arrays.asList(result));
+		}
+
+		while (!queue.isEmpty()) {
+			Object currentChild = queue.poll();
+
+			if (currentChild instanceof RepositoryBundleVersion rpv) {
+				allChildren.add(rpv);
+			}
+
+			Object[] childrenOfChild = getChildren(currentChild);
+			if (childrenOfChild != null) {
+				queue.addAll(Arrays.asList(childrenOfChild));
+			}
+		}
+		return allChildren;
 	}
 }

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -117,7 +117,6 @@ import bndtools.model.repo.RepositoryBundle;
 import bndtools.model.repo.RepositoryBundleVersion;
 import bndtools.model.repo.RepositoryEntry;
 import bndtools.model.repo.RepositoryTreeLabelProvider;
-import bndtools.model.repo.ResourceProvider;
 import bndtools.model.repo.SearchableRepositoryTreeContentProvider;
 import bndtools.preferences.BndPreferences;
 import bndtools.preferences.WorkspaceOfflineChangeAdapter;
@@ -1166,38 +1165,37 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 				"Add list of bundles containing packages which are imported and exported in their Manifest.", true,
 				false, rp, () -> {
 
-				final StringBuilder sb = new StringBuilder();
+					final StringBuilder sb = new StringBuilder();
 
-				Object[] result = contentProvider.getChildren(rp);
-				for (Object object : result) {
-					if (object instanceof ResourceProvider prov) {
-						org.osgi.resource.Resource r = prov.getResource();
-
-						Collection<PackageExpression> selfImports = ResourceUtils.getSelfImportPackages(r);
-						long numWithoutRange = selfImports.stream()
-							.filter(pckExp -> pckExp.getRangeExpression() == null)
-							.count();
+					for (RepositoryBundleVersion rpv : contentProvider.allRepoBundleVersions(rp)) {
+						org.osgi.resource.Resource r = rpv.getResource();
+						Collection<PackageExpression> selfImports = ResourceUtils
+							.getSubstitutionPackages(r);
 
 						if (!selfImports.isEmpty()) {
-								sb.append(r.toString() + " has " + selfImports.size()
-									+ " substitution packages (self-imports)");
-							if(numWithoutRange > 0) {
+							long numWithoutRange = selfImports.stream()
+								.filter(pckExp -> pckExp.getRangeExpression() == null)
+								.count();
+							sb.append(
+								r.toString() + " has " + selfImports.size() + " substitution packages (self-imports)");
+							if (numWithoutRange > 0) {
 								sb.append(" (" + numWithoutRange + " without version range)");
 							}
-
 							sb.append(" -> " + selfImports + "\n");
 						}
-					}
-				}
 
-				if (sb.isEmpty()) {
-					clipboard.copy("-Empty-");
-				} else {
-					clipboard.copy(sb.toString());
-				}
+					}
+
+					if (sb.isEmpty()) {
+						clipboard.copy("-Empty-");
+					} else {
+						clipboard.copy(sb.toString());
+					}
 
 			}));
 	}
+
+
 
 	private HierarchicalLabel<Action> createContextMenueCopyInfoRepoBundle(Actionable act, final RepositoryPlugin rp,
 		final Clipboard clipboard, RepositoryBundle rb) {

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1168,6 +1168,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 					final StringBuilder sb = new StringBuilder(
 						"Shows list of bundles in the repository '" + rp.getName()
 							+ "' containing substitution packages / self-imports (i.e. same package imported and exported) in their Manifest. \n"
+							+ "Note: a missing version range can cause wiring / resolution problems.\n"
 							+ "See https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 "
 							+ "and https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module-import.export.same.package "
 							+ "for more information."

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1166,7 +1166,11 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 				false, rp, () -> {
 
 					final StringBuilder sb = new StringBuilder(
-						"Shows list of bundles containing packages which are imported and exported in their Manifest. See https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 for more information."
+						"Shows list of bundles in the repository '" + rp.getName()
+							+ "' containing substitution packages / self-imports (i.e. same package imported and exported) in their Manifest. \n"
+							+ "See https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 "
+							+ "and https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module-import.export.same.package "
+							+ "for more information."
 							+ "\n\n");
 
 					for (RepositoryBundleVersion rpv : contentProvider.allRepoBundleVersions(rp)) {
@@ -1178,12 +1182,34 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 							long numWithoutRange = selfImports.stream()
 								.filter(pckExp -> pckExp.getRangeExpression() == null)
 								.count();
-							sb.append(
-								r.toString() + " has " + selfImports.size() + " substitution packages (self-imports)");
+
+							// Main package information
+							sb.append(r.toString())
+								.append("\n");
+							sb.append("    Substitution packages: ")
+								.append(selfImports.size());
+
+							// Additional information about packages without
+							// version range
 							if (numWithoutRange > 0) {
-								sb.append(" (" + numWithoutRange + " without version range)");
+								sb.append("    (")
+									.append(numWithoutRange)
+									.append(" without version range)");
 							}
-							sb.append(" -> " + selfImports + "\n");
+							sb.append("\n");
+
+							// List of substitution packages
+							sb.append("    [\n");
+							for (PackageExpression pckExp : selfImports) {
+								sb.append("        ")
+									.append(pckExp.toString())
+									.append(",\n");
+							}
+							// Remove the last comma and newline
+							if (!selfImports.isEmpty()) {
+								sb.setLength(sb.length() - 2);
+							}
+							sb.append("\n    ]\n\n");
 						}
 
 					}

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1165,7 +1165,9 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 				"Add list of bundles containing packages which are imported and exported in their Manifest.", true,
 				false, rp, () -> {
 
-					final StringBuilder sb = new StringBuilder();
+					final StringBuilder sb = new StringBuilder(
+						"Shows list of bundles containing packages which are imported and exported in their Manifest. See https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 for more information."
+							+ "\n\n");
 
 					for (RepositoryBundleVersion rpv : contentProvider.allRepoBundleVersions(rp)) {
 						org.osgi.resource.Resource r = rpv.getResource();


### PR DESCRIPTION
For debugging purposes it is useful to identify bundles containing substitution packages (especially such without a version range)  (see https://docs.osgi.org/specification/osgi.core/8.0.0/framework.api.html#org.osgi.annotation.bundle.Export.Substitution and  https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 and
https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module-import.export.same.package ). 

I added this to the Repo-Browser on **Right Click on a Repo / Copy to Clipboard / Bundles with Substitution packages**. It outputs a simple list to the clipboard which can be pased to a texteditor for further analysis. In the future this might be refactored into more sophisticated solution but for the moment it is already useful.

This is related and originated from all the discussions around https://github.com/bndtools/bnd/issues/6220 where an unwanted self-imported package without a version range caused problems. 
This PR is an attempt to make it easier to identify those problems and make it more visible.

## Example output 

<img width="664" alt="image" src="https://github.com/user-attachments/assets/6ee70a78-284c-40f8-9d06-73e5a1e00cf6">


```
Shows list of bundles in the repository 'OSGI R8 - Runtime Distro' containing substitution packages / self-imports (i.e. same package imported and exported) in their Manifest. 
Note: a missing version range can cause wiring / resolution problems.
See https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#i3238802 and https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module-import.export.same.package for more information.

com.google.gson version=2.10.0
    Substitution packages: 1    (1 without version range)
    [
        com.google.gson.annotations
    ]

com.google.gson version=2.11.0
    Substitution packages: 1    (1 without version range)
    [
        com.google.gson.annotations
    ]

org.apache.aries.async version=1.0.1
    Substitution packages: 6
    [
        org.apache.aries.async.promise; version=[1.0.0,2.0.0),
        org.osgi.service.async; version=[1.0.0,1.1.0),
        org.osgi.service.async.delegate; version=[1.0.0,2.0.0),
        org.osgi.util.function; version=[1.0.0,2.0.0),
        org.osgi.util.promise; version=[1.0.0,1.1.0),
        org.osgi.service.log; version=[1.3.0,2.0.0)
    ]

org.apache.felix.configadmin version=1.9.26
    Substitution packages: 3
    [
        org.apache.felix.cm; version=[1.2.0,2.0.0),
        org.apache.felix.cm.file; version=[1.1.0,2.0.0),
        org.osgi.service.cm; version=[1.6.0,1.7.0)
    ]

org.apache.felix.converter version=1.0.18
    Substitution packages: 1
    [
        org.osgi.util.converter; version=[1.0.0,2.0.0)
    ]

org.apache.felix.coordinator version=1.0.2
    Substitution packages: 1
    [
        org.osgi.service.coordinator; version=[1.0.0,2.0.0)
    ]

org.apache.felix.eventadmin version=1.6.4
    Substitution packages: 1
    [
        org.osgi.service.event; version=[1.4.0,1.5.0)
    ]

org.apache.felix.gogo.runtime version=1.1.6
    Substitution packages: 3
    [
        org.apache.felix.gogo.runtime.threadio; version=[1.1.0,2.0.0),
        org.apache.felix.service.command; version=[1.0.0,2.0.0),
        org.apache.felix.service.threadio; version=[1.0.0,2.0.0)
    ]

org.apache.felix.http.jetty version=5.1.4
    Substitution packages: 46
    [
        org.osgi.service.http; version=[1.2.1,1.3.0),
        org.osgi.service.http.context; version=[1.1.0,1.2.0),
        org.osgi.service.http.runtime; version=[1.1.0,1.2.0),
        org.osgi.service.http.runtime.dto; version=[1.1.0,1.2.0),
        org.osgi.service.http.whiteboard; version=[1.1.0,2.0.0),
        org.osgi.service.servlet.context; version=[2.0.0,3.0.0),
        org.osgi.service.servlet.runtime; version=[2.0.0,2.1.0),
        org.osgi.service.servlet.runtime.dto; version=[2.0.0,3.0.0),
        org.osgi.service.servlet.whiteboard; version=[2.0.0,3.0.0),
        org.eclipse.jetty.alpn.server; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http.compression; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http.pathmap; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.api; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.api.server; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.frames; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.generator; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.hpack; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.parser; version=[11.0.0,12.0.0),
        org.eclipse.jetty.http2.server; version=[11.0.0,12.0.0),
        org.eclipse.jetty.io; version=[11.0.0,12.0.0),
        org.eclipse.jetty.io.ssl; version=[11.0.0,12.0.0),
        org.eclipse.jetty.jmx; version=[11.0.0,12.0.0),
        org.eclipse.jetty.security; version=[11.0.0,12.0.0),
        org.eclipse.jetty.security.authentication; version=[11.0.0,12.0.0),
        org.eclipse.jetty.server; version=[11.0.0,12.0.0),
        org.eclipse.jetty.server.handler; version=[11.0.0,12.0.0),
        org.eclipse.jetty.server.handler.gzip; version=[11.0.0,12.0.0),
        org.eclipse.jetty.server.resource; version=[11.0.0,12.0.0),
        org.eclipse.jetty.server.session; version=[11.0.0,12.0.0),
        org.eclipse.jetty.servlet; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.ajax; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.annotation; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.component; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.compression; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.resource; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.security; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.ssl; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.statistic; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.thread; version=[11.0.0,12.0.0),
        org.eclipse.jetty.util.thread.strategy; version=[11.0.0,12.0.0),
        org.apache.felix.http.jetty; version=[3.0.0,4.0.0),
        org.apache.felix.http.jakartawrappers; version=[1.0.0,2.0.0),
        org.apache.felix.http.javaxwrappers; version=[1.0.0,2.0.0)
    ]

org.apache.felix.inventory version=2.0.0
    Substitution packages: 1
    [
        org.apache.felix.inventory; version=[1.0.0,2.0.0)
    ]

org.apache.felix.log version=1.3.0
    Substitution packages: 2
    [
        org.osgi.service.log; version=[1.5.0,1.6.0),
        org.osgi.service.log.admin; version=[1.0.0,1.1.0)
    ]

org.apache.felix.metatype version=1.2.4
    Substitution packages: 1
    [
        org.osgi.service.metatype; version=[1.4.0,1.5.0)
    ]

org.apache.felix.scr version=2.2.6
    Substitution packages: 2
    [
        org.apache.felix.scr.component; version=[1.1.0,1.2.0),
        org.apache.felix.scr.info; version=[1.0.0,1.1.0)
    ]

org.apache.felix.shell.remote version=1.2.0
    Substitution packages: 1    (1 without version range)
    [
        org.apache.felix.shell.remote
    ]

org.apache.felix.webconsole version=4.9.6
    Substitution packages: 4
    [
        org.apache.felix.webconsole; version=[3.5.0,3.6.0),
        org.apache.felix.webconsole.bundleinfo; version=[1.0.0,1.1.0),
        org.apache.felix.webconsole.servlet; version=[1.0.0,1.1.0),
        org.apache.felix.webconsole.spi; version=[1.3.0,2.0.0)
    ]

org.eclipse.concierge.service.clusterinfo version=1.0.0
    Substitution packages: 1
    [
        org.osgi.service.clusterinfo; version=[1.0.0,2.0.0)
    ]

org.eclipse.equinox.supplement version=1.10.700.v20230509-2241
    Substitution packages: 13    (13 without version range)
    [
        org.eclipse.equinox.log,
        org.eclipse.osgi.framework.console,
        org.eclipse.osgi.framework.eventmgr,
        org.eclipse.osgi.framework.log,
        org.eclipse.osgi.report.resolution,
        org.eclipse.osgi.service.datalocation,
        org.eclipse.osgi.service.debug,
        org.eclipse.osgi.service.environment,
        org.eclipse.osgi.service.localization,
        org.eclipse.osgi.service.runnable,
        org.eclipse.osgi.service.urlconversion,
        org.eclipse.osgi.storagemanager,
        org.eclipse.osgi.util
    ]

org.eclipse.lsp4j version=0.20.0.v20230216-1815
    Substitution packages: 4    (4 without version range)
    [
        org.eclipse.lsp4j,
        org.eclipse.lsp4j.adapters,
        org.eclipse.lsp4j.services,
        org.eclipse.lsp4j.util
    ]

org.glassfish.javax.json version=1.1.4
    Substitution packages: 4    (1 without version range)
    [
        javax.json; version=[1.1.0,2.0.0),
        javax.json.spi; version=[1.1.0,2.0.0),
        javax.json.stream; version=[1.1.0,2.0.0),
        org.glassfish.json.api
    ]

org.knopflerfish.bundle.useradmin version=4.1.1
    Substitution packages: 4
    [
        org.knopflerfish.service.log; version=[1.2.0,2.0.0),
        org.knopflerfish.service.um.ipam; version=[1.0.0,2.0.0),
        org.knopflerfish.service.um.useradmin; version=[1.0.0,2.0.0),
        org.osgi.service.useradmin; version=[1.1.0,1.2.0)
    ]


```