### PR TITLE
Eclipse: Support source attachments for sub-bundles + ${repo} refs

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/RepoCollector.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/RepoCollector.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import aQute.bnd.build.Container.TYPE;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.Constants;
@@ -132,6 +133,27 @@ public class RepoCollector extends Processor {
 		}
 
 		return join(paths);
+	}
+
+	/**
+	 * Shortcut to get repo-references for a processor.
+	 *
+	 * @return list of containers of ${repo} references.
+	 * @throws IOException
+	 */
+	public static List<Container> collectRepoReferences(Processor p) throws IOException {
+
+		try (RepoCollector repoCollector = new RepoCollector(p)) {
+
+			// only consider type=REPO because we are
+			// interested in bundles added e.g. via
+			// '-includeresource:
+			// ${repo;bsn;latest}'
+			return repoCollector.repoRefs()
+				.stream()
+				.filter(repoRef -> repoRef != null && TYPE.REPO == repoRef.getType())
+				.toList();
+		}
 	}
 
 	@Override

--- a/bndtools.core.services/src/org/bndtools/core/editors/actions/BndRunAnalyzer.java
+++ b/bndtools.core.services/src/org/bndtools/core/editors/actions/BndRunAnalyzer.java
@@ -22,13 +22,11 @@ import org.osgi.resource.Resource;
 import org.osgi.service.repository.Repository;
 
 import aQute.bnd.build.Container;
-import aQute.bnd.build.Container.TYPE;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.RepoCollector;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.osgi.Constants;
-import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.MultiReleaseNamespace;
 import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.service.RepositoryPlugin;
@@ -178,13 +176,13 @@ class BndRunAnalyzer {
 					result.addAll(project.getTestpath());
 					result.addAll(project.getClasspath());
 					result.addAll(project.getRunpath());
-					result.addAll(collectRepoReferences(project));
+					result.addAll(RepoCollector.collectRepoReferences(project));
 					result.addAll(project.getSubProjects()
 						.stream()
 						.map(sp -> {
 
 							try {
-								return collectRepoReferences(sp);
+								return RepoCollector.collectRepoReferences(sp);
 							} catch (IOException e) {
 								throw Exceptions.duck(e);
 							}
@@ -200,22 +198,7 @@ class BndRunAnalyzer {
 		return result;
 	}
 
-	private static List<Container> collectRepoReferences(Processor project) throws IOException {
 
-		try (RepoCollector repoCollector = new RepoCollector(project)) {
-
-			Collection<Container> repoRefs = repoCollector.repoRefs();
-			// only consider type=REPO because we
-			// are
-			// interested in bundles added via
-			// '-includeresource:
-			// ${repo;bsn;latest}'
-			List<Container> filtered = repoRefs.stream()
-				.filter(repoRef -> repoRef != null && TYPE.REPO == repoRef.getType())
-				.toList();
-			return filtered;
-		}
-	}
 
 	/**
 	 * @return containers for -runbundles, -runfw


### PR DESCRIPTION
This makes the Eclipse Source Attachments work also for sub-bundles. This is especially useful for  pure wrapper bundles which contains only sub-bundles to wrap non-osgi jars and all projects in the workspace only have a build-path reference to the wrapper bundle, but not to the wrapped actual jars (which have the `-sources.jar` in `~/.m2` repo).

Also improved how the version is used, but also using `Container.getVersion()` in case `Container.getAttributes().get(Constants.VERSION_ATTRIBUTE)` is `null`. This makes it work for cases where a ${repo} reference specifies an explicit version (not latest) e.g.` -includeresource: ${repo;org.apache.lucene:lucene-analyzers-common;[4.0.0,4.0.1)};lib:=true`


## Example of a wrapper bundle

```
# bnd.bnd

-resourceonly: true
-sub: *.bnd
```

And there are a bundle of subbundles wrapping the actual wrapped non-osgi jars:

<img width="284" alt="image" src="https://github.com/user-attachments/assets/4864cc61-2dff-46c3-839b-91c4788edafd" />


**Before:**

<img width="318" alt="image" src="https://github.com/user-attachments/assets/eac6fb19-c955-4a65-8bab-8af6f9ea45df" />

Using Type Search Dialog (Cmd + Shift + T) for a class inside a wrapper sub-bundles showed this:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/105c1396-42ea-4cd4-967e-e3a5716b9f09" />


**After:**

<img width="244" alt="image" src="https://github.com/user-attachments/assets/bc97c463-b317-41e0-b6bf-2299a460b264" />


As you see the **Bnd Bundle Path** now also contains references to the actual contained dependencies. 
And doing the same  Type Search Dialog (Cmd + Shift + T) I go to the class which is referenced in the project and correctly source attached:

<img width="591" alt="image" src="https://github.com/user-attachments/assets/ba268ba1-570d-4215-9ef2-051e7f4192cc" />


<img width="911" alt="image" src="https://github.com/user-attachments/assets/4faf8233-5676-4bcc-a724-558483f1d28e" />



## TODO

- [ ] Update description on https://bndtools.org/manual/packageexplorer.html#icons

<img width="661" alt="image" src="https://github.com/user-attachments/assets/0efc9d54-fc77-46ac-a2de-1aecf616dd4c" />

e.g. we should mention that also `${repo}` references are taken into account
