### PR TITLE
RepoBrowser: show the bnd-cache repo

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java
@@ -638,11 +638,25 @@ public class Workspace extends Processor {
 	}
 
 	class CachedFileRepo extends FileRepo {
+
 		final Lock	lock	= new ReentrantLock();
 		boolean		inited;
 
 		CachedFileRepo() {
 			super(BND_CACHE_REPONAME, getCache(BND_CACHE_REPONAME), false);
+		}
+
+		@Override
+		public String tooltip(Object... target) throws Exception {
+
+			if (target == null || target.length == 0) {
+				String statustext = isTrue(getProperty(NOBUILDINCACHE)) ? "Disabled by -nobuildincache"
+					: "Enabled - Use -nobuildincache to disable this cache";
+				return String.format("%s (%s)%n%s", getName(), statustext, root);
+			}
+
+			return super.tooltip(target);
+
 		}
 
 		@Override
@@ -708,6 +722,7 @@ public class Workspace extends Processor {
 				}
 			}
 		}
+
 	}
 
 	public void syncCache() throws Exception {

--- a/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
+++ b/bndtools.core/src/bndtools/views/repository/RepositoriesView.java
@@ -1066,7 +1066,7 @@ public class RepositoriesView extends ViewPart implements RepositoriesViewRefres
 
 	@Override
 	public List<RepositoryPlugin> getRepositories() {
-		return RepositoryUtils.listRepositories(true);
+		return RepositoryUtils.listRepositories(false);
 	}
 
 	private static boolean isJarFile(File candidate) {


### PR DESCRIPTION
this makes the previously hidden [CachedFileRepo](https://github.com/bndtools/bnd/blob/fda9509b81a0e61b90c4600d68ead2cf6b43d9ec/biz.aQute.bndlib/src/aQute/bnd/build/Workspace.java#L640) visible in the repo-browser. It helps devs to know what's going on behind the scenes e.g. because this bnd-cache contains the ProjectLauncher which is automatically added to exportable .jars. But so far it has been unclear where this launcher is magically coming from. So this is an attempt to make this repo visible.

<img width="586" height="486" alt="image" src="https://github.com/user-attachments/assets/7da4e323-e6a6-4323-a834-0fec6da8b854" />

Btw: I found there is the instruction https://bnd.bndtools.org/instructions/nobuildincache.html which can disable this cache completely (@amitjoy might be interesting in context of Launcher too for you)

TODO 

- [ ] what are other places where this should be shown... e.g. what about the .bndrun editor for `-runrepos`

## Docs

I found the following places where this bnd-cache is mentioned. 

- https://bnd.bndtools.org/chapters/150-build.html#the-cnfcache-directory
- https://bnd.bndtools.org/chapters/150-build.html#overriding-the-plugins