### PR TITLE
-pedantic: Add hint that Eclipse restart is required

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -576,7 +576,9 @@ public class Syntax implements Constants {
 			"If set, is used a template to calculate the output file. It can use any macro but the ${@bsn} and ${@version} macros refer to the current JAR being saved. The default is bsn + \".jar\".",
 			OUTPUTMASK + "=my_file.zip", null, null),
 		new Syntax(PACKAGEINFOTYPE, "Sets the different types of package info.", PACKAGEINFOTYPE + "=osgi", null, null),
-		new Syntax(PEDANTIC, "Warn about things that are not really wrong but still not right.", PEDANTIC + "=true",
+		new Syntax(PEDANTIC,
+			"Warn about things that are not really wrong but still not right. Note: Currently a change to this instruction requires a restart of Eclipse.",
+			PEDANTIC + "=true",
 			"true,false", Verifier.TRUEORFALSEPATTERN),
 
 		new Syntax(PLUGIN, "Define the plugins.",

--- a/docs/_instructions/pedantic.md
+++ b/docs/_instructions/pedantic.md
@@ -5,8 +5,7 @@ title: -pedantic BOOLEAN
 summary: Warn about things that are not really wrong but still not right. 
 ---
 
-	protected void begin() {
-		if (isTrue(getProperty(PEDANTIC)))
-			setPedantic(true);
-	}
+When setting this instruction to `true` there will be more warnings about *things that are not really wrong but still not right*.
+It can be helpful to fix problems in your workspace.
 
+**Note for Eclipse users:** Currently a change to this instruction requires a restart of Eclipse. The Refresh-Workspace button is not enough.


### PR DESCRIPTION
Closes #6507 

This is not really a fix, but a band-aid.
 
Adjust description of the warning, so at least it is mentioned somewhere. unfortunatelly I could not figure out how to reliably sync the `Processor.pendatic` field with the `.bnd` files on change. The problem is that `Processor.pedantic` can be set via `.bnd` files but also via `Processor.setPedantic(boolean)` e.g. from testcases, there is some magic hen-egg-caching going on in `Processor.begin()` and `Processor.getProperties()` 
- in the end I was not able to figure out, what to call in which order so that the **Workspace Refresh Button** behaves the same as an Eclipse restart.

If anybody has a better idea, feel free. 