### PR TITLE
Update to latest guava 33.4.8

### DIFF
--- a/biz.aQute.bnd.reporter/bnd.bnd
+++ b/biz.aQute.bnd.reporter/bnd.bnd
@@ -10,18 +10,19 @@ jtwig.version: 5.86.1.RELEASE
 	biz.aQute.bnd.util;version=latest,\
 	biz.aQute.bndlib;version=latest,\
 	slf4j.api;version=latest,\
-	org.jtwig:jtwig-core;version=${jtwig.version},\
- 	org.jtwig:jtwig-reflection;version=${jtwig.version},\
+	org.jtwig:jtwig-core;version='${jtwig.version}',\
+	org.jtwig:jtwig-reflection;version='${jtwig.version}',\
 	org.parboiled:parboiled-java;version=latest,\
 	org.parboiled:parboiled-core;version=latest,\
-	org.apache.commons.lang3;version="[3.4,4.0)",\
-	com.google.guava;version="[18.0,19.0)",\
-	com.googlecode.concurrentlinkedhashmap.lru;version="[1.4.2,2.0.0)",\
+	org.apache.commons.lang3;version='[3.4,4.0)',\
+	com.google.guava;version='[33.4.8,34.0.0)',\
+	com.googlecode.concurrentlinkedhashmap.lru;version='[1.4.2,2.0.0)',\
 	org.objectweb.asm,\
 	org.objectweb.asm.tree.analysis,\
 	org.objectweb.asm.tree,\
 	org.objectweb.asm.util,\
-	com.github.javaparser.javaparser-core;version=3.13
+	com.github.javaparser.javaparser-core;version='3.13',\
+	com.google.guava.failureaccess
 	
 -testpath: \
 	biz.aQute.bnd.test;version=project,\

--- a/biz.aQute.bnd/bnd.bnd
+++ b/biz.aQute.bnd/bnd.bnd
@@ -110,7 +110,7 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
     ${repo;org.parboiled:parboiled-java;latest},\
     ${repo;org.parboiled:parboiled-core;latest},\
     ${repo;org.apache.commons.lang3;[3.4,4.0)},\
-    ${repo;com.google.guava;[18.0,19.0)},\
+    ${repo;com.google.guava;[33.4.8,34.0.0)},\
     ${repo;com.googlecode.concurrentlinkedhashmap.lru;[1.4.2,2.0.0)},\
     ${repo;org.objectweb.asm},\
     ${repo;org.objectweb.asm.tree.analysis},\
@@ -125,13 +125,14 @@ Bundle-Description: This command line utility is the Swiss army knife of OSGi. I
     org.parboiled:parboiled-java;version=latest,\
     org.parboiled:parboiled-core;version=latest,\
     org.apache.commons.lang3;version="[3.4,4.0)",\
-    com.google.guava;version="[18.0,19.0)",\
+    com.google.guava;version="[33.4.8,34.0.0)",\
+	com.google.guava.failureaccess,\
     com.googlecode.concurrentlinkedhashmap.lru;version="[1.4.2,2.0.0)",\
     org.objectweb.asm,\
     org.objectweb.asm.tree.analysis,\
     org.objectweb.asm.tree,\
     org.objectweb.asm.util,\
-	com.github.javaparser.javaparser-core;version=3.13
+	com.github.javaparser.javaparser-core;version=3.13,\
 
 
 -builderignore: testdata, installers

--- a/biz.aQute.http.testservers/bnd.bnd
+++ b/biz.aQute.http.testservers/bnd.bnd
@@ -28,7 +28,7 @@ Bundle-Description: \
 	${junit}, \
 	slf4j.api;version=latest, \
 	slf4j.simple;version=latest, \
-	com.google.guava;version='[19.0,20)', \
+	com.google.guava;version='[33.4.8,34.0.0)', \
 	org.apache.commons.lang3;version=latest, \
 	org.apache.commons.codec;version=latest
 

