### PR TITLE
try to fix error "Missing system library"

### DIFF
--- a/bndtools.core/src/org/bndtools/refactor/util/ASTEngine.java
+++ b/bndtools.core/src/org/bndtools/refactor/util/ASTEngine.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -101,6 +102,20 @@ public class ASTEngine {
 		optionsx.put(JavaCore.COMPILER_SOURCE, sourceLevel);
 		parser.setCompilerOptions(optionsx);
 		parser.setUnitName(unit);
+
+		this.unit = (CompilationUnit) parser.createAST(null);
+		this.ast = this.unit.getAST();
+		this.rewriter = ASTRewrite.create(ast);
+	}
+
+	public ASTEngine(IJavaProject javaProject, String source, int jls, int kind, String unit) {
+		this.source = source;
+		ASTParser parser = ASTParser.newParser(jls);
+		parser.setResolveBindings(true);
+		parser.setSource(source.toCharArray());
+		parser.setKind(kind);
+		parser.setUnitName(unit);
+		parser.setProject(javaProject);
 
 		this.unit = (CompilationUnit) parser.createAST(null);
 		this.ast = this.unit.getAST();

--- a/bndtools.core/src/org/bndtools/refactor/util/RefactorAssistant.java
+++ b/bndtools.core/src/org/bndtools/refactor/util/RefactorAssistant.java
@@ -38,6 +38,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -1033,8 +1034,10 @@ public class RefactorAssistant {
 					unit = underlyingResource.getFullPath()
 						.lastSegment();
 				}
-				return new ASTEngine(iunit.getSource(), AST.getJLSLatest(), ASTParser.K_COMPILATION_UNIT, unit,
-					iunit.getOptions(true));
+
+				IJavaProject javaProject = iunit.getJavaProject();
+				return new ASTEngine(javaProject, iunit.getSource(), AST.getJLSLatest(), ASTParser.K_COMPILATION_UNIT,
+					unit);
 			} catch (JavaModelException e) {
 				throw Exceptions.duck(e);
 			}


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6521

It seems ASTParser now has a stricter check on the options (see https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3063/files#diff-5155d744fdf221c04316cc2e0751b9ed207740927ccb1a36d82f85ca4e2bee5cR277)

Based on some manual code analysis, debugging and a fix from somebody else [here](https://github.com/anjlab/eclipse-tapestry5-plugin/commit/fc149b5ea04eb9e260659b44113efc9f15f694e2#diff-3383f8a572a18d2bcbe9fca95ac81a225654d66263a02dcdaf1a68cef187b480L484-R480) 

 we now pass the `javaproject` to configure the parser, which should contain everything needed, instead of a Map.


Note: this is experimental. I will merge it and revert if it is not working. 
Unfortunately this is a bit hard to test and debug, because it happens only with **Eclipse > 2024-12**. The error of #6521  does not happen in the bndtools Development instance (Eclipse 2022-09)