### PR TITLE
Template Fragments: add more zip slip tests

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
@@ -273,6 +273,18 @@ public class FragmentTemplateEngine {
 		public void commit() {
 			try (Processor processor = new Processor(workspace)) {
 				updates.forEach((k, us) -> {
+
+					try {
+						File canonicalK = k.getCanonicalFile();
+						if (!canonicalK.getPath()
+							.startsWith(folder.getCanonicalPath())) {
+							// Zip Slip attack
+							throw new SecurityException("Blocked write outside base folder: " + canonicalK);
+						}
+					} catch (IOException e) {
+						throw Exceptions.duck(e);
+					}
+
 					if (us.isEmpty())
 						return;
 					k.getParentFile()

--- a/biz.aQute.bndlib/test/aQute/bnd/wstemplates/ZipSlipCreator.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/wstemplates/ZipSlipCreator.java
@@ -1,0 +1,40 @@
+package aQute.bnd.wstemplates;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+class ZipSlipCreator {
+	public static void createZipSlip1(File zipFile) throws IOException {
+		try (FileOutputStream fos = new FileOutputStream(zipFile); ZipOutputStream zos = new ZipOutputStream(fos)) {
+			addEntry(zos, "../evil.txt", "This is evil!");
+		}
+	}
+
+	public static void createZipSlip2(File zipFile) throws IOException {
+		try (FileOutputStream fos = new FileOutputStream(zipFile); ZipOutputStream zos = new ZipOutputStream(fos)) {
+			addEntry(zos, "../../outside.txt", "Going outside!");
+		}
+	}
+
+	public static void createZipSlip3(File zipFile) throws IOException {
+		try (FileOutputStream fos = new FileOutputStream(zipFile); ZipOutputStream zos = new ZipOutputStream(fos)) {
+			addEntry(zos, "subdir/../../../traversal.txt", "Sneaky traversal!");
+		}
+	}
+
+	public static void createZipSlip4(File zipFile) throws IOException {
+		try (FileOutputStream fos = new FileOutputStream(zipFile); ZipOutputStream zos = new ZipOutputStream(fos)) {
+			addEntry(zos, "/abs/abspath.txt", "Absolute path file!");
+		}
+	}
+
+	private static void addEntry(ZipOutputStream zos, String entryName, String content) throws IOException {
+		ZipEntry entry = new ZipEntry(entryName);
+		zos.putNextEntry(entry);
+		zos.write(content.getBytes());
+		zos.closeEntry();
+	}
+}


### PR DESCRIPTION
specifically add some more tests if Zip entries could break out of the extracted base folder. 
Seems this is is mainly handled by Jar.java and ZipUtil.cleanPath() already, but this test ensures it for Template Fragments.