### PR TITLE
add back summary in markdown frontmatter block

### DIFF
--- a/docs/_heads/export_package.md
+++ b/docs/_heads/export_package.md
@@ -2,6 +2,7 @@
 layout: default
 class: Header
 title: Export-Package  ::= export ( ',' export)* 
+summary: The Export-Package header contains a declaration of exported packages
 ---
 
 The `Export-Package` header contains a declaration of exported packages. Also see [`-exportcontents`](/instructions/exportcontents.html).

--- a/docs/_instructions/exportcontents.md
+++ b/docs/_instructions/exportcontents.md
@@ -2,6 +2,7 @@
 layout: default
 class: Project
 title: -exportcontents PACKAGE-SPEC, ( ',' PACKAGE-SPEC )*
+summary: Exports the given packages but does not try to include them from the class path. The packages should be loaded with alternative means. 
 ---
 
 Exports the given packages but does not try to include them from the class path. The packages should be loaded with alternative means. The syntax is similar to the [`Export-Package`](/heads/export_package.html) header.

--- a/docs/_instructions/sub.md
+++ b/docs/_instructions/sub.md
@@ -2,9 +2,10 @@
 layout: default
 class: Builder
 title: -sub FILE-SPEC ( ',' FILE-SPEC )*
+summary:  Enable sub-bundles to build a set of .bnd files that use bnd.bnd file as a basis. The list of bnd files can be specified with wildcards.
 ---
 
-You can enable **sub-bundles** with the `-sub` instruction, to build a set of `.bnd` files that use the `bnd.bnd` file as a basis. The list of sub-`.bnd` file can be specified with wildcards.
+You can enable **sub-bundles** with the `-sub` instruction, to build a set of `.bnd` files that use the `bnd.bnd` file as a basis. The list of sub-`.bnd` files can be specified with wildcards.
 
 ## Example 
 


### PR DESCRIPTION
I accidentally removed them earlier, but they were needed in the overview pages.
