### PR TITLE
Fix missing '.' in filter name

### DIFF
--- a/bndtools.jareditor/resources/plugin.xml
+++ b/bndtools.jareditor/resources/plugin.xml
@@ -26,7 +26,7 @@
 				</instanceof>
 				<test
 					property="org.eclipse.core.resources.name"
-					value="BndtoolsJAREditorTempFiles">
+					value=".BndtoolsJAREditorTempFiles">
 				</test>
 			</filterExpression>
 		</commonFilter>


### PR DESCRIPTION
Now that PDE is shipping the jar editor I noticed since a while that a folder/project .BndtoolsJAREditorTempFiles is shown, even though there is a filter to hide it.

Looking a bit closer it seems to me that while it was renamed three years ago to start with a dot the actual filterExpression was not adjusted (only the description/name)

![grafik](https://github.com/user-attachments/assets/f1a58785-37b4-410a-a899-7d1b86ea163e)
