### PR TITLE
Use PDE Views (RepoBrowser/Resolution)

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -222,13 +222,13 @@
 		</view>
 		<view category="bndtools.viewCategory"
 			class="bndtools.views.resolution.ResolutionView"
-			icon="${icons.capreq}" id="bndtools.impExpView" name="Resolution"
+			icon="${icons.capreq}" id="bndtools.impExpView" name="Resolution (EOL)"
 			restorable="true">
 		</view>
 		<view category="bndtools.viewCategory"
 			class="bndtools.views.repository.RepositoriesView"
 			icon="icons/database.png" id="bndtools.repositoriesView"
-			name="Repositories" restorable="true">
+			name="Repositories (EOL)" restorable="true">
 		</view>
         <view category="bndtools.viewCategory"
 	        name="OpenAI"

--- a/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
@@ -27,6 +27,7 @@
 	osgi.identity;filter:='(osgi.identity=*win32*)',\
 
 -runbundles: \
+	aQute.libg;version=snapshot,\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
@@ -42,6 +43,7 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.github.weisj.jsvg;version='[1.7.2,1.7.3)',\
 	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
@@ -49,6 +51,8 @@
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
+	jakarta.activation-api;version='[2.1.3,2.1.4)',\
+	jakarta.xml.bind-api;version='[4.0.2,4.0.3)',\
 	javaewah;version='[1.1.13,1.1.14)',\
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
@@ -250,6 +254,7 @@
 	org.eclipse.osgi.compatibility.state;version='[1.2.700,1.2.701)',\
 	org.eclipse.osgi.services;version='[3.11.0,3.11.1)',\
 	org.eclipse.osgi.util;version='[3.7.100,3.7.101)',\
+	org.eclipse.pde.bnd.ui;version='[1.2.200,1.2.201)',\
 	org.eclipse.pde.build;version='[3.11.300,3.11.301)',\
 	org.eclipse.pde.core;version='[3.15.300,3.15.301)',\
 	org.eclipse.pde.genericeditor.extension;version='[1.1.300,1.1.301)',\