--- a/bndtools.core.test/test.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core.test/test.cocoa.macosx.aarch64.bndrun
@@ -40,9 +40,10 @@
 	bndtools.core.services;version=snapshot;startlevel=1,\
 	bndtools.core.test.launch;version=snapshot;startlevel=2,\
 	bndtools.core.test.tests;version=snapshot;startlevel=5,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)';startlevel=3,\
 	com.google.gson;version='[2.9.1,2.9.2)';startlevel=3,\
-	com.google.guava;version='[31.1.0,31.1.1)';startlevel=3,\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)';startlevel=3,\
+	com.google.guava;version='[33.4.8,33.4.9)';startlevel=3,\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)';startlevel=3,\
 	com.ibm.icu;version='[67.1.0,67.1.1)';startlevel=3,\
 	com.sun.jna;version='[5.8.0,5.8.1)';startlevel=3,\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)';startlevel=3,\
@@ -68,7 +69,6 @@
 	org.apache.commons.jxpath;version='[1.3.0,1.3.1)';startlevel=3,\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)';startlevel=3,\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)';startlevel=3,\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)';startlevel=3,\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)';startlevel=3,\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)';startlevel=3,\
@@ -291,6 +291,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)';startlevel=3,\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)';startlevel=3,\
 	org.hamcrest.core;version='[1.3.0,1.3.1)';startlevel=3,\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)';startlevel=3,\
 	org.junit;version='[4.13.2,4.13.3)';startlevel=3,\
 	org.opentest4j;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)';startlevel=1,\

--- a/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core.test/test.cocoa.macosx.x86_64.bndrun
@@ -40,9 +40,10 @@
 	bndtools.core.services;version=snapshot;startlevel=1,\
 	bndtools.core.test.launch;version=snapshot;startlevel=2,\
 	bndtools.core.test.tests;version=snapshot;startlevel=5,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)';startlevel=3,\
 	com.google.gson;version='[2.9.1,2.9.2)';startlevel=3,\
-	com.google.guava;version='[31.1.0,31.1.1)';startlevel=3,\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)';startlevel=3,\
+	com.google.guava;version='[33.4.8,33.4.9)';startlevel=3,\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)';startlevel=3,\
 	com.ibm.icu;version='[67.1.0,67.1.1)';startlevel=3,\
 	com.sun.jna;version='[5.8.0,5.8.1)';startlevel=3,\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)';startlevel=3,\
@@ -68,7 +69,6 @@
 	org.apache.commons.jxpath;version='[1.3.0,1.3.1)';startlevel=3,\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)';startlevel=3,\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)';startlevel=3,\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)';startlevel=3,\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)';startlevel=3,\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)';startlevel=3,\
@@ -291,6 +291,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)';startlevel=3,\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)';startlevel=3,\
 	org.hamcrest.core;version='[1.3.0,1.3.1)';startlevel=3,\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)';startlevel=3,\
 	org.junit;version='[4.13.2,4.13.3)';startlevel=3,\
 	org.opentest4j;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)';startlevel=1,\

--- a/bndtools.core.test/test.gtk.linux.x86_64.bndrun
+++ b/bndtools.core.test/test.gtk.linux.x86_64.bndrun
@@ -39,9 +39,10 @@
 	bndtools.core.services;version=snapshot;startlevel=1,\
 	bndtools.core.test.launch;version=snapshot;startlevel=2,\
 	bndtools.core.test.tests;version=snapshot;startlevel=5,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)';startlevel=3,\
 	com.google.gson;version='[2.9.1,2.9.2)';startlevel=3,\
-	com.google.guava;version='[31.1.0,31.1.1)';startlevel=3,\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)';startlevel=3,\
+	com.google.guava;version='[33.4.8,33.4.9)';startlevel=3,\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)';startlevel=3,\
 	com.ibm.icu;version='[67.1.0,67.1.1)';startlevel=3,\
 	com.sun.jna;version='[5.8.0,5.8.1)';startlevel=3,\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)';startlevel=3,\
@@ -67,7 +68,6 @@
 	org.apache.commons.jxpath;version='[1.3.0,1.3.1)';startlevel=3,\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)';startlevel=3,\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)';startlevel=3,\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)';startlevel=3,\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)';startlevel=3,\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)';startlevel=3,\
@@ -288,6 +288,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)';startlevel=3,\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)';startlevel=3,\
 	org.hamcrest.core;version='[1.3.0,1.3.1)';startlevel=3,\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)';startlevel=3,\
 	org.junit;version='[4.13.2,4.13.3)';startlevel=3,\
 	org.opentest4j;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)';startlevel=1,\

