### PR TITLE
allow dropping advanced search result to reqs

### DIFF
--- a/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
+++ b/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
@@ -49,6 +49,7 @@ import bndtools.model.repo.ProjectBundle;
 import bndtools.model.repo.RepositoryBundle;
 import bndtools.model.repo.RepositoryBundleUtils;
 import bndtools.model.repo.RepositoryBundleVersion;
+import bndtools.model.repo.RepositoryResourceElement;
 import bndtools.preferences.BndPreferences;
 import bndtools.wizards.repo.RepoBundleSelectionWizard;
 
@@ -276,6 +277,11 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 			VersionedClause clause = (VersionedClause) elem;
 			bsn = clause.getName();
 			versionRange = clause.getVersionRange();
+		} else if (elem instanceof RepositoryResourceElement rre) {
+			RepositoryBundleVersion repositoryBundleVersion = rre.getRepositoryBundleVersion();
+			bsn = repositoryBundleVersion.getBsn();
+			versionRange = RepositoryBundleUtils.toVersionRangeUpToNextMajor(repositoryBundleVersion.getVersion())
+				.toString();
 		} else {
 			throw new IllegalArgumentException("Unable to derive identity from an object of type " + elem.getClass()
 				.getSimpleName());


### PR DESCRIPTION
This fixes the problem that an Advanced Search result cannot be drag/dropped ont 
- Run Editor / Requirements
- Run Editor / Blacklist

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/d095fa6c-efdd-43b2-afda-35248d7f055e" />

Before this PR it resulted in Exception:

```
Error adding one or more requirements
  Error generating requirement
  Unable to derive identity from an object of type RepositoryResourceElement

```