### PR TITLE
Effective view: show merged properties

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -1601,7 +1601,7 @@ public class BndEditModel {
 			return (Converter) converters.get(header);
 	}
 
-	private static String getStem(String header) {
+	public static String getStem(String header) {
 		int n = header.indexOf('.');
 		if (n < 0)
 			return header;

--- a/bndtools.core/src/bndtools/editor/completion/BndHover.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndHover.java
@@ -52,38 +52,7 @@ public class BndHover extends DefaultTextHover {
 						.collect(Collectors.joining());
 				}
 
-				Syntax syntax = Syntax.HELP.get(key);
-				StringBuilder sb = new StringBuilder();
-				if (syntax == null) {
-					if (!key.startsWith("-"))
-						key = "-" + key;
-					syntax = Syntax.HELP.get("-" + key);
-				}
-
-				if (syntax != null) {
-
-					sb.append(syntax.getLead());
-					String values = syntax.getValues();
-					if (values != null && !values.isBlank()) {
-						sb.append("\nValues: ");
-						sb.append(syntax.getValues());
-					}
-					sb.append("\nExample: ");
-					sb.append(syntax.getExample());
-				}
-				Parameters decorated = properties.decorated(key);
-				if (!decorated.isEmpty()) {
-					sb.append("\n")
-						.append(key)
-						.append("=")
-						.append(decorated);
-				}
-
-				String text = sb.toString();
-
-				if (text.length() > 30) {
-					text = wrap(text, 30);
-				}
+				String text = syntaxHoverText(key, properties);
 				if (!text.isEmpty())
 					return text;
 
@@ -159,4 +128,39 @@ public class BndHover extends DefaultTextHover {
 		return sb.toString();
 	}
 
+	public static String syntaxHoverText(String key, Processor properties) {
+		Syntax syntax = Syntax.HELP.get(key);
+		StringBuilder sb = new StringBuilder();
+		if (syntax == null) {
+			if (!key.startsWith("-"))
+				key = "-" + key;
+			syntax = Syntax.HELP.get("-" + key);
+		}
+
+		if (syntax != null) {
+
+			sb.append(syntax.getLead());
+			String values = syntax.getValues();
+			if (values != null && !values.isBlank()) {
+				sb.append("\nValues: ");
+				sb.append(syntax.getValues());
+			}
+			sb.append("\nExample: ");
+			sb.append(syntax.getExample());
+		}
+		Parameters decorated = properties.decorated(key);
+		if (!decorated.isEmpty()) {
+			sb.append("\n")
+				.append(key)
+				.append("=")
+				.append(decorated);
+		}
+
+		String text = sb.toString();
+
+		if (text.length() > 30) {
+			text = wrap(text, 30);
+		}
+		return text;
+	}
 }


### PR DESCRIPTION
Closes #6525

- add a new option to show the properties as merged properties (group the properties by stem)
- works in table and source view
- refactored BndSourceEffectivePage slightly. I removed the functions from ColSpec and introduced record PropertyRow which is populated in getTableData()
- added: hovering over 'key' column now also shows the Syntax.HELP text like the sourceViewer does

![image](https://github.com/user-attachments/assets/9dda4587-2822-419a-aa90-fd324640a97c)
