### PR TITLE
bndrun: refresh model before Resolve to get changes of included .bndrun files

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
@@ -159,6 +159,11 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 	private void doResolve() {
 		IFormPage formPage = (IFormPage) getManagedForm().getContainer();
 		BndEditor editor = (BndEditor) formPage.getEditor();
+
+		// editor.doSave() is important
+		// to get changes of included .bndrun files before resolving
+		// (e.g. -include: shared.bndrun)
+		editor.doSave(null);
 		refreshFromModel();
 		commit(false);
 		editor.resolveRunBundles(new NullProgressMonitor(), false);


### PR DESCRIPTION
this fixes the problem that the Resolve button did not "see" changes of included .bndrun files (e.g. -include: shared.bndrun). So when you changed something in an include and pressed the "Resolve" button , then the "Resolve" process would still see the old state when the BndEditor was initially opened and as if the change to -include: shared.bndrun would not have happened. Previous workaround was to close and open the BndEditor of the actual .bndrun file again


# Steps to reproduce

(you can also use this [workspace3.zip](https://github.com/user-attachments/files/19620021/workspace3.zip))

1. Create `a.bndrun`

`-include: shared.bndrun` 

2. Create a `shared.bndrun`

```
-runrequires: \
	bnd.identity;id='bar.impl',\
	bnd.identity;id='bar.consumer',\
	bnd.identity;id='org.apache.felix.gogo.command',\
	bnd.identity;id='org.apache.felix.gogo.runtime',\
	bnd.identity;id='org.apache.felix.gogo.shell'

-runfw: org.apache.felix.framework

-runrepos: \
	Workspace,\
	OSGI R8 - Build,\
	OSGI R8 - Runtime Distro
```


3. Now open `a.bndrun` and press **Resolve** and do not close the editor. 

Resolve should Succeed.

4. Now open `shared.bndrun` and remove e.g. two runrepos 
-OSGI R8 - Build,\
-OSGI R8 - Runtime Distro

5. go back to the still opened `a.bndrun` editor and press **Resolve** again.

Actual Result: It still resolves sucessfully. 
Expected Result: Resolve should fail, because we removed the runrepos 

If you close and reopen `a.bndrun` and resolve again, then this will expectedly fail, because the model is reloaded and the change to 'shared.bndrun' is seen. 

This PR basically does that automatically on each press to "Resolve", so that the workaround is no longer needed. 

It drastically improves developer experience, because I often was misled by the previous behavior, because I made a change and was suprised that it was not used. I found out by accident that I had to reopen the editor.