@@ -261,8 +266,9 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.126.0,3.126.1)',\
-	org.eclipse.swt.cocoa.macosx.aarch64;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt;version='[3.130.0,3.130.1)',\
+	org.eclipse.swt.cocoa.macosx.aarch64;version='[3.130.0,3.130.1)',\
+	org.eclipse.swt.svg;version='[3.130.0,3.130.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
 	org.eclipse.text;version='[3.12.200,3.12.201)',\
@@ -299,9 +305,11 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
-	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.namespace.contract;version='[1.0.0,1.0.1)',\
+	org.osgi.namespace.extender;version='[1.0.1,1.0.2)',\
+	org.osgi.namespace.service;version='[1.0.0,1.0.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.coordinator;version='[1.0.2,1.0.3)',\
@@ -318,6 +326,7 @@
 	org.osgi.util.measurement;version='[1.0.2,1.0.3)',\
 	org.osgi.util.position;version='[1.0.1,1.0.2)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.xml;version='[1.0.2,1.0.3)',\
 	org.sat4j.core;version='[2.3.6,2.3.7)',\
 	org.sat4j.pb;version='[2.3.6,2.3.7)',\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -27,6 +27,7 @@
 	osgi.identity;filter:='(osgi.identity=*win32*)',\
 
 -runbundles: \
+	aQute.libg;version=snapshot,\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
@@ -42,6 +43,7 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.github.weisj.jsvg;version='[1.7.2,1.7.3)',\
 	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
@@ -49,6 +51,8 @@
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
+	jakarta.activation-api;version='[2.1.3,2.1.4)',\
+	jakarta.xml.bind-api;version='[4.0.2,4.0.3)',\
 	javaewah;version='[1.1.13,1.1.14)',\
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
@@ -250,6 +254,7 @@
 	org.eclipse.osgi.compatibility.state;version='[1.2.700,1.2.701)',\
 	org.eclipse.osgi.services;version='[3.11.0,3.11.1)',\
 	org.eclipse.osgi.util;version='[3.7.100,3.7.101)',\
+	org.eclipse.pde.bnd.ui;version='[1.2.200,1.2.201)',\
 	org.eclipse.pde.build;version='[3.11.300,3.11.301)',\
 	org.eclipse.pde.core;version='[3.15.300,3.15.301)',\
 	org.eclipse.pde.genericeditor.extension;version='[1.1.300,1.1.301)',\
@@ -261,8 +266,9 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.126.0,3.126.1)',\
-	org.eclipse.swt.cocoa.macosx.x86_64;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt;version='[3.130.0,3.130.1)',\
+	org.eclipse.swt.cocoa.macosx.x86_64;version='[3.130.0,3.130.1)',\
+	org.eclipse.swt.svg;version='[3.130.0,3.130.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
 	org.eclipse.text;version='[3.12.200,3.12.201)',\
@@ -299,9 +305,11 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
-	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.namespace.contract;version='[1.0.0,1.0.1)',\
+	org.osgi.namespace.extender;version='[1.0.1,1.0.2)',\
+	org.osgi.namespace.service;version='[1.0.0,1.0.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.coordinator;version='[1.0.2,1.0.3)',\
@@ -318,6 +326,7 @@
 	org.osgi.util.measurement;version='[1.0.2,1.0.3)',\
 	org.osgi.util.position;version='[1.0.1,1.0.2)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.xml;version='[1.0.2,1.0.3)',\
 	org.sat4j.core;version='[2.3.6,2.3.7)',\
 	org.sat4j.pb;version='[2.3.6,2.3.7)',\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -26,6 +26,7 @@
 	osgi.identity;filter:='(osgi.identity=*win32*)',\
 
 -runbundles: \
+	aQute.libg;version=snapshot,\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
@@ -41,6 +42,7 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.github.weisj.jsvg;version='[1.7.2,1.7.3)',\
 	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
@@ -48,6 +50,8 @@
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
+	jakarta.activation-api;version='[2.1.3,2.1.4)',\
+	jakarta.xml.bind-api;version='[4.0.2,4.0.3)',\
 	javaewah;version='[1.1.13,1.1.14)',\
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
@@ -248,6 +252,7 @@
 	org.eclipse.osgi.compatibility.state;version='[1.2.700,1.2.701)',\
 	org.eclipse.osgi.services;version='[3.11.0,3.11.1)',\
 	org.eclipse.osgi.util;version='[3.7.100,3.7.101)',\
+	org.eclipse.pde.bnd.ui;version='[1.2.200,1.2.201)',\
 	org.eclipse.pde.build;version='[3.11.300,3.11.301)',\
 	org.eclipse.pde.core;version='[3.15.300,3.15.301)',\
 	org.eclipse.pde.genericeditor.extension;version='[1.1.300,1.1.301)',\
@@ -259,8 +264,9 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt;version='[3.130.0,3.130.1)',\
 	org.eclipse.swt.gtk.linux.x86_64;version='[3.121.0,3.121.1)',\
+	org.eclipse.swt.svg;version='[3.130.0,3.130.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
 	org.eclipse.text;version='[3.12.200,3.12.201)',\
@@ -296,9 +302,11 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
-	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.namespace.contract;version='[1.0.0,1.0.1)',\
+	org.osgi.namespace.extender;version='[1.0.1,1.0.2)',\
+	org.osgi.namespace.service;version='[1.0.0,1.0.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.coordinator;version='[1.0.2,1.0.3)',\
@@ -315,6 +323,7 @@
 	org.osgi.util.measurement;version='[1.0.2,1.0.3)',\
 	org.osgi.util.position;version='[1.0.1,1.0.2)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.xml;version='[1.0.2,1.0.3)',\
 	org.sat4j.core;version='[2.3.6,2.3.7)',\
 	org.sat4j.pb;version='[2.3.6,2.3.7)',\

--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -98,15 +98,17 @@
 	bnd.identity;id='org.eclipse.ui.console',\
 	bnd.identity;id='org.eclipse.ui.ide',\
 	bnd.identity;id='org.eclipse.ui.ide.application',\
-	bnd.identity;id='junit-platform-commons';version='${range;[===,==+);${junit.platform.eclipse.version}}',\
-	bnd.identity;id='junit-platform-engine';version='${range;[===,==+);${junit.platform.eclipse.version}}',\
-	bnd.identity;id='junit-platform-launcher';version='${range;[===,==+);${junit.platform.eclipse.version}}',\
+	bnd.identity;id=junit-platform-commons;version='${range;[===,==+);${junit.platform.eclipse.version}}',\
+	bnd.identity;id=junit-platform-engine;version='${range;[===,==+);${junit.platform.eclipse.version}}',\
+	bnd.identity;id=junit-platform-launcher;version='${range;[===,==+);${junit.platform.eclipse.version}}',\
 	bnd.identity;id='org.eclipse.ui.intro',\
 	bnd.identity;id='org.eclipse.ui.intro.quicklinks',\
 	bnd.identity;id='org.eclipse.ui.intro.quicklinks.source',\
 	bnd.identity;id='org.eclipse.ui.intro.source',\
 	bnd.identity;id='org.eclipse.ui.intro.universal',\
-	bnd.identity;id='org.eclipse.ui.intro.universal.source'
+	bnd.identity;id='org.eclipse.ui.intro.universal.source',\
+	bnd.identity;id='org.eclipse.pde.bnd.ui',\
+	bnd.identity;id='org.eclipse.swt.svg'
 
 -runblacklist: \
 	bnd.identity;id='biz.aQute.bnd.annotation',\
@@ -117,7 +119,7 @@
 	bnd.identity;id='org.osgi.*.annotations'
 
 
--runee: JavaSE-17
+-runee: JavaSE-21
 
 # This will help us keep -runbundles sorted
 -runstartlevel: \

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -25,6 +25,7 @@
 	osgi.identity;filter:='(osgi.identity=*linux*)',\
 
 -runbundles: \
+	aQute.libg;version=snapshot,\
 	biz.aQute.bnd.embedded-repo;version=snapshot,\
 	biz.aQute.bnd.maven;version=snapshot,\
 	biz.aQute.bnd.util;version=snapshot,\
@@ -40,6 +41,7 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
+	com.github.weisj.jsvg;version='[1.7.2,1.7.3)',\
 	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
@@ -47,6 +49,8 @@
 	com.ibm.icu;version='[67.1.0,67.1.1)',\
 	com.sun.jna;version='[5.8.0,5.8.1)',\
 	com.sun.jna.platform;version='[5.8.0,5.8.1)',\
+	jakarta.activation-api;version='[2.1.3,2.1.4)',\
+	jakarta.xml.bind-api;version='[4.0.2,4.0.3)',\
 	javaewah;version='[1.1.13,1.1.14)',\
 	javax.annotation;version='[1.3.5,1.3.6)',\
 	javax.inject;version='[1.0.0,1.0.1)',\
@@ -249,6 +253,7 @@
 	org.eclipse.osgi.compatibility.state;version='[1.2.700,1.2.701)',\
 	org.eclipse.osgi.services;version='[3.11.0,3.11.1)',\
 	org.eclipse.osgi.util;version='[3.7.100,3.7.101)',\
+	org.eclipse.pde.bnd.ui;version='[1.2.200,1.2.201)',\
 	org.eclipse.pde.build;version='[3.11.300,3.11.301)',\
 	org.eclipse.pde.core;version='[3.15.300,3.15.301)',\
 	org.eclipse.pde.genericeditor.extension;version='[1.1.300,1.1.301)',\
@@ -260,7 +265,8 @@
 	org.eclipse.platform;version='[4.25.0,4.25.1)',\
 	org.eclipse.sdk;version='[4.25.0,4.25.1)',\
 	org.eclipse.search;version='[3.14.200,3.14.201)',\
-	org.eclipse.swt;version='[3.126.0,3.126.1)',\
+	org.eclipse.swt;version='[3.130.0,3.130.1)',\
+	org.eclipse.swt.svg;version='[3.130.0,3.130.1)',\
 	org.eclipse.swt.win32.win32.x86_64;version='[3.121.0,3.121.1)',\
 	org.eclipse.team.core;version='[3.9.500,3.9.501)',\
 	org.eclipse.team.ui;version='[3.9.400,3.9.401)',\
@@ -298,9 +304,11 @@
 	org.eclipse.wst.sse.core;version='[1.2.800,1.2.801)',\
 	org.eclipse.wst.xml.core;version='[1.2.600,1.2.601)',\
 	org.hamcrest.core;version='[1.3.0,1.3.1)',\
-	org.jspecify.jspecify;version='[1.0.0,1.0.1)',\
 	org.junit;version='[4.13.2,4.13.3)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.namespace.contract;version='[1.0.0,1.0.1)',\
+	org.osgi.namespace.extender;version='[1.0.1,1.0.2)',\
+	org.osgi.namespace.service;version='[1.0.0,1.0.1)',\
 	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.coordinator;version='[1.0.2,1.0.3)',\
@@ -317,6 +325,7 @@
 	org.osgi.util.measurement;version='[1.0.2,1.0.3)',\
 	org.osgi.util.position;version='[1.0.1,1.0.2)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	org.osgi.util.xml;version='[1.0.2,1.0.3)',\
 	org.sat4j.core;version='[2.3.6,2.3.7)',\
 	org.sat4j.pb;version='[2.3.6,2.3.7)',\

--- a/bndtools.core/src/bndtools/PartConstants.java
+++ b/bndtools.core/src/bndtools/PartConstants.java
@@ -3,9 +3,10 @@ package bndtools;
 public final class PartConstants {
 
 	private static final String	PREFIX						= "bndtools.";
+	private static final String	PREFIX_PDE							= "pde.bnd.ui.";
 
-	public static final String	VIEW_ID_IMPORTSEXPORTS		= PREFIX + "impExpView";
-	public static final String	VIEW_ID_REPOSITORIES		= PREFIX + "repositoriesView";
+	public static final String	VIEW_ID_IMPORTSEXPORTS				= PREFIX_PDE + "impExpView";
+	public static final String	VIEW_ID_REPOSITORIES				= PREFIX_PDE + "repositoriesView";
 	public static final String	VIEW_ID_JPM					= "org.bndtools.core.views.jpm.JPMBrowserView";
 
 	public static final String	WIZARD_ID_NEWBND			= PREFIX + "newBndFile";

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -40,7 +40,7 @@ org.osgi:org.osgi.service.wireadmin:1.0.2
 org.osgi:org.osgi.util.function:1.2.0
 org.osgi:org.osgi.util.measurement:1.0.2
 org.osgi:org.osgi.util.position:1.0.1
-org.osgi:org.osgi.util.promise:1.2.0
+org.osgi:org.osgi.util.promise:1.3.0
 org.osgi:org.osgi.util.pushstream:1.0.2
 org.osgi:org.osgi.util.xml:1.0.2
 org.osgi:org.osgi.util.tracker:1.5.4
@@ -170,7 +170,14 @@ org.codehaus.plexus:plexus-build-api:1.2.0
 org.codehaus.plexus:plexus-utils:3.0.24
 org.codehaus.plexus:plexus-classworlds:2.5.2
 
-## higher SWT version required because of SWT bug with MacOS Sonoma 
-org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:jar:3.126.0
-org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:jar:3.126.0
-org.eclipse.platform:org.eclipse.swt:jar:3.126.0
+## higher SWT version required because of SWT bug with MacOS Sonoma
+## and because of required .svg support for org.eclipse.pde:org.eclipse.pde.bnd.ui below
+org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:jar:3.130.0
+org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:jar:3.130.0
+org.eclipse.platform:org.eclipse.swt:jar:3.130.0
+org.eclipse.platform:org.eclipse.swt.svg:3.130.0
+com.github.weisj:jsvg:1.7.2
+
+org.eclipse.pde:org.eclipse.pde.bnd.ui:1.2.200
+jakarta.xml.bind:jakarta.xml.bind-api:4.0.2
+jakarta.activation:jakarta.activation-api:2.1.3


### PR DESCRIPTION
- Eclipse 4.36 (2025-06) deployes org.eclipse.pde:org.eclipse.pde.bnd.ui:1.2.200 to maven central and includes the views (Repositories View / Resolutions View ) which were migrated from bndtools as part of the bndtools-PDE-colaboration.
- this is the first step now to include the Eclipde PDE views into the bndtools Perspective.
- the existing views from bndtools are still there, but not in the perspective anymore (but can be used independently via Eclipse / Window / Show View. They are marked with "EOL" (End of life) in the part title
- in future releases we can remove them from bndtools completely as development will happen in Eclipse PDE for those parts