### PR TITLE
addSources context menu for BndPomRepo

### DIFF
--- a/biz.aQute.repository/bnd.bnd
+++ b/biz.aQute.repository/bnd.bnd
@@ -61,3 +61,4 @@ Export-Package: \
 
 -baseline: *
 -metatypeannotations: *
+Private-Package: aQute.bnd.repository.maven.util

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/util/RepoActionsUtil.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/util/RepoActionsUtil.java
@@ -1,0 +1,62 @@
+package aQute.bnd.repository.maven.util;
+
+import java.io.File;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.osgi.util.promise.Promise;
+
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.osgi.Jar;
+import aQute.maven.api.Archive;
+
+/**
+ * Common helper methods used by MavenBndRepository and BndPomRepository
+ */
+public class RepoActionsUtil {
+
+	public static void addSources(final Archive archive, Function<Archive, Promise<File>> lookup,
+		Map<String, Runnable> map) throws Exception {
+		Promise<File> pBinary = lookup.apply(archive);
+
+		if (pBinary.getFailure() == null) {
+			final File binary = pBinary.getValue();
+			final File out = new File(binary.getParentFile(), "+" + binary.getName());
+
+			if (!out.isFile()) {
+				Archive a = archive.revision.archive("jar", "sources");
+				Promise<File> pSources = lookup.apply(a);
+
+				if (pSources.getFailure() == null) {
+					final File sources = pSources.getValue();
+
+					if (sources.isFile() && sources.length() > 1000) {
+						map.put("Add Sources", () -> {
+
+							try {
+
+								try (Jar src = new Jar(sources)) {
+
+									try (Jar bin = new Jar(binary)) {
+										bin.setDoNotTouchManifest();
+										for (String path : src.getResources()
+											.keySet())
+											bin.putResource("OSGI-OPT/src/" + path, src.getResource(path));
+										bin.write(out);
+									}
+									out.setLastModified(System.currentTimeMillis());
+								}
+							} catch (Exception e) {
+								throw Exceptions.duck(e);
+							}
+						});
+						return;
+					}
+				}
+			}
+		}
+
+		map.put("-Add Sources", null);
+	}
+
+}


### PR DESCRIPTION
Relates to https://github.com/bndtools/bnd/issues/6578#issuecomment-2840463367


This adds the "Add Sources" feature - known from MavenBndRepository - to download source code for a Repo Revision 
 also to BndPomRepository.

<img width="289" alt="image" src="https://github.com/user-attachments/assets/ef026609-6da9-4fdc-acf0-20e77a4638f0" />

It shares the same code with a minor refactoring.
