### PR TITLE
Custom tooltip with help button in BndEditor source view

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/help/SyntaxAnnotation.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/SyntaxAnnotation.java
@@ -51,4 +51,9 @@ public @interface SyntaxAnnotation {
 	 */
 	String pattern() default "";
 
+	/**
+	 * A optional URL e.g. to the manual.
+	 */
+	String helpurl() default "";
+
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/ResolutionInstructions.java
@@ -91,6 +91,6 @@ public interface ResolutionInstructions {
 		never
 	}
 
-	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched, batchlaunch is like beforelaunch but only in batch mode", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch|batch)")
+	@SyntaxAnnotation(lead = "Resolve mode defines when resolving takes place. The default, manual, requires a manual step in bndtools. Auto will resolve on save, and beforelaunch runs the resolver before being launched, batchlaunch is like beforelaunch but only in batch mode", example = "'-resolve manual", pattern = "(manual|auto|beforelaunch|batch)", helpurl = "https://bnd.bndtools.org/instructions/resolve.html")
 	ResolveMode resolve();
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/instructions/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("1.8.0")
+@org.osgi.annotation.versioning.Version("1.8.1")
 package aQute.bnd.help.instructions;

--- a/biz.aQute.bndlib/src/aQute/bnd/help/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/package-info.java
@@ -1,2 +1,2 @@
-@org.osgi.annotation.versioning.Version("2.0.0")
+@org.osgi.annotation.versioning.Version("2.1.0")
 package aQute.bnd.help;

