### PR TITLE
[Deprecation] Deprecate Search/Query feature in BndPomRepository

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -147,6 +147,9 @@ public class BndPomRepository extends BaseRepository
 				status("Archive is neither a file nor a revision " + configuration.revision());
 			}
 		} else if (configuration.query() != null) {
+			reporter
+				.warning(
+					"The query feature for search.maven.org/solrsearch is deprecated since bnd 7.2.0 and targeted for remove in bnd 8.0");
 			this.query = configuration.query();
 			this.queryUrl = configuration.queryUrl("https://search.maven.org/solrsearch/select");
 		} else {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
@@ -67,13 +67,23 @@ public interface PomConfiguration {
 
 	/**
 	 * The query used to search Maven Central Search.
+	 *
+	 * @deprecated targeted for removal in bnd 8.0, because
+	 *             search.maven.org/solrsearch is consired "legacy" and very
+	 *             instable (see https://status.maven.org/)
 	 */
+	@Deprecated(forRemoval = true, since = "7.2.0")
 	String query();
 
 	/**
-	 * The url of the Maven Central Search.
+	 * The url of the Maven Central Search. default
+	 * "http://search.maven.org/solrsearch/select"
+	 *
+	 * @deprecated targeted for removal in bnd 8.0, because
+	 *             search.maven.org/solrsearch is consired "legacy" and very
+	 *             instable (see https://status.maven.org/)
 	 */
-	// default "http://search.maven.org/solrsearch/select"
+	@Deprecated(forRemoval = true, since = "7.2.0")
 	String queryUrl(String deflf);
 
 	/**

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/pom/provider/PomRepositoryTest.java
@@ -558,6 +558,7 @@ public class PomRepositoryTest {
 		assertFalse(pom.isStale());
 	}
 
+	@Disabled("Disabled because query feature is deprecated in bnd 7.2.0 for removal in bnd 8.0.")
 	@Test
 	public void testSearchRepoSimple() throws Exception {
 		try (BndPomRepository mcsr = new BndPomRepository()) {
@@ -578,6 +579,7 @@ public class PomRepositoryTest {
 		}
 	}
 
+	@Disabled("Disabled because query feature is deprecated in bnd 7.2.0 for removal in bnd 8.0.")
 	@Test
 	public void testSearchRepoMultipleConfigurationsDontBreak() throws Exception {
 		Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
@@ -626,7 +628,7 @@ public class PomRepositoryTest {
 		}
 	}
 
-	@Disabled("This test is flaky because http://search.maven.org/solrsearch/select often returns 400")
+	@Disabled("Disabled because query feature is deprecated in bnd 7.2.0 for removal in bnd 8.0. This test is flaky because http://search.maven.org/solrsearch/select often returns 400")
 	@Test
 	public void testSearchRepoAllVersions() throws Exception {
 		try (BndPomRepository mcsr = new BndPomRepository()) {
@@ -665,6 +667,7 @@ public class PomRepositoryTest {
 		}
 	}
 
+	@Disabled("Disabled because query feature is deprecated in bnd 7.2.0 for removal in bnd 8.0.")
 	@Test
 	public void testSearchRepoFailNoName() throws Exception {
 		try (BndPomRepository mcsr = new BndPomRepository()) {

--- a/docs/_plugins/pomrepo.md
+++ b/docs/_plugins/pomrepo.md
@@ -39,6 +39,10 @@ Opening the `Run` tab of the bndrun editor on this file will show you all transi
 
 ## Searching
 
+
+**DEPRECATION:** The searching feature below will be deprecated in bnd 7.2.0 for removal in bnd 8.0. 
+The reason is that this search is considered "legacy" (see https://status.maven.org/), and also is often instable recently.
+
 Maven Central supports a [searching facility](https://blog.sonatype.com/2011/06/you-dont-need-a-browser-to-use-maven-central/) based on Solr. For example, you want all the artifacts of a given group id. In that case you could use the following Bnd Pom Repository plugin:
 
     -standalone: true


### PR DESCRIPTION
We deprecate the Searching Feature (see https://bnd.bndtools.org/plugins/pomrepo.html#searching ) for removal in bnd 8.0.0

The reason is that this search is considered "legacy" (see https://status.maven.org/), and also is often instable recently.

7.2.0 will log a warning

```
[main] WARN aQute.bnd.repository.maven.pom.provider.BndPomRepository - The query feature for search.maven.org/solrsearch is deprecated since bnd 7.2.0 and targeted for remove in bnd 8.0
```

We also use this to disable some "flaky" tests which too often broke our build.