### PR TITLE
allow usage of lower biz.aQute.launcher versions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -92,10 +92,17 @@ jobs:
     #      ~/.bnd/urlcache/
     #    key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/cnf/**/*.bnd', '**/cnf/**/*.mvn', '**/cnf/**/*.maven', '**/cnf/ext/*.*') }}
 
-    - name: Build
+    - name: Build (default)
       id: build
+      if: ${{ matrix.java != '24' }}
       run: |
         ${{ format(matrix.runner, './.github/scripts/ci-build.sh') }}
+
+    - name: Build Java 24 with stacktrace output
+      id: buildJDK24
+      if: ${{ matrix.java == '24' }}
+      run: |
+        ${{ format(matrix.runner, './.github/scripts/ci-build.sh --stacktrace') }}
 
     - name: Configure settings.xml for Publish
       if: ${{ matrix.canonical }}

--- a/.project
+++ b/.project
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>_root</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1753880320173</id>
+			<name></name>
+			<type>5</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-true-.*</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1753880320175</id>
+			<name></name>
+			<type>9</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-true-(\.github|\.mvn)</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
+++ b/biz.aQute.bndall.tests/test/biz/aQute/launcher/AlsoLauncherTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -77,6 +78,19 @@ public class AlsoLauncherTest {
 	public void setUp() throws Exception {
 		prior = new Properties();
 		prior.putAll(System.getProperties());
+		String javaVersion = System.getProperty("java.version");
+		int majorJavaVersion = Integer.parseInt(javaVersion.split("\\.")[0]);
+		if (majorJavaVersion >= 24) {
+			System.out
+				.println(
+					"Running on Java Runtime >=24. adding Properties `jdk.xml.*[Size|Expansion]Limit` support for large xml parsing");
+			System.getProperties()
+				.setProperty("jdk.xml.totalEntitySizeLimit", "0");
+			System.getProperties()
+				.setProperty("jdk.xml.maxGeneralEntitySizeLimit", "0");
+			System.getProperties()
+				.setProperty("jdk.xml.entityExpansionLimit", "0");
+		}
 
 		File wsRoot = new File(testDir, "test ws");
 		for (String folder : Arrays.asList("cnf", "demo", "biz.aQute.launcher", "biz.aQute.junit", "biz.aQute.tester",
@@ -1144,6 +1158,7 @@ public class AlsoLauncherTest {
 	 */
 	// @Ignore("Just seems to wait for no obvious reason")
 	@Test
+	@EnabledForJreRange(maxVersion = 23)
 	public void testFrameworkExtension() throws Exception {
 		try (Run run = new Run(project.getWorkspace(), project.getFile("frameworkextension.bndrun"))) {
 			run.setProperty(Constants.RUNTRACE, "true");
@@ -1172,7 +1187,7 @@ public class AlsoLauncherTest {
 	 * <pre>
 	 * isJava24OrAbove
 	 * </pre>
-	 * 
+	 *
 	 * refers to a static helper method in this class (see
 	 * https://junit.org/junit5/docs/5.9.2/api/org.junit.jupiter.api/org/junit/jupiter/api/condition/DisabledIf.html#value())
 	 */

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2951,7 +2951,7 @@ public class Project extends Processor {
 		// one
 		List<Container> withDefault = Create.list();
 		withDefault.addAll(containers);
-		withDefault.addAll(getBundles(Strategy.HIGHEST, defaultHandler, null));
+		withDefault.addAll(getBundles(Strategy.LOWEST, defaultHandler, null));
 		logger.debug("candidates for handler {}: {}", target, withDefault);
 
 		for (Container c : withDefault) {

--- a/biz.aQute.resolve/testdata/enroute/index.xml
+++ b/biz.aQute.resolve/testdata/enroute/index.xml
@@ -746,26 +746,7 @@
       <directive name="filter" value="(&amp;(osgi.ee=JavaSE)(version=1.5))"/>
     </requirement>
   </resource>
-  <resource>
-    <capability namespace="osgi.identity">
-      <attribute name="osgi.identity" value="biz.aQute.launcher"/>
-      <attribute name="type" value="osgi.bundle"/>
-      <attribute name="version" type="Version" value="3.0.0.201508170645"/>
-    </capability>
-    <capability namespace="osgi.content">
-      <attribute name="osgi.content" value="5578718ad0517fa214d8801792b8681e94f186f9de598f92d4f5031e2b344ad1"/>
-      <attribute name="url" value="biz.aQute.launcher/biz.aQute.launcher-3.0.0.jar"/>
-      <attribute name="size" type="Long" value="140770"/>
-      <attribute name="mime" value="application/vnd.osgi.bundle"/>
-    </capability>
-    <capability namespace="osgi.wiring.bundle">
-      <attribute name="osgi.wiring.bundle" value="biz.aQute.launcher"/>
-      <attribute name="bundle-version" type="Version" value="3.0.0.201508170645"/>
-    </capability>
-    <capability namespace="osgi.wiring.host">
-      <attribute name="osgi.wiring.host" value="biz.aQute.launcher"/>
-      <attribute name="bundle-version" type="Version" value="3.0.0.201508170645"/>
-    </capability>
+  <resource>   
     <requirement namespace="osgi.wiring.package">
       <directive name="filter" value="(&amp;(osgi.wiring.package=aQute.bnd.build)(version&gt;=2.6.0)(!(version&gt;=3.0.0)))"/>
     </requirement>


### PR DESCRIPTION
resolves #6737
enables the capability of launching with the lowest available version of 'biz.aQute.launcher' inside the workspace repositories - if no lower version is available the existing behaviour is persisted and the version from the workspace/release is used