### PR TITLE
post guava upgrade fix

### DIFF
--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -16,7 +16,8 @@
 	org.eclipse.equinox.common,\
 	org.antlr:ST4:jar:complete;maven-scope=provided,\
 	com.github.spullara.mustache.java:compiler;maven-scope=provided,\
-	com.google.guava;version="[33.4.8,33.4.9)";maven-scope=provided
+	com.google.guava;version="[33.4.8,33.4.9)";maven-scope=provided,\
+	org.jspecify.jspecify;version='[1.0.0,2.0.0)';maven-scope=provided
 
 -testpath: \
 	slf4j.api,\
@@ -30,7 +31,8 @@
 	aQute.lib.*,\
 	aQute.libg.*,\
 	com.github.mustachejava.*,\
-	com.google.common.*
+	com.google.common.*,\
+	org.jspecify.*
 	
 Bundle-ActivationPolicy: lazy
 


### PR DESCRIPTION
Fixes the problem when installation SNAPSHOT

```
Cannot complete the install because one or more required items could not be found.
  Software being installed: Bndtools 7.2.0.DEV-202505232135-g7bd7b10 (bndtools.main.feature.feature.group 7.2.0.DEV-202505232135-g7bd7b10)
  Missing requirement: org.bndtools.templating 7.2.0.202505232135-SNAPSHOT (org.bndtools.templating 7.2.0.202505232135-SNAPSHOT) requires 'java.package; org.jspecify.annotations 0.0.0' but it could not be found
  Cannot satisfy dependency:
    From: Bndtools 7.2.0.DEV-202505232135-g7bd7b10 (bndtools.main.feature.feature.group 7.2.0.DEV-202505232135-g7bd7b10)
    To: org.eclipse.equinox.p2.iu; org.bndtools.templating [7.2.0.202505232135-SNAPSHOT,7.2.0.202505232135-SNAPSHOT]
```

