### PR TITLE
JarViewer: Fix orphaned temp files (remove background jobs)

### DIFF
--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARPrintPage.java
@@ -43,6 +43,7 @@ import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.print.JarPrinter;
 
@@ -393,10 +394,13 @@ public class JARPrintPage extends FormPage {
 			return;
 		}
 		loading = true;
-		JAREditor.background("Printing ZIP file", monitor -> print(uri), text -> {
+		try {
+			String text = print(uri);
 			styledText.setText(text);
 			styledText.setFocus();
-		});
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
 
 	}
 

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreeEntryPart.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreeEntryPart.java
@@ -38,6 +38,7 @@ import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.lib.hex.Hex;
 import aQute.lib.io.ByteBufferOutputStream;
 import aQute.lib.io.IO;
@@ -201,13 +202,13 @@ public class JARTreeEntryPart extends AbstractFormPart implements IPartSelection
 		lastModified.setText("");
 		if (resource instanceof IFile) {
 			IFile node = (IFile) resource;
-			JAREditor.background("Loading " + resource.getName(), mon -> {
-				try (InputStream in = limitRead ? new LimitedInputStream(node.getContents(), READ_LIMIT)
-					: node.getContents()) {
-					return IO.copy(in, new ByteBufferOutputStream())
-						.toByteBuffer();
-				}
-			}, this::setContent);
+			try (InputStream in = limitRead ? new LimitedInputStream(node.getContents(), READ_LIMIT)
+				: node.getContents()) {
+				setContent(IO.copy(in, new ByteBufferOutputStream())
+					.toByteBuffer());
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
 		} else {
 			setContent("");
 		}

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePage.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreePage.java
@@ -8,6 +8,7 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.graphics.Image;
@@ -19,6 +20,8 @@ import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+
+import aQute.bnd.exceptions.Exceptions;
 
 public class JARTreePage extends FormPage {
 
@@ -101,19 +104,21 @@ public class JARTreePage extends FormPage {
 		if (loading.getAndIncrement() > 1)
 			return;
 
-		JAREditor.background("Reading zip file", monitor -> {
+		try {
 			IFolder folder;
 			do {
-				folder = getFolder(uri, monitor);
+				folder = getFolder(uri, new NullProgressMonitor());
 				loading.getAndDecrement();
 			} while (loading.getAndSet(0) > 0);
-			return folder;
-		}, folder -> {
+
 			if (closed)
 				return;
 			setFolder(folder);
 			tree.setFormInput(folder);
-		});
+		} catch (CoreException e) {
+			throw Exceptions.duck(e);
+		}
+
 	}
 
 	private void setFolder(IFolder folder) {


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6340

this fixes all the race conditions where update methods was called multiple times by different threads and created temp folders multiple times. Now only one temp folder per opened jar is created. Also did not notice a performance problem when opening the jar.

Not sure if not using a Background Job is a good or bad to do in Eclipse. But I had the feeling they do more harm than good in this case.