### PR TITLE
Issue #6273: Accessing POM via XPath is very slow

### DIFF
--- a/biz.aQute.repository/src/aQute/maven/provider/POM.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/POM.java
@@ -317,12 +317,15 @@ public class POM implements IPom {
 		return "true".equalsIgnoreCase(other);
 	}
 
-	private String get(Element dependency, String name, String deflt) throws XPathExpressionException {
-		String value = xp.evaluate(name, dependency);
-		if (value == null || value.isEmpty())
-			return Strings.trim(deflt);
+	private String get(Element dependency, String name, String deflt) {
+		var matchingElements = dependency.getElementsByTagName(name);
+		if (matchingElements.getLength() > 0) {
+			var value = matchingElements.item(0).getTextContent();
+			if (value != null && !value.isEmpty())
+				return Strings.trim(replaceMacros(value));
+		}
 
-		return Strings.trim(replaceMacros(value));
+		return Strings.trim(deflt);
 	}
 
 	private String getOrSet(String key, String deflt) {


### PR DESCRIPTION
- For the simple get() method, simply use DOM methods instead of going through XPath

I have tried to profile the issue again, but so far have not been able to encounter the situation where this `get()` method is called again. I even tried setting a breakpoint in the method while using Eclipse "in production" - but so far, the breakpoint did not hit again...