### PR TITLE
rework Add sources & calculateSourceAttachmentPath

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -582,9 +582,6 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 		}
 
 		File f = storage.toLocalFile(archive);
-		File withSources = new File(f.getParentFile(), "+" + f.getName());
-		if (withSources.isFile() && withSources.lastModified() > f.lastModified())
-			f = withSources;
 
 		if (listeners.length == 0) {
 			return f;


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6593

This PR does mainly 2 things:

- it removes a "hack" in `MavenBndRepository.get()` which was using the +-prefixed jar file (e.g. +somedependency-6.1.17.jar) which is created by "Add sources" in the repo browser. This had negative side effects because those +jars were put into the build output e.g. by `-includeresources`. 
- It improves the Eclipse Source attachment lookup to properly use bnds integrated mechanism to get a -sources.jar if it exists via the BSN_SOURCE_SUFFIX (bsn + ".source") mechanism

Note: I did not change the "Add sources" behavior. The +-jar with included sourcecode under OSGI-OPT is still created. I initially had it and it is reflected in the discussions below, but I reverted that. 

## What does it solve?

- for the initial issue https://github.com/bndtools/bnd/issues/6593 it solves the problem that other jars put inside my jar via `-includeresource` no longer contain the source code just because I used "Add sources" in the IDE
- this also makes the Eclipse IDE created jars more reproducible because they now should be the same as in a CI build

