### PR TITLE
Docs: add page.summary dynamically to all page where it is maintained in frontmatter block

### DIFF
--- a/docs/_commands/action.md
+++ b/docs/_commands/action.md
@@ -4,9 +4,7 @@ title: create
 summary: Create a JAR                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/baseline.md
+++ b/docs/_commands/baseline.md
@@ -4,9 +4,7 @@ title: baseline [options] <[newer jar]> <[older jar]>
 summary: Compare a newer bundle to a baselined bundle and provide versioning advice.                                
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/bash.md
+++ b/docs/_commands/bash.md
@@ -4,9 +4,7 @@ title:   bash
 summary:  Generate autocompletion file for bash
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/bnd.md
+++ b/docs/_commands/bnd.md
@@ -4,9 +4,7 @@ title: bnd
 summary: The swiss army tool for OSGi
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/bootstrap.md
+++ b/docs/_commands/bootstrap.md
@@ -4,9 +4,7 @@ title: bootstrap
 summary: Interactive gogo shell                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/bsn2url.md
+++ b/docs/_commands/bsn2url.md
@@ -4,9 +4,7 @@ title: bsn2url
 summary: From a set of bsns, create a list of urls if found in the repo                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/build.md
+++ b/docs/_commands/build.md
@@ -4,9 +4,7 @@ title: build [options]
 summary: Build a project. This will create the jars defined in the bnd.bnd and sub-builders.                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/buildx.md
+++ b/docs/_commands/buildx.md
@@ -3,9 +3,7 @@ layout: default
 title: buildx [options] 
 summary: Build project, is deprecated but here for backward compatibility. If you use it, you should know how to use it so no more info is provided.                                 
 ---
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/bump.md
+++ b/docs/_commands/bump.md
@@ -4,9 +4,7 @@ title: bump [options] <<major|minor|micro>>
 summary: Bumps the version of a project. Will take the current version and then increment with a major, minor, or micro increment. The default bump is minor.                                 
 ---
    
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/changes.md
+++ b/docs/_commands/changes.md
@@ -4,9 +4,7 @@ title: changes [options]
 summary: Show the changes in this release of bnd                                 
 ---
    
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/clean.md
+++ b/docs/_commands/clean.md
@@ -4,9 +4,7 @@ title: clean [options] ...
 summary: Clean a project                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/convert.md
+++ b/docs/_commands/convert.md
@@ -4,9 +4,7 @@ title:    convert [options] <[from]> <[to]>
 summary: Converter to different formats                                 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/create.md
