### PR TITLE
conditonalpackage missed classes added by plugins, like Blueprint.

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
@@ -48,7 +48,6 @@ class T3 extends T2 {}
 public class AnalyzerTest {
 	static File cwd = new File(System.getProperty("user.dir"));
 
-
 	/**
 	 * Verify that the manifest overrides a version in a package info
 	 */
@@ -314,6 +313,32 @@ public class AnalyzerTest {
 				"((, )?(org.osgi.service.event|org.osgi.service.component|org.osgi.service.http|org.osgi.service.log|org.osgi.service.condpermadmin|org.osgi.service.wireadmin|org.osgi.service.device)){7,7}"));
 		} finally {
 			b.close();
+		}
+	}
+
+	/**
+	 * Check if bnd handles blueprint
+	 */
+
+	@Test
+	public void testBlueprintReferences() throws Exception {
+		try (Builder b = new Builder()) {
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setIncludeResource(
+				"""
+					OSGI-INF/blueprint/blueprint.xml;literal='<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+						xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+						xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+						<bean id="fw" class="org.osgi.framework.Framework"/>
+						<bean id="ea" class="org.osgi.service.event.EventAdmin" factory-method="newBuilder"/>
+					</blueprint>'""");
+			b.setConditionalPackage("org.osgi.*");
+			b.setProperty("-plugin", "aQute.lib.spring.SpringXMLType");
+			Jar jar = b.build();
+			assertTrue(b.check());
+			assertThat(jar.getResources()).containsKey("org/osgi/service/event/packageinfo");
+			assertThat(jar.getResources()).containsKey("org/osgi/framework/packageinfo");
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -220,6 +220,10 @@ public class Analyzer extends Processor {
 
 			doPlugins();
 
+			// Conditional packages
+
+			doConditionalPackages();
+
 			//
 			// calculate class versions in use
 			//
@@ -476,9 +480,6 @@ public class Analyzer extends Processor {
 			logger.debug("activator {} {}", s, activator);
 		}
 
-		// Conditional packages
-
-		doConditionalPackages();
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #6408. The conditional package has been moved _after_ the plugin processing. This felt dangerous but no test failed. We need to keep a close eye on this however.

---
 Signed-off-by: github-actions <github-actions@bndtools.org>