### PR TITLE
[junit-platform] Add implementation of new discovery methods

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
@@ -31,6 +31,7 @@ import org.junit.platform.commons.support.ReflectionSupport;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryFilter;
 import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.EngineDiscoveryListener;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
@@ -38,6 +39,7 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.discovery.MethodSelector;
+import org.junit.platform.engine.reporting.OutputDirectoryProvider;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -570,6 +572,16 @@ public class BundleSelectorResolver {
 		@Override
 		public ConfigurationParameters getConfigurationParameters() {
 			return request.getConfigurationParameters();
+		}
+
+		@Override
+		public EngineDiscoveryListener getDiscoveryListener() {
+			return request.getDiscoveryListener();
+		}
+
+		@Override
+		public OutputDirectoryProvider getOutputDirectoryProvider() {
+			return request.getOutputDirectoryProvider();
 		}
 	}
 

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -1,6 +1,6 @@
 # Compile versions for testers
 junit4.tester.version=4.10
-junit.platform.tester.version=1.3.1
+junit.platform.tester.version=1.12.0
 opentest4j.tester.version=1.1.0
 
 # Runtime versions


### PR DESCRIPTION
Provides an implementation of new methods in `EngineDiscoveryRequest`. Simply delegates to the launcher's discovery request (as per other methods).

Fixes #6614.