### PR TITLE
Reduce pedantic warnings "Imports that lack version ranges" for some JDK packages

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/model/EETest.java
+++ b/biz.aQute.bndlib.tests/test/test/model/EETest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import aQute.bnd.build.model.EE;
 import aQute.bnd.osgi.Clazz;
+import aQute.bnd.osgi.Descriptors;
+import aQute.bnd.osgi.Descriptors.PackageRef;
 import aQute.bnd.version.MavenVersion;
 import aQute.bnd.version.Version;
 
@@ -141,6 +143,20 @@ public class EETest {
 	@DisplayName("Validate Modules exist for each EE beyond Java 8")
 	public void checkEEHasModules(EE ee) throws Exception {
 		assertThat(ee.getModules()).isNotEmpty();
+	}
+
+	@Test
+	public void testEEIsJDKPackage() {
+		// this package appeared in JDK 1.6+
+		// see .properties in aQute.bnd.build.model
+		PackageRef pck = new Descriptors().getPackageRef("javax.xml.transform.stax");
+		assertThat(EE.J2SE_1_2.getPackages().containsKey(pck.getFQN())).isFalse();
+		assertThat(EE.J2SE_1_5.getPackages()
+			.containsKey(pck.getFQN())).isFalse();
+		assertThat(EE.JavaSE_1_6.getPackages()
+			.containsKey(pck.getFQN())).isTrue();
+		assertThat(EE.JavaSE_17.getPackages()
+			.containsKey(pck.getFQN())).isTrue();
 	}
 
 	static class EEsArgumentsProvider implements ArgumentsProvider {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Descriptors.java
@@ -120,6 +120,9 @@ public class Descriptors {
 			return binaryName;
 		}
 
+		/**
+		 * @return <code>true</code> if this is a "java." package.
+		 */
 		public boolean isJava() {
 			return java;
 		}


### PR DESCRIPTION
This reduces warning noise with pedantic:true regarding the warning "Imports that lack version ranges". This warning is not useful for packages from the JDK like java. , javax.net. , javax.security. (and maybe more), because JDK packges have no version. we did not add "javax." because it would be too broad, as there are packages out there not coming from the JDK (e.g. javax.xml.bind)

For example we had lots of warnings like:

```
Imports that lack version ranges: [javax.net.ssl.SSLSessionContext]
Imports that lack version ranges: [javax.net.ssl.SSLSocket]
```

But since those are JDK packages, they do not have version. 

See https://bnd.discourse.group/t/how-to-handle-imports-that-lack-version-ranges-warning-pedantic-true/504