### PR TITLE
docs: remove toc of FAQ

### DIFF
--- a/docs/_chapters/920-faq.md
+++ b/docs/_chapters/920-faq.md
@@ -3,22 +3,6 @@ title: FAQ - Frequently Asked Questions
 layout: default
 ---
 
-
-* [How to Ask a Question](?#howToAsk)
-* [Too Many Imports](?#tooManyImports)
-* [Remove unwanted imports](?#removeUnwantedImports)
-* [Importing Default Package](?#importingDefaultPackage)
-* [Why No Automatic Bundle-Activator](?#automaticActivator)
-* [How to set the unbind method with @Reference?](?#unbindMethod)
-* [packageinfo or package-info.java](?#packageinfo)
-* [Why are super classes not inspected for annotations?](?#supercomps)
-* [Where do the exported package versions come from?](?#exportversions)
-* [Should I use the Bundle-ClassPath?](?#bundleclasspath)
-* [What Should I use instead of the Bundle-ClassPath?](?#bundleclasspath2)
-* [Sharing CNF Folder and bnd Projects](?#workspaceSharing)
-
----
-
 ## How to ask a question <a name="howToAsk"/>
 You can use the [bnd discourse site](https://bnd.discourse.group) mail list or [mail me](mailto:Peter.Kriens@aQute.biz).
 


### PR DESCRIPTION
because it is error prone to manually keep it in sync and github pages does not support the jekyll toc plugin