### PR TITLE
fix Image already disposed error

### DIFF
--- a/bndtools.core/src/bndtools/views/repository/AdvancedSearchDialog.java
+++ b/bndtools.core/src/bndtools/views/repository/AdvancedSearchDialog.java
@@ -2,8 +2,6 @@ package bndtools.views.repository;
 
 import java.beans.PropertyChangeListener;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -55,7 +53,6 @@ public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistabl
 
 		PropertyChangeListener changeListener = evt -> updateFromPanel();
 
-		final List<Image> images = new LinkedList<>();
 
 		for (Entry<String, SearchPanel> panelEntry : panelMap.entrySet()) {
 			String title = panelEntry.getKey();
@@ -76,19 +73,11 @@ public class AdvancedSearchDialog extends TitleAreaDialog implements IPersistabl
 
 			Image image = panel.createImage(tabFolder.getDisplay());
 			if (image != null) {
-				images.add(image);
 				item.setImage(image);
 			}
 
 			panel.addPropertyChangeListener(changeListener);
 		}
-
-		tabFolder.addDisposeListener(e -> {
-			for (Image image : images) {
-				if (!image.isDisposed())
-					image.dispose();
-			}
-		});
 
 		tabFolder.setSelection(activeTabIndex);
 		SearchPanel currentPanel = (SearchPanel) tabFolder.getItem(activeTabIndex)

--- a/bndtools.core/src/bndtools/views/repository/SearchPanel.java
+++ b/bndtools.core/src/bndtools/views/repository/SearchPanel.java
@@ -3,6 +3,7 @@ package bndtools.views.repository;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
+import org.bndtools.core.ui.icons.Icons;
 import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -61,6 +62,11 @@ public abstract class SearchPanel implements IPersistable {
 		propSupport.firePropertyChange(PROP_VALUE, oldRequiremenmt, requirement);
 	}
 
+	/**
+	 * Returns a managed / cached instance of an Image (via
+	 * {@link Icons#image(String, String...)}. Callers must not call
+	 * image.dispose().
+	 */
 	public Image createImage(@SuppressWarnings("unused") Device device) {
 		return null;
 	}

--- a/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
+++ b/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
@@ -143,6 +143,9 @@ public final class Icons {
 		}
 	}
 
+	/**
+	 * @return a shared / managed Image. Callers must NOT call .dispose()
+	 */
 	public static Image image(String name, boolean nullIfAbsent) {
 
 		ImageDescriptor desc = desc(name, nullIfAbsent);
@@ -160,6 +163,9 @@ public final class Icons {
 		}
 	}
 
+	/**
+	 * @return a shared / managed Image. Callers must NOT call .dispose()
+	 */
 	public static Image image(String name, String... decorators) {
 		synchronized (images) {
 			Key k = new Key(name, decorators);


### PR DESCRIPTION
By removing call to `image.dispose()` in RepoView/AdvancedSearchm because the image is created via `Icons.image()` which is a shared / cached image instance where Icons.java class takes care of calling `.dispose()` at the appropriate time.

Closes https://github.com/bndtools/bnd/issues/6322

