### PR TITLE
bndtools: fix Eclipse sourcelookup for runfw

### DIFF
--- a/org.bndtools.launch/src/bndtools/launch/sourcelookup/containers/BndrunDirectiveSourceContainer.java
+++ b/org.bndtools.launch/src/bndtools/launch/sourcelookup/containers/BndrunDirectiveSourceContainer.java
@@ -57,7 +57,7 @@ public class BndrunDirectiveSourceContainer extends CompositeSourceContainer {
 				break;
 			case "runfw" :
 				directiveGetter = run::getRunFw;
-				containsBundles = false;
+				containsBundles = true;
 				break;
 			default :
 				throw new IllegalArgumentException("Invalid bndrun directive: " + directive);


### PR DESCRIPTION
This allows to view the source code attachment for classes in the Runframework. For example I needed to debug org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse which did not find the sourcecode, although I have it in my local ~/.m2 maven repo and (downloaded via bndtools repo browser).

This change fixes it by using the same lookup mechanism as for other bundles

<img width="391" height="321" alt="image" src="https://github.com/user-attachments/assets/4972892c-af82-4c4e-88a7-d53c3b09f3b4" />

<img width="452" height="289" alt="image" src="https://github.com/user-attachments/assets/7fe44b92-ece8-42ef-8c28-28baf13351c7" />

Notice the different icon.