### PR TITLE
docs: add syntax highlighter for code snippets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -110,3 +110,26 @@ or to use a different `pagefind` version.
 
 See the files `.github/workflows/cibuild.yml` and `.github/scripts/docs.sh` for how 
 building the site and executing `pagefind` is done in the final build on github.
+
+
+### CSS Styling for Code Highlighter
+
+- jekyll uses `rouge` code highlighter
+- see `_config.yml` and section `syntax_highlighter_opts`
+- also see this website https://jekyll-themes.com/brazacz/rouge-themes for examples
+- rouge is compatible with and can use 'pygments' styles (see https://pygments.org/styles/)
+- these styles can be generated with the command 
+
+The following commands locally will help to generate the .css files for the pygment styles:
+
+```
+gem install rouge
+# show a list of supported styles
+rougify help style
+# go to the css folder
+cd css
+# generate the css
+rougify style github.dark > github.dark.css
+```
+
+Then reference the `.css` file in `_includes/head.htm `

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,12 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
 markdown: kramdown
+highlighter: rouge
+kramdown:
+  input: GFM
+  syntax_highlighter_opts:
+    default_lang: shell
+    css_class   : 'highlight' ## see https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers
 
 collections:
   chapters:

--- a/docs/_includes/footer.htm
+++ b/docs/_includes/footer.htm
@@ -32,6 +32,41 @@
 				header.appendChild(wrapper);
 			});
 		});
+
+
+		// copy to clipboard buttons
+
+		const copyButtonLabel = "Copy";
+		let blocks = document.querySelectorAll("pre.highlight");
+
+		blocks.forEach((block) => {
+		// only add button if browser supports Clipboard API
+		if (navigator.clipboard) {
+			let button = document.createElement("button");
+			button.classList.add("copycodebtn");
+
+			button.innerText = copyButtonLabel;
+			block.appendChild(button);
+
+			button.addEventListener("click", async () => {
+			await copyCode(block, button);
+			});
+
+		}
+		});
+
+		async function copyCode(block, button) {
+		let code = block.querySelector("code");
+		let text = code.innerText;
+
+		await navigator.clipboard.writeText(text);
+
+		button.innerText = "Copied";
+
+			setTimeout(()=> {
+				button.innerText = copyButtonLabel;
+			},2000)
+		}
 	</script>
 
 </footer>

--- a/docs/_includes/head.htm
+++ b/docs/_includes/head.htm
@@ -3,6 +3,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="{{ '/css/style.css' | prepend:site.baseurl }}" rel="stylesheet" />
+<link rel="stylesheet" href="/css/github.dark.css" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
 <script src="/js/releases.js"></script>

--- a/docs/css/github.dark.css
+++ b/docs/css/github.dark.css
@@ -1,0 +1,116 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #c9d1d9;
+  background-color: #161b22;
+}
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kt, .highlight .kv {
+  color: #ff7b72;
+}
+.highlight .gr {
+  color: #f0f6fc;
+}
+.highlight .gd {
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+.highlight .nb {
+  color: #ffa657;
+}
+.highlight .nc {
+  color: #ffa657;
+}
+.highlight .no {
+  color: #ffa657;
+}
+.highlight .nn {
+  color: #ffa657;
+}
+.highlight .sr {
+  color: #7ee787;
+}
+.highlight .na {
+  color: #7ee787;
+}
+.highlight .nt {
+  color: #7ee787;
+}
+.highlight .gi {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .kc {
+  color: #79c0ff;
+}
+.highlight .l, .highlight .ld, .highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx {
+  color: #79c0ff;
+}
+.highlight .sb {
+  color: #79c0ff;
+}
+.highlight .bp {
+  color: #79c0ff;
+}
+.highlight .ne {
+  color: #79c0ff;
+}
+.highlight .nl {
+  color: #79c0ff;
+}
+.highlight .py {
+  color: #79c0ff;
+}
+.highlight .nv, .highlight .vc, .highlight .vg, .highlight .vi, .highlight .vm {
+  color: #79c0ff;
+}
+.highlight .o, .highlight .ow {
+  color: #79c0ff;
+}
+.highlight .gh {
+  color: #1f6feb;
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #1f6feb;
+  font-weight: bold;
+}
+.highlight .s, .highlight .sa, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .se, .highlight .sh, .highlight .sx, .highlight .s1, .highlight .ss {
+  color: #a5d6ff;
+}
+.highlight .nd {
+  color: #d2a8ff;
+}
+.highlight .nf, .highlight .fm {
+  color: #d2a8ff;
+}
+.highlight .err {
+  color: #f0f6fc;
+  background-color: #8e1519;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cp, .highlight .cpf, .highlight .c1, .highlight .cs {
+  color: #8b949e;
+}
+.highlight .gl {
+  color: #8b949e;
+}
+.highlight .gt {
+  color: #8b949e;
+}
+.highlight .ni {
+  color: #c9d1d9;
+}
+.highlight .si {
+  color: #c9d1d9;
+}
+.highlight .ge {
+  color: #c9d1d9;
+  font-style: italic;
+}
+.highlight .gs {
+  color: #c9d1d9;
+  font-weight: bold;
+}

--- a/docs/css/style.scss
+++ b/docs/css/style.scss
@@ -243,3 +243,29 @@ h4:hover .header-link-wrapper {
   text-decoration: underline;
   color: #333;
 }
+
+
+.highlight{
+  padding: 5px;
+}
+
+pre.highlight{
+  border: none;
+}
+
+code {
+  all: revert !important;
+}
+
+div[class*="language-"] {
+  position: relative;
+  margin: 5px 0 ;
+  padding: 1.75rem 0 1.75rem 1rem;
+}
+
+div[class*="language-"] button{
+  position: absolute;
+  top: 35px;
+  right: 5px;
+}
+


### PR DESCRIPTION
and copy to clipboard button .
Use same theme (github.dark) as on bndtools.org

e.g. code areas now look like this

<img width="1244" height="236" alt="image" src="https://github.com/user-attachments/assets/d028acb8-3e37-4599-9a5b-11a6d8e18a11" />

