### PR TITLE
use Eclipse 2022-09 simrel p2 site

### DIFF
--- a/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
@@ -231,7 +231,7 @@
 	org.eclipse.m2e.binaryproject;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.binaryproject.ui;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.core;version='[2.0.3,2.0.4)',\
-	org.eclipse.m2e.core.ui;version='[2.0.1,2.0.2)',\
+	org.eclipse.m2e.core.ui;version='[2.0.0,2.0.2)',\
 	org.eclipse.m2e.discovery;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.editor;version='[2.0.1,2.0.2)',\
 	org.eclipse.m2e.jdt;version='[2.0.1,2.0.2)',\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -231,7 +231,7 @@
 	org.eclipse.m2e.binaryproject;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.binaryproject.ui;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.core;version='[2.0.3,2.0.4)',\
-	org.eclipse.m2e.core.ui;version='[2.0.1,2.0.2)',\
+	org.eclipse.m2e.core.ui;version='[2.0.0,2.0.2)',\
 	org.eclipse.m2e.discovery;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.editor;version='[2.0.1,2.0.2)',\
 	org.eclipse.m2e.jdt;version='[2.0.1,2.0.2)',\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -229,7 +229,7 @@
 	org.eclipse.m2e.binaryproject;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.binaryproject.ui;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.core;version='[2.0.3,2.0.4)',\
-	org.eclipse.m2e.core.ui;version='[2.0.1,2.0.2)',\
+	org.eclipse.m2e.core.ui;version='[2.0.0,2.0.2)',\
 	org.eclipse.m2e.discovery;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.editor;version='[2.0.1,2.0.2)',\
 	org.eclipse.m2e.jdt;version='[2.0.1,2.0.2)',\

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -230,7 +230,7 @@
 	org.eclipse.m2e.binaryproject;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.binaryproject.ui;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.core;version='[2.0.3,2.0.4)',\
-	org.eclipse.m2e.core.ui;version='[2.0.1,2.0.2)',\
+	org.eclipse.m2e.core.ui;version='[2.0.0,2.0.2)',\
 	org.eclipse.m2e.discovery;version='[2.0.0,2.0.1)',\
 	org.eclipse.m2e.editor;version='[2.0.1,2.0.2)',\
 	org.eclipse.m2e.jdt;version='[2.0.1,2.0.2)',\

--- a/cnf/ext/repositories.bnd
+++ b/cnf/ext/repositories.bnd
@@ -24,11 +24,9 @@ ossrh:                  https://oss.sonatype.org/content/repositories/snapshots
         noupdateOnRelease=true
 
 -plugin.1.Eclipse:\
-    aQute.bnd.repository.osgi.OSGiRepository;\
-        name="Eclipse 4.25 (2022-09)";\
-        locations="https://bndtools.jfrog.io/bndtools/bnd-build/eclipse/4.25/index.xml.gz";\
-        poll.time=-1;\
-        cache="${workspace}/cnf/cache/stable/Eclipse-4.25"
+	aQute.bnd.repository.p2.provider.P2Repository; \
+	 	url = https://download.eclipse.org/releases/2022-09/; \
+	 	name = "Eclipse 4.25 (2022-09)"
 
 -plugin.9.Baseline:\
     aQute.bnd.repository.maven.provider.MavenBndRepository;\


### PR DESCRIPTION
instead of handcrafted at https://bndtools.jfrog.io/bndtools/bnd-build/eclipse/4.25/index.xml.gz

This could make it easier to test and use newer Eclipse Versions, since we start having more and more bugs only happening in newer Eclipse versions.