### PR TITLE
sub-bundles: show warning markers in sub .bnd file

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Processor.java
@@ -232,13 +232,23 @@ public class Processor extends Domain implements Reporter, Registry, Constants, 
 	@SuppressWarnings("resource")
 	@Override
 	public SetLocation warning(String string, Object... args) {
-		return current().reporter.warning(string, args);
+		SetLocation warning = current().reporter.warning(string, args);
+		File propertiesFile = getPropertiesFile();
+		if (propertiesFile != null) {
+			warning.file(propertiesFile.getAbsolutePath());
+		}
+		return warning;
 	}
 
 	@SuppressWarnings("resource")
 	@Override
 	public SetLocation error(String string, Object... args) {
-		return current().reporter.error(string, args);
+		SetLocation error = current().reporter.error(string, args);
+		File propertiesFile = getPropertiesFile();
+		if (propertiesFile != null) {
+			error.file(propertiesFile.getAbsolutePath());
+		}
+		return error;
 	}
 
 	/**


### PR DESCRIPTION
instead of project bnd.bnd

This fixes the problem that previously, when you had sub-subbundles, then Warning / Error Markers where always shown at the parent bnd.bnd in the project, instead of in the sub-bundle's .bnd file (where the warning actually belongs to).

Now it is showing up correctly in the sub-bundle's .bnd file if it is comming from a sub-bundle, or if it is a normal bundle, it shows at the bnd.bnd as it already was the case.

**Before:**

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/057727c2-9983-440f-b917-0f8d91b46329" />

<img width="839" alt="image" src="https://github.com/user-attachments/assets/9d21285f-187c-49ab-8186-45dc1e90aec6" />


- actual: warning is shown for project `bnd.bnd`  (see _Resource_ column), but it actually belongs to the sub-bundle
- when I double click the warning, I go to the project `bnd.bnd` file
- the graphical marker in the bndeditor  is in the project `bnd.bnd`

**After:**

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/5f67a409-8717-49c0-ac02-58da2eec429e" />

<img width="873" alt="image" src="https://github.com/user-attachments/assets/88729a40-2ae9-4328-8833-129a2098ec3b" />

- Correct: warning is shown for the sub-bundle .bnd file (see _Resource_ column)
- when I double click the warning, I come to the correct sub-bundle .bnd file
- also the graphical marker in the bndeditor  is now in the .bnd of the sub-bundle (instead of the project `bnd.bnd`)

