### PR TITLE
docs: exclude /releases urls from search engines

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,11 @@ defaults:
       path: ""
     values:
       layout: default
+  # exclude all the files from `/releases/` in the sitemap
+  - scope:
+      path:            releases/**
+    values:
+      sitemap:         false
 
 exclude:
   - 'ADDING_RELEASE_DOCS.md'

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,7 @@
+# This robots.txt file controls crawling of URLs under https://bnd.bndtools.org.
+# All crawlers are disallowed to crawl files in the "releases" directory, 
+# because they dilute search results, because they are outdated.
+User-agent: *
+Disallow: /releases/
+
+Sitemap: https://bnd.bndtools.org/sitemap.xml


### PR DESCRIPTION
everything under urls like https://bnd.bndtools.org/releases/ will be excluded from the sitemap.xml and via robots.txt, so that google (hopefully) does not crawl them

Why? e.g. https://bnd.bndtools.org/releases/4.0.0/instructions/sub.html contains outdated information from previous releases. but the problem is those pages dilute the search results in google and sometimes outdated pages come up first. it is better for bnd / bndtools that current information is preferred.