+++ b/docs/_commands/create.md
@@ -4,9 +4,7 @@ title: action [options] ...
 summary: Equivalent jar command c[v0mf] command (supports the jar tool's syntax). Will wrap the bundle unless --wrapnot is specified
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/debug.md
+++ b/docs/_commands/debug.md
@@ -4,9 +4,7 @@ title:    debug [options] ...
 summary: Show a lot of info about the project you're in
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/defaults.md
+++ b/docs/_commands/defaults.md
@@ -4,9 +4,7 @@ title: defaults
 summary: 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/deliverables.md
+++ b/docs/_commands/deliverables.md
@@ -4,9 +4,7 @@ title:    deliverables [options]
 summary:  Show all deliverables from this workspace. with their current version and path.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/diff.md
+++ b/docs/_commands/diff.md
@@ -5,9 +5,7 @@ summary:  Compares two jars. Without specifying the JARs (and when there is a cu
 ---
 
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/digest.md
+++ b/docs/_commands/digest.md
@@ -4,9 +4,7 @@ title:   digest [options] <[file...]>
 summary: Digest a number of files 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/do.md
+++ b/docs/_commands/do.md
@@ -4,9 +4,7 @@ title:      do [options] ...
 summary: Execute a file based on its extension. Supported extensions are bnd (build), bndrun (run), and jar (print) 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/eclipse-pde.md
+++ b/docs/_commands/eclipse-pde.md
@@ -7,9 +7,7 @@ bnd: 4
 
 _THIS IS WORK IN PROGRESS_
 
-## Description
 
-{{page.summary}}
 
 The control file (-i) has the following properties: 
 

--- a/docs/_commands/eclipse.md
+++ b/docs/_commands/eclipse.md
@@ -4,9 +4,7 @@ title:      eclipse [options]
 summary: Show info about the current directory's eclipse project
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/ees.md
+++ b/docs/_commands/ees.md
@@ -4,9 +4,7 @@ title:         ees <[jar-file]...>
 summary:  Show the Execution Environments of a JAR
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/exportreport.md
+++ b/docs/_commands/exportreport.md
@@ -4,9 +4,7 @@ title:   exportreport <sub-cmd> [options]
 summary: Generate and export reports of a workspace, a project or of a Jar.
 ---
 
-## Description
 
-{{page.summary}}
 
 Custom reports must first be configured in the project or the workspace with the [-exportreport](../instructions/exportreport.html) intruction and optionaly with the [-reportconfig](../instructions/reportconfig.html) intruction. For an "external" Jar the reports can be configured directly with the command line (replacing the `-exportreport` instruction), however if you need to fine tune the report the `-reportconfig` has to be in a properties file. 
 

--- a/docs/_commands/extract.md
+++ b/docs/_commands/extract.md
@@ -4,9 +4,7 @@ title:   extract [options] ...
 summary:  Extract files from a JAR file, equivalent jar command x[vf] (syntax supported)
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/find.md
+++ b/docs/_commands/find.md
@@ -4,9 +4,7 @@ title:   find [options] <[file]...>
 summary:  Go through the exports and/or imports and match the given exports/imports globs. If they match, print the file, package and version.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/generate.md
+++ b/docs/_commands/generate.md
@@ -4,9 +4,7 @@ title: generate
 summary: Generate autocompletion file for bash
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/grep.md
+++ b/docs/_commands/grep.md
@@ -4,9 +4,7 @@ title:     grep [options] <[pattern]> <[file]...>
 summary:  Grep the manifest of bundles/jar files.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/identity.md
+++ b/docs/_commands/identity.md
@@ -4,9 +4,7 @@ title: identity
 summary: 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/index.md
+++ b/docs/_commands/index.md
@@ -4,9 +4,7 @@ title: index [options] <[bundles]...>
 summary: Index bundles from the local file system
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/info.md
+++ b/docs/_commands/info.md
@@ -4,9 +4,7 @@ title:  info [options]
 summary: Show key project variables
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/junit.md
+++ b/docs/_commands/junit.md
@@ -6,9 +6,7 @@ summary:  Test a project according to an OSGi test
 
 TODO Does not work yet
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/macro.md
+++ b/docs/_commands/macro.md
@@ -3,9 +3,7 @@ layout: default
 title:     macro [options] <[macro]> <[...]> 
 summary:  Show macro value. Macro can contain the  { and } parentheses but it is also ok without. You can use the ':' instead of the ';' in a macro
 ---
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/maven.md
+++ b/docs/_commands/maven.md
@@ -4,9 +4,7 @@ title:     maven ( 'settings' | 'bundle'
 summary:  Special maven commands
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/package.md
+++ b/docs/_commands/package.md
@@ -4,9 +4,7 @@ title:    package [options] <<bnd|bndrun>> <[...]>
 summary: Package a bnd or bndrun file into a single jar that executes with java -jar <>.jar. The JAR contains all dependencies, including the framework and the launcher. A profile can be specified which will be used to find properties. If a property is not found, a property with the name [<profile>]NAME will be looked up. This allows you to make different profiles for testing and runtime.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/plugins.md
+++ b/docs/_commands/plugins.md
@@ -4,9 +4,7 @@ title: plugins [options]
 summary: Execute a Project action, or if no parms given, show information about the project 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/print.md
+++ b/docs/_commands/print.md
@@ -4,9 +4,7 @@ title:  print [options] <[jar-file]...>
 summary: Provides detailed view of the bundle. It will analyze the bundle and then show its contents from different perspectives. If no options are specified, prints the manifest. 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/project.md
+++ b/docs/_commands/project.md
@@ -4,9 +4,7 @@ title:    project [options]
 summary: Execute a Project action, or if no parms given, show information about the project 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/release.md
+++ b/docs/_commands/release.md
@@ -4,9 +4,7 @@ title:    release [options]
 summary: Release this project 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/repo.md
+++ b/docs/_commands/repo.md
@@ -4,9 +4,7 @@ title:   repo [options] <[sub-cmd]> ...
 summary: Access to the repositories. Provides a number of sub commands to manipulate the repository (see repo help) that provide access to the installed repos for the current project.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/run.md
+++ b/docs/_commands/run.md
@@ -4,9 +4,7 @@ title:   run [options] <[bndrun]>
 summary: Run a project in the OSGi launcher. If not bndrun is specified, the current project is used for the run specification 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/runtests.md
+++ b/docs/_commands/runtests.md
@@ -4,9 +4,7 @@ title:   runtests [options] ...
 summary: Run OSGi tests and create report 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/schema.md
+++ b/docs/_commands/schema.md
@@ -4,9 +4,7 @@ title:     schema [options] ...
 summary: Print out the packages from spec jars and check in which ees they appear. Very specific. For example, schema ee.j2se-1.6.0 ee.j2se-1.5.0 ee.j2ee-1.4.0 
 ---
 
-## Description
 
-{{page.summary}}
 
 Is used to start package versioning and figure out the semantic history
 

--- a/docs/_commands/select.md
+++ b/docs/_commands/select.md
@@ -4,9 +4,7 @@ title:     select [options] <[jar-path]> <[...]>
 summary: Helps finding information in a set of JARs by filtering on manifest data and printing out selected information. 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/settings.md
+++ b/docs/_commands/settings.md
@@ -4,9 +4,7 @@ title: settings [options] <[key][=<[value]>]...>
 summary: Set bnd global variables. The key can be wildcarded. 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/source.md
+++ b/docs/_commands/source.md
@@ -4,9 +4,7 @@ title:  source [options] <[jar path]> <[source path]>
 summary: Merge a binary jar with its sources. It is possible to specify source path 
 ---
    
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/sync.md
+++ b/docs/_commands/sync.md
@@ -4,9 +4,7 @@ title:   sync [options]
 summary: Execute a Project action, or if no parms given, show information about the project 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/syntax.md
+++ b/docs/_commands/syntax.md
@@ -4,9 +4,7 @@ title:   syntax [options] <header|instruction> ...
 summary: Access the internal bnd database of keywords and options 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/test.md
+++ b/docs/_commands/test.md
@@ -4,9 +4,7 @@ title:   test [options] <testclass[:method]...>
 summary: Test a project according to an OSGi test 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/type.md
+++ b/docs/_commands/type.md
@@ -4,9 +4,7 @@ title:     type [options] ...
 summary: List files int a JAR file, equivalent jar command t[vf] (syntax supported) 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/verify.md
+++ b/docs/_commands/verify.md
@@ -4,9 +4,7 @@ title:   verify <[jar path]> <[...]>
 summary: Verify jars 
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/version.md
+++ b/docs/_commands/version.md
@@ -4,9 +4,7 @@ title:   version [options]
 summary: Show version information about bnd
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/view.md
+++ b/docs/_commands/view.md
@@ -4,9 +4,7 @@ title:   view [options] <[jar-file]>> <[resource]> <[...]>
 summary: View a resource from a JAR file. Manifest will be pretty printed and class files are shown disassembled.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/wrap.md
+++ b/docs/_commands/wrap.md
@@ -4,9 +4,7 @@ title:  wrap [options] <[jar-file]> <[...]>
 summary: Wrap a jar into a bundle. This is a poor man's facility to quickly turn a non-OSGi JAR into an OSGi bundle. It is usually better to write a bnd file and use the bnd <file>.bnd command because that has greater control. Even better is to wrap in bndtools.
 ---
 
-## Description
 
-{{page.summary}}
 
 The wrap command takes an existing JAR file and guesses the manifest headers that will make this JAR useful for an OSGi Service Platform. If the output file is not overridden, the name of the input file is used with a .bar extension. The default bnd file for the header calculation is:
 

--- a/docs/_commands/xmlrepodiff.md
+++ b/docs/_commands/xmlrepodiff.md
@@ -5,9 +5,7 @@ summary: Compares two XML resource repositories
 ---
 
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_commands/xref.md
+++ b/docs/_commands/xref.md
@@ -4,9 +4,7 @@ title:  xref [options] <[jar path]> <[...]>
 summary: Show cross references for all classes in a set of jars.
 ---
 
-## Description
 
-{{page.summary}}
 
 ## Synopsis
 

--- a/docs/_heads/bundle_activationpolicy.md
+++ b/docs/_heads/bundle_activationpolicy.md
@@ -5,57 +5,7 @@ title: Bundle-ActivationPolicy ::= policy ( ';' directive )*
 summary: The Bundle-ActivationPolicy specifies how the framework should activate the bundle once started.
 ---
 
-Activation Policies
-The activation of a bundle can also be deferred to a later time from its start using an activation policy. This policy is specified in the Bundle-ActivationPolicy header with the following syntax:
-Bundle-ActivationPolicy ::= policy ( ';' directive )*
-policy ::= 'lazy'
-The only policy defined is the lazy activation policy. If no Bundle-ActivationPolicy header is speci- fied, the bundle will use eager activation.
-Lazy Activation Policy
-A lazy activation policy indicates that the bundle, once started, must not be activated until it re- ceives the first request to load a class. This request can originate either during normal class load- ing or via the Bundle loadClass method. Resource loading and a request for a class that is re-direct- ed to another bundle must not trigger the activation. The first request is relative to the bundle class loader, a bundle will not be lazily started if it is stopped and then started again without being re- freshed in the mean time.
-This change from the default eager activation policy is reflected in the state of the bundle and its events. When a bundle is started using a lazy activation policy, the following steps must be taken:
-• A Bundle Context is created for the bundle.
-• The bundle state is moved to the STARTING state.
-• The LAZY_ACTIVATION event is fired.
-• The system waits for a class load from the bundle to occur.
-• The normal STARTING event is fired.
-• The bundle is activated.
-• The bundle state is moved to ACTIVE.
-• The STARTED event is fired.
-If the activation fails because the Bundle Activator start method has thrown an exception, the bun- dle must be stopped without calling the Bundle Activator stop method. These steps are pictured in a flow chart in Figure 4.5. This flow chart also shows the difference in activation policy of the normal eager activation and the lazy activation.
-•
-￼￼Page 110
-OSGi Core Release 6
-Life Cycle Layer Version 1.8
-The Bundle Object
-￼￼Figure 4.5
-Starting with eager activation versus lazy activation
-￼￼￼￼￼￼started? no
-yes
-￼￼￼￼￼￼￼state=STARTING
-￼￼￼￼￼￼￼￼lazyactivation? yes no
-exception?
-Waitforclass load trigger
-event LAZY_ACTIVATION
-￼￼￼￼￼￼￼￼￼￼event STARTING
-￼￼activate the bundle
-￼￼￼￼￼￼￼yes
-no
-￼￼￼￼￼￼￼￼￼￼￼state=STOPPING event STOPPING state=RESOLVED event STOPPED
-state=ACTIVE event STARTED
-￼￼￼￼￼￼￼￼￼￼The lazy activation policy allows a Framework implementation to defer the creation of the bundle class loader and activation of the bundle until the bundle is first used; potentially saving resources and initialization time during startup.
-By default, any class loaded from the bundle can trigger the lazy activation, however, resource loads must not trigger the activation. The lazy activation policy can define which classes cause the activa- tion with the following directives:
-• include - A list of package names that must trigger the activation when a class is loaded from any of these packages. The default is all package names present in the bundle.
-• exclude - A list of package names that must not trigger the activation of the bundle when a class is loaded from any of these packages. The default is no package names.
-For example:
-Bundle-ActivationPolicy: lazy; «
-    include:="com.acme.service.base,com.acme.service.help"
-When a class load triggers the lazy activation, the Framework must first define the triggering class. This definition can trigger additional lazy activations. These activations must be deferred until all transitive class loads and defines have finished. Thereafter, the activations must be executed in the reverse order of detection. That is, the last detected activation must be executed first. Only after
-￼￼OSGi Core Release 6
-Page 111
-The Bundle Object Life Cycle Layer Version 1.8
-￼￼4.4.6.3
-all deferred activations are finished must the class load that triggered the activation return with the loaded class. If an error occurs during this process, it should be reported as a Framework ERROR event. However, the class load must succeed normally. A bundle that fails its lazy activation should not be activated again until the framework is restarted or the bundle is explicitly started by calling the Bundle start method.
-
+See [OSGi Specification](https://docs.osgi.org/specification/osgi.core/8.0.0/framework.lifecycle.html#i3270439) for a description of this header.
 
 	public boolean verifyActivationPolicy(String policy) {
 		Parameters map = parseHeader(policy);

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -24,7 +24,15 @@
                    </div>
                 {% endif %}     
 				</h1>
-				
+{% if page.summary %}
+
+{% if page.collection == "commands" %}
+<h2>Description</h2>
+{% endif %}
+
+{{page.summary}}
+<br /><br />
+{% endif %}
 				{{content}}
 				</main>
 			</div>


### PR DESCRIPTION
Currently almost each page for macros, instructions or commands defines a frontmatter block with a summary:

```
---
layout: default
class: Macro
title: dir ( ';' FILE )*
summary: Returns a list of the directories containing each specified file
---

```

Unfortunatelly this summary is not printed to the visible Html but only used in html meta tags (description) or in overview tables. 

Now I add it to the top of each page. 

This is especially useful for not-well maintained instructions which currently only display a source code snippet. 
Now they at least also display the summary sentence, which already makes the page more useful.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/9f0d2838-8209-4230-9faf-9920fbd2b4aa" />
