### PR TITLE
Set bndeditor as default for bnd extensions

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -47,22 +47,22 @@
 
 	<!-- EDITORS -->
 	<extension point="org.eclipse.ui.editors">
-		<editor class="bndtools.editor.BndEditor" default="false"
+		<editor class="bndtools.editor.BndEditor" default="true"
 			extensions="bnd" icon="${icons.bundle}" id="bndtools.bndEditor"
 			contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
 			name="Bnd Bundle Editor">
 		</editor>
-		<editor class="bndtools.editor.BndEditor" default="false"
+		<editor class="bndtools.editor.BndEditor" default="true"
 			filenames="bnd.bnd" icon="icons/bricks.png"
 			contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
 			id="bndtools.bndProjectEditor" name="Bnd Project Editor">
 		</editor>
-		<editor class="bndtools.editor.BndEditor" default="false"
+		<editor class="bndtools.editor.BndEditor" default="true"
 			extensions="bndrun" icon="${icons.bndrun}" id="bndtools.bndRunEditor"
 			contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"
 			name="Bnd Run File Editor">
 		</editor>
-		<editor class="bndtools.editor.BndEditor" default="false"
+		<editor class="bndtools.editor.BndEditor" default="true"
 			filenames="build.bnd,ext/*.bnd" icon="icons/bndtools-logo-16x16.png"
 			id="bndtools.bndWorkspaceConfigEditor"
 			contributorClass="org.eclipse.ui.texteditor.BasicTextEditorActionContributor"


### PR DESCRIPTION
based on discussion https://github.com/bndtools/bnd/issues/6642#issuecomment-3022090707

This is an attempt to fix the problem that newer Eclipse version took over the .bnd extension and opened in an Eclipse editor instead of the bndtools' BndEditor.