### PR TITLE
fix docs build of init.md instruction

### DIFF
--- a/docs/_instructions/init.md
+++ b/docs/_instructions/init.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 class: Project
-title: -init: ${MACRO} ( ',' ${MACRO}) * 
+title: -init ${MACRO} ( ',' ${MACRO}) * 
 summary:  Executes the macros while initializing the project for building.
 ---
 


### PR DESCRIPTION
this fixes the  Error: YAML Exception reading bnd/docs/_instructions/init.md: (<unknown>): mapping values are not allowed in this context at line 4 column 13

and finally makes the init macro appear in the list