### PR TITLE
Fix MessageReporter#details return null instead of this

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/MessageReporter.java
@@ -85,7 +85,7 @@ public class MessageReporter {
 		@Override
 		public SetLocation details(Object details) {
 			this.details = details;
-			return null;
+			return this;
 		}
 
 		@Override


### PR DESCRIPTION
`MessageReporter#details` return `null` instead of `this` leading to NPE if one relies on chaining method calls.