### PR TITLE
Whitespace after the quote character is skipped

### DIFF
--- a/aQute.libg/src/aQute/lib/json/JSONCodec.java
+++ b/aQute.libg/src/aQute/lib/json/JSONCodec.java
@@ -390,7 +390,7 @@ public class JSONCodec {
 		char quote = (char) r.current();
 		assert r.current() == '"' || (promiscuous && r.current == '\'');
 
-		int c = r.next(); // skip first "
+		int c = r.read(); // skip first "
 
 		StringBuilder sb = new StringBuilder();
 		while (c != quote) {


### PR DESCRIPTION
The parseString method skips whitespace after the " or ' character. This is obviously wrong. next() was called instead of read to 'eat' the quote character


---
 Signed-off-by: github-actions <github-actions@bndtools.org>