### PR TITLE
Launcher: don't include source code in OSGI-OPT

### DIFF
--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -32,3 +32,6 @@
 -builderignore: testresources
 
 -baseline: *
+
+# Do not include source code in OSGI-OPT  
+-sources: false

--- a/biz.aQute.launcher/bnd/pre.bnd
+++ b/biz.aQute.launcher/bnd/pre.bnd
@@ -3,3 +3,6 @@
 	aQute.launcher.pre
 
 -baseline:
+
+# Do not include source code in OSGI-OPT  
+-sources: false


### PR DESCRIPTION
- Related to #6578 where it was requested to not include source code in the jars, to keep them smaller

The source code is available as separate jars on Maven Central anyway. 

https://repo1.maven.org/maven2/biz/aQute/bnd/biz.aQute.launcher/7.1.0/

<img width="666" alt="Image" src="https://github.com/user-attachments/assets/573bee29-b535-4c79-83d8-850557813755" />


I also added  https://github.com/bndtools/bnd/pull/6581 , which adds the "Add sources" context menu for in Repo browser for BndPomRepo. This then makes it easier to use the source code artifacts on maven central if needed.

