### PR TITLE
Workspace Templates: show error when fetching templates from Github

### DIFF
--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -9,7 +9,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.bndtools.core.ui.icons.Icons;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
@@ -49,6 +52,7 @@ import aQute.bnd.result.Result;
 import aQute.bnd.wstemplates.FragmentTemplateEngine;
 import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateInfo;
 import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateUpdater;
+import bndtools.Plugin;
 import bndtools.central.Central;
 import bndtools.util.ui.UI;
 
@@ -86,6 +90,19 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 					ui.write(() -> model.templates = templates.getAvailableTemplates());
 				} catch (Exception e) {
 					log.error("failed to read default index {}", e, e);
+
+					Display.getDefault()
+						.asyncExec(() -> {
+
+							IStatus status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID, "failed to read default index",
+								e);
+							ErrorDialog.openError(getShell(), "Error", "An error occurred", status);
+						});
+
+					Plugin.getDefault()
+						.getLog()
+						.log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,
+							"failed to read default index " + DEFAULT_INDEX, e));
 				}
 			});
 			job.schedule();

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -298,9 +298,9 @@ public class TemplateSelectionWizardPage extends WizardPage {
 
 							shell.getDisplay()
 								.asyncExec(() -> {
-									txtDescription.setText("Failed to load from template loader (" + name
-										+ ") See Error Log for stack trace: "
-										+ failure.getMessage());
+									IStatus status = new Status(IStatus.ERROR, Plugin.PLUGIN_ID,
+										"Error loading templates", failure);
+									ErrorDialog.openError(shell, "Error", "An error occurred", status);
 								});
 
 							Plugin.getDefault()

--- a/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
+++ b/bndtools.core/src/org/bndtools/core/ui/wizards/shared/TemplateSelectionWizardPage.java
@@ -62,8 +62,8 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentConstants;
 import org.osgi.util.promise.Promise;
 
-import aQute.bnd.osgi.Processor;
 import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.osgi.Processor;
 import aQute.lib.io.IO;
 import aQute.libg.tuple.Pair;
 import bndtools.Plugin;
@@ -294,11 +294,20 @@ public class TemplateSelectionWizardPage extends WizardPage {
 					try {
 						Throwable failure = namedPromise.getSecond()
 							.getFailure();
-						if (failure != null)
+						if (failure != null) {
+
+							shell.getDisplay()
+								.asyncExec(() -> {
+									txtDescription.setText("Failed to load from template loader (" + name
+										+ ") See Error Log for stack trace: "
+										+ failure.getMessage());
+								});
+
 							Plugin.getDefault()
 								.getLog()
 								.log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,
 									"Failed to load from template loader: " + name, failure));
+						}
 						else {
 							Collection<Template> loadedTemplates = namedPromise.getSecond()
 								.getValue();

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/Cache.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/Cache.java
@@ -28,6 +28,11 @@ public class Cache {
 				TaggedData td = client.connectTagged(uri.toURL());
 				if (td == null || td.isNotFound())
 					throw new FileNotFoundException("Not found");
+
+				if (td.getInputStream() == null) {
+					throwNoResponseError(td);
+				}
+
 				data = IO.read(td.getInputStream());
 				if (td.getTag() != null)
 					cache.put(uri, new Pair<>(td.getTag(), data));
@@ -41,6 +46,11 @@ public class Cache {
 					data = cachedTag.getSecond();
 				} else {
 					// changed
+
+					if (td.getInputStream() == null) {
+						throwNoResponseError(td);
+					}
+
 					data = IO.read(td.getInputStream());
 					if (td.getTag() == null) {
 						// server now not giving an etag -> remove from cache
@@ -57,6 +67,11 @@ public class Cache {
 		} catch (Exception e) {
 			throw new IOException(e);
 		}
+	}
+
+	private void throwNoResponseError(TaggedData td) throws IOException {
+		throw new IOException("Error (HTTP " + td.getResponseCode() + ") - no response: " + td
+			+ " (Check https://bnd.bndtools.org/instructions/connection-settings.html in case of connection or authentication errors.)");
 	}
 
 }

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHub.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHub.java
@@ -1,5 +1,6 @@
 package org.bndtools.templating.jgit;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Objects;
 import java.util.concurrent.Executor;
@@ -33,6 +34,9 @@ public class GitHub {
 			return new JSONCodec().dec()
 				.from(detailsDtoData)
 				.get(GithubRepoDetailsDTO.class);
+		})
+			.onFailure(t -> {
+				throw new IOException("Error fetching Github repo details: " + URL_PREFIX + repository, t);
 		});
 	}
 }

--- a/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHub.java
+++ b/org.bndtools.templating.gitrepo/src/org/bndtools/templating/jgit/GitHub.java
@@ -1,6 +1,5 @@
 package org.bndtools.templating.jgit;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Objects;
 import java.util.concurrent.Executor;
@@ -34,9 +33,6 @@ public class GitHub {
 			return new JSONCodec().dec()
 				.from(detailsDtoData)
 				.get(GithubRepoDetailsDTO.class);
-		})
-			.onFailure(t -> {
-				throw new IOException("Error fetching Github repo details: " + URL_PREFIX + repository, t);
 		});
 	}
 }


### PR DESCRIPTION
## In this PR

This PR is about error handling the following two wizards:

![image](https://github.com/user-attachments/assets/98fa4f0d-5f1b-4eaa-bbd9-2ec62cae07b7)


This shows an ErrorDialog the UI when there are problems fetching from Github. The error message also includes a hint to https://bnd.bndtools.org/instructions/connection-settings.html because sometimes you have a ~/.m2/settings.xml with some credentials which can lead to "Bad Credentials" http errors from the Github API, but before this fix you had no idea what was going on, because the UI was blank and the existance of ~/.m2/settings.xml is easily forgotten

The message reads (wording improvements welcome):

> 
> Failed to load from template loader (Load workspace templates from GitHub repositories) See Error Log for stack trace: 
> java.io.IOException: Error (HTTP 520) - no response: TaggedData [tag=, code=520, modified=Thu Jan 01 00:59:59 CET 
> 1970, url=https://api.github.com/repos/bndtools/bndtools.workspace.min, state=OTHER] (Check https://bnd.bndtools.org/instructions/connection-settings.html in case of connection or authentication errors.)

![image](https://github.com/user-attachments/assets/75a81e22-432d-4734-bf4b-581d8294b5de)


Eclipse Error Log tab:

<img width="2159" alt="image" src="https://github.com/user-attachments/assets/a0e55d34-c524-43ed-a8e0-a9975b163b8f" />


At least now you see that something is wrong and also get some information. 
Before this it was completely unknown, since the list of templates just appeared empty. 

Last but not least, I added the same ErrorDialog also to the (new) Template Fragment Wizard... which can suffer from the same HTTP connection problems. Now the user sees an error dialog too and knows what's going on