### PR TITLE
Fix of-by-one error in AbstractBndMavenPlugin

### DIFF
--- a/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -722,7 +722,8 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 			}
 			File f = location.file == null ? propertiesFile : new File(location.file);
 			markedFiles.add(f);
-			buildContext.addMessage(f, location.line, location.length, location.message, BuildContext.SEVERITY_WARNING,
+			buildContext.addMessage(f, location.line + 1, location.length, location.message,
+				BuildContext.SEVERITY_WARNING,
 				null);
 		}
 		List<String> errors = builder.getErrors();
@@ -734,7 +735,8 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 			}
 			File f = location.file == null ? propertiesFile : new File(location.file);
 			markedFiles.add(f);
-			buildContext.addMessage(f, location.line, location.length, location.message, BuildContext.SEVERITY_ERROR,
+			buildContext.addMessage(f, location.line + 1, location.length, location.message,
+				BuildContext.SEVERITY_ERROR,
 				null);
 		}
 		buildContext.setValue(MARKED_FILES, markedFiles);


### PR DESCRIPTION
According to aQute.service.reporter.Reporter.SetLocation.line(int) javadoc "Line 0 is the top line" but BuildContext#addMessage says "Use 1 (not 0) for the first line" so when converting from bnd location > build context we need to add one to the line.