### PR TITLE
improve TemplateFragment icons

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,6 +58,7 @@ public class FragmentTemplateEngine {
 	private static final String	DESCRIPTION			= "description";
 	private static final String	WORKSPACE_TEMPLATES	= "-workspace-templates";
 	private static final String	NAME				= "name";
+	private static final Pattern	COMMIT_SHA			= Pattern.compile("[a-f0-9]{40}$");
 
 	final static Logger			log					= LoggerFactory.getLogger(FragmentTemplateEngine.class);
 	final List<TemplateInfo>	templates			= new ArrayList<>();
@@ -90,9 +92,24 @@ public class FragmentTemplateEngine {
 		 *         by us".
 		 */
 		public boolean isOfficial() {
-			return id.organisation()
-				.equals("bndtools");
+			return "bndtools".equals(id.organisation());
 		}
+
+		/**
+		 * Check if the id points to a specific commit SHA e.g.
+		 * githuborg/myrepo/subfolder/workspace-template#b96e0a8877bad1c68cdc050d5854829253ef63bb
+		 * In this case b96e0a8877bad1c68cdc050d5854829253ef63bb would be the
+		 * SHA.
+		 *
+		 * @return <code>true</code> if the repoUrl points to a specific commit
+		 *         SHA.
+		 */
+		public boolean isCommitSHA() {
+			String ref = id.ref();
+			return ref != null && COMMIT_SHA.matcher(ref)
+				.matches();
+		}
+
 	}
 
 

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.DirectoryDialog;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
@@ -66,8 +67,8 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 	final FragmentTemplateEngine			templates;
 	private ScrolledFormText		txtDescription;
 
-	final static Image				ok				= Icons.image("icons/tick.png", false);
-	final static Image				warn			= Icons.image("icons/warning_obj.gif", false);
+	final static Image				verified			= Icons.image("icons/tick.png", false);
+	final static Image				verifiedGreyedOut	= new Image(Display.getDefault(), verified, SWT.IMAGE_DISABLE);
 
 	public NewWorkspaceWizard() throws Exception {
 		setWindowTitle("Create New bnd Workspace");
@@ -240,8 +241,8 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 				@Override
 				public Image getImage(Object element) {
 					if (element instanceof TemplateInfo ti) {
-						return ti
-							.isOfficial() ? ok : warn;
+						boolean officialOrSHA = ti.isOfficial() || ti.isCommitSHA();
+						return officialOrSHA ? verified : verifiedGreyedOut;
 					}
 
 					return super.getImage(element);


### PR DESCRIPTION
- show green icon for bndtools org (ours) or 3rd-party with a specific commit SHA

```
-workspace-templates \
    bndtools/workspace-templates/gradle; \
        name=gradle; \
        description="Setup gradle build for bnd workspace", \
    bndtools/workspace-templates/maven; \
        name=maven; \
        description="Use the maven directory layout for sources and binaries", \
    bndtools/workspace-templates/osgi; \
        name=osgi; \
        description="OSGi R8 with Felix distribution", \
    mnlipp/de.mnl.osgi/de.mnl.osgi.bnd.repository/workspace-template#b96e0a8877bad1c68cdc050d5854829253ef63bb; \
        name=IndexedMavenRepository; \
        description="Provide an OSGi repository derived from a subset of one or more maven repositories"

```

would show all green (notice the commit SHA at the end of the last entry):

![image](https://github.com/user-attachments/assets/66109cdd-9fb4-441d-adaf-f7d4832126aa)


- show greyish icon for 3rdParty template fragments not pointing to a specific commit SHA... e.g. master branch. This basically means: we verified it when PR was added, but it could change in the future by the author. 

```
-workspace-templates \
    bndtools/workspace-templates/gradle; \
        name=gradle; \
        description="Setup gradle build for bnd workspace", \
    bndtools/workspace-templates/maven; \
        name=maven; \
        description="Use the maven directory layout for sources and binaries", \
    bndtools/workspace-templates/osgi; \
        name=osgi; \
        description="OSGi R8 with Felix distribution", \
    mnlipp/de.mnl.osgi/de.mnl.osgi.bnd.repository/workspace-template; \
        name=IndexedMavenRepository; \
        description="Provide an OSGi repository derived from a subset of one or more maven repositories"

```

This would show the last entry with a grey icon, because it is 3rd-party (not bndtools org) and does not point to a specific commit SHA.

![image](https://github.com/user-attachments/assets/d5fb1253-3729-4b92-9a8b-6e3c7984b941)

@pkriens as discussed today