### PR TITLE
Add explicit dependencies to biz.aQute.bnd.maven

### DIFF
--- a/maven-plugins/bnd-baseline-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-baseline-maven-plugin/pom.xml
@@ -51,6 +51,10 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>biz.aQute.bndlib</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>biz.aQute.bnd.maven</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/maven-plugins/bnd-reporter-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-reporter-maven-plugin/pom.xml
@@ -60,7 +60,10 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>biz.aQute.bnd.reporter</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>biz.aQute.bnd.maven</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
It has shown that the invoker-test in this setup could pull in an outdated artifact if it is not declared as a *direct* dependency.

This adds an explicit dependency to biz.aQute.bnd.maven so we always use the current build version.

This was extracted from
- https://github.com/bndtools/bnd/pull/6362

as it actually do not belong to that change and is a configuration change only that can be merged independently.