### PR TITLE
Improve warning for optional Imports w/o version

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -3733,7 +3733,8 @@ public class BuilderTest {
 			b.setPedantic(true);
 			b.setProperty("Import-Package", "foo.bar");
 			b.build();
-			softly.assertThat(b.check("Imports that lack version ranges: \\[foo.bar\\]",
+			softly.assertThat(b.check(
+				"Imports that lack version ranges due to not being found in any bundle on the -buildpath: \\[foo.bar\\]",
 				"The JAR is empty: The instructions for the JAR named biz.aQute.bndlib.tests did not cause any content to be included, this is likely wrong"))
 				.isTrue();
 			softly.assertThat(b.getImports()
@@ -3810,7 +3811,8 @@ public class BuilderTest {
 			b.build();
 			// there should be NO warning: Imports that lack version ranges:
 			// [javax.xml.transform.stax]
-			softly.assertThat(b.check("Imports that lack version ranges: \\[javax.xml.transform.stax\\]",
+			softly.assertThat(b.check(
+				"Imports that lack version ranges due to not being found in any bundle on the -buildpath: \\[javax.xml.transform.stax\\]",
 				"The JAR is empty: The instructions for the JAR named biz.aQute.bndlib.tests did not cause any content to be included, this is likely wrong"))
 				.isTrue();
 			softly.assertThat(b.getImports()

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -2128,7 +2128,10 @@ public class Analyzer extends Processor {
 		}
 
 		if (isPedantic() && noimports.size() != 0) {
-			warning("Imports that lack version ranges: %s", noimports);
+			warning(
+				"Imports that lack version ranges due to not being found in any bundle on the -buildpath: %s (These could stem from transitive dependencies of non-OSGi jars in your classpath (e.g. from -includeresource). "
+					+ "Adding this dependency to your -buildpath could help bnd adding version information.)",
+				noimports);
 		}
 	}
 


### PR DESCRIPTION
This is an attempt / idea to improve the pedantic warning "Imports that lack version ranges" .

