### PR TITLE
CLI: remove -i / --index option for add workspace and add fragment

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
@@ -58,9 +58,6 @@ public class AddCommands {
 	@Description("Add template fragment(s) to the current workspace. Leave the name empty to see a list of available templates at the index."
 		+ "\\n\\nExample:\\n bnd add fragment osgi gradle ")
 	interface AddTemplateOptions extends Options {
-		@Description("Optional: URL of an alternative template fragment index, for testing purposes. Default is: "
-			+ DEFAULT_INDEX)
-		String index();
 	}
 
 	@Description("Add template fragment(s) to the current workspace.")
@@ -74,7 +71,7 @@ public class AddCommands {
 		}
 
 		List<String> selectedFragmentNames = args;
-		String indexUrl = options.index();
+		String indexUrl = DEFAULT_INDEX;
 		installTemplateFragment(ws, selectedFragmentNames, indexUrl);
 
 	}
@@ -91,9 +88,6 @@ public class AddCommands {
 			+ "To see a list of available templates use 'bnd add fragment' without arguments.")
 		List<String> fragment();
 
-		@Description("Optional: URL of an alternative template fragment index, for testing purposes. Default is: "
-			+ DEFAULT_INDEX)
-		String index();
 	}
 
 	@Description("Create a bnd workspace in the current folder. The workspace can also be inialized with a set of template fragments.")
@@ -116,7 +110,7 @@ public class AddCommands {
 		List<String> fragments = options.fragment();
 		if (fragments != null && !fragments
 			.isEmpty()) {
-			String indexUrl = options.index();
+			String indexUrl = DEFAULT_INDEX;
 			installTemplateFragment(ws, fragments, indexUrl);
 		}
 

--- a/docs/_commands/add.md
+++ b/docs/_commands/add.md
@@ -19,10 +19,7 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 Add template fragment(s) to the current workspace. Leave the name empty to see a list of available templates at the index.\n\nExample:\n bnd add fragment osgi gradle 
 
 #### Synopsis: 
-	   fragment [options]  <[name]...>
-
-##### Options: 
-- `[ -i --index <string> ]` Optional: URL of an alternative template fragment index, for testing purposes. Default is: https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd
+	   fragment  <[name]...>
 
 ### plugin 
 Add a plugin
@@ -53,5 +50,4 @@ See https://bnd.bndtools.org/chapters/620-template-fragments.html for more infor
 
 ##### Options: 
 - `[ -f --fragment <string>* ]` Specify template fragment(s) by name to install together with the created workspace. Fragments are identified by the 'name' attribute in the index. Specify multiple fragments by repeating the -f option. To see a list of available templates use 'bnd add fragment' without arguments.
-- `[ -i --index <string> ]` Optional: URL of an alternative template fragment index, for testing purposes. Default is: https://raw.githubusercontent.com/bndtools/workspace-templates/master/index.bnd
 


### PR DESCRIPTION
Let's first discuss this in more detail, as I see potential security risks with this option to specify a custom tempate fragment index by url. (@peterkir @pkriens )

Successor of https://github.com/bndtools/bnd/pull/6685/
