### PR TITLE
parallelize build of -sub bundles

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -1520,7 +1520,11 @@ public class Builder extends Analyzer {
 		List<Builder> builders = getSubBuilders();
 
 		for (Builder builder : builders) {
-			startBuild(builder);
+			try {
+				startBuild(builder);
+			} catch (Exception e) {
+				builder.exception(e, "Exception Start Building %s", builder.getBsn());
+			}
 		}
 
 		Collection<Jar> result = new ConcurrentLinkedQueue<>();
@@ -1538,12 +1542,17 @@ public class Builder extends Analyzer {
 				} catch (Exception e) {
 					builder.exception(e, "Exception Building %s", builder.getBsn());
 				}
-				if (builder != this)
-					getInfo(builder, builder.getBsn() + ": ");
 			});
 
 		for (Builder builder : doneBuilders) {
-			doneBuild(builder);
+			try {
+				doneBuild(builder);
+			} catch (Exception e) {
+				builder.exception(e, "Exception Done Building %s", builder.getBsn());
+			}
+
+			if (builder != this)
+				getInfo(builder, builder.getBsn() + ": ");
 		}
 
 		return result.toArray(new Jar[0]);

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -1521,20 +1521,21 @@ public class Builder extends Analyzer {
 
 		builders = getSubBuilders();
 
-		for (Builder builder : builders) {
-			try {
-				startBuild(builder);
-				Jar jar = builder.build();
-				jar.setName(builder.getBsn());
+		builders.parallelStream()
+			.forEach(builder -> {
+				try {
+					startBuild(builder);
+					Jar jar = builder.build();
+					jar.setName(builder.getBsn());
+					result.add(jar);
+					doneBuild(builder);
+				} catch (Exception e) {
+					builder.exception(e, "Exception Building %s", builder.getBsn());
+				}
+				if (builder != this)
+					getInfo(builder, builder.getBsn() + ": ");
+			});
 
-				result.add(jar);
-				doneBuild(builder);
-			} catch (Exception e) {
-				builder.exception(e, "Exception Building %s", builder.getBsn());
-			}
-			if (builder != this)
-				getInfo(builder, builder.getBsn() + ": ");
-		}
 		return result.toArray(new Jar[0]);
 	}
 


### PR DESCRIPTION
I could speed up our wrapper project which contains currently 12 sub-bundles from `19s` down to `11s`. 
This project mainly wraps 3rd party non-osgi jars to make them OSGi bundles for our application. 

Feedback welcome whether there are side-effects I don't see. 
Are sub-bundle builds independent from each-other? 