### PR TITLE
fix RunRequirements could not be saved

### DIFF
--- a/bndtools.core/src/bndtools/editor/common/BndEditorPart.java
+++ b/bndtools.core/src/bndtools/editor/common/BndEditorPart.java
@@ -79,8 +79,8 @@ public abstract class BndEditorPart extends SectionPart implements PropertyChang
 	@Override
 	public final void commit(boolean onSave) {
 		committing.compareAndSet(false, true);
-		super.commit(onSave);
 		commitToModel(onSave);
+		super.commit(onSave);
 		committing.compareAndSet(true, false);
 	}
 


### PR DESCRIPTION
The problem was that before this fix the call to super.commit(onSave); has reset the dirty flag from true back to false, which was the reason why commitToModel(onSave); did not work, because it checks for dirty==true

@stbischof could you test the PR? 