### PR TITLE
fix Customize Imports forgets selection after save

### DIFF
--- a/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsListPart.java
+++ b/bndtools.core/src/bndtools/editor/pkgpatterns/PkgPatternsListPart.java
@@ -360,6 +360,8 @@ public abstract class PkgPatternsListPart<C extends HeaderClause> extends Sectio
 	public void refresh() {
 		super.refresh();
 
+		List<String> previouslySelected = getSelectedClauseNames();
+
 		// Deep-copy the model
 		Collection<C> tmp = loadFromModel(model);
 		if (tmp != null) {
@@ -374,6 +376,31 @@ public abstract class PkgPatternsListPart<C extends HeaderClause> extends Sectio
 		}
 		viewer.setInput(clauses);
 		validate();
+		viewer.refresh();
+
+		IFormPage page = (IFormPage) managedForm.getContainer();
+
+		if (page.isActive()) {
+			// only restore the previous selection if we are on the Bundle
+			// Content Page
+			restoreSelectionByName(previouslySelected);
+		}
+	}
+
+	private List<String> getSelectedClauseNames() {
+		return selection != null ? selection.stream()
+			.map(HeaderClause::getName)
+			.toList() : List.of();
+	}
+
+	private void restoreSelectionByName(List<String> namesToSelect) {
+		List<C> matches = clauses.stream()
+			.filter(c -> namesToSelect.contains(c.getName()))
+			.toList();
+
+		if (!matches.isEmpty()) {
+			viewer.setSelection(new StructuredSelection(matches), true);
+		}
 	}
 
 	public void validate() {


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6565

this fixes the bug that after saving e.g. a change to the _optional_ checkbox, _version_ or _name_ did not have an effect immediatelly and the UI element of the checkbox was not in sync with the actual values in the source tab and also in the table viewer

Now after the fix the state of the UI Elements and source are always in sync after saving. Bonus: the current selection of values (multiple selections) is remembered.

This fix goes hand in hand with https://github.com/bndtools/bnd/pull/6564