### PR TITLE
Improve repo tagging

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/service/Registry.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/Registry.java
@@ -22,7 +22,8 @@ public interface Registry {
 	 * @param c
 	 * @param tags
 	 * @return all plugins matching the given class and any of the given tags.
-	 *         If no tags are given, all plugins are returned without filtering.
+	 *         If a plugin does not support tags or no tags are given, all
+	 *         plugins are returned without filtering.
 	 */
 	default <T> List<T> getPlugins(Class<T> c, String... tags) {
 
@@ -31,8 +32,8 @@ public interface Registry {
 		}
 
 		return getPlugins(c).stream()
-			.filter(repo -> repo instanceof Tagged taggedRepo && taggedRepo.getTags()
-				.includesAny(tags))
+			.filter(repo -> (repo instanceof Tagged taggedRepo) ? taggedRepo.getTags()
+				.includesAny(tags) : true)
 			.collect(Collectors.toList());
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/service/Registry.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/Registry.java
@@ -21,9 +21,8 @@ public interface Registry {
 	 * @param <T>
 	 * @param c
 	 * @param tags
-	 * @return all plugins matching the given class and any of the given tags.
-	 *         If a plugin does not support tags or no tags are given, all
-	 *         plugins are returned without filtering.
+	 * @return All plugins that have a tag that matches at least one of the
+     *         given tags or have no tags.
 	 */
 	default <T> List<T> getPlugins(Class<T> c, String... tags) {
 
@@ -32,7 +31,7 @@ public interface Registry {
 		}
 
 		return getPlugins(c).stream()
-			.filter(repo -> (repo instanceof Tagged taggedRepo) ? taggedRepo.getTags()
+			.filter(plugin -> (plugin instanceof Tagged taggedPlugin) ? taggedPlugin.getTags()
 				.includesAny(tags) : true)
 			.collect(Collectors.toList());
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/service/RepositoryPlugin.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/RepositoryPlugin.java
@@ -28,7 +28,7 @@ public interface RepositoryPlugin extends Tagged {
 	 * tags are set at the repo definition in build.bnd That means it is
 	 * consider
 	 */
-	Tags DEFAULT_REPO_TAGS = Tags.of(Constants.REPOTAGS_RESOLVE);
+	Tags DEFAULT_REPO_TAGS = Tags.NO_TAGS;
 
 	/**
 	 * Options used to steer the put operation

--- a/biz.aQute.bndlib/src/aQute/bnd/service/tags/Tags.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/tags/Tags.java
@@ -11,6 +11,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import aQute.libg.glob.Glob;
+
 /**
  * A set of tags. A tag is a string-token which can be attached to an entity for
  * categorization and filtering. Typically these entities then implement the
@@ -110,7 +112,7 @@ public class Tags implements Set<String> {
 	}
 
 	/**
-	 * @param tags
+	 * @param tags (globs)
 	 * @return <code>true</code> if any of the given tags is included in the
 	 *         current set of tags, otherwise returns <code>false</code>. Also
 	 *         if the current set of tags is empty, also <code>true</code> is
@@ -126,13 +128,19 @@ public class Tags implements Set<String> {
 			return true;
 		}
 
-		for (String tag : tags) {
-			if (contains(tag)) {
+		for (String tagGlob : tags) {
+			if (matchesAny(new Glob(tagGlob))) {
 				return true;
 			}
 		}
 
 		return false;
+
+	}
+
+	private boolean matchesAny(Glob glob) {
+		return internalSet.stream()
+			.anyMatch(s -> glob.matches(s));
 	}
 
 	/**

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
@@ -75,9 +75,10 @@ public class WorkspaceTest {
 
 		Repository repo = repos.get(0);
 		assertTrue(repo instanceof Tagged);
-		assertEquals(1, ((Tagged) repo).getTags()
+		assertEquals(0, ((Tagged) repo).getTags()
 			.size());
-		assertEquals(Constants.REPOTAGS_RESOLVE, new ArrayList<>(((Tagged) repo).getTags()).get(0));
+		assertTrue(((Tagged) repo).getTags()
+			.includesAny(Constants.REPOTAGS_RESOLVE));
 
 	}
 


### PR DESCRIPTION
As discussed with @pkriens today:

- The Repo Browser does not show 'resolve' tag anymore, for repos which do not have defined a tag

![image](https://github.com/user-attachments/assets/2a06acbd-b151-4759-b764-7dbb80301683)

- instead only if developer has manually entered a tag in a repo it is shown

![image](https://github.com/user-attachments/assets/38758dcc-b58d-48e6-8c7f-d2350dea9130)

![image](https://github.com/user-attachments/assets/7a2c309d-88ae-4a8a-85b1-bb7624e76735)



Also fixed a bug I discovered regarding Repository implementations which currently do not implement the `Tagged` interface. Those repositories should still be considered for resolution by default (as if they have the `resolve` tag). This is e.g. the case for any custom Respository plugin in the wild which `implements Repository` but not Tagged (because Tagged interface is just being added in 7.1.0)