--- a/bndtools.core/src/bndtools/editor/completion/CustomTooltip.java
+++ b/bndtools.core/src/bndtools/editor/completion/CustomTooltip.java
@@ -1,0 +1,147 @@
+package bndtools.editor.completion;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.text.AbstractInformationControl;
+import org.eclipse.jface.text.AbstractReusableInformationControlCreator;
+import org.eclipse.jface.text.IInformationControl;
+import org.eclipse.jface.text.IInformationControlCreator;
+import org.eclipse.jface.text.IInformationControlExtension2;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.ToolBar;
+
+import bndtools.utils.EditorUtils;
+
+/**
+ * A tooltip for hovering in source and effective view with an optional help
+ * icon which can open a URL in the browser e.g. for a manual page.
+ */
+class CustomTooltip extends AbstractInformationControl implements IInformationControlExtension2 {
+
+
+	private StyledText				label;
+	private ToolBarManager		toolBarManager;
+	private ActionContributionItem	helpAction;
+    private String url;
+
+	public CustomTooltip(Shell parent) {
+		super(parent, true);
+		create();
+	}
+
+	@Override
+	protected void createContent(Composite parent) {
+		parent.setLayout(new GridLayout(1, false));
+
+		Color background = parent.getDisplay()
+			.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
+		parent.setBackground(background);
+
+		// StyledText (main content)
+		label = new StyledText(parent, SWT.READ_ONLY | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+		label.setCaret(null);
+		label.setMargins(5, 5, 5, 5);
+
+		GridData labelData = new GridData(SWT.FILL, SWT.FILL, true, true);
+		labelData.widthHint = 350;
+		labelData.heightHint = 200;
+		label.setLayoutData(labelData);
+
+
+		helpAction = new ActionContributionItem(
+			EditorUtils.createHelpButton(() -> url, () -> "Open help for more information"));
+
+		toolBarManager = new ToolBarManager(SWT.FLAT);
+		ToolBar toolBar = toolBarManager.createControl(parent);
+		toolBar.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+		toolBarManager.update(true);
+
+	}
+
+    @Override
+    public void setInformation(String information) {
+        setInformation(information, null);
+    }
+
+    public void setInformation(String information, String url) {
+        this.url = url;
+
+		boolean showHelp = (url != null && !url.isEmpty());
+		if (showHelp) {
+			toolBarManager.add(helpAction);
+			toolBarManager.update(true);
+		} else if (!showHelp) {
+			toolBarManager.remove(helpAction);
+			toolBarManager.update(true);
+		}
+
+		refreshToolbar();
+        label.setText(information != null ? information : "");
+		label.setFocus();
+    }
+
+	private void refreshToolbar() {
+		ToolBar toolBar = toolBarManager.getControl();
+		if (toolBar != null && !toolBar.isDisposed()) {
+			Composite parent = toolBar.getParent();
+			toolBar.requestLayout();
+			toolBar.redraw();
+			parent.layout(true, true);
+			parent.update();
+		}
+	}
+
+
+    @Override
+    public void setSizeConstraints(int width, int height) {}
+
+
+    @Override
+    public void setFocus() {
+		if (!label.isDisposed()) {
+            label.setFocus();
+        }
+    }
+
+    @Override
+	public boolean hasContents() {
+        return label.getText() != null && !label.getText().isEmpty();
+    }
+
+
+    @Override
+    public void setInput(Object input) {
+        if (input instanceof TooltipInput) {
+            TooltipInput ti = (TooltipInput) input;
+            setInformation(ti.text, ti.url);
+        } else if (input instanceof String) {
+            setInformation((String) input, null);
+        }
+
+    }
+
+
+    @Override
+    public IInformationControlCreator getInformationPresenterControlCreator() {
+        return new AbstractReusableInformationControlCreator() {
+            @Override
+            public IInformationControl doCreateInformationControl(Shell parent) {
+                return new CustomTooltip(parent);
+            }
+        };
+    }
+
+
+    @Override
+    public Point computeSizeConstraints(int widthInChars, int heightInChars) {
+        return computeSizeHint();
+    }
+
+}

--- a/bndtools.core/src/bndtools/editor/completion/TooltipInput.java
+++ b/bndtools.core/src/bndtools/editor/completion/TooltipInput.java
@@ -1,0 +1,10 @@
+package bndtools.editor.completion;
+public class TooltipInput {
+    public final String text;
+    public final String url;
+
+    public TooltipInput(String text, String url) {
+        this.text = text;
+        this.url = url;
+    }
+}

--- a/bndtools.core/src/bndtools/utils/EditorUtils.java
+++ b/bndtools.core/src/bndtools/utils/EditorUtils.java
@@ -1,6 +1,7 @@
 package bndtools.utils;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
 
 import org.bndtools.core.ui.icons.Icons;
 import org.eclipse.jface.action.Action;
@@ -49,18 +50,37 @@ public class EditorUtils {
 	 * @param tooltipText
 	 */
 	public static final Action createHelpButton(String url, String tooltipText) {
+		return createHelpButton(() -> url, () -> tooltipText);
+	}
+
+	/**
+	 * Alternative to {@link #createHelpButton(String, String)} but if you need
+	 * to pass parameters lazy.
+	 *
+	 * @param urlSupplier
+	 * @param tooltipTextSupplier
+	 */
+	public static final Action createHelpButton(Supplier<String> urlSupplier, Supplier<String> tooltipTextSupplier) {
 		Action btn = new Action("Help", IAction.AS_PUSH_BUTTON) {
 			@Override
 			public void run() {
-				Program.launch(url);
+				String url = urlSupplier.get();
+				if (url != null) {
+					Program.launch(url);
+				}
+			}
+
+			@Override
+			public String getToolTipText() {
+				return tooltipTextSupplier.get();
 			}
 		};
 		btn.setEnabled(true);
-		btn.setToolTipText(tooltipText);
 		btn.setImageDescriptor(Icons.desc("help"));
 
 		return btn;
 	}
+
 
 	/**
 	 * Creates a help button with help-icon, text and tool-tip.


### PR DESCRIPTION
The goal is to add a link with with a help button to the tooltip shown when you hover over a word in BndEditor.
The help button should link to e.g. a URL in /docs / bnd manual 

Originated from https://github.com/bndtools/bnd/issues/6642#issuecomment-3017862729 

> ... where is the information in the tooltip coming from?
> We could add the link to the documentation there or grep the content from the docs on demand?

Current WIP preview:

<img width="334" alt="image" src="https://github.com/user-attachments/assets/07bb914e-4a02-4be5-8695-25e1ff05490d" />

<img width="747" alt="image" src="https://github.com/user-attachments/assets/33b85e53-e38b-453c-bf6a-4f87fe080203" />


## Auto-detect help url

I added an auto-detection / heuristic for constructing the URL to the manual (because it is a rather predictable pattern). This makes it easier to provide useful help urls for most instructions and headers without manually specifying it. 

For example: 

<img width="325" alt="image" src="https://github.com/user-attachments/assets/0366f52e-71eb-411c-ac5e-7fc70d4b3e3e" />

This is an icon pointing to https://bnd.bndtools.org/instructions/export.html although this URL is nowhere specified, but automatically constructed.