--- a/bndtools.core.test/test.shared.bndrun
+++ b/bndtools.core.test/test.shared.bndrun
@@ -15,7 +15,8 @@
 	bnd.identity;id='bndtools.core.services',\
 	bnd.identity;id='bndtools.core.test.launch',\
 	bnd.identity;id='bndtools.core.test.tests',\
-	bnd.identity;id='com.google.guava',\
+	bnd.identity;id='com.google.guava';version='[33.4.8,34.0.0)',\
+	bnd.identity;id='com.google.guava.failureaccess',\
 	bnd.identity;id='javax.annotation',\
 	bnd.identity;id='org.apache.ant',\
 	bnd.identity;id='org.bndtools.headless.build.manager',\

--- a/bndtools.core.test/test.win32.x86_64.bndrun
+++ b/bndtools.core.test/test.win32.x86_64.bndrun
@@ -38,9 +38,10 @@
 	bndtools.core.services;version=snapshot;startlevel=1,\
 	bndtools.core.test.launch;version=snapshot;startlevel=2,\
 	bndtools.core.test.tests;version=snapshot;startlevel=5,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)';startlevel=3,\
 	com.google.gson;version='[2.9.1,2.9.2)';startlevel=3,\
-	com.google.guava;version='[31.1.0,31.1.1)';startlevel=3,\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)';startlevel=3,\
+	com.google.guava;version='[33.4.8,33.4.9)';startlevel=3,\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)';startlevel=3,\
 	com.ibm.icu;version='[67.1.0,67.1.1)';startlevel=3,\
 	com.sun.jna;version='[5.8.0,5.8.1)';startlevel=3,\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)';startlevel=3,\
@@ -66,7 +67,6 @@
 	org.apache.commons.jxpath;version='[1.3.0,1.3.1)';startlevel=3,\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)';startlevel=3,\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)';startlevel=3,\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)';startlevel=3,\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)';startlevel=3,\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)';startlevel=3,\
@@ -290,6 +290,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)';startlevel=3,\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)';startlevel=3,\
 	org.hamcrest.core;version='[1.3.0,1.3.1)';startlevel=3,\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)';startlevel=3,\
 	org.junit;version='[4.13.2,4.13.3)';startlevel=3,\
 	org.opentest4j;version='[1.2.0,1.2.1)';startlevel=3,\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)';startlevel=1,\

--- a/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
@@ -42,9 +42,10 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	com.google.guava;version='[31.1.0,31.1.1)',\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
+	com.google.guava;version='[33.4.8,33.4.9)',\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
@@ -68,7 +69,6 @@
 	org.apache.felix.gogo.runtime;version='[1.1.6,1.1.7)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)',\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)',\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)',\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)',\
@@ -299,6 +299,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -42,9 +42,10 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	com.google.guava;version='[31.1.0,31.1.1)',\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
+	com.google.guava;version='[33.4.8,33.4.9)',\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
@@ -68,7 +69,6 @@
 	org.apache.felix.gogo.runtime;version='[1.1.6,1.1.7)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)',\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)',\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)',\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)',\
@@ -299,6 +299,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -41,9 +41,10 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	com.google.guava;version='[31.1.0,31.1.1)',\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
+	com.google.guava;version='[33.4.8,33.4.9)',\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
@@ -67,7 +68,6 @@
 	org.apache.felix.gogo.runtime;version='[1.1.6,1.1.7)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)',\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)',\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)',\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)',\
@@ -296,6 +296,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -37,7 +37,8 @@
 	bnd.identity;id='bndtools.m2e.debug.fragment',\
 	bnd.identity;id='bndtools.pde',\
 	bnd.identity;id='bndtools.release',\
