### PR TITLE
Print remote agent stack traces to the System.err instead of remote console

### DIFF
--- a/biz.aQute.remote/src/aQute/remote/agent/AgentServer.java
+++ b/biz.aQute.remote/src/aQute/remote/agent/AgentServer.java
@@ -597,7 +597,7 @@ public class AgentServer implements Agent, Closeable, FrameworkListener {
 
 	private void printStack(Exception e1) {
 		try {
-			e1.printStackTrace(redirector.getOut());
+			e1.printStackTrace();
 		} catch (Exception e) {
 			//
 		}


### PR DESCRIPTION
With a remote agent and remote console running exception (stack traces) on the agent will printout to the remote console resulting in a clattered output as the shell tries to interpret them as commands.
 
```
g! gogo: CommandNotFoundException: Command not found: org.osgi.framework.BundleException:
g! gogo: IOException: no matches found: org.apache.felix.framework.BundleImpl.createRevision(BundleImpl.java:1352)
g! gogo: EOFException: Expected file name for redirection
g! gogo: IOException: no matches found: org.apache.felix.framework.Felix.installBundle(Felix.java:3287)
g! gogo: IOException: no matches found: org.apache.felix.framework.BundleContextImpl.installBundle(BundleContextImpl.java:147)
g! gogo: IOException: no matches found: aQute.remote.agent.AgentServer.update(AgentServer.java:315)
g! gogo: IOException: no matches found: java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
g! gogo: IOException: no matches found: java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
g! gogo: IOException: no matches found: java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
g! gogo: IOException: no matches found: java.base/java.lang.reflect.Method.invoke(Method.java:569)
g! gogo: IOException: no matches found: aQute.remote.util.Link.executeCommand(Link.java:340)
g! gogo: IOException: no matches found: aQute.remote.util.Link.lambda(Link.java:169)
g! gogo: IOException: no matches found: java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
g! gogo: IOException: no matches found: java.base/java.util.concurrent.ThreadPoolExecutor(ThreadPoolExecutor.java:635)
```