### PR TITLE
[junit-platform] Restrict upper end of version range

### DIFF
--- a/biz.aQute.tester.junit-platform/bnd.bnd
+++ b/biz.aQute.tester.junit-platform/bnd.bnd
@@ -12,11 +12,15 @@ Bundle-Description: \
 # The dependency on aQute packages is only for the
 # launcher side. When launched, those dependencies
 # are not necessary
+# Note about the unusually restricted version range for org.junit.platform - refer
+# GitHub issue #6651. The original import package directive is here and can be restored
+# if/when #6651 is fixed:
+# 	org.junit.platform.*;version="${range;[==,+);${junit.platform.tester.version}}",\
 Import-Package: \
 	aQute.*;resolution:=optional,\
 	junit.*;version="${range;[==,5);${junit3.version}}";resolution:=optional,\
 	org.apache.felix.service.command;resolution:=optional,\
-	org.junit.platform.*;version="${range;[==,+);${junit.platform.tester.version}}",\
+	org.junit.platform.*;version="[${junit.platform.tester.version},1.13)",\
 	org.junit.*;version="${range;[==,+);${junit4.tester.version}}";resolution:=optional,\
 	*
 


### PR DESCRIPTION
Restrict version range to more explicitly reflect the limitation expressed in #6651.

The Import-Package directives for junit-platform now specify an exclusive upper bound of 1.13 to indicate that a version < 1.13 is required. 