### PR TITLE
Fix Bnd Launcher with Java 24

### DIFF
--- a/biz.aQute.launcher/src/aQute/launcher/Launcher.java
+++ b/biz.aQute.launcher/src/aQute/launcher/Launcher.java
@@ -490,7 +490,12 @@ public class Launcher implements ServiceListener, FrameworkListener {
 
 	@SuppressWarnings("removal")
 	private int activate(String[] args) throws Exception {
-		java.security.Policy.setPolicy(new AllPolicy());
+		try {
+			java.security.Policy.setPolicy(new AllPolicy());
+		} catch (Throwable e) {
+			// ignore. Java 24 throws an Exception: Setting a
+			// system-wide Policy object is not supported
+		}
 
 		systemBundle = createFramework();
 		if (systemBundle == null)


### PR DESCRIPTION
Related to #6370
hope to fix a Java 24 build problem, where the Launcher isn't working with Java 24.

@pkriens is this something which should still go to 7.1.0 ?

And also: I added Java 23 temporarily to the build (Java 24 was not available in the Github actions... probably because it is still early access @timothyjward ). But maybe we already see something with JDK23. 

@scordio Are you able to test this fix in your build with Java 24 to see if it fixes your problem?
