### PR TITLE
[CLI] Change bnd build to also compile

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -984,9 +984,15 @@ public class bnd extends Processor {
 	@Description("Build a project. This will create the jars defined in the bnd.bnd and sub-builders.")
 	public void _build(final buildoptions opts) throws Exception {
 
-		perProject(opts, p -> p.build(opts.test()));
+		perProject(opts, p -> {
+			p.getGenerate()
+				.generate(opts.force());
+			p.compile(opts.test());
+			p.build(opts.test());
+		});
 	}
 
+	@Description("Compile a project or the workspace. DEPRECATED: This command will be removed in bnd 8.0. Use 'bnd build' for compile and build.")
 	interface CompileOptions extends ProjectWorkspaceOptions {
 
 		@Description("Compile for test")
@@ -994,8 +1000,10 @@ public class bnd extends Processor {
 
 	}
 
-	@Description("Compile a project or the workspace")
+	@Description("Compile a project or the workspace. DEPRECATED: This command will be removed in bnd 8.0. Use 'bnd build' for compile and build.")
+	@Deprecated(forRemoval = true, since = "7.2.0")
 	public void _compile(final CompileOptions opts) throws Exception {
+		out.format("%nDEPRECATED: This command will be removed in bnd 8.0. Use 'bnd build' for compile and build.");
 		perProject(opts, p -> p.compile(opts.test()));
 	}
 

--- a/docs/_commands/compile.md
+++ b/docs/_commands/compile.md
@@ -2,7 +2,7 @@
 layout: default
 title: compile
 summary: |
-   Compile a project or the workspace
+   Compile a project or the workspace. DEPRECATED: This command will be removed in bnd 8.0. Use 'bnd build' for compile and build.
 note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in _ext sub-folder. 
 ---
 

--- a/docs/_instructions/executable.md
+++ b/docs/_instructions/executable.md
@@ -13,6 +13,18 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 
 ### Directives 
 
+- `strip` Strips files from embedded JARs. The syntax JARPATHMATCH ':' RESOURCEPATHMATCH, both globs.
+  - Example: `strip=*:OSGI-OPT/*`
+
+  - Pattern: `.*`
+
+
+- `location` A pattern to form the location for the bundle. This pattern is processed by the macro processor. @bsn is the bsn, and @version is the version, and @name is the file name. If no pattern is given, the file name is used to make a unique name in the /jar directory. If multiple bundles end up with the same name then the last one wins.The expansion may not contain file separators like /.If the storage area is not cleaned, use the example pattern
+  - Example: `location=location='${@bsn}-${version;=;${@version}}.jar'`
+
+  - Pattern: `.*`
+
+
 - `rejar` Re-jar the -runpath and -runbundles to the given compression. If not set, bundles are not touched. This should not change the signatures
   - Example: `rejar=rejar=STORE`
 
@@ -31,18 +43,6 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
       - Values: `STORE`
 
       - Pattern: `\QSTORE\E`
-
-
-- `strip` Strips files from embedded JARs. The syntax JARPATHMATCH ':' RESOURCEPATHMATCH, both globs.
-  - Example: `strip=*:OSGI-OPT/*`
-
-  - Pattern: `.*`
-
-
-- `location` A pattern to form the location for the bundle. This pattern is processed by the macro processor. @bsn is the bsn, and @version is the version, and @name is the file name. If no pattern is given, the file name is used to make a unique name in the /jar directory. If multiple bundles end up with the same name then the last one wins.The expansion may not contain file separators like /.If the storage area is not cleaned, use the example pattern
-  - Example: `location=location='${@bsn}-${version;=;${@version}}.jar'`
-
-  - Pattern: `.*`
 
 <!-- Manual content from: ext/executable.md --><br /><br />
 


### PR DESCRIPTION
because `bnd compile` alone just compiles .java files to class files but will fail for workspace bundles which require another bundle (because compile expects the built .jar  of that dependent bundle on the classpath, but the .jar is not there unless bnd build has created the jar file). So kind of a henn-egg problem.

My use case was this:

I'm trying to build my workspace with it (instead of gradle) but somehow. 

I first tried 

```
cd mybndworkspace
```

```
bnd clean
bnd build
```

That has produced `/generated/xxx.jar` files per bundle but the jar files did not contain the .class files of the bundle. 
After thinking about it, because ```build``` expects the classes to be _compiled_ first.

So I went ahead and tried

```
bnd clean
bnd compile
```

Unfortunatelly compile failed as soon as it arived at a bundle which required a previously compiled bundle - because it needs the .jar from it. 

But the jar is created by `bnd build`. 

Henn egg ?

Somehow compile and build per bundle should be done together.

## Conclusion

This PR basically does `compile` + `build` together when you do a 

```
bnd build
```

I could also create another command e.g. `bnd compilebuild`. Not sure what is better.


## Question:

`bnd compile` alone is not useful at the moment to compile a full workspace. 
It only works for very small self contained bundles. I wonder what the idea was behind that.

Or am I doing something wrong? 

