### PR TITLE
Support reading the manifest from an exploded bundle

### DIFF
--- a/biz.aQute.bndlib/test/aQute/bnd/build/ContainerTest.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/build/ContainerTest.java
@@ -1,0 +1,24 @@
+package aQute.bnd.build;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
+
+public class ContainerTest {
+	@Test
+	public void testExplodedBundle(@TempDir
+	Path tempDir) throws Exception {
+		try (Jar jar = new Jar("testme"); Analyzer analyzer = new Analyzer(jar)) {
+			jar.setManifest(analyzer.calcManifest());
+			jar.writeFolder(tempDir.toFile());
+		}
+		Container container = new Container(tempDir.toFile(), null);
+		assertThat(container.getManifest()).isNotNull();
+	}
+}


### PR DESCRIPTION
Currently if a Container is pointing to an exploded bundle one gets an exception when calling getManifest because it assumes it is always a jar file.

This now adds support fo reading such "exploded" bundles as well that are a folder.