### PR TITLE
allow excluding repositories from Project -buildpath via tags

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -105,7 +105,6 @@ import aQute.bnd.service.action.NamedAction;
 import aQute.bnd.service.export.Exporter;
 import aQute.bnd.service.release.ReleaseBracketingPlugin;
 import aQute.bnd.service.specifications.RunSpecification;
-import aQute.bnd.service.tags.Tags;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.version.Version;
 import aQute.bnd.version.VersionRange;
@@ -638,6 +637,8 @@ public class Project extends Processor {
 			decorator.decorate(bundles, true);
 		}
 
+		List<RepositoryPlugin> repos = getRepositories(repoTagsBySource(source));
+
 		List<Container> result = new ArrayList<>();
 		try {
 			for (Entry<String, Attrs> entry : bundles.entrySet()) {
@@ -650,12 +651,12 @@ public class Project extends Processor {
 				boolean triedGetBundle = false;
 
 				if (bsn.indexOf('*') >= 0) {
-					return getBundlesWildcard(bsn, versionRange, strategyx, attrs);
+					return getBundlesWildcard(bsn, versionRange, strategyx, attrs, repos);
 				}
 
 				if (versionRange != null) {
 					if (versionRange.equals(VERSION_ATTR_LATEST) || versionRange.equals(VERSION_ATTR_SNAPSHOT)) {
-						found = getBundle(bsn, versionRange, strategyx, attrs);
+						found = getBundle(bsn, versionRange, strategyx, attrs, repos);
 						triedGetBundle = true;
 					}
 				}
@@ -694,7 +695,7 @@ public class Project extends Processor {
 							found = new Container(this, bsn, "file", Container.TYPE.EXTERNAL, f, error, attrs, null);
 						}
 					} else if (!triedGetBundle) {
-						found = getBundle(bsn, versionRange, strategyx, attrs);
+						found = getBundle(bsn, versionRange, strategyx, attrs, repos);
 					}
 				}
 
@@ -728,6 +729,25 @@ public class Project extends Processor {
 		return result;
 	}
 
+	private String[] repoTagsBySource(String source) {
+
+		if (source == null) {
+			return null;
+		}
+
+		if (Constants.BUILDPATH.equals(source)) {
+			return new String[] {
+				Constants.REPOTAGS_COMPILE
+			};
+		} else if (Constants.TESTPATH.equals(source)) {
+			return new String[] {
+				Constants.REPOTAGS_COMPILE, Constants.REPOTAGS_TEST
+			};
+		}
+		// TODO how to determine tag "debug"
+		return null;
+	}
+
 	/**
 	 * Just calls a new method with a default parm.
 	 *
@@ -750,6 +770,13 @@ public class Project extends Processor {
 	 */
 	public List<Container> getBundlesWildcard(String bsnPattern, String range, Strategy strategyx,
 		Map<String, String> attrs) throws Exception {
+
+		List<RepositoryPlugin> plugins = getRepositories();
+		return getBundlesWildcard(bsnPattern, range, strategyx, attrs, plugins);
+	}
+
+	private List<Container> getBundlesWildcard(String bsnPattern, String range, Strategy strategyx,
+		Map<String, String> attrs, List<RepositoryPlugin> repos) throws Exception {
 
 		if (VERSION_ATTR_SNAPSHOT.equals(range) || VERSION_ATTR_PROJECT.equals(range))
 			return Collections.singletonList(new Container(this, bsnPattern, range, TYPE.ERROR, null,
@@ -774,8 +801,7 @@ public class Project extends Processor {
 
 		SortedMap<String, Pair<Version, RepositoryPlugin>> providerMap = new TreeMap<>();
 
-		List<RepositoryPlugin> plugins = getRepositories();
-		for (RepositoryPlugin plugin : plugins) {
+		for (RepositoryPlugin plugin : repos) {
 
 			if (repoFilter != null && !repoFilter.match(plugin))
 				continue;
@@ -1256,6 +1282,14 @@ public class Project extends Processor {
 	public Container getBundle(String bsn, String range, Strategy strategy, Map<String, String> attrs)
 		throws Exception {
 
+		List<RepositoryPlugin> plugins = getRepositories();
+		return getBundle(bsn, range, strategy, attrs, plugins);
+
+	}
+
+	private Container getBundle(String bsn, String range, Strategy strategy, Map<String, String> attrs,
+		List<RepositoryPlugin> repos) throws Exception {
+
 		if (range == null)
 			range = "0";
 		if (attrs == null) {
@@ -1281,7 +1315,7 @@ public class Project extends Processor {
 		useStrategy = overrideStrategy(attrs, useStrategy);
 		RepoFilter repoFilter = parseRepoFilter(attrs);
 
-		List<RepositoryPlugin> plugins = getRepositories();
+
 
 		if (useStrategy == Strategy.EXACT) {
 			if (!Verifier.isVersion(range))
@@ -1291,7 +1325,8 @@ public class Project extends Processor {
 			// For an exact range we just iterate over the repos
 			// and return the first we find.
 			Version version = new Version(range);
-			for (RepositoryPlugin plugin : plugins) {
+
+			for (RepositoryPlugin plugin : repos) {
 				DownloadBlocker blocker = new DownloadBlocker(this);
 				File result = plugin.get(bsn, version, attrs, blocker);
 				if (result != null)
@@ -1307,7 +1342,8 @@ public class Project extends Processor {
 			// multiple repos we take the first
 
 			SortedMap<Version, RepositoryPlugin> versions = new TreeMap<>();
-			for (RepositoryPlugin plugin : plugins) {
+
+			for (RepositoryPlugin plugin : repos) {
 
 				if (repoFilter != null && !repoFilter.match(plugin))
 					continue;
@@ -1385,8 +1421,7 @@ public class Project extends Processor {
 		//
 
 		return new Container(this, bsn, range, Container.TYPE.ERROR, null,
-			bsn + ";version=" + range + " Not found in " + plugins, attrs, null);
-
+			bsn + ";version=" + range + " Not found in " + repos, attrs, null);
 	}
 
 	/**
@@ -1397,19 +1432,8 @@ public class Project extends Processor {
 	 *
 	 * @return a list of relevant repositories used by various methods.
 	 */
-	public List<RepositoryPlugin> getRepositories() {
-
-		return workspace.getRepositories()
-			.stream()
-			.filter(repo -> {
-				Tags tags = repo.getTags();
-
-				if (tags == null || tags.includesAny(Constants.REPOTAGS_COMPILE)) {
-					return true;
-				}
-				return false;
-			})
-			.toList();
+	public List<RepositoryPlugin> getRepositories(String... tags) {
+		return workspace.getRepositories(tags);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -105,6 +105,7 @@ import aQute.bnd.service.action.NamedAction;
 import aQute.bnd.service.export.Exporter;
 import aQute.bnd.service.release.ReleaseBracketingPlugin;
 import aQute.bnd.service.specifications.RunSpecification;
+import aQute.bnd.service.tags.Tags;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.version.Version;
 import aQute.bnd.version.VersionRange;
@@ -822,11 +823,13 @@ public class Project extends Processor {
 
 			DownloadBlocker downloadBlocker = new DownloadBlocker(this);
 			File bundle = repo.get(bsn, version, attrs, downloadBlocker);
+
 			if (bundle != null && !bundle.getName()
 				.endsWith(".lib")) {
 				containers
 					.add(new Container(this, bsn, range, Container.TYPE.REPO, bundle, null, attrs, downloadBlocker));
 			}
+
 		}
 
 		return containers;
@@ -1395,7 +1398,19 @@ public class Project extends Processor {
 	 * @return a list of relevant repositories used by various methods.
 	 */
 	public List<RepositoryPlugin> getRepositories() {
-		return workspace.getRepositories();
+		// if (tags == null || tags.includesAny(Constants.REPOTAGS_RESOLVE)) {
+
+		return workspace.getRepositories()
+			.stream()
+			.filter(repo -> {
+				Tags tags = repo.getTags();
+
+				if (tags == null || tags.includesAny(Constants.REPOTAGS_RESOLVE)) {
+					return true;
+				}
+				return false;
+			})
+			.toList();
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1404,7 +1404,7 @@ public class Project extends Processor {
 			.filter(repo -> {
 				Tags tags = repo.getTags();
 
-				if (tags == null || !tags.includesAny(Constants.REPOTAGS_NOCOMPILE)) {
+				if (tags == null || tags.isEmpty() || !tags.includesAny(Constants.REPOTAGS_NOCOMPILE)) {
 					return true;
 				}
 				return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1405,7 +1405,7 @@ public class Project extends Processor {
 			.filter(repo -> {
 				Tags tags = repo.getTags();
 
-				if (tags == null || tags.includesAny(Constants.REPOTAGS_RESOLVE)) {
+				if (tags == null || tags.includesAny(Constants.REPOTAGS_COMPILE)) {
 					return true;
 				}
 				return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1404,7 +1404,7 @@ public class Project extends Processor {
 			.filter(repo -> {
 				Tags tags = repo.getTags();
 
-				if (tags == null || tags.isEmpty() || !tags.includesAny(Constants.REPOTAGS_NOCOMPILE)) {
+				if (tags == null || tags.includesAny(Constants.REPOTAGS_COMPILE)) {
 					return true;
 				}
 				return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1398,14 +1398,13 @@ public class Project extends Processor {
 	 * @return a list of relevant repositories used by various methods.
 	 */
 	public List<RepositoryPlugin> getRepositories() {
-		// if (tags == null || tags.includesAny(Constants.REPOTAGS_RESOLVE)) {
 
 		return workspace.getRepositories()
 			.stream()
 			.filter(repo -> {
 				Tags tags = repo.getTags();
 
-				if (tags == null || tags.includesAny(Constants.REPOTAGS_COMPILE)) {
+				if (tags == null || !tags.includesAny(Constants.REPOTAGS_NOCOMPILE)) {
 					return true;
 				}
 				return false;

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -98,6 +98,7 @@ import aQute.bnd.service.lifecycle.LifeCyclePlugin;
 import aQute.bnd.service.repository.Prepare;
 import aQute.bnd.service.repository.RepositoryDigest;
 import aQute.bnd.service.repository.SearchableRepository.ResourceDescriptor;
+import aQute.bnd.service.tags.Tags;
 import aQute.bnd.stream.MapStream;
 import aQute.bnd.url.MultiURLConnectionHandler;
 import aQute.bnd.util.home.Home;
@@ -718,6 +719,29 @@ public class Workspace extends Processor {
 
 	public List<RepositoryPlugin> getRepositories() {
 		return data.repositories.get();
+	}
+
+	/**
+	 * @param tags list tags to filter. <code>null</code> means all.
+	 * @return matching repositories.
+	 */
+	public List<RepositoryPlugin> getRepositories(String... tags) {
+
+		if (tags == null) {
+			return data.repositories.get();
+		}
+
+		return data.repositories.get()
+			.stream()
+			.filter(repo -> {
+				Tags repotags = repo.getTags();
+
+				if (repotags == null || repotags.includesAny(tags)) {
+					return true;
+				}
+				return false;
+			})
+			.toList();
 	}
 
 	private List<RepositoryPlugin> initRepositories() {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -731,14 +731,17 @@ public class Workspace extends Processor {
 			return data.repositories.get();
 		}
 
+		Tags activeTags = Tags.parse(getProperty(Constants.ACTIVETAGS), Tags.of(Constants.REPOTAGS_RESOLVE));
+
 		return data.repositories.get()
 			.stream()
 			.filter(repo -> {
 				Tags repotags = repo.getTags();
 
-				if (repotags == null || repotags.includesAny(tags)) {
+				if (repotags == null || !activeTags.includesAny(tags) || repotags.includesAny(tags)) {
 					return true;
 				}
+
 				return false;
 			})
 			.toList();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -266,11 +266,10 @@ public interface Constants {
 	String		REPOTAGS_RESOLVE							= "resolve";
 
 	/**
-	 * tag for repos which should be used for project compilation (-buildpath,
-	 * -testpath). This is also the default tag for all repos which not have
-	 * specified tags (also for bc reasons)
+	 * tag for repos which should be excluded from project compilation
+	 * (-buildpath, -testpath).
 	 */
-	String		REPOTAGS_COMPILE							= "compile";
+	String		REPOTAGS_NOCOMPILE							= "nocompile";
 
 	String		RUNBLACKLIST								= "-runblacklist";
 	String		RUNREQUIRES									= "-runrequires";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -265,6 +265,13 @@ public interface Constants {
 	 */
 	String		REPOTAGS_RESOLVE							= "resolve";
 
+	/**
+	 * tag for repos which should be used for project compilation (-buildpath,
+	 * -testpath). This is also the default tag for all repos which not have
+	 * specified tags (also for bc reasons)
+	 */
+	String		REPOTAGS_COMPILE							= "compile";
+
 	String		RUNBLACKLIST								= "-runblacklist";
 	String		RUNREQUIRES									= "-runrequires";
 	String		RUNEE										= "-runee";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -258,6 +258,7 @@ public interface Constants {
 
 	String		REMOTEWORKSPACE								= "-remoteworkspace";
 
+	String		ACTIVETAGS									= "-activetags";
 	/**
 	 * tags for repos which should be used for Resolving bundles. This is also
 	 * the default tag for all repos which not have specified tags (also for bc

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -266,10 +266,10 @@ public interface Constants {
 	String		REPOTAGS_RESOLVE							= "resolve";
 
 	/**
-	 * tag for repos which should be excluded from project compilation
+	 * tag for repos which should be included in project compilation
 	 * (-buildpath, -testpath).
 	 */
-	String		REPOTAGS_NOCOMPILE							= "nocompile";
+	String		REPOTAGS_COMPILE							= "compile";
 
 	String		RUNBLACKLIST								= "-runblacklist";
 	String		RUNREQUIRES									= "-runrequires";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -259,17 +259,14 @@ public interface Constants {
 	String		REMOTEWORKSPACE								= "-remoteworkspace";
 
 	/**
-	 * tag for repos which should be used for Resolving bundles. This is also
+	 * tags for repos which should be used for Resolving bundles. This is also
 	 * the default tag for all repos which not have specified tags (also for bc
 	 * reasons)
 	 */
 	String		REPOTAGS_RESOLVE							= "resolve";
-
-	/**
-	 * tag for repos which should be included in project compilation
-	 * (-buildpath, -testpath).
-	 */
 	String		REPOTAGS_COMPILE							= "compile";
+	String		REPOTAGS_TEST								= "test";
+	String		REPOTAGS_DEBUG								= "debug";
 
 	String		RUNBLACKLIST								= "-runblacklist";
 	String		RUNREQUIRES									= "-runrequires";

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
@@ -80,6 +80,10 @@ public class WorkspaceTest {
 		assertTrue(((Tagged) repo).getTags()
 			.includesAny(Constants.REPOTAGS_RESOLVE));
 
+		// same for 'compile' tag
+		List<Repository> compileRepos = workspace.getPlugins(Repository.class, Constants.REPOTAGS_RESOLVE);
+		assertEquals(repos, compileRepos);
+
 	}
 
 	@Test

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
@@ -11,9 +11,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.Workspace;
@@ -25,6 +28,7 @@ import aQute.http.testservers.HttpTestServer.Config;
 import aQute.lib.io.IO;
 import aQute.maven.provider.FakeNexus;
 
+@ExtendWith(SoftAssertionsExtension.class)
 public class WorkspaceTest {
 	@InjectTemporaryDirectory
 	File						tmp;
@@ -149,5 +153,63 @@ public class WorkspaceTest {
 		assertEquals("-", Tags.print(Tags.of(Tagged.EMPTY_TAGS)));
 		assertEquals("foo", Tags.print(Tags.of(Tagged.EMPTY_TAGS, "foo")));
 		assertEquals("bar,foo", Tags.print(Tags.of(Tagged.EMPTY_TAGS, "foo", "bar")));
+	}
+
+	@Test
+	public void testTags(SoftAssertions softly) {
+
+		softly.assertThat(Tags.of()
+			.includesAny("resolve"))
+			.isTrue();
+
+		softly.assertThat(Tags.of()
+			.includesAny("compile"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve")
+			.includesAny("resolve"))
+			.isTrue();
+		// only in 7.2.0, will be stop working in 7.3.0
+		softly.assertThat(Tags.of("resolve")
+			.includesAny("compile"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "compile")
+			.includesAny("resolve"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "compile")
+			.includesAny("compile"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "compile")
+			.includesAny("compile", "resolve"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "compile")
+			.includesAny("resolve", "compile"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "compile", "somethingelse")
+			.includesAny("resolve", "compile"))
+			.isTrue();
+
+		// negative
+		softly.assertThat(Tags.of("resolve", "nocompile")
+			.includesAny("resolve"))
+			.isTrue();
+
+		softly.assertThat(Tags.of("resolve", "nocompile")
+			.includesAny("compile"))
+			.isFalse();
+
+		softly.assertThat(Tags.of("noresolve", "nocompile")
+			.includesAny("resolve"))
+			.isFalse();
+
+		softly.assertThat(Tags.of("noresolve", "nocompile")
+			.includesAny("compile"))
+			.isFalse();
+
 	}
 }

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/WorkspaceTest.java
@@ -169,10 +169,7 @@ public class WorkspaceTest {
 		softly.assertThat(Tags.of("resolve")
 			.includesAny("resolve"))
 			.isTrue();
-		// only in 7.2.0, will be stop working in 7.3.0
-		softly.assertThat(Tags.of("resolve")
-			.includesAny("compile"))
-			.isTrue();
+
 
 		softly.assertThat(Tags.of("resolve", "compile")
 			.includesAny("resolve"))

--- a/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
+++ b/biz.aQute.resolve/test/biz/aQute/resolve/RunResolutionTest.java
@@ -591,7 +591,7 @@ public class RunResolutionTest {
 		}
 
 		@Override
-		public List<RepositoryPlugin> getRepositories() {
+		public List<RepositoryPlugin> getRepositories(String... tags) {
 			return getPlugins(RepositoryPlugin.class);
 		}
 

--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -826,7 +826,7 @@
 			helpUrl="https://bnd.bndtools.org/plugins/filerepo.html">
 			<property name="name" type="string"
 				description="Name of the repository" />
-			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
+			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />
 			<property name="location" type="string"
 				description="Local directory path" />
 			<property name="readonly" type="boolean" default="false" />
@@ -837,7 +837,7 @@
 			helpUrl="https://bnd.bndtools.org/plugins/osgirepo.html">
 			<property name="name" type="string"
 				description="Name of the repository" />
-			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />	
+			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />	
 			<property name="locations" type="string"
 				description="Index locations (comma-separated list of URLs)" />
 			<property name="cache" type="string"
@@ -850,7 +850,7 @@
 			helpUrl="https://bnd.bndtools.org/plugins/localindexrepo.html">
 			<property name="name" type="string"
 				description="Name of the repository" />
-			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
+			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />
 			<property name="local" type="string"
 				description="Local directory path" />
 			<property name="phase" type="string"
@@ -889,7 +889,7 @@
 			helpUrl="https://bnd.bndtools.org/plugins/maven.html"
 			rank="10">
 		    <property name="name" type="string" description="The name of this repository" default="Maven Repository" />
-			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
+			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />
 			<property name="releaseUrl" type="string" description="The urls to the remote release repository." default="https://repo.maven.apache.org/maven2/" />
 		    <property name="stagingUrl" type="string" description="The url of the staging release repository." />
 		    <property name="snapshotUrl" type="string" description="The urls to the remote snapshot repository." default="https://repository.apache.org/snapshots/" />
@@ -909,7 +909,7 @@
 			name="P2Repository"
 			helpUrl="https://bnd.bndtools.org/plugins/p2repo.html">
 		    <property name="name" type="string" description="The name of this repository" default="P2Repository" />
-		    <property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
+		    <property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />
 			<property name="url" type="string" description="The URL to either the P2 repository (a directory) or an Eclipse target platform. Required." />
 		    <property name="location" type="string" description="The location to store the index file. Default: 'cnf/cache/p2-index-reponame/index.xml.gz'" />
 		</plugin>
@@ -919,7 +919,7 @@
 			name="Maven POM Repository"
 			helpUrl="https://bnd.bndtools.org/plugins/pomrepo.html">
 		    <property name="name" type="string" description="The name of the repo. Required." default="Maven POM Repository" />
-		    <property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
+		    <property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details. 'compile' for compilation. See -buildpath and -testpath for details). If any other tag like &lt;&lt;EMPTY&gt;&gt;  is used, then this repo is excluded from resolution and compilation." options="resolve,compile,&lt;&lt;EMPTY&gt;&gt;"  />
 		    <property name="releaseUrl" type="string" description="The url to the remote release repository. Can be a comma separated list of urls." default="https://repo.maven.apache.org/maven2/" />
 		    <property name="snapshotUrl" type="string" description="The url to the remote snapshot repository. If this is not specified, it falls back to the release repository or just local if this is also not specified. Can be a comma separated list of urls." default="https://repository.apache.org/snapshots/" />
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />


### PR DESCRIPTION
It is related to a forum post some time ago which was the base for [Repo-Tagging](https://bnd.bndtools.org/chapters/870-plugins.html#tagging-of-repository-plugins):

- https://bnd.discourse.group/t/baseline-repo-exclude-from-the-build-path/391/2

e.g. only consider "resolve" repos for Project. getRepositories()



This fixes a cornerish-case problem with compilation errors when you temporarily add a new Repository to  your workspace which is purely for lookup/research/browsing purposes and should neither be considered for resolution nor to the buildpath or Eclipse Classpath. It should just "be there" but do nothing.

It fixes a problem I had when I temporarily added an Eclipse Repo for the research purpose above and suddenly got compile errors because the new repo contained a 2.x version of slf4j.simple while the code expected to get an 1.7.x via 

`-buildpath: slf4j.simple;version=latest`

But maybe this is a practical feature, not only for this corner case.

## Example

Let's say I temporarily want to add this repo for research & lookup purposes.

```
-plugin.1.EclipseMilestone:\
	aQute.bnd.repository.p2.provider.P2Repository; \
	 	url = https://download.eclipse.org/eclipse/updates/4.36-I-builds/I20250515-1800/; \
	 	name = "Eclipse-4_36";\
	 	tags = "noResolve"
```

adding 
```
tags = "noResolve"
```

allows me to exclude this repository from any `-buildpath`. 

<img width="244" alt="image" src="https://github.com/user-attachments/assets/8d13a40e-21c8-4ed2-92d9-c5f3bd0dbe94" />

This has two positive effects:
- also the Eclipse classpath ignores this repo (because currently bnd adds -buildpath of all projects to build the Eclipse classpath)
- the build works in case it got broken by the new repository (see slf4j.simple case above)


## TODO

This is experimental and only for discussion. 
What are drawbacks of this approach? Is it useful? Or should I just not do this or use a narrower version-range instead of 'latest' (`-buildpath: slf4j.simple;version=latest`)