### PR TITLE
Fix double-resolve when having resolveMode=AUTO

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -276,7 +276,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 		}
 	}
 
-	private void reallySave(IProgressMonitor monitor) {
+	public void reallySave(IProgressMonitor monitor) {
 		// Actually save, via the source editor
 		try {
 			boolean saveLocked = this.saving.compareAndSet(false, true);

--- a/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
@@ -160,10 +160,11 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 		IFormPage formPage = (IFormPage) getManagedForm().getContainer();
 		BndEditor editor = (BndEditor) formPage.getEditor();
 
-		// editor.doSave() is important
-		// to get changes of included .bndrun files before resolving
+		// get changes of included .bndrun files before resolving
 		// (e.g. -include: shared.bndrun)
-		editor.doSave(null);
+		editor.commitDirtyPages();
+		editor.reallySave(null);
+
 		refreshFromModel();
 		commit(false);
 		editor.resolveRunBundles(new NullProgressMonitor(), false);


### PR DESCRIPTION
This fixes a double-resolve when having resolveMode=AUTO introduced by my laster PR https://github.com/bndtools/bnd/pull/6550

I needed to make the reallySave() method public, so I can call it from the Resolve button action in the RunRequirements part