### PR TITLE
Template Fragments Wizard: increase column with of template name

### DIFF
--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -268,7 +268,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			});
 
 
-			tableLayout.addColumnData(new ColumnWeightData(1, 80, false));
+			tableLayout.addColumnData(new ColumnWeightData(1, 150, false));
 			tableLayout.addColumnData(new ColumnWeightData(10, 200, true));
 			tableLayout.addColumnData(new ColumnWeightData(20, 80, true));
 


### PR DESCRIPTION
We have some upcoming templates with longer names. In order to display them better we should make the column a bit wider

<img width="580" alt="image" src="https://github.com/user-attachments/assets/cc60f460-a406-4f25-8d7a-aca590d02c26" />
