### PR TITLE
cnf change: prevent full build although 'Build automatically' is disabled

### DIFF
--- a/bndtools.core/src/bndtools/central/sync/WorkspaceChange.java
+++ b/bndtools.core/src/bndtools/central/sync/WorkspaceChange.java
@@ -49,6 +49,12 @@ public class WorkspaceChange {
 			if (cancel || monitor.isCanceled())
 				return Status.CANCEL_STATUS;
 
+			if (!ResourcesPlugin.getWorkspace()
+				.isAutoBuilding()) {
+				return Status.warning(
+					"[cnf change] Skip FULL build, because 'Build Automatically' is disabled.");
+			}
+
 			workspace.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
 		} catch (CoreException e) {
 			return Status.error("trying to build", e);

--- a/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
+++ b/bndtools.core/src/bndtools/explorer/BndtoolsExplorer.java
@@ -406,7 +406,8 @@ public class BndtoolsExplorer extends PackageExplorerPart {
 	}
 
 	private Action reloadAction() {
-		Action rebuild = new Action("Reload workspace", Icons.desc("refresh")) {
+		Action rebuild = new Action("Reload workspace (Rebuilds all projects if 'Build Automatically' is enabled)",
+			Icons.desc("refresh")) {
 			WorkspaceSynchronizer s;
 
 			@Override


### PR DESCRIPTION
This improves the DX in the following scenario:

When you edit any file inside the `cnf` folder like `/cnf/build.bnd` and you Save the file before this fix, a FULL build was always triggered (by `CnfWatcher.java`), even if `Project / Build Automatically` was disabled. (and such a build can take very long and can become anoying in cases where you need tweak build.bnd) 

Now a build is only triggered if `Build Automatically`  is **enabled**. This at least gives the developer a knob to disable the build-on-change behavior in cases where you work on the file and want to save it a few times along the way (without waiting for a build everytime)

![image](https://github.com/user-attachments/assets/92dbc84a-1862-40d1-8472-76dd952c3520)

A warning is written the Error Log to make it visible somewhere:

![image](https://github.com/user-attachments/assets/1f65c548-24b5-4548-89b1-6e9575462015)

**Note:** The "Reload Workspace" Button in the Bndtools Explorer is also affected by this change and does not  trigger a FULL build if _Build Automatically_ setting is disabled. This behavior is still handy as a "Reload Workspace without build" could still do some useful work like validation e.g. to add Problem markers.

The tooltip of the "Reload workspace" button now mentions the build behavior:

![image](https://github.com/user-attachments/assets/afc17fe8-66b4-4165-9c84-0c06fa8d26ad)
