### PR TITLE
Add a ProjectLauncher#getCommand for easier extension

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/JUnitLauncher.java
@@ -53,7 +53,10 @@ public class JUnitLauncher extends ProjectLauncher {
 	}
 
 	@Override
-	public int launch() throws Exception {
+	public Command getCommand() throws Exception {
+		if (java != null) {
+			return java;
+		}
 		java = new Command();
 		java.add(getJavaExecutable("java"));
 
@@ -65,17 +68,7 @@ public class JUnitLauncher extends ProjectLauncher {
 		if (getTimeout() != 0L)
 			java.setTimeout(getTimeout() + 1000L, TimeUnit.MILLISECONDS);
 
-		logger.debug("cmd line {}", java);
-		try {
-			int result = java.execute(System.in, System.err, System.err);
-			if (result == Integer.MIN_VALUE)
-				return TIMEDOUT;
-			reportResult(result);
-			return result;
-		} finally {
-			cleanup();
-		}
-
+		return java;
 	}
 
 	private boolean traverse(List<String> fqns, File testSrc, String prefix, Pattern filter) {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectLauncher.java
@@ -330,6 +330,25 @@ public abstract class ProjectLauncher extends Processor {
 	}
 
 	public int launch() throws Exception {
+		Command command = getCommand();
+
+		logger.debug("cmd line {}", command);
+		try {
+			int result = command.execute(in, out, err);
+			if (result == Integer.MIN_VALUE)
+				return TIMEDOUT;
+			reportResult(result);
+			return result;
+		} finally {
+			cleanup();
+			listeners.clear();
+		}
+	}
+
+	public Command getCommand() throws Exception {
+		if (java != null) {
+			return java;
+		}
 		prepare();
 		java = new Command();
 
@@ -375,18 +394,7 @@ public abstract class ProjectLauncher extends Processor {
 		File cwd = getCwd();
 		if (cwd != null)
 			java.setCwd(cwd);
-
-		logger.debug("cmd line {}", java);
-		try {
-			int result = java.execute(in, out, err);
-			if (result == Integer.MIN_VALUE)
-				return TIMEDOUT;
-			reportResult(result);
-			return result;
-		} finally {
-			cleanup();
-			listeners.clear();
-		}
+		return java;
 	}
 
 	/**
@@ -486,7 +494,7 @@ public abstract class ProjectLauncher extends Processor {
 	}
 
 	public void cancel() throws Exception {
-		java.cancel();
+		getCommand().cancel();
 	}
 
 	public Map<String, ? extends Map<String, String>> getSystemPackages() {

--- a/biz.aQute.remote/src/aQute/remote/plugin/RemoteProjectLauncherPlugin.java
+++ b/biz.aQute.remote/src/aQute/remote/plugin/RemoteProjectLauncherPlugin.java
@@ -24,6 +24,7 @@ import aQute.bnd.osgi.Resource;
 import aQute.bnd.version.Version;
 import aQute.lib.converter.Converter;
 import aQute.lib.strings.Strings;
+import aQute.libg.command.Command;
 import aQute.remote.embedded.activator.EmbeddedActivator;
 import aQute.remote.util.JMXBundleDeployer;
 
@@ -190,6 +191,11 @@ public class RemoteProjectLauncherPlugin extends ProjectLauncher {
 		}
 
 		return 0;
+	}
+
+	@Override
+	public Command getCommand() throws Exception {
+		return new Command();
 	}
 
 	/**


### PR DESCRIPTION
Currently if one wants to extend a Project launcher it is required to completely reimplement the launch() method even if one only wants to add some argument to the commandline. Also things like returncode handling and reporting of results need to be implemented again.

This now adds a new method `ProjectLauncher#getCommand() `that externalize the process of creating a commandline, this also allows to access the final commandline from the outside (e.g. to show it to the user) or further customize it.