-	bnd.identity;id='com.google.guava',\
+	bnd.identity;id='com.google.guava';version='[33.4.8,34.0.0)',\
+	bnd.identity;id='com.google.guava.failureaccess',\
 	bnd.identity;id='javax.annotation',\
 	bnd.identity;id='org.apache.ant',\
 	bnd.identity;id='org.apache.felix.gogo.command',\

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -40,9 +40,10 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	com.google.guava;version='[31.1.0,31.1.1)',\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
+	com.google.guava;version='[33.4.8,33.4.9)',\
+	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
@@ -66,7 +67,6 @@
 	org.apache.felix.gogo.runtime;version='[1.1.6,1.1.7)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
-	org.apache.geronimo.specs.geronimo-atinject_1.0_spec;version='[1.1.0,1.1.1)',\
 	org.apache.httpcomponents.httpclient;version='[4.5.13,4.5.14)',\
 	org.apache.httpcomponents.httpcore;version='[4.4.15,4.4.16)',\
 	org.apache.lucene.analyzers-common;version='[8.4.1,8.4.2)',\
@@ -298,6 +298,7 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
+	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\

--- a/bndtools.test/tester/cnf/ext/central.mvn
+++ b/bndtools.test/tester/cnf/ext/central.mvn
@@ -42,7 +42,7 @@ org.apache.felix:org.apache.felix.inventory:1.0.6
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.junit:4.12_1
 org.assertj:assertj-core:3.12.1
 
-com.google.guava:guava:19.0
+com.google.guava:guava:33.4.8-jre
 
 org.opentest4j:opentest4j:1.2.0
 org.apiguardian:apiguardian-api:1.1.2

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -119,9 +119,11 @@ org.littleshoot:littleproxy:1.1.2
 
 io.netty:netty-all:4.1.0.Final
 
-com.google.guava:guava:19.0
-com.google.guava:guava:30.1-jre
-com.google.guava:failureaccess:1.0.1
+com.google.guava:guava:19.0 # only required for biz.aQute.bndlib.comm.tests
+com.google.guava:guava:33.4.8-jre
+com.google.guava:failureaccess:1.0.3
+com.google.errorprone:error_prone_annotations:2.38.0
+org.jspecify:jspecify:1.0.0
 
 org.nanohttpd:nanohttpd:2.2.0
 
@@ -133,7 +135,6 @@ jline:jline:2.14.6
 
 # Bndtools
 com.github.spullara.mustache.java:compiler:0.8.18
-com.google.guava:guava:16.0.1
 org.antlr:ST4:jar:complete:4.0.8
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.kxml2:2.3.0_3
 org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlpull:1.1.3.4a_1
@@ -143,7 +144,6 @@ org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlpull:1.1.3.4a_1
 #
 org.jtwig:jtwig-core:5.86.1.RELEASE
 org.jtwig:jtwig-reflection:5.86.1.RELEASE
-com.google.guava:guava:18.0
 com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2
 org.parboiled:parboiled-java:1.4.1
 org.parboiled:parboiled-core:jar:1.4.1

--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -16,7 +16,7 @@
 	org.eclipse.equinox.common,\
 	org.antlr:ST4:jar:complete;maven-scope=provided,\
 	com.github.spullara.mustache.java:compiler;maven-scope=provided,\
-	com.google.guava;version="[16.0.1,17)";maven-scope=provided
+	com.google.guava;version="[33.4.8,33.4.9)";maven-scope=provided
 
 -testpath: \
 	slf4j.api,\
@@ -38,6 +38,7 @@ Import-Package: \
  sun.misc;resolution:=optional,\
  com.google.appengine.*;resolution:=optional,\
  com.google.apphosting.*;resolution:=optional,\
+ android.os.*;resolution:=optional,\
  ${eclipse.importpackage},\
  *
 


### PR DESCRIPTION
@stbischof pointed out 3 CVEs in https://mvnrepository.com/artifact/biz.aQute.bnd/biz.aQute.bnd.reporter/7.1.0 because of an old Guava version. 

This is an attempt upgrade to the latest version. 

This seems possible.
The only case where Guava 19.0 is still needed is for `biz.aQute.bndlib.comm.tests` which uses no-longer maintained `littleshoot proxy` (https://mvnrepository.com/artifact/org.littleshoot/littleproxy)

