### PR TITLE
bring back the no-projects links

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -137,11 +137,9 @@
             class="bndtools.wizards.newworkspace.NewWorkspaceWizard"
             finalPerspective="bndtools.perspective"
             preferredPerspectives="bndtools.perspective"
-            icon="icons/bndtools-logo-16x16.png" name="New bnd workspace">
+            icon="icons/bndtools-logo-16x16.png" name="New bnd workspace" project="true">
 			<description>
-			Creates a new bnd workspace. You will be able to select template fragments
-			that will define the new workspace. At finish, you can switch to the new
-			workspace.
+			Create a new bnd workspace.
 			</description>
         </wizard>
         <wizard id="bndtools.workspaceWizardDeprecated"
@@ -149,9 +147,9 @@
 			class="bndtools.wizards.workspace.WorkspaceSetupWizard"
 			finalPerspective="bndtools.perspective"
 			preferredPerspectives="bndtools.perspective"
-			icon="icons/bndtools-logo-16x16.png" name="Bnd OSGi Workspace (Deprecated)">
+			icon="icons/bndtools-logo-16x16.png" name="Bnd OSGi Workspace (Deprecated)" project="true">
 			<description>
-			Old style workspace creation, will be deprecated in a coming release.
+			Bnd OSGi Workspace (Deprecated)
 			</description>
 		</wizard>
         


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6301

now the links for
1. Create a new bnd workspace.
2. Bnd OSGi Workspace (Deprecated)

appear again in the Bnd Perspective for an empty workspace if you have no projects. unfortunately I had to shorten the description because it is used instead of the name and was too long. Drawback is, that  the File / New Entries used that as a tooltip, which is now much shorter. But at least both views look ok

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/b301d241-e385-4467-ac35-8d48013cb2fa">

<img width="841" alt="image" src="https://github.com/user-attachments/assets/b0d8197b-3df2-4f5d-aae1-1c4fbff6a119">

@juergen-albert 