### PR TITLE
Resolution view: improve wording of hideSelfImportsFilter Button

### DIFF
--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -321,7 +321,6 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 				return true;
 			}
 		};
-		reqsViewer.setFilters(hideSelfImportsFilter);
 
 		hideOptionalRequirements = new ViewerFilter() {
 
@@ -418,7 +417,7 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 			.getToolBarManager();
 
 		// Reqs Buttons
-		toolBarManager.add(createToggleShowSelfImportsButton());
+		toolBarManager.add(createToggleHideSelfImportsButton());
 		toolBarManager.add(createToggleHideOptionalReqsFilterButton());
 		toolBarManager.add(new Separator());
 
@@ -923,26 +922,27 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 		return toggleLockInput;
 	}
 
-	private IAction createToggleShowSelfImportsButton() {
-		String toggleShowSelfImportsUnchecked = "Showing resolved requirements.\n\n"
-			+ "Includes requirements that are resolved within the set of selected bundles. Click to show all requirements.";
+	private IAction createToggleHideSelfImportsButton() {
+		String toolTipTextShowAll = "Showing all requirements.";
+		String toolTipTextHideSelfImports = "Hiding resolved (including self-imported) requirements.\n\n"
+			+ "Requirements that are resolved (exported and imported) within the set of selected bundles are hidden. Click to show all requirements.";
 
 		IAction toggleShowSelfImports = new Action("showSelfImports", IAction.AS_CHECK_BOX) {
 			@Override
 			public void runWithEvent(Event event) {
 				if (isChecked()) {
-					reqsViewer.removeFilter(hideSelfImportsFilter);
-					this.setToolTipText("Showing all requirements.");
-				} else {
 					reqsViewer.addFilter(hideSelfImportsFilter);
-					this.setToolTipText(toggleShowSelfImportsUnchecked);
+					this.setToolTipText(toolTipTextHideSelfImports);
+				} else {
+					reqsViewer.removeFilter(hideSelfImportsFilter);
+					this.setToolTipText(toolTipTextShowAll);
 				}
 				updateReqsLabel();
 			}
 		};
 		toggleShowSelfImports.setChecked(false);
 		toggleShowSelfImports.setImageDescriptor(Icons.desc("/icons/package_folder_impexp.gif"));
-		toggleShowSelfImports.setToolTipText(toggleShowSelfImportsUnchecked);
+		toggleShowSelfImports.setToolTipText(toolTipTextShowAll);
 		return toggleShowSelfImports;
 	}
 


### PR DESCRIPTION
the wording of the button for  hideSelfImportsFilter was not clear and misleading.
After working on https://github.com/bndtools/bnd/pull/6270 I finally understood what this button actually does.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/5de177b1-5ff8-4aa8-af3d-a4179f00bfe8">

<img width="887" alt="image" src="https://github.com/user-attachments/assets/1f53a4cd-8abf-4954-b50b-315cc02d10f8">
