### PR TITLE
Docs: add anchor links to all headlines

### DIFF
--- a/docs/_includes/footer.htm
+++ b/docs/_includes/footer.htm
@@ -9,4 +9,26 @@
 				<li><a href="{{ "/" | prepend:site.baseurl }}">Home</a>
 			</ul>
 	</ul>
+
+	<script type="text/javascript">
+		document.addEventListener('DOMContentLoaded', () => {
+			const headers = document.querySelectorAll('h1[id], h2[id], h3[id], h4[id]');
+
+			headers.forEach(header => {
+				const iconLink = document.createElement('a');
+				iconLink.href = `#${header.id}`;
+				iconLink.innerHTML = '#';
+				iconLink.className = 'header-link';
+
+				// Wrap the icon inside a span to control visibility with CSS
+				const wrapper = document.createElement('span');
+				wrapper.className = 'header-link-wrapper';
+				wrapper.appendChild(iconLink);
+
+				// Append the wrapper to the header
+				header.appendChild(wrapper);
+			});
+		});
+	</script>
+
 </footer>

--- a/docs/css/style.scss
+++ b/docs/css/style.scss
@@ -201,3 +201,20 @@ ul .side-nav-section{
 pre.highlight {
   overflow: auto;
 }
+
+.header-link-wrapper{
+  visibility: hidden;
+  margin-left: 2px;
+  padding-left: 2px;
+}
+/* Show the icon link on hover */
+h1:hover .header-link-wrapper,
+h2:hover .header-link-wrapper,
+h3:hover .header-link-wrapper,
+h4:hover .header-link-wrapper {
+  visibility: visible;
+}
+.header-link{
+  color:#ccc !important
+}
+


### PR DESCRIPTION
this makes it easier to send a link to a specific section to somebody. just hover over the headline and click on the little '#' symbol. now copy&paste the URL in the browser which contains the #anchor to this section.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/5d4c2652-67a9-4e72-8813-e66f45ac295f" />
