### PR TITLE
Clarify major version 0 with respect to baselining

### DIFF
--- a/docs/_chapters/180-baselining.md
+++ b/docs/_chapters/180-baselining.md
@@ -4,15 +4,15 @@ layout: default
 requires: 2.2.0
 ---
 
-Baselining compares a bundle with another bundle, the _baseline_, to find mistakes in the semantic versioning. For example, there is a binary incompatible change in the new bundle but the version has not been bumped. Baselining can be run from the command line (see `bnd help baseline`) or it can be run as part of a project build. 
+Baselining compares a bundle with another bundle, the _baseline_, to find mistakes in the [semantic versioning](https://docs.osgi.org/whitepaper/semantic-versioning/). For example, there is a binary incompatible change in the new bundle but the version has not been bumped. Baselining can be run from the command line (see `bnd help baseline`) or it can be run as part of a project build. 
 
 APIs are compared for backward compatibility using the semantic versioning rules defined in this chapter. Baselining is aware of the `@ConsumerType` and `@ProviderType` rules. Proper versions are calculated and suggested.
 
 ## Setting Up a Project for Baselining
 
-During the build, bnd will check the `-baseline` instruction at the end of the build when the JAR is ready. This instruction is a selector on the symbolic name of the building bundle. If it matches, the baselining is started with one exception: the bundle version must be more than 1.0.0. If the version is less no baselining is possible, the purpose is to allow the primordial baseline to be established without errors.
+During the build, bnd will check the [`-baseline` instruction](../_instructions/baseline.html) at the end of the build when the JAR is ready. This instruction is a selector on the symbolic name of the building bundle. If it matches, the baselining is started with one exception: the bundle/package version must be 1.0.0 or above. If the version is less (i.e. major version being `0`) no baselining is possible, the purpose is to allow the [primordial baseline to be established without errors](https://semver.org/#spec-item-4).
 
-By default the baseline is a bundle from one of the repositories with the same symbolic name as the building bundle and the highest possible version. However, it is possible to specify the version or to baseline against a file, see [-baseline](../instructions/baseline.html).
+By default the baseline is a bundle from one of the repositories with the same symbolic name as the building bundle and the highest possible version. However, it is possible to specify the version or to baseline against a file.
 
 It is recommended to enable baselining per project since not all project requires baselining. For example, baselining is overkill for a project that is always compiled with all its dependencies and thus has no external dependencies. The recommended practice is therefore to add the following instruction to a project that requires baselining (usually API bundles):
 
@@ -29,6 +29,10 @@ Only bundles that are not _staging_ are considered for the baseline, this means 
 
 By default the bundle and baseline are compared (_diffed_) and then analyzed for semantic version violations. Certain headers always change because they contain time or digest information. Most of these headers are already automatically ignored but the [-diffignore](../instructions/diffignore.html) instruction can add more ignorance. You can use the 
 [-diffpackages](../instructions/diffpackages.html) instruction to specify the names of exported packages to be baseline compared. The default is to baseline compare all exported packages.
+
+### Maven Support
+
+There is a dedicated [Maven plugin for baselining](../../maven-plugins/bnd-baseline-maven-plugin/README.md).
 
 ## Example baselining Project Instructions
 


### PR DESCRIPTION
Add some more links to Maven plugin and semantic versioning specs. This closes #6691