### PR TITLE
Fix NPE

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,10 +31,13 @@ import aQute.bnd.osgi.Builder;
 import aQute.bnd.osgi.Clazz;
 import aQute.bnd.osgi.Constants;
 import aQute.bnd.osgi.Domain;
+import aQute.bnd.osgi.EmbeddedResource;
 import aQute.bnd.osgi.FileResource;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.osgi.Packages;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Resource;
+import aQute.bnd.osgi.metainf.MetaInfService;
 import aQute.lib.io.IO;
 
 class T0 {}
@@ -1413,6 +1417,35 @@ public class AnalyzerTest {
 				.getByFQN("com.foo") != null);
 			assertTrue(h.getExports()
 				.getByFQN("com.bar") != null);
+		}
+	}
+
+	@Test
+	public void testEmptyMetaInfServicesFolder() throws Exception {
+
+		Resource r = new EmbeddedResource("foo", 0L);
+		try (Jar jar = new Jar("test")) {
+			jar.putResource("META-INF/services/subfolder/", r);
+
+			Map<String, Resource> map = jar.getDirectories()
+				.getOrDefault("META-INF/services", Collections.emptyMap());
+
+			assertTrue(jar.getDirectories()
+				.containsKey("META-INF/services/subfolder"));
+			assertNotNull(jar.getDirectories()
+				.get("META-INF/services/subfolder"));
+			assertEquals(1, jar.getDirectories()
+				.get("META-INF/services/subfolder")
+				.size());
+
+			assertTrue(jar.getDirectories()
+				.containsKey("META-INF/services"));
+			assertNull(jar.getDirectories()
+				.get("META-INF/services"));
+
+			Map<String, MetaInfService> serviceFiles = MetaInfService.getServiceFiles(jar);
+			assertNotNull(serviceFiles);
+			assertTrue(serviceFiles.isEmpty());
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/metainf/MetaInfService.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/metainf/MetaInfService.java
@@ -60,6 +60,11 @@ public class MetaInfService {
 		Map<String, Resource> map = jar.getDirectories()
 			.getOrDefault(META_INF_SERVICES_STEM, Collections.emptyMap());
 
+		if (map == null) {
+			// can happen when META-INF/services is empty, but has subfolders
+			return result;
+		}
+
 		for (Map.Entry<String, Resource> e : map.entrySet()) {
 			String path = e.getKey();
 			Resource resource = e.getValue();


### PR DESCRIPTION
Closes #6387

Seems jar.getDirectories() can contain null values, if there is a jar with META-INF/services/subfolder, but META-INF/services itself does not contain any files. In this case the directories() map contains a key for "META-INF/services" but a null value (which is the map which is null here)