### PR TITLE
Fix NPE in ResolutionView when opening a file inside the JARViewer

### DIFF
--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -172,16 +172,22 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 			} else if (part instanceof IEditorPart) {
 				IEditorInput editorInput = ((IEditorPart) part).getEditorInput();
 				IFile file = ResourceUtil.getFile(editorInput);
+
 				if (file != null) {
-					CapReqLoader loader = getLoaderForFile(file.getLocation()
-						.toFile());
-					if (loader != null) {
-						setLoaders(Collections.singleton(loader));
-						if (getSite().getPage()
-							.isPartVisible(ResolutionView.this)) {
-							executeAnalysis();
-						} else {
-							outOfDate = true;
+					IPath location = file.getLocation();
+
+					if (location != null) {
+						CapReqLoader loader = getLoaderForFile(location.toFile());
+
+						if (loader != null) {
+							setLoaders(Collections.singleton(loader));
+
+							if (getSite().getPage()
+								.isPartVisible(ResolutionView.this)) {
+								executeAnalysis();
+							} else {
+								outOfDate = true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
when double clicking on a File inside the JAR viewer, an NPE is thrown because the ResolutionView tries to analyze this file but cannot find it.


```
java.lang.NullPointerException: Cannot invoke "org.eclipse.core.runtime.IPath.toFile()" because the return value of "org.eclipse.core.resources.IFile.getLocation()" is null
	at bndtools.views.resolution.ResolutionView$1.partActivated(ResolutionView.java:177)
	at org.eclipse.ui.internal.WorkbenchPage$2.run(WorkbenchPage.java:4887)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.ui.internal.WorkbenchPage.firePartActivated(WorkbenchPage.java:4884)
	at org.eclipse.ui.internal.WorkbenchPage$E4PartListener.partActivated(WorkbenchPage.java:215)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl$2.run(PartServiceImpl.java:250)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.firePartActivated(PartServiceImpl.java:247)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:780)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.activate(PartServiceImpl.java:686)
	at org.eclipse.e4.ui.internal.workbench.swt.AbstractPartRenderer.activate(AbstractPartRenderer.java:95)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.lambda$0(ContributedPartRenderer.java:63)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4660)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1657)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1680)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1665)
	at org.eclipse.swt.widgets.Shell.setActiveControl(Shell.java:1626)
	at org.eclipse.swt.widgets.Shell.setActiveControl(Shell.java:1589)
	at org.eclipse.swt.widgets.Control.sendFocusEvent(Control.java:3414)
	at org.eclipse.swt.widgets.Canvas.sendFocusEvent(Canvas.java:80)
	at org.eclipse.swt.widgets.Display.checkFocus(Display.java:750)
	at org.eclipse.swt.widgets.Shell.makeFirstResponder(Shell.java:1308)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6466)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSend_bool(Native Method)
	at org.eclipse.swt.internal.cocoa.NSWindow.makeFirstResponder(NSWindow.java:197)
	at org.eclipse.swt.widgets.Control.forceFocus(Control.java:1440)
	at org.eclipse.swt.widgets.Control.forceFocus(Control.java:1420)
	at org.eclipse.swt.widgets.Control.setFocus(Control.java:3847)
	at org.eclipse.swt.widgets.Composite.setFocus(Composite.java:1129)
	at org.eclipse.swt.custom.StyledText.setFocus(StyledText.java:8759)
	at org.eclipse.ui.texteditor.AbstractTextEditor.setFocus(AbstractTextEditor.java:6225)
	at org.eclipse.ui.texteditor.StatusTextEditor.setFocus(StatusTextEditor.java:149)
	at org.eclipse.ui.internal.e4.compatibility.CompatibilityPart.delegateSetFocus(CompatibilityPart.java:226)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:56)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:299)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:227)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:148)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.focusGui(PartRenderingEngine.java:789)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer$1.setFocus(ContributedPartRenderer.java:107)
	at org.eclipse.swt.custom.CTabItem.setFocus(CTabItem.java:379)
	at org.eclipse.swt.custom.CTabFolder.setFocus(CTabFolder.java:2700)
	at org.eclipse.swt.widgets.Control.fixFocus(Control.java:1344)
	at org.eclipse.swt.widgets.Control.setVisible(Control.java:4415)
	at org.eclipse.swt.widgets.ToolBar.setVisible(ToolBar.java:798)
	at org.eclipse.swt.custom.CTabFolder.setItemSize(CTabFolder.java:2881)
	at org.eclipse.swt.custom.CTabFolder.updateItems(CTabFolder.java:3901)
	at org.eclipse.swt.custom.CTabFolder.updateItems(CTabFolder.java:3834)
	at org.eclipse.swt.custom.CTabFolder.onResize(CTabFolder.java:2140)
	at org.eclipse.swt.custom.CTabFolder.lambda$0(CTabFolder.java:339)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4660)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1657)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1680)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1661)
	at org.eclipse.swt.widgets.Control.resized(Control.java:3375)
	at org.eclipse.swt.widgets.Composite.resized(Composite.java:1027)
	at org.eclipse.swt.widgets.Control.setFrameSize(Control.java:3940)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6275)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSend(Native Method)
	at org.eclipse.swt.internal.cocoa.NSView.setFrameSize(NSView.java:260)
	at org.eclipse.swt.widgets.Control.setBounds(Control.java:3672)
	at org.eclipse.swt.widgets.Control.setSize(Control.java:4249)
	at org.eclipse.swt.widgets.Control.pack(Control.java:2751)
	at org.eclipse.swt.widgets.Control.pack(Control.java:2725)
	at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer.adjustTopRight(StackRenderer.java:932)
	at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer.showTab(StackRenderer.java:1405)
	at org.eclipse.e4.ui.workbench.renderers.swt.LazyStackRenderer.lambda$0(LazyStackRenderer.java:84)
	at org.eclipse.e4.ui.services.internal.events.UIEventHandler.lambda$0(UIEventHandler.java:38)
	at org.eclipse.swt.widgets.Synchronizer.syncExec(Synchronizer.java:183)
	at org.eclipse.ui.internal.UISynchronizer.syncExec(UISynchronizer.java:133)
	at org.eclipse.swt.widgets.Display.syncExec(Display.java:5264)
	at org.eclipse.e4.ui.workbench.swt.DisplayUISynchronize.syncExec(DisplayUISynchronize.java:34)
	at org.eclipse.e4.ui.services.internal.events.UIEventHandler.handleEvent(UIEventHandler.java:38)
	at org.eclipse.equinox.internal.event.EventHandlerWrapper.handleEvent(EventHandlerWrapper.java:206)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:201)
	at org.eclipse.equinox.internal.event.EventHandlerTracker.dispatchEvent(EventHandlerTracker.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:151)
	at org.eclipse.equinox.internal.event.EventAdminImpl.dispatchEvent(EventAdminImpl.java:131)
	at org.eclipse.equinox.internal.event.EventAdminImpl.sendEvent(EventAdminImpl.java:73)
	at org.eclipse.equinox.internal.event.EventComponent.sendEvent(EventComponent.java:44)
	at org.eclipse.e4.ui.services.internal.events.EventBroker.send(EventBroker.java:55)
	at org.eclipse.e4.ui.internal.workbench.UIEventPublisher.notifyChanged(UIEventPublisher.java:60)
	at org.eclipse.emf.common.notify.impl.BasicNotifierImpl.eNotify(BasicNotifierImpl.java:424)
	at org.eclipse.e4.ui.model.application.ui.impl.ElementContainerImpl.setSelectedElementGen(ElementContainerImpl.java:168)
	at org.eclipse.e4.ui.model.application.ui.impl.ElementContainerImpl.setSelectedElement(ElementContainerImpl.java:187)
	at org.eclipse.e4.ui.internal.workbench.ModelServiceImpl.showElementInWindow(ModelServiceImpl.java:661)
	at org.eclipse.e4.ui.internal.workbench.ModelServiceImpl.bringToTop(ModelServiceImpl.java:625)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.delegateBringToTop(PartServiceImpl.java:796)
	at org.eclipse.e4.ui.internal.workbench.PartServiceImpl.showPart(PartServiceImpl.java:1268)
	at org.eclipse.ui.internal.WorkbenchPage.busyOpenEditor(WorkbenchPage.java:3228)
	at org.eclipse.ui.internal.WorkbenchPage.lambda$11(WorkbenchPage.java:3118)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)
	at org.eclipse.ui.internal.WorkbenchPage.openEditor(WorkbenchPage.java:3116)
	at org.eclipse.ui.internal.WorkbenchPage.openEditor(WorkbenchPage.java:3086)
	at org.eclipse.ui.internal.WorkbenchPage.openEditor(WorkbenchPage.java:3077)
	at bndtools.jareditor.internal.JARTreePart.lambda$new$1(JARTreePart.java:141)
	at org.eclipse.jface.viewers.StructuredViewer$1.run(StructuredViewer.java:779)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.StructuredViewer.fireDoubleClick(StructuredViewer.java:776)
	at org.eclipse.jface.viewers.AbstractTreeViewer.handleDoubleSelect(AbstractTreeViewer.java:1579)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetDefaultSelected(StructuredViewer.java:1205)
	at org.eclipse.jface.util.OpenStrategy.fireDefaultSelectionEvent(OpenStrategy.java:271)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:328)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4660)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1657)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1680)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1665)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1394)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4427)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4003)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:668)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:576)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:178)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:670)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:607)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1492)



```


e.g. when I click on a MANIFEST.MF File inside the jar.

`org.eclipse.ui.part.FileEditorInput(/.BndtoolsJAREditorTempFiles/temp/10000004/com.synesty.studio.service.pdf.jar/META-INF/MANIFEST.MF)`

