### PR TITLE
upgrade plexus-build-api to 1.2.0

### DIFF
--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -37,7 +37,7 @@
 	org.eclipse.m2e.core,\
 	org.eclipse.m2e.jdt,\
 	org.eclipse.osgi,\
-	org.sonatype.plexus:plexus-build-api
+	org.codehaus.plexus:plexus-build-api
 
 Bundle-SymbolicName: ${p};singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -166,8 +166,8 @@ org.apache.maven:maven-plugin-api:${maven.target.version}
 org.apache.maven:maven-repository-metadata:${maven.target.version}
 org.apache.maven:maven-settings:${maven.target.version}
 org.eclipse.aether:aether-api:${aether.version}
-org.sonatype.plexus:plexus-build-api:0.0.7
-org.codehaus.plexus:plexus-utils:3.0.22
+org.codehaus.plexus:plexus-build-api:1.2.0
+org.codehaus.plexus:plexus-utils:3.0.24
 org.codehaus.plexus:plexus-classworlds:2.5.2
 
 ## higher SWT version required because of SWT bug with MacOS Sonoma 

--- a/maven-plugins/bnd-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-maven-plugin/pom.xml
@@ -40,7 +40,7 @@
 			<artifactId>maven-mapping</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.sonatype.plexus</groupId>
+			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 		</dependency>
 		<dependency>

--- a/maven-plugins/bnd-plugin-parent/pom.xml
+++ b/maven-plugins/bnd-plugin-parent/pom.xml
@@ -114,9 +114,9 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.sonatype.plexus</groupId>
+				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-build-api</artifactId>
-				<version>0.0.7</version>
+				<version>1.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>

--- a/maven-plugins/bnd-reporter-maven-plugin/pom.xml
+++ b/maven-plugins/bnd-reporter-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
 			<artifactId>maven-mapping</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.sonatype.plexus</groupId>
+			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-build-api</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
- plexus-build-api had CVEs
- org.sonatype.plexus has moved to org.codehaus.plexus

Closes https://github.com/bndtools/bnd/issues/6598