### PR TITLE
first draft of Effective tab for BndEditor

### DIFF
--- a/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/PropertiesParser.java
@@ -2,7 +2,6 @@ package aQute.lib.utf8properties;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Properties;
 
 import aQute.lib.hex.Hex;
 import aQute.lib.strings.Strings;
@@ -40,18 +39,20 @@ final class PropertiesParser {
 		INFO['\\'] = NOKEY;
 	}
 
-	private int			n				= 0;
-	private int			line			= 0;
-	private int			pos				= -1;
-	private int			marker			= 0;
-	private char		current;
-	private Properties	properties;
-	private boolean		validKey;
-	private boolean		continuation	= true;
+	private int							n				= 0;
+	private int							line			= 0;
+	private int							pos				= -1;
+	private int							marker			= 0;
+	private char						current;
+	private UTF8Properties				properties;
+	private boolean						validKey;
+	private boolean						continuation	= true;
 	private final Collection<String>	syntaxHeaders;
+	private final String				provenance;
 
-	PropertiesParser(String source, String file, Reporter reporter, Properties properties,
-		Collection<String> syntaxHeaders) {
+	PropertiesParser(String source, String file, Reporter reporter, UTF8Properties properties,
+		Collection<String> syntaxHeaders, String provenance) {
+		this.provenance = provenance;
 		this.source = source.toCharArray();
 		this.file = file;
 		this.reporter = reporter;
@@ -154,7 +155,7 @@ final class PropertiesParser {
 				next();
 				skipWhitespace();
 				if (current == '\n') {
-					properties.put(key, "");
+					properties.setProperty(key, "", provenance);
 					continue;
 				}
 			}
@@ -162,11 +163,10 @@ final class PropertiesParser {
 			if (current != '\n') {
 
 				String value = token(LINE, isSyntaxHeader(key));
-				properties.put(key, value);
-
+				properties.setProperty(key, value, provenance);
 			} else {
 				error("No value specified for key: %s. An empty value should be specified as '%<s:' or '%<s='", key);
-				properties.put(key, "");
+				properties.setProperty(key, "", provenance);
 				continue;
 			}
 			assert current == '\n';

--- a/aQute.libg/src/aQute/lib/utf8properties/package-info.java
+++ b/aQute.libg/src/aQute/lib/utf8properties/package-info.java
@@ -1,4 +1,4 @@
-@Version("4.1.0")
+@Version("4.2.0")
 package aQute.lib.utf8properties;
 
 import org.osgi.annotation.versioning.Version;

--- a/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
+++ b/aQute.libg/test/aQute/lib/utf8properties/UTF8PropertiesTest.java
@@ -405,6 +405,41 @@ public class UTF8PropertiesTest {
 		assertThat(p1).containsExactlyInAnyOrderEntriesOf(p);
 	}
 
+	@Test
+	public void testProvenance() throws IOException {
+		UTF8Properties a = new UTF8Properties();
+		a.load("""
+			a.a = 1
+			a.b = 2
+			x = 0
+			""", null, null, null, "from_a");
+		UTF8Properties b = new UTF8Properties();
+		b.load("""
+			b.a = 1
+			b.c = 3
+			x = 0
+			""", null, null, null, "from_b");
+
+		assertThat(a.getProvenance("x")).isPresent()
+			.get()
+			.isEqualTo("from_a");
+		assertThat(b.getProvenance("x")).isPresent()
+			.get()
+			.isEqualTo("from_b");
+		assertThat(a.getProvenance("y")).isNotPresent();
+
+		a.load(b, true);
+		assertThat(a.getProvenance("x")).isPresent()
+			.get()
+			.isEqualTo("from_b");
+		assertThat(a.getProvenance("a.a")).isPresent()
+			.get()
+			.isEqualTo("from_a");
+		assertThat(a.getProvenance("b.a")).isPresent()
+			.get()
+			.isEqualTo("from_b");
+	}
+
 	private void testProperty(String content, String key, String value) throws IOException {
 		testProperty(content, key, value, null);
 	}

--- a/biz.aQute.bndlib.tests/testresources/provenance/bnd.bnd
+++ b/biz.aQute.bndlib.tests/testresources/provenance/bnd.bnd
@@ -1,0 +1,2 @@
+-include a/sup.bnd,~a/inf.bnd
+ 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/MagicBnd.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/MagicBnd.java
@@ -25,6 +25,7 @@ import javax.xml.stream.XMLStreamReader;
 import aQute.bnd.result.Result;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
+import aQute.lib.utf8properties.UTF8Properties;
 import aQute.libg.re.Catalog;
 import aQute.libg.re.RE;
 import aQute.libg.re.RE.Match;
@@ -77,8 +78,8 @@ public class MagicBnd {
 				.append("'");
 		}
 
-		Properties p = new Properties();
-		p.put("-plugin.ext." + file.getName(), sb.toString());
+		UTF8Properties p = new UTF8Properties();
+		p.setProperty("-plugin.ext." + file.getName(), sb.toString(), file.getAbsolutePath());
 		return Result.ok(p);
 	}
 
@@ -163,8 +164,8 @@ public class MagicBnd {
 				.collect(Collectors.joining()))
 			.append("'");
 
-		Properties p = new Properties();
-		p.put("-plugin.ext." + file.getName(), sb.toString());
+		UTF8Properties p = new UTF8Properties();
+		p.setProperty("-plugin.ext." + file.getName(), sb.toString(), file.getAbsolutePath());
 		return Result.ok(p);
 	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -324,7 +324,7 @@ public class Project extends Processor {
 
 				// We use a builder to construct all the properties for
 				// use.
-				setProperty("basedir", basePath);
+				setProperty("basedir", basePath, "[project]");
 
 				// If a bnd.bnd file exists, we read it.
 				// Otherwise, we just do the build properties.

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -1580,14 +1580,33 @@ public class BndEditModel {
 
 	@SuppressWarnings("unchecked")
 	public static <T> String format(String header, String input) {
-		Converter<T, String> converter = (Converter<T, String>) converters.get(header);
+		Converter<T, String> converter = getConverter(converters, header);
 		if (converter == null)
 			return input;
 
 		T converted = converter.convert(input);
 
-		Converter<String, T> formatter = (Converter<String, T>) formatters.get(header);
+		Converter<String, T> formatter = getConverter(formatters, header);
 		return formatter.convert(converted);
+	}
+
+	@SuppressWarnings({
+		"unchecked", "rawtypes"
+	})
+	private static Converter getConverter(Map converters, String header) {
+		String stem = getStem(header);
+		if (Constants.MERGED_HEADERS.contains(stem)) {
+			return (Converter) converters.get(stem);
+		} else
+			return (Converter) converters.get(header);
+	}
+
+	private static String getStem(String header) {
+		int n = header.indexOf('.');
+		if (n < 0)
+			return header;
+
+		return header.substring(0, n);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -1656,7 +1675,8 @@ public class BndEditModel {
 	}
 
 	/**
-	 * Return if this model is handling effective properties (and this read only) or actual document properties.
+	 * Return if this model is handling effective properties (and this read
+	 * only) or actual document properties.
 	 */
 
 	public boolean isEffective() {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("4.6.0")
+@Version("4.7.0")
 package aQute.bnd.build;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/maven/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.5.0")
+@Version("3.6.0")
 package aQute.bnd.maven;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -523,15 +523,13 @@ public interface Constants {
 	 * Headers that if **all** are absent will trigger the -includepackage
 	 * `*;from:=project` (include all packages from the project's output.
 	 */
-	Set<String>	EXPAND_HEADERS							= Sets.of(
-		Constants.RESOURCEONLY, Constants.INCLUDEPACKAGE, Constants.PRIVATE_PACKAGE, Constants.PRIVATEPACKAGE,
-		Constants.EXPORT_PACKAGE
-	);
+	Set<String>	EXPAND_HEADERS								= Sets.of(Constants.RESOURCEONLY, Constants.INCLUDEPACKAGE,
+		Constants.PRIVATE_PACKAGE, Constants.PRIVATEPACKAGE, Constants.EXPORT_PACKAGE);
 
 	/**
 	 * Marker resource set by the ProjectBuilder to mark a JAR as the project
-	 * output's entry in the classpath. Used for the
-	 * {@link #EXPAND_HEADERS} processing.
+	 * output's entry in the classpath. Used for the {@link #EXPAND_HEADERS}
+	 * processing.
 	 */
 	String		PROJECT_MARKER								= "META-INF/.project";
 
@@ -580,7 +578,6 @@ public interface Constants {
 	String		SERVICELOADER_REGISTER_DIRECTIVE			= "register:";
 	String		SERVICELOADER_NAMESPACE						= "osgi.serviceloader";
 
-
 	/**
 	 * Launch constants that should be shared by launchers
 	 */
@@ -601,6 +598,58 @@ public interface Constants {
 	String		LAUNCH_ACTIVATION_EAGER						= "launch.activation.eager";
 
 	/**
+	 * A list of headers that use merged properties
+	 */
+	Set<String>	MERGED_HEADERS								= Set.of(																																								//
+		AUGMENT,																																																					//
+		BUILDERIGNORE,																																																				//
+		BUILDREPO,																																																					//
+		BUILDPATH,																																																					//
+		CONDITIONAL_PACKAGE,																																																		//
+		CONNECTION_SETTINGS,																																																		//
+		DEFINE_CONTRACT,																																																			//
+		DEFAULT_PROP_SRC_DIR,																																																		//
+		DEPENDSON,																																																					//
+		DONOTCOPY,																																																					//
+		DSANNOTATIONS_OPTIONS,																																																		//
+		EXPORT_PACKAGE,																																																				//
+		EXTENSION,																																																					//
+		FIXUPMESSAGES,																																																				//
+		GESTALT,																																																					//
+		IMPORT_PACKAGE,																																																				//
+		INCLUDERESOURCE,																																																			//
+		MAKE,																																																						//
+		MAVEN_DEPENDENCIES,																																																			//
+		PLUGIN,																																																						//
+		PLUGINPATH,																																																					//
+		PREPROCESSMATCHERS,																																																			//
+		PRIVATE_PACKAGE,																																																			//
+		PROVIDE_CAPABILITY,																																																			//
+		RELEASEREPO,																																																				//
+		REMOVEHEADERS,																																																				//
+		REQUIRE_CAPABILITY,																																																			//
+		RESOLVE_REJECT,																																																				//
+		RUNBLACKLIST,																																																				//
+		RUNBUNDLES,																																																					//
+		RUNBUNDLES_DECORATOR,																																																		//
+		RUNPATH,																																																					//
+		RUNPROGRAMARGS,																																																				//
+		RUNPROPERTIES,																																																				//
+		RUNPROVIDEDCAPABILITIES,																																																	//
+		RUNREPOS,																																																					//
+		RUNREQUIRES,																																																				//
+		RUNSYSTEMCAPABILITIES,																																																		//
+		RUNSYSTEMPACKAGES,																																																			//
+		RUNVM,																																																						//
+		SOURCEPATH,																																																					//
+		STANDALONE,																																																					//
+		SYSTEMPROPERTIES,																																																			//
+		TESTPACKAGES,																																																				//
+		TESTPATH,																																																					//
+		WORKINGSET,																																																					//
+		"-pomaugment");
+
+	/**
 	 * Any attributes that should be removed from the attributes before
 	 * printing.
 	 */
@@ -614,8 +663,6 @@ public interface Constants {
 	);
 
 	String		INTERNAL_PREFIX								= "-internal-";
-
-
 
 	/*
 	 * Deprecated Section

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
@@ -1,4 +1,4 @@
-@Version("7.3.0")
+@Version("7.5.0")
 package aQute.bnd.osgi;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/repository/package-info.java
@@ -1,6 +1,6 @@
 /**
  */
-@Version("3.2.0")
+@Version("3.3.0")
 package aQute.bnd.osgi.repository;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/print/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.2.0")
+@Version("2.3.0")
 package aQute.bnd.print;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/service/generate/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.2.0")
+@org.osgi.annotation.versioning.Version("2.3.0")
 package aQute.bnd.service.generate;

--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -109,6 +109,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	public static final String					WORKSPACE_EDITOR	= "bndtools.bndWorkspaceConfigEditor";
 
 	public static final String					SOURCE_PAGE			= "__source_page";
+	public static final String					SOURCE_PAGE_EFFECTIVE	= "__source_page_effective";
 
 	public static final String					CONTENT_PAGE		= "__content_page";
 	public static final String					WORKSPACE_PAGE		= "__workspace_page";
@@ -126,6 +127,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	private final static Image					buildFileImg		= Icons.image("icons/bndtools-logo-16x16.png");
 
 	private BndSourceEditorPage					sourcePage;
+	private BndSourceEffectivePage				sourcePageEffective;
 	private Promise<Workspace>					modelReady;
 
 	private IResource							inputResource;
@@ -150,6 +152,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 			requiredPageIds.addAll(getPagesBnd(path));
 		}
 		requiredPageIds.add(SOURCE_PAGE);
+		requiredPageIds.add(SOURCE_PAGE_EFFECTIVE);
 
 		// Remove pages no longer required and remember the rest in a map
 		int i = 0;
@@ -167,8 +170,13 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 		// Cache new pages
 		for (String pageId : requiredPageIds) {
 			if (!pageCache.containsKey(pageId)) {
-				IFormPage page = SOURCE_PAGE.equals(pageId) ? sourcePage
-					: pageFactories.get(pageId)
+				IFormPage page;
+				if (SOURCE_PAGE.equals(pageId))
+					page = sourcePage;
+				else if (SOURCE_PAGE_EFFECTIVE.equals(pageId))
+					page = sourcePageEffective;
+				else
+					page = pageFactories.get(pageId)
 						.createPage(this, model, pageId);
 				pageCache.put(pageId, page);
 			}
@@ -184,6 +192,8 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 				if (existingPointer >= getPageCount()) {
 					if (SOURCE_PAGE.equals(requiredId))
 						addPage(sourcePage, getEditorInput());
+					else if (SOURCE_PAGE_EFFECTIVE.equals(requiredId))
+						addPage(sourcePageEffective, getEditorInput());
 					else
 						addPage(pageCache.get(requiredId));
 				} else {
@@ -191,6 +201,8 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 					if (!requiredId.equals(existingPage.getId())) {
 						if (SOURCE_PAGE.equals(requiredId))
 							addPage(existingPointer, sourcePage, getEditorInput());
+						else if (SOURCE_PAGE_EFFECTIVE.equals(requiredId))
+							addPage(existingPointer, sourcePageEffective, getEditorInput());
 						else
 							addPage(existingPointer, pageCache.get(requiredId));
 					}
@@ -204,6 +216,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 
 		// Set the source page title
 		setPageText(sourcePage.getIndex(), "Source");
+		setPageText(sourcePageEffective.getIndex(), "Effective");
 
 	}
 
@@ -224,6 +237,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	private final AtomicBoolean	saving	= new AtomicBoolean(false);
 	private IHandlerActivation	resolveHandlerActivation;
 	private JobChangeAdapter	resolveJobListener;
+
 
 	/*
 	 * (non-Javadoc)
@@ -255,6 +269,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	public void commitDirtyPages() {
 		if (sourcePage.isActive() && sourcePage.isDirty()) {
 			sourcePage.commit(true);
+			sourcePageEffective.setInput(this.model);
 		} else {
 			commitPages(true);
 			sourcePage.refresh();
@@ -677,6 +692,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 	private void initPages(IEditorSite site, IEditorInput input) throws PartInitException {
 		// Initialise pages
 		sourcePage = new BndSourceEditorPage(SOURCE_PAGE, this);
+		sourcePageEffective = new BndSourceEffectivePage(this, SOURCE_PAGE_EFFECTIVE, "Effective");
 		pageFactories.put(WORKSPACE_PAGE, WorkspacePage.MAIN_FACTORY);
 		pageFactories.put(WORKSPACE_EXT_PAGE, WorkspacePage.EXT_FACTORY);
 		pageFactories.put(CONTENT_PAGE, BundleContentPage.FACTORY);
@@ -700,6 +716,8 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 			}
 		sourcePage.init(site, input);
 		sourcePage.initialize(this);
+		sourcePageEffective.init(site, input);
+		sourcePageEffective.initialize(this);
 	}
 
 	private void setPartNameForInput(IEditorInput input) {
@@ -784,6 +802,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 					SWTConcurrencyUtil.execForDisplay(display, true, () -> {
 						setPartNameForInput(newInput);
 						sourcePage.setInput(newInput);
+						sourcePageEffective.setInput(this.model);
 					});
 				}
 			} else {

--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -151,8 +151,8 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 		} else {
 			requiredPageIds.addAll(getPagesBnd(path));
 		}
-		requiredPageIds.add(SOURCE_PAGE);
 		requiredPageIds.add(SOURCE_PAGE_EFFECTIVE);
+		requiredPageIds.add(SOURCE_PAGE);
 
 		// Remove pages no longer required and remember the rest in a map
 		int i = 0;

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -102,7 +102,7 @@ public class BndSourceEffectivePage extends FormPage {
 		body.setLayout(new GridLayout(1, false));
 
 		// Create toggle button
-		toggleButton = toolkit.createButton(body, "Toggle View", SWT.PUSH);
+		toggleButton = toolkit.createButton(body, "Show as Source", SWT.PUSH);
 		toggleButton.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
 		// Create composite for viewers
@@ -123,7 +123,7 @@ public class BndSourceEffectivePage extends FormPage {
 		createTableViewer(managedForm, viewersComposite);
 
 		// Set initial view
-		stackLayout.topControl = sourceViewer.getControl();
+		stackLayout.topControl = tableViewer.getControl();
 
 		// Add toggle button listener
 		toggleButton.addSelectionListener(new SelectionAdapter() {
@@ -131,10 +131,10 @@ public class BndSourceEffectivePage extends FormPage {
 			public void widgetSelected(SelectionEvent e) {
 				if (stackLayout.topControl == sourceViewer.getControl()) {
 					stackLayout.topControl = tableViewer.getControl();
-					toggleButton.setText("Show Source");
+					toggleButton.setText("Show as Source");
 				} else {
 					stackLayout.topControl = sourceViewer.getControl();
-					toggleButton.setText("Show Table");
+					toggleButton.setText("Show as Table");
 				}
 				viewersComposite.layout();
 			}

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -20,6 +20,7 @@ import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
@@ -76,6 +77,34 @@ public class BndSourceEffectivePage extends FormPage {
 		Composite body = form.getBody();
 		body.setLayout(new FillLayout());
 
+		// Create a SashForm for horizontal resizing
+		SashForm sashForm = new SashForm(body, SWT.HORIZONTAL);
+		sashForm.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		createSourceViewer(managedForm, sashForm);
+		createTableViewer(managedForm, sashForm);
+
+		// Set the initial weights so each section takes half the space
+		sashForm.setWeights(new int[] {
+			1, 1
+		});
+
+	}
+
+	private void createSourceViewer(IManagedForm managedForm, Composite body) {
+
+		Section section = managedForm.getToolkit()
+			.createSection(body, Section.TITLE_BAR | Section.EXPANDED);
+		section.setText("Effective Source");
+		section.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		Composite sectionClient = managedForm.getToolkit()
+			.createComposite(section, SWT.NONE);
+		sectionClient.setLayout(new org.eclipse.swt.layout.GridLayout(1, false));
+		managedForm.getToolkit()
+			.paintBordersFor(sectionClient);
+		section.setClient(sectionClient);
+
 		// ruler for line numbers
 		CompositeRuler ruler = new CompositeRuler();
 		LineNumberRulerColumn ln = new LineNumberRulerColumn();
@@ -83,13 +112,15 @@ public class BndSourceEffectivePage extends FormPage {
 			.getSystemColor(SWT.COLOR_DARK_GRAY));
 		ruler.addDecorator(0, ln);
 
-		this.viewer = new SourceViewer(body, ruler, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL) {
+		this.viewer = new SourceViewer(sectionClient, ruler, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL) {
 			@Override
 			protected boolean canPerformFind() {
 				return true;
 			}
 		};
 		viewer.setDocument(new Document());
+		viewer.getControl()
+			.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		viewer.configure(new BndSourceViewerConfiguration(bndEditor, JavaUI.getColorManager()));
 		styledText = viewer.getTextWidget();
 		styledText.setEditable(false);
@@ -97,7 +128,11 @@ public class BndSourceEffectivePage extends FormPage {
 
 		activateFindAndReplace(viewer, getSite(), this);
 
-		// Table
+		// Force layout to update
+		sectionClient.layout(true, true);
+	}
+
+	private void createTableViewer(IManagedForm managedForm, Composite body) {
 		Section section = managedForm.getToolkit()
 			.createSection(body, Section.TITLE_BAR | Section.EXPANDED);
 		section.setText("Sortable Table");
@@ -110,8 +145,9 @@ public class BndSourceEffectivePage extends FormPage {
 			.paintBordersFor(sectionClient);
 		section.setClient(sectionClient);
 
-		tableViewer = new TableViewer(sectionClient,
+		this.tableViewer = new TableViewer(sectionClient,
 			SWT.BORDER | SWT.FULL_SELECTION | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
+
 		Table table = tableViewer.getTable();
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
@@ -121,7 +157,10 @@ public class BndSourceEffectivePage extends FormPage {
 		tableViewer.setContentProvider(ArrayContentProvider.getInstance());
 		tableViewer.setInput(getTableData());
 
+		// Force layout to update
+		sectionClient.layout(true, true);
 	}
+
 
 	/**
 	 * Setup Eclipse's built in Search / Replace dialog. Also see

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -395,13 +395,17 @@ public class BndSourceEffectivePage extends FormPage {
 		try {
 
 			Processor p = new BndEditModel(editModel, true).getProperties();
-			// Set<String> propertyKeys = p.getPropertyKeys(true);
 			List<PropertyKey> propertyKeys = p.getPropertyKeys(k -> true);
 
-			Object[] result = new Object[propertyKeys.size()];
+			// avoid duplicates because Project is parent of bnd.bnd and also
+			// gets the same properties
+			// but with higher floor
+			List<PropertyKey> visible = PropertyKey.findVisible(propertyKeys);
+
+			Object[] result = new Object[visible.size()];
 			int index = 0;
 
-			for (PropertyKey prop : propertyKeys) {
+			for (PropertyKey prop : visible) {
 				String key = prop.key();
 				String value = p.getProperty(key);
 				String path = "";

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -1,0 +1,200 @@
+package bndtools.editor;
+
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IFindReplaceTarget;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.source.CompositeRuler;
+import org.eclipse.jface.text.source.LineNumberRulerColumn;
+import org.eclipse.jface.text.source.SourceViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.forms.IManagedForm;
+import org.eclipse.ui.forms.editor.FormEditor;
+import org.eclipse.ui.forms.editor.FormPage;
+import org.eclipse.ui.forms.widgets.Form;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.eclipse.ui.forms.widgets.ScrolledForm;
+import org.eclipse.ui.handlers.IHandlerService;
+import org.eclipse.ui.texteditor.FindReplaceAction;
+
+import aQute.bnd.build.model.BndEditModel;
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.osgi.Processor;
+import bndtools.editor.completion.BndSourceViewerConfiguration;
+
+/**
+ * The 'Effective source' tab in a Bnd Editor which renders an effective
+ * readonly view of all properties of the BndEditModel. This means that it shows
+ * all available properties which are pulled in via various include-mechanisms.
+ * This it is a useful debugging tool to make things visible to the human eye.
+ */
+public class BndSourceEffectivePage extends FormPage {
+
+
+	private final BndEditor		bndEditor;
+	private BndEditModel	editModel;
+	private SourceViewer	viewer;
+	private StyledText	styledText;
+	private boolean		loading;
+
+	public BndSourceEffectivePage(FormEditor formEditor, String id, String title) {
+		super(formEditor, id, title);
+		this.bndEditor = ((BndEditor) formEditor);
+		this.editModel = bndEditor.getModel();
+	}
+
+	@Override
+	protected void createFormContent(IManagedForm managedForm) {
+		FormToolkit toolkit = managedForm.getToolkit();
+		ScrolledForm scrolledForm = managedForm.getForm();
+		Form form = scrolledForm.getForm();
+		toolkit.setBorderStyle(SWT.NULL);
+
+		Composite body = form.getBody();
+		body.setLayout(new FillLayout());
+
+		// ruler for line numbers
+		CompositeRuler ruler = new CompositeRuler();
+		LineNumberRulerColumn ln = new LineNumberRulerColumn();
+		ln.setForeground(Display.getCurrent()
+			.getSystemColor(SWT.COLOR_DARK_GRAY));
+		ruler.addDecorator(0, ln);
+
+		this.viewer = new SourceViewer(body, ruler, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL) {
+			@Override
+			protected boolean canPerformFind() {
+				return true;
+			}
+		};
+		viewer.setDocument(new Document());
+		viewer.configure(new BndSourceViewerConfiguration(bndEditor, JavaUI.getColorManager()));
+		styledText = viewer.getTextWidget();
+		styledText.setEditable(false);
+		styledText.setFont(JFaceResources.getTextFont());
+
+		activateFindAndReplace(viewer, getSite(), this);
+
+
+	}
+
+	/**
+	 * Setup Eclipse's built in Search / Replace dialog. Also see
+	 * {@link #getAdapter(Class)}
+	 *
+	 * @param textViewer
+	 * @param site
+	 * @param page
+	 */
+	private static void activateFindAndReplace(TextViewer textViewer, IWorkbenchPartSite site,
+		IWorkbenchPart page) {
+		FindReplaceAction findReplaceAction = new FindReplaceAction(
+			ResourceBundle.getBundle("org.eclipse.ui.texteditor.ConstructedEditorMessages"), "Editor.FindReplace.",
+			page);
+		IHandlerService handlerService = site.getService(IHandlerService.class);
+		IHandler handler = new AbstractHandler() {
+
+			@Override
+			public Object execute(ExecutionEvent event) throws ExecutionException {
+				if (textViewer != null && textViewer.getDocument() != null) {
+					findReplaceAction.run();
+				}
+				return null;
+			}
+		};
+
+		handlerService.activateHandler("org.eclipse.ui.edit.findReplace", handler);
+	}
+
+
+	@Override
+	public boolean isEditor() {
+		return true;
+	}
+
+	@Override
+	public void setActive(boolean active) {
+		super.setActive(active);
+
+		IActionBars actionBars = getEditorSite().getActionBars();
+
+		if (active) {
+			update();
+		} else {
+		}
+	}
+
+	private static String print(BndEditModel model) throws Exception {
+		if (model == null) {
+			return "...";
+		}
+
+		try {
+			StringBuilder sb = new StringBuilder();
+
+			Processor p = new BndEditModel(model, true).getProperties();
+			Set<String> propertyKeys = p.getPropertyKeys(true);
+			for (String k : propertyKeys) {
+
+				String value = p.getProperty(k);
+				sb.append(k)
+					.append(": ")
+					.append(value)
+					.append("\n");
+			}
+
+			return sb.toString();
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+
+	}
+
+
+	private void update() {
+		if (loading || styledText == null || !isActive()) {
+			return;
+		}
+		loading = true;
+		try {
+			String text = print(editModel);
+			viewer.setDocument(new Document(text));
+			styledText.setFocus();
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+
+	}
+
+	public void setInput(BndEditModel model) {
+		this.editModel = model;
+		loading = false;
+		update();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (IFindReplaceTarget.class.equals(adapter)) {
+			// needed for find/replace via CMD+F / Ctrl+F
+			return (T) viewer.getFindReplaceTarget();
+		}
+		return super.getAdapter(adapter);
+	}
+
+
+}

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -394,12 +394,6 @@ public class BndSourceEffectivePage extends FormPage {
 						return path;
 					}
 
-					if (path.equals(prop.processor()
-						.getBase()
-						.getPath())) {
-						return "-same-";
-					}
-
 					// cut the beginning to get only e.g. /cnf/build.bnd instead
 					// of absolute path
 					return path.replaceAll(prop.processor()
@@ -418,16 +412,11 @@ public class BndSourceEffectivePage extends FormPage {
 
 	private String getPropertyKeyPath(PropertyKey prop) {
 		String path = "";
-		if (!prop.isLocalTo(editModel.getOwner())) {
-			File propertiesFile = prop.processor()
-				.getPropertiesFile();
-			if (propertiesFile != null) {
-				path = propertiesFile.getPath();
-				// .replaceAll(prop.processor()
-				// .getBase()
-				// .getPath(), "")
-				// .substring(1);
-			}
+
+		File propertiesFile = prop.processor()
+			.getPropertiesFile();
+		if (propertiesFile != null) {
+			path = propertiesFile.getPath();
 		}
 		return path;
 	}

--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -1,5 +1,7 @@
 package bndtools.editor;
 
+import java.io.File;
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
@@ -43,6 +45,7 @@ import org.eclipse.ui.texteditor.FindReplaceAction;
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Processor.PropertyKey;
 import bndtools.editor.completion.BndSourceViewerConfiguration;
 
 /**
@@ -71,6 +74,9 @@ public class BndSourceEffectivePage extends FormPage {
 	protected void createFormContent(IManagedForm managedForm) {
 		FormToolkit toolkit = managedForm.getToolkit();
 		ScrolledForm scrolledForm = managedForm.getForm();
+		scrolledForm.setExpandHorizontal(true);
+		scrolledForm.setExpandVertical(true);
+
 		Form form = scrolledForm.getForm();
 		toolkit.setBorderStyle(SWT.NULL);
 
@@ -128,8 +134,6 @@ public class BndSourceEffectivePage extends FormPage {
 
 		activateFindAndReplace(viewer, getSite(), this);
 
-		// Force layout to update
-		sectionClient.layout(true, true);
 	}
 
 	private void createTableViewer(IManagedForm managedForm, Composite body) {
@@ -157,8 +161,6 @@ public class BndSourceEffectivePage extends FormPage {
 		tableViewer.setContentProvider(ArrayContentProvider.getInstance());
 		tableViewer.setInput(getTableData());
 
-		// Force layout to update
-		sectionClient.layout(true, true);
 	}
 
 
@@ -269,10 +271,10 @@ public class BndSourceEffectivePage extends FormPage {
 	// Table
 	private void createColumns() {
 		String[] titles = {
-			"key", "value"
+			"key", "value", "path"
 		};
 		int[] bounds = {
-			100, 100
+			100, 200, 200
 		};
 
 		for (int i = 0; i < titles.length; i++) {
@@ -318,15 +320,26 @@ public class BndSourceEffectivePage extends FormPage {
 		try {
 
 			Processor p = new BndEditModel(editModel, true).getProperties();
-			Set<String> propertyKeys = p.getPropertyKeys(true);
+			// Set<String> propertyKeys = p.getPropertyKeys(true);
+			List<PropertyKey> propertyKeys = p.getPropertyKeys(k -> true);
 
 			Object[] result = new Object[propertyKeys.size()];
 			int index = 0;
 
-			for (String key : propertyKeys) {
+			for (PropertyKey prop : propertyKeys) {
+				String key = prop.key();
 				String value = p.getProperty(key);
+				String path = "";
+				if (!prop.isLocalTo(p)) {
+					File propertiesFile = prop.processor()
+						.getPropertiesFile();
+					if (propertiesFile != null) {
+						path = propertiesFile.getAbsolutePath();
+
+					}
+				}
 				result[index] = new String[] {
-					key, value
+					key, value, path
 				};
 				index++;
 			}

--- a/bndtools.core/src/org/bndtools/core/ui/ExtendedFormEditor.java
+++ b/bndtools.core/src/org/bndtools/core/ui/ExtendedFormEditor.java
@@ -21,7 +21,6 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public abstract class ExtendedFormEditor extends FormEditor {
 
 	private ITextEditor		sourcePage;
-
 	private ImageDescriptor	baseImageDescriptor;
 	private Image			titleImage;
 
@@ -115,5 +114,6 @@ public abstract class ExtendedFormEditor extends FormEditor {
 	protected void setSourcePage(ITextEditor sourcePage) {
 		this.sourcePage = sourcePage;
 	}
+
 
 }


### PR DESCRIPTION
adds a first draft of an readonly "Effective Source view" of a Bnd Editor based on comment https://github.com/bndtools/bnd/pull/6401#issuecomment-2540856340

> It shows you all the effective properties with inheritance and includes.

- supports find text via CMD+F
- add Syntax highlighting (same as Source view)

![image](https://github.com/user-attachments/assets/09b63bfa-6768-4c5e-8b22-d4085b98e200)

This is a nice additional debugging tool, because it makes things visible to the human eye, which were previously hidden. 

Comment about code: I reused some code of the JarEditor (JarPrintPage.java) and added search-dialog and syntax highlighting. Sorry if this is not state-of-the-art Eclipse JFace code.