### PR TITLE
[CLI] add 'bnd add fragment' command  to add template fragments

### DIFF
--- a/aQute.libg/src/aQute/lib/getopt/CommandLine.java
+++ b/aQute.libg/src/aQute/lib/getopt/CommandLine.java
@@ -69,8 +69,10 @@ public class CommandLine {
 		if (cmd.equals("help")) {
 			StringBuilder sb = new StringBuilder();
 			Formatter f = new Formatter(sb);
-			if (input.isEmpty())
+			if (input.isEmpty()) {
 				help(f, target);
+				f.format("More help at: https://bnd.bndtools.org/chapters/400-commands.html");
+			}
 			else {
 				for (String s : input) {
 					help(f, target, s);
@@ -199,8 +201,7 @@ public class CommandLine {
 		f.flush();
 	}
 
-	public void generateDocumentationForCommand(MarkdownFormatter f, String command,
-		Method method, int level) {
+	public void generateDocumentationForCommand(MarkdownFormatter f, String command, Method method, int level) {
 
 		Class<? extends Options> specification = (Class<? extends Options>) method.getParameterTypes()[0];
 		Map<String, Method> options = getOptions(specification);
@@ -267,7 +268,7 @@ public class CommandLine {
 
 					Class<? extends Options> specificationSub = (Class<? extends Options>) submethod
 						.getParameterTypes()[0];
-					Description descr = submethod.getAnnotation(Description.class);
+					Description descr = specificationSub.getAnnotation(Description.class);
 
 					if (descr != null) {
 						f.format("%s%n%n", descr.value());
@@ -278,7 +279,7 @@ public class CommandLine {
 
 			}
 
-					}
+		}
 	}
 
 	private String help(Object target, String cmd, Class<? extends Options> type) throws Exception {
@@ -502,6 +503,7 @@ public class CommandLine {
 		f.format(getSynopsis(cmd, options, patterns));
 
 		help(f, specification, "OPTIONS");
+
 	}
 
 	private void help(Formatter f, Class<? extends Options> specification, String title) {
@@ -573,7 +575,7 @@ public class CommandLine {
 	/**
 	 * Show all commands in a target
 	 */
-	public void help(Formatter f, Object target) throws Exception {
+	public void help(Formatter f, Object target) {
 		f.format("%n");
 		Description descr = target.getClass()
 			.getAnnotation(Description.class);
@@ -619,6 +621,13 @@ public class CommandLine {
 		else {
 			Class<? extends Options> options = (Class<? extends Options>) m.getParameterTypes()[0];
 			help(f, target, cmd, options);
+
+			SubCommands subCmds = m.getAnnotation(SubCommands.class);
+			if (subCmds != null) {
+				help(f, subCmds.value());
+			}
+
+			f.format("More help at: https://bnd.bndtools.org/commands/%s.html", cmd);
 		}
 	}
 

--- a/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
@@ -1,9 +1,18 @@
 package aQute.bnd.main;
 
+import static aQute.bnd.wstemplates.FragmentTemplateEngine.DEFAULT_INDEX;
+
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
+import java.util.Objects;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.wstemplates.FragmentTemplateEngine;
+import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateInfo;
 import aQute.lib.collections.ExtList;
 import aQute.lib.getopt.Arguments;
 import aQute.lib.getopt.CommandLine;
@@ -14,7 +23,7 @@ public class AddCommands {
 
 	private bnd			bnd;
 
-	@Description("Create a project")
+	@Description("Create a project in the current workspace")
 	@Arguments(arg = {
 		"name", "..."
 	})
@@ -24,7 +33,7 @@ public class AddCommands {
 		this.bnd = bnd;
 	}
 
-	@Description("Create a project")
+	@Description("Create a project in the current workspace")
 	public void _project(AddProjectOptions options) throws Exception {
 		List<String> args = options._arguments();
 
@@ -43,23 +52,75 @@ public class AddCommands {
 
 	}
 
-	@Description("Create a workspace")
+	@Arguments(arg = {
+		"[name]..."
+	})
+	@Description("Add template fragment(s) to the current workspace. Leave the name empty to see a list of available templates at the index."
+		+ "\\n\\nExample:\\n bnd add fragment osgi gradle ")
+	interface AddTemplateOptions extends Options {
+		@Description("Optional: URL of an alternative template fragment index, for testing purposes. Default is: "
+			+ DEFAULT_INDEX)
+		String index();
+	}
+
+	@Description("Add template fragment(s) to the current workspace.")
+	public void _fragment(AddTemplateOptions options) throws Exception {
+		List<String> args = options._arguments();
+
+		Workspace ws = bnd.getWorkspace(bnd.getBase());
+		if (ws == null) {
+			bnd.error("No workspace found from %s", bnd.getBase());
+			return;
+		}
+
+		List<String> selectedFragmentNames = args;
+		String indexUrl = options.index();
+		installTemplateFragment(ws, selectedFragmentNames, indexUrl);
+
+	}
+
 	@Arguments(arg = {
 		"name", "..."
 	})
-	interface AddWorkspaceOptions extends Options {}
+	@Description("Create a bnd workspace in the current folder. The workspace can also be inialized with a set of template fragments.\n\n"
+		+ "Example:\n bnd add workspace -f osgi -f gradle 'myworkspace'"
+		+ "\n\nSee https://bnd.bndtools.org/chapters/620-template-fragments.html for more information.")
+	interface AddWorkspaceOptions extends Options {
 
-	@Description("Create a workspace")
+		@Description("Specify template fragment(s) by name to install together with the created workspace. Fragments are identified by the 'name' attribute in the index. Specify multiple fragments by repeating the -f option. "
+			+ "To see a list of available templates use 'bnd add fragment' without arguments.")
+		List<String> fragment();
+
+		@Description("Optional: URL of an alternative template fragment index, for testing purposes. Default is: "
+			+ DEFAULT_INDEX)
+		String index();
+	}
+
+	@Description("Create a bnd workspace in the current folder. The workspace can also be inialized with a set of template fragments.")
 	public void _workspace(AddWorkspaceOptions options) throws Exception {
+
+
 		List<String> args = options._arguments();
 		Workspace ws = null;
 		for (String pname : args) {
 			File wsdir = bnd.getFile(pname);
 			ws = Workspace.createWorkspace(wsdir);
 			if (ws == null) {
-				bnd.error("Could not create workspace");
+				bnd.error("Could not create workspace: %s (Check if the folder exists already)", pname);
+				return;
 			}
+
+			bnd.out.format("%nCreated workspace: %s%n", pname);
 		}
+
+		List<String> fragments = options.fragment();
+		if (fragments != null && !fragments
+			.isEmpty()) {
+			String indexUrl = options.index();
+			installTemplateFragment(ws, fragments, indexUrl);
+		}
+
+
 		bnd.getInfo(ws);
 		return;
 	}
@@ -95,6 +156,55 @@ public class AddCommands {
 		bnd.getInfo(ws);
 		return;
 
+	}
+
+	private void installTemplateFragment(Workspace ws, List<String> selectedFragmentNames, String index)
+		throws MalformedURLException {
+		FragmentTemplateEngine engine = initFragmentTemplateEngine(ws, index);
+		List<TemplateInfo> availableTemplates = engine.getAvailableTemplates();
+
+		if (selectedFragmentNames.isEmpty()) {
+			// show templates
+			showAvailableTemplates(availableTemplates);
+			return;
+		}
+
+		List<TemplateInfo> selectedTemplates = availableTemplates.stream()
+			.filter(ti -> {
+				return selectedFragmentNames.contains(ti.name());
+			})
+			.toList();
+		engine.updater(ws.getBase(), selectedTemplates)
+			.commit();
+
+		bnd.out.format("Added template fragment(s): %n");
+		selectedTemplates.forEach(ti -> bnd.out.format("%s - %s (Organisation: %s Repo: %s) %n", ti.name(),
+			ti.description(), ti.id()
+				.organisation(),
+			ti.id()
+				.repoUrl()));
+	}
+
+	private void showAvailableTemplates(List<TemplateInfo> availableTemplates) {
+		bnd.out.format("Available template fragments:%n");
+		availableTemplates.forEach(ti -> bnd.out.format("%s - %s (Organisation: %s Repo: %s) %n", ti.name(),
+			ti.description(), ti.id()
+				.organisation(),
+			ti.id()
+				.repoUrl()));
+	}
+
+	private FragmentTemplateEngine initFragmentTemplateEngine(Workspace ws, String index) throws MalformedURLException {
+		FragmentTemplateEngine engine = new FragmentTemplateEngine(ws);
+		String indexUrl = Objects.toString(index, DEFAULT_INDEX);
+
+		engine.read(new URL(indexUrl))
+			.unwrap()
+			.forEach(engine::add);
+		Parameters p = ws.getMergedParameters(Constants.WORKSPACE_TEMPLATES);
+		engine.read(p)
+			.forEach(engine::add);
+		return engine;
 	}
 
 }

--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -3837,15 +3837,18 @@ public class bnd extends Processor {
 	}
 
 	/**
-	 * Add a project, workspace, or plugin
+	 * Add a project, workspace, plugin or templates
 	 */
 
-
+	@Arguments(arg = {
+		"what", "..."
+	})
+	@Description("Add a project, workspace, plugin or template fragment to the workspace")
 	interface AddOptions extends Options {
 
 	}
 
-	@Description("Add a workspace, or a project or a plugin to the workspace")
+	@Description("Add a project, workspace, plugin or template fragment to the workspace")
 	@SubCommands(AddCommands.class)
 	public void _add(AddOptions opts) throws Exception {
 
@@ -3858,10 +3861,12 @@ public class bnd extends Processor {
 			out.println(help);
 		return;
 
+
+
 	}
 
 	@Arguments(arg = {
-		"what", "name..."
+		"what", "[name]..."
 	})
 	interface RemoveOptions extends Options {}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
@@ -53,6 +53,9 @@ import aQute.lib.strings.Strings;
  * concatenated during {@link TemplateUpdater#commit()}
  */
 public class FragmentTemplateEngine {
+
+	public static final String		DEFAULT_INDEX		= "https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd";
+
 	private static final String	TAG					= "tag";
 	private static final String	REQUIRE				= "require";
 	private static final String	DESCRIPTION			= "description";

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package aQute.bnd.wstemplates;
 
 import org.osgi.annotation.versioning.Version;

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -1,6 +1,6 @@
 package bndtools.wizards.newworkspace;
 
-import static aQute.bnd.osgi.Constants.WORKSPACE_TEMPLATES;
+import static aQute.bnd.wstemplates.FragmentTemplateEngine.DEFAULT_INDEX;
 import static org.eclipse.jface.dialogs.MessageDialog.openConfirm;
 
 import java.io.File;
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Parameters;
+import aQute.bnd.osgi.Constants;
 import aQute.bnd.result.Result;
 import aQute.bnd.wstemplates.FragmentTemplateEngine;
 import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateInfo;
@@ -63,7 +64,6 @@ import bndtools.util.ui.UI;
 public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWizard {
 
 
-	static final String				DEFAULT_INDEX	= "https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd";
 	static final Logger				log				= LoggerFactory.getLogger(NewWorkspaceWizard.class);
 
 	final Model						model;
@@ -87,7 +87,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 					templates.read(new URL(DEFAULT_INDEX))
 						.unwrap()
 						.forEach(templates::add);
-					Parameters p = workspace.getMergedParameters(WORKSPACE_TEMPLATES);
+					Parameters p = workspace.getMergedParameters(Constants.WORKSPACE_TEMPLATES);
 					templates.read(p)
 						.forEach(templates::add);
 					ui.write(() -> model.templates = templates.getAvailableTemplates());

--- a/docs/_commands/add.md
+++ b/docs/_commands/add.md
@@ -2,18 +2,27 @@
 layout: default
 title: add
 summary: |
-   Add a workspace, or a project or a plugin to the workspace
+   Add a project, workspace, plugin or template fragment to the workspace
 note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in _ext sub-folder. 
 ---
 
 ### Synopsis: 
-	   add  ...
-
+	   add  <what> ...
 
 ## Available sub-commands 
+-  `fragment` - Add template fragment(s) to the current workspace. 
 -  `plugin` - Add a plugin 
--  `project` - Create a project 
--  `workspace` - Create a workspace 
+-  `project` - Create a project in the current workspace 
+-  `workspace` - Create a bnd workspace in the current folder. The workspace can also be inialized with a set of template fragments. 
+
+### fragment 
+Add template fragment(s) to the current workspace. Leave the name empty to see a list of available templates at the index.\n\nExample:\n bnd add fragment osgi gradle 
+
+#### Synopsis: 
+	   fragment [options]  <[name]...>
+
+##### Options: 
+- `[ -i --index <string> ]` Optional: URL of an alternative template fragment index, for testing purposes. Default is: https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd
 
 ### plugin 
 Add a plugin
@@ -26,14 +35,23 @@ Add a plugin
 - `[ -f --force ]` 
 
 ### project 
-Create a project
+Create a project in the current workspace
 
 #### Synopsis: 
 	   project  <name> ...
 
 ### workspace 
-Create a workspace
+Create a bnd workspace in the current folder. The workspace can also be inialized with a set of template fragments.
+
+Example:
+ bnd add workspace -f osgi -f gradle 'myworkspace'
+
+See https://bnd.bndtools.org/chapters/620-template-fragments.html for more information.
 
 #### Synopsis: 
-	   workspace  <name> ...
+	   workspace [options]  <name> ...
+
+##### Options: 
+- `[ -f --fragment <string>* ]` Specify template fragment(s) by name to install together with the created workspace. Fragments are identified by the 'name' attribute in the index. Specify multiple fragments by repeating the -f option. To see a list of available templates use 'bnd add fragment' without arguments.
+- `[ -i --index <string> ]` Optional: URL of an alternative template fragment index, for testing purposes. Default is: https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd
 

--- a/docs/_commands/exportreport.md
+++ b/docs/_commands/exportreport.md
@@ -69,7 +69,7 @@ List the user defined reports.
 - `[ -w --workspace <string> ]` Use the following workspace
 
 ### readme 
-Export a set of readme files (template can be parametrized with system properties starting with 'bnd.reporter.*').
+Export the user defined reports.
 
 #### Synopsis: 
 	   readme [options]  ...

--- a/docs/_commands/nexus.md
+++ b/docs/_commands/nexus.md
@@ -24,7 +24,7 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 -  `upload` - Upload a file to staging repository by id 
 
 ### createstaging 
-Create a staging repository. The profileId specifies a particular profile. If you go to nexus, select the staging profiles, and then select the profile you want to use. The profile id is then in the url.
+Create a staging repo
 
 #### Synopsis: 
 	   createstaging [options]  <profileId>
@@ -33,8 +33,6 @@ Create a staging repository. The profileId specifies a particular profile. If yo
 - `[ -d --description <string> ]` 
 
 ### delete 
-Delete a file in a staging repository by id
-
 #### Synopsis: 
 	   delete [options]  <repositoryId> <remotepath_or_gav>
 
@@ -42,8 +40,6 @@ Delete a file in a staging repository by id
 - `[ -f --force ]` 
 
 ### fetch 
-Fetch a file to staging repository by id
-
 #### Synopsis: 
 	   fetch [options]  <repositoryId> <remotepath_or_gav>
 
@@ -72,6 +68,8 @@ Fetch a file to staging repository by id
 - `[ -r --referal <uri> ]` 
 
 ### sign 
+Artifact signing subcommand.
+
 #### Synopsis: 
 	   sign [options]  <path...>
 
@@ -86,8 +84,6 @@ Fetch a file to staging repository by id
 - `[ -x --xclude <string> ]` Specify the exclude pattern for artifacts from the '--from' option. Defaults to no exclude pattern.
 
 ### upload 
-Upload a file to staging repository by id
-
 #### Synopsis: 
 	   upload [options]  <repositoryId> <remotepath_or_gav> <file>
 

--- a/docs/_commands/remote.md
+++ b/docs/_commands/remote.md
@@ -26,6 +26,8 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 -  `uninstall` - Uninstall the specified bundles 
 
 ### distro 
+Create a distro jar (or xml) from a remote agent
+
 #### Synopsis: 
 	   distro [options]  <bsn> <[version]>
 
@@ -38,11 +40,13 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 - `[ -x --xml ]` Generate xml instead of a jar with manifest
 
 ### framework 
+Get the framework info
+
 #### Synopsis: 
 	   framework 
 
 ### install 
-Install/update the specified bundle.
+Communicate with the remote framework to install or update bundle
 
 #### Synopsis: 
 	   install [options]  <filespec...>
@@ -51,7 +55,7 @@ Install/update the specified bundle.
 - `[ -l --location <string;> ]` By default the location is 'manual:<bsn>'. You can specify multiple locations when installing multiple bundles
 
 ### list 
-List the bundles installed in the remote framework
+Communicate with the remote framework to list the installed bundles
 
 #### Synopsis: 
 	   list [options]  ...
@@ -61,27 +65,31 @@ List the bundles installed in the remote framework
 - `[ -j --json ]` Specify to return the output as JSON
 
 ### ping 
+Ping the remote framework
+
 #### Synopsis: 
 	   ping 
 
 ### revisions 
+Get the bundle revisions
+
 #### Synopsis: 
 	   revisions  <bundleid...>
 
 ### start 
-Start the specified bundles
+Communicate with the remote framework to perform bundle operation
 
 #### Synopsis: 
 	   start  <bundleId...>
 
 ### stop 
-Stop the specified bundles
+Communicate with the remote framework to perform bundle operation
 
 #### Synopsis: 
 	   stop  <bundleId...>
 
 ### uninstall 
-Uninstall the specified bundles
+Communicate with the remote framework to perform bundle operation
 
 #### Synopsis: 
 	   uninstall  <bundleId...>

--- a/docs/_commands/remove.md
+++ b/docs/_commands/remove.md
@@ -7,7 +7,7 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 ---
 
 ### Synopsis: 
-	   remove  <what> <name...>
+	   remove  <what> <[name]...>
 
 ## Available sub-commands 
 -  `plugin` - Remove a plugin from the workspace 

--- a/docs/_commands/repo.md
+++ b/docs/_commands/repo.md
@@ -43,7 +43,7 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 - `[ -s --standalone <string> ]` A stanalone bndrun file
 
 ### diff 
-Diff jars (or show tree)
+Show the diff tree of a single repo or compare 2  repos. A diff tree is a detailed tree of all aspects of a bundle, including its packages, types, methods, fields, and modifiers.
 
 #### Synopsis: 
 	   diff [options]  <newer repo> <[older repo]>
@@ -115,6 +115,8 @@ List the current repositories
 	   repos 
 
 ### sync 
+
+
 #### Synopsis: 
 	   sync [options]  ...
 
@@ -126,6 +128,8 @@ List the current repositories
 - `[ -w --workspace <string> ]` 
 
 ### topom 
+Create a POM out of a bnd repository
+
 #### Synopsis: 
 	   topom [options]  <repo> <name>
 
@@ -135,7 +139,7 @@ List the current repositories
 - `[ -p --parent <string> ]` The parent of the pom (default none.xml)
 
 ### versions 
-Displays a list of versions for a given bsn that can be found in the current repositories.
+Displays a sorted set of versions for a given bsn that can be found in the current repositories.
 
 #### Synopsis: 
 	   versions  <bsn>

--- a/docs/_commands/resolve.md
+++ b/docs/_commands/resolve.md
@@ -71,7 +71,7 @@ Resolve a bndrun file
 - `[ -x --xchange ]` Fail on changes
 
 ### validate 
-Resolve a repository index against a base to determine if the index is 'complete'
+Validate an OBR file by trying to resolve each entry against itself
 
 #### Synopsis: 
 	   validate [options]  <[index-path]>


### PR DESCRIPTION
This will add the Eclipse Template Fragment Functionality to the CLI
https://bnd.bndtools.org/chapters/620-template-fragments.html


## Create a workspace with a template fragment

`bnd add workspace --fragment osgi --fragment gradle myworkspace`
or short:

`bnd add workspace -f osgi -f gradle myworkspace`

this will create a new workspace 'myworkspace' with two template fragments for osgi and gradle

## Add template fragment(s) to an existing workspace

```
NAME
  add                         - Add a project, workspace, plugin or workspace
                                template fragment to the workspace

SYNOPSIS
   add <what> ...

Available sub-commands: 

  plugin                      - Add a plugin 
  project                     - Create a project in the current workspace 
  fragment                    - Add a template fragment to the current
                                workspace 
  workspace                   - Create a bnd workspace in the current folder 

More help at: https://bnd.bndtools.org/commands/add.html

```

e.g. `bnd add fragment osgi gradle`

this will add the two templates for `osgi` and `gradle` to the current workspace.

`bnd add fragment` will just list the available templates

It is a sub-command of https://bnd.bndtools.org/commands/add.html


## Example

Show available templates

```
bnd -b ~/mybndworkspace add fragment

Available templates fragments:
gradle - Setup gradle build for bnd workspace (Organisation: bndtools Repo: https://github.com/bndtools/workspace-templates/tree/master/gradle) 
maven - Use the maven directory layout for sources and binaries (Organisation: bndtools Repo: https://github.com/bndtools/workspace-templates/tree/master/maven) 
osgi - OSGi R8 with Felix distribution (Organisation: bndtools Repo: https://github.com/bndtools/workspace-templates/tree/master/osgi) 
IndexedMavenRepository - Provide an OSGi repository derived from a subset of one or more maven repositories (Organisation: mnlipp Repo: https://github.com/mnlipp/de.mnl.osgi/tree/master/de.mnl.osgi.bnd.repository/workspace-template) 
maven-tycho-build - Setup a maven pomless build for bnd workspace (IDE / bndtools first). (Organisation: eclipse-tycho Repo: https://github.com/eclipse-tycho/tycho/tree/master/setup/bnd-templates/pomless) 
maven-tycho-build2 - Setup a maven pomless build for bnd workspace (IDE / bndtools first) including customization using a configurator pom. (Organisation: eclipse-tycho Repo: https://github.com/eclipse-tycho/tycho/tree/master/setup/bnd-templates/pomless-configurator) 

```

```
bnd -b ~/mybndworkspace add fragment osgi gradle

Added templates: 
gradle - Setup gradle build for bnd workspace (Organisation: bndtools Repo: https://github.com/bndtools/workspace-templates/tree/master/gradle) 
osgi - OSGi R8 with Felix distribution (Organisation: bndtools Repo: https://github.com/bndtools/workspace-templates/tree/master/osgi) 
```




