### PR TITLE
Improve mvn refetch after cacheclear

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -33,7 +33,7 @@ import aQute.maven.api.Revision;
 
 class RepoActions {
 
-	private MavenBndRepository repo;
+	private MavenBndRepository	repo;
 	private MbrUpdater			mbr;
 
 	RepoActions(MavenBndRepository mavenBndRepository) {
@@ -84,6 +84,23 @@ class RepoActions {
 
 	Map<String, Runnable> getRevisionActions(final Archive archive, final Clipboard clipboard) throws Exception {
 		Map<String, Runnable> map = new LinkedHashMap<>();
+
+		map.put("Refresh Cache (re-download)", () -> {
+
+			File dir = repo.storage.toLocalFile(archive)
+				.getParentFile();
+			IO.delete(dir);
+
+			try {
+				// try re-download
+				Promise<File> promise = repo.storage.get(archive, true);
+				promise.getValue();
+
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+
+		});
 		map.put("Clear from Cache", () -> {
 			File dir = repo.storage.toLocalFile(archive)
 				.getParentFile();

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleVersion.java
@@ -74,6 +74,7 @@ public class RepositoryBundleVersion extends RepositoryEntry implements Actionab
 				map = ((Actionable) bundle.getRepo()).actions(bundle.getBsn(), version);
 			}
 		} catch (Exception e) {
+			e.printStackTrace();
 			// just default
 		}
 		return map;

--- a/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreeEntryPart.java
+++ b/bndtools.jareditor/src/bndtools/jareditor/internal/JARTreeEntryPart.java
@@ -95,7 +95,7 @@ public class JARTreeEntryPart extends AbstractFormPart implements IPartSelection
 		toolkit.createLabel(encodingPanel, "Size");
 		size = new Text(encodingPanel, SWT.READ_ONLY);
 
-		toolkit.createLabel(encodingPanel, "Last Modfied");
+		toolkit.createLabel(encodingPanel, "Last Modified");
 		lastModified = new Text(encodingPanel, SWT.READ_ONLY);
 
 		toolkit.createLabel(encodingPanel, "Show As:");


### PR DESCRIPTION
Closes #6427

## In this PR

- Adds a right-click context menu to a RepoBrowser / RepoBundleVersion "Refresh Cache" 
- which does the same as existing "Clear-Cache" but immediately redownloads the archive from Maven Central. 
- Clear cache actually means removing the version folder from the local maven repository (~/.m2/repository)

![image](https://github.com/user-attachments/assets/e623c0af-692b-4bf0-b728-2edd84103861)

Hope this solves the problem @pconley-onc is seeing. 

If it works, then maybe this could replace the existing "Clear Cache" which currently is buggy when you double click on the Repo Bundle Revision after "Clear Cache" (see https://github.com/bndtools/bnd/issues/6427#issuecomment-2595052533)


