### PR TITLE
Remove fixed bnd workspace problem markers from Problem view again

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
+++ b/bndtools.builder/src/org/bndtools/builder/CnfWatcher.java
@@ -79,6 +79,8 @@ public class CnfWatcher implements IResourceChangeListener {
 							MarkerSupport ms = new MarkerSupport(cnfProject);
 							ms.deleteMarkers("*");
 							ms.setMarkers(workspace, BndtoolsConstants.MARKER_BND_WORKSPACE_PROBLEM);
+							// clear errors/warnings, to avoid re-adding
+							workspace.clear();
 						} catch (Exception e) {
 							return new Status(IStatus.ERROR, BndtoolsBuilder.PLUGIN_ID,
 								"error during workspace refresh",


### PR DESCRIPTION
This fixes an annoyance, that Bndtools Workspace Problem Markers in `/cnf/build.bnd` where not removed from Eclipse's Problem-View, although you have fixed a problem. The reason was that model.getErrors() and model.getWarnings() used by org.bndtools.builder.MarkerSupport.setMarkers(Processor, String) where never cleared, so the errors and warnings where always re-added.

@pkriens we just talked about this today

## Example / Testing

1. Make a syntax error in `/cnf/build.bnd `
2. check Eclipse's Problem view that it creates an error marker of type `Bndtools Workspace Problem Marker`

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/9db8df3a-bcb0-4499-ab54-4ca5ca5fd374">

3. Now fix the syntax error.

Expected behavior:
- The marker should also be removed from Eclipse's Problem view

Actual behavior before fix:
- the marker stayed there (in fact it was deleted but re-added...but very quickly)