### PR TITLE
init MavenImplicitProjectRepository again to fix resolving M2E Maven projects in non-bnd-workspaces

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
+import org.bndtools.api.RunMode;
 import org.bndtools.api.editor.IBndEditor;
 import org.bndtools.api.launch.LaunchConstants;
 import org.bndtools.core.jobs.JobUtil;
@@ -619,8 +620,12 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 			Processor p = workspace.readLocked(() -> workspace.findProcessor(inputFile)
 				.orElseGet(() -> {
 					try {
-						Bndrun bndrun = Bndrun.createBndrun(workspace, inputFile);
-						return bndrun;
+						if (inputResource != null) {
+							return LaunchUtils.createRun(inputResource, RunMode.EDIT);
+						} else {
+							return Bndrun.createBndrun(workspace, this.inputFile);
+						}
+
 					} catch (Exception e) {
 						throw Exceptions.duck(e);
 					}

--- a/bndtools.test/workspace2/.metadata/.plugins/org.eclipse.core.resources/.history/8d/f0559db362b5001f1aa89e1fa67986db
+++ b/bndtools.test/workspace2/.metadata/.plugins/org.eclipse.core.resources/.history/8d/f0559db362b5001f1aa89e1fa67986db
@@ -1,0 +1,5 @@
+-resolve.effective: active
+-runfw: org.eclipse.osgi;version='3.21.0'
+-runee: JavaSE-17
+-runrequires: bnd.identity;id='org.example.bndtools.bndrun.reproducer'
+-runbundles: org.example.bndtools.bndrun.reproducer;version='[1.0.0,1.0.1)'


### PR DESCRIPTION
Fixes #6393
in 7.0.0 `LaunchUtils.createRun()` was called which is responsible for creating an instance of `MavenImplicitProjectRepository` which is required for resolving bndrun in an m2e project. but it was removed in 7.1.0 for some reason. So in 7.1.0 `MavenImplicitProjectRepository` was never initialized, which seems to be the reason that the Maven Repositories which are show in the Repository Browser are not seen by the BndRunResolveContext.

With this PR resolving the reproducer from https://github.com/bndtools/bnd/issues/6393 works again. 

![image](https://github.com/user-attachments/assets/ef973b9c-7e55-4dd3-ab98-12559b94ccc3)


@pkriens I am not 100% what other effects this change might have. I just noticed the difference between 7.1.0 and 7.0.0.
and try to bring back the code from 7.0.0. Please have a look if this makes sense, or if some other logic is required. 
In my test it went into the if-branch which calls `LaunchUtils.createRun(inputResource, RunMode.EDIT);` (instead of `Bndrun.createBndrun(workspace, this.inputFile);`) and then resolving worked again (as per expected behavior in https://github.com/bndtools/bnd/issues/6393

**7.0.0.:**

https://github.com/bndtools/bnd/blob/b82dc867a7920edfcf32cb2cfa408795f4af6aea/bndtools.core/src/bndtools/editor/BndEditor.java#L617

**7.1.0:**
https://github.com/bndtools/bnd/blob/f9b2c857859dd3e46401f2f19aba4b09f308a16e/bndtools.core/src/bndtools/editor/BndEditor.java#L622


