### PR TITLE
#6216 no locations in synthetic resources made for MRJs.

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceBuilder.java
@@ -10,6 +10,7 @@ import static org.osgi.framework.namespace.ExecutionEnvironmentNamespace.EXECUTI
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -1023,8 +1024,8 @@ public class ResourceBuilder {
 
 		try (Jar jar = new Jar(file)) {
 			ResourceBuilder rb = new ResourceBuilder();
-			boolean hasIdentity = rb.addJar(jar);
 
+			boolean hasIdentity = rb.addJar(jar);
 			String mime = hasIdentity ? MIME_TYPE_BUNDLE : MIME_TYPE_JAR;
 
 			rb.addContentCapability(uri,
@@ -1135,7 +1136,22 @@ public class ResourceBuilder {
 		rqb.addFilter(fb);
 		builder.addRequirement(rqb);
 
+		builder.addSyntheticContentCapability("urn:osgi-bnd-mrj:" + bsn + ":" + version + ":" + release);
 		return builder.build();
+	}
+
+	/*
+	 * Pass a urn that is unique for this resource.
+	 */
+	private void addSyntheticContentCapability(String urn) {
+		try {
+			URI uri = URI.create(urn);
+			String sha = SHA256.digest(urn.getBytes(StandardCharsets.UTF_8))
+				.asHex();
+			addContentCapability(uri, sha, 0, "application/octetstream");
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
 	}
 
 	public boolean addManifest(Manifest m) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/resource/ResourceImpl.java
@@ -173,7 +173,12 @@ class ResourceImpl implements Resource, SupportingResource, Comparable<Resource>
 		this.requirementMap = allRequirements.stream()
 			.collect(groupingBy(Requirement::getNamespace, Lists.toList()));
 		this.locations = ResourceUtils.getLocations(this);
-		this.hashCode = locations.hashCode();
+		this.hashCode = this.locations.keySet()
+			.stream()
+			.map(URI::toString)
+			.sorted()
+			.map(String::hashCode)
+			.reduce(0, (prev, next) -> prev * 31 + next);
 		return this;
 	}
 


### PR DESCRIPTION
Added a content cap in the synthetic resource so equals works. Turned out hashcode did not work well in ResourceImpl so also fixed this.

Fixes #6212

---
 Signed-off-by: Peter Kriens <Peter.Kriens@aQute.biz>