### PR TITLE
[CLI] new Command: bnd dev & bnd build -watch for continuous build run workflow

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/BuildCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/BuildCommands.java
@@ -1,0 +1,243 @@
+package aQute.bnd.main;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.build.Workspace;
+import aQute.bnd.exceptions.Exceptions;
+import aQute.bnd.main.bnd.PerProject;
+import aQute.bnd.main.bnd.buildoptions;
+import aQute.bnd.main.bnd.devOptions;
+import aQute.libg.forker.Forker;
+
+/**
+ * Container for build related commands.
+ */
+public class BuildCommands {
+
+	private bnd bnd;
+
+	public BuildCommands(bnd bnd) {
+		this.bnd = bnd;
+	}
+
+	public void _build(buildoptions opts) throws Exception {
+		if (opts.watch()) {
+			// continous build (for Live Coding)
+			Executor executor = Executors.newCachedThreadPool();
+			ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+			List<Project> projects = bnd.getFilteredProjects(opts);
+			buildAndWatch(opts.test(), opts.verbose(), opts.force(), executor, scheduler, projects);
+			return;
+		}
+
+		// default build
+		boolean force = opts.force();
+		if (opts.parallel()) {
+			boolean test = opts.test();
+			long syncms = opts.synctime() <= 0 ? 20000 : opts.synctime();
+			bnd.out.format("Build parallel%n");
+			List<Project> projects = bnd.getFilteredProjects(opts);
+			buildParallelInternal(projects, force, test, syncms);
+		} else {
+			bnd.perProject(opts, p -> {
+				p.getGenerate()
+					.generate(force);
+				p.compile(opts.test());
+				p.build(opts.test());
+			});
+		}
+
+	}
+
+	public void _dev(devOptions opts) throws Exception {
+
+		Workspace ws = bnd.getWorkspace(bnd.getBase());
+		if (ws == null) {
+			bnd.error("No workspace found from %s", bnd.getBase());
+			return;
+		}
+
+		List<Project> runs = bnd.getRuns(opts._arguments(), opts.project());
+		if (runs == null || runs.isEmpty()) {
+			bnd.messages.NoProject();
+			return;
+		}
+
+		ExecutorService buildExecutor = Executors.newFixedThreadPool(2);
+		ExecutorService watchExecutor = Executors.newFixedThreadPool(2);
+		ScheduledExecutorService buildScheduler = Executors.newSingleThreadScheduledExecutor();
+		ExecutorService runExecutor = Executors.newFixedThreadPool(runs.size());
+
+		boolean force = opts.force();
+		Collection<Project> projects = ws.getAllProjects();
+		buildFullIfNeeded(opts, projects, force);
+
+		buildExecutor.submit(() -> {
+			try {
+				buildAndWatch(opts.test(), opts.verbose(), force, watchExecutor, buildScheduler, projects);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		});
+
+		runs.forEach(run -> {
+			buildExecutor.submit(() -> {
+				try {
+					bnd.doRun(run, opts.verify());
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+			});
+		});
+
+		// Wait for tasks to complete
+		buildExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+
+	}
+
+	private void buildFullIfNeeded(devOptions opts, Collection<Project> projects, boolean force)
+		throws Exception, InterruptedException {
+		Set<Project> projectsNeedRebuild = new LinkedHashSet<>();
+		for (Project project : projects) {
+			// TODO there is project.isStale() but it seems true too often.
+			// so we just check if there are built files which reduces the
+			// number of rebuilts
+			File[] files = project.getBuildFiles(false);
+			if (files == null) {
+				projectsNeedRebuild.add(project);
+			}
+		}
+
+		if (!projectsNeedRebuild.isEmpty()) {
+
+			bnd.out.format("Stale projects detected (%s of %s). Doing a full build now. [%s]%n",
+				projectsNeedRebuild.size(),
+				projects.size(), projectsNeedRebuild);
+
+			if (opts.parallel()) {
+				boolean test = opts.test();
+				long syncms = opts.synctime() <= 0 ? 20000 : opts.synctime();
+				bnd.out.format("Build parallel%n");
+				buildParallelInternal(projects, force, test, syncms);
+			} else {
+
+				Set<Project> projectsDone = new HashSet<>(projects.size());
+				for (Project proj : projects) {
+					bnd.perProject(proj, opts.verbose(), p -> {
+						bnd.out.format("Build Project %s%n", p.getName());
+						proj.getGenerate()
+							.generate(force);
+						p.compile(opts.test());
+						p.build(opts.test());
+					}, true, projectsDone);
+
+				}
+			}
+
+			bnd.out.format("Full build finished%n");
+		}
+	}
+
+	public void buildParallelInternal(Collection<Project> projects, boolean force, boolean test, long syncms)
+		throws Exception, InterruptedException {
+		ExecutorService pool = Executors.newCachedThreadPool();
+		final AtomicBoolean quit = new AtomicBoolean();
+
+		try {
+			final Forker<Project> forker = new Forker<>(pool);
+
+			for (final Project proj : projects) {
+				forker.doWhen(proj.getDependson(), proj, () -> {
+					if (!quit.get()) {
+
+						try {
+							proj.getGenerate()
+								.generate(force);
+							if (!quit.get()) {
+								proj.compile(test);
+							}
+							if (!quit.get())
+								proj.build(test);
+
+							if (!proj.isOk()) {
+								quit.set(true);
+							}
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+					}
+					bnd.getInfo(proj, proj + ": ");
+				});
+			}
+			bnd.err.flush();
+
+			forker.start(syncms);
+		} finally {
+			pool.shutdownNow();
+		}
+	}
+
+	private void buildAndWatch(boolean undertest, boolean verbose, boolean force, Executor watchExecutor,
+		ScheduledExecutorService buildScheduler, Collection<Project> projects) throws InterruptedException, Exception {
+
+		Set<Project> projectsWellDone = new HashSet<Project>();
+		try (BuildWatcher bw = new BuildWatcher(projects, (p) -> {
+			try {
+				perProjectAnDependents(p, verbose, (p2) -> {
+					p.getGenerate()
+						.generate(force);
+					p2.compile(undertest);
+					p2.build(undertest);
+				}, true, projectsWellDone);
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		}, watchExecutor, buildScheduler, bnd.out)) {
+			bnd.out.format("Watching %s project(s) for changes. Press Ctrl+C to stop.", projects.size());
+			new CountDownLatch(1).await();
+			return;
+
+		}
+	}
+
+	/**
+	 * Builds the project and all its dependents
+	 */
+	private void perProjectAnDependents(Project p, boolean verbose, PerProject run, boolean manageDeps,
+		final Set<Project> projectsWellDone) throws Exception {
+		bnd.out.println("Build project: " + p.getName());
+		run.doit(p);
+
+		if (manageDeps) {
+			final Collection<Project> projectDeps = p.getDependents(); // ordered
+			if (verbose && !projectDeps.isEmpty()) {
+				bnd.out.println("Project dependents for: " + p.getName());
+				projectDeps.forEach(pr -> bnd.out
+					.println(" + " + pr.getName() + " " + (projectsWellDone.contains(pr) ? "<handled before>" : "")));
+			}
+
+			projectDeps.removeAll(projectsWellDone);
+
+			for (Project dep : projectDeps) {
+				run.doit(dep);
+				projectsWellDone.add(dep);
+			}
+		}
+
+		bnd.getInfo(p, p + ": ");
+	}
+}

--- a/biz.aQute.bnd/src/aQute/bnd/main/BuildWatcher.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/BuildWatcher.java
@@ -1,0 +1,146 @@
+package aQute.bnd.main;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import aQute.bnd.build.Project;
+import aQute.bnd.exceptions.Exceptions;
+import aQute.lib.io.IO;
+import aQute.lib.watcher.FileWatcher;
+import aQute.lib.watcher.FileWatcher.Builder;
+
+/**
+ * Watches a bnd Project for changes and triggers a build automatically. TODO We
+ * could move it to same package as aQute.bnd.build.ProjectLauncher.LiveCoding
+ * since it was based on that.
+ */
+class BuildWatcher implements Closeable {
+	private static final Logger logger = LoggerFactory.getLogger(BuildWatcher.class);
+
+	private Collection<Project>				projects;
+	private final Map<File, Project>		fileToProject		= new HashMap<>();
+	private final Executor					watchExecutor;
+	private final ScheduledExecutorService	buildScheduler;
+	private final Semaphore semaphore = new Semaphore(1);
+	private final AtomicBoolean propertiesChanged = new AtomicBoolean(false);
+	private volatile FileWatcher fw;
+	private final Consumer<Project>			perProject;
+	private final PrintStream				out;
+
+	public BuildWatcher(Collection<Project> projects, Consumer<Project> perProject, Executor executor,
+		ScheduledExecutorService scheduledExecutor, PrintStream out) throws Exception {
+		this.projects = projects;
+		this.perProject = perProject;
+		this.watchExecutor = executor;
+		this.buildScheduler = scheduledExecutor;
+		this.out = out;
+		watch();
+	}
+
+	private void watch() throws Exception {
+		Builder builder = new FileWatcher.Builder()
+			.executor(watchExecutor)
+			.changed(this::onFileChanged);
+
+		for (Project project : projects) {
+
+			List<File> watchFolders = Collections.singletonList(project.getBase());
+			Collection<File> watchedFiles = collectSourceFolders(project, watchFolders);
+			builder.files(watchedFiles);
+			for (File f : watchedFiles) {
+				fileToProject.put(f, project);
+			}
+		}
+
+		FileWatcher old = fw;
+		fw = builder.build();
+		if (old != null) {
+			old.close();
+		}
+		out.println(String.format("[BuildWatcher] Watching projects (%s files and folders): %s ",
+			fileToProject.size(), projects));
+	}
+
+	private static Collection<File> collectSourceFolders(Project project, Collection<File> sourceRoots) {
+		try {
+			Path targetDir = project.getTarget()
+				.toPath()
+				.normalize()
+				.toAbsolutePath();
+
+			Set<File> files = new LinkedHashSet<>();
+			for (File root : sourceRoots) {
+				if (root.isDirectory()) {
+					IO.tree(root)
+					.stream()
+						// exclude target-dir, .class files etc.
+						.filter(f -> !f.getName()
+							.endsWith(".class")
+							&& !f.toPath()
+							.startsWith(targetDir))
+					.forEach(files::add);
+				}
+			}
+			return files;
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	private void onFileChanged(File file, String kind) {
+		out.println(String.format("[BuildWatcher] Detected change to %s (%s)", file.getName(), kind));
+		Project project = fileToProject.get(file);
+
+		propertiesChanged.compareAndSet(false,
+			project.getPropertiesFile().equals(file) ||
+			project.getIncluded().contains(file));
+
+		if (semaphore.tryAcquire()) {
+			buildScheduler.schedule(() -> {
+				try {
+					logger.debug("[BuildWatcher] Rebuilding project: {}", project.getName());
+					perProject.accept(project);
+					logger.debug("[BuildWatcher] Build successful for {}", project.getName());
+				} catch (Exception e) {
+					logger.error("[BuildWatcher] Build failed for {}", project.getName(), e);
+				} finally {
+					semaphore.release();
+
+					if (propertiesChanged.compareAndSet(true, false)) {
+						logger.debug("[BuildWatcher] Detected bnd file change — resetting file watcher.");
+						try {
+							watch();
+						} catch (Exception e) {
+							logger.error("[BuildWatcher] Failed to reset watcher", e);
+						}
+					}
+				}
+			}, 600, TimeUnit.MILLISECONDS); // debounce delay
+		}
+	}
+
+	@Override
+	public void close() {
+		if (fw != null) {
+			fw.close();
+		}
+	}
+}

--- a/docs/_commands/build.md
+++ b/docs/_commands/build.md
@@ -2,7 +2,7 @@
 layout: default
 title: build
 summary: |
-   Build a project. This will create the jars defined in the bnd.bnd and sub-builders.
+   Build a project. This will create the jars defined in the bnd.bnd and sub-builders. Adding the -w option allows live code / continous compile-build-loop which automatically watches for changes.
 note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in _ext sub-folder. 
 ---
 
@@ -13,8 +13,11 @@ note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same fil
 #### Options: 
 - `[ -e --exclude <string;> ]` Exclude files by pattern
 - `[ -f --force ]` Force non-incremental
-- `[ -p --project <string> ]` Identify another project
+- `[ -p --parallel ]` Build in parallel (Experimental)
+- `[ -P --project <string> ]` Identify another project
+- `[ -s --synctime <long> ]` 
 - `[ -t --test ]` Build for test
 - `[ -v --verbose ]` prints more processing information
-- `[ -w --workspace <string> ]` Use the following workspace
+- `[ -w --watch ]` Continuous incremental build
+- `[ -W --workspace <string> ]` Use the following workspace
 

--- a/docs/_commands/dev.md
+++ b/docs/_commands/dev.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: dev
+summary: |
+   Experimental: Live coding. Run 1..n .bndrun files in the OSGi launcher, and continously rebuild all projects in the workspace when changes are detected. If no bndrun is specified, the current project is used for the run specification. An initial full build is done when one project not built is detected.
+note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in _ext sub-folder. 
+---
+
+### Synopsis: 
+	   dev [options]  <[bndrun...]>
+
+#### Options: 
+- `[ -e --exclude <string;> ]` Exclude files by pattern
+- `[ -f --force ]` Force non-incremental
+- `[ -p --parallel ]` Do the initial full build in parallel (Experimental)
+- `[ -P --project <string> ]` Path to another project than the current project. Only valid if no bndrun is specified
+- `[ -s --synctime <long> ]` 
+- `[ -t --test ]` Build for test
+- `[ -v --verbose ]` prints more processing information
+- `[ -V --verify ]` Verify all the dependencies before launching (runpath, runbundles)
+- `[ -w --workspace <string> ]` Use the following workspace
+

--- a/docs/_commands/run.md
+++ b/docs/_commands/run.md
@@ -2,7 +2,7 @@
 layout: default
 title: run
 summary: |
-   Run a project in the OSGi launcher.  If not bndrun is specified, the current project is used for the run specification
+   Run a project in the OSGi launcher.  If no bndrun is specified, the current project is used for the run specification
 note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in _ext sub-folder. 
 ---
 


### PR DESCRIPTION
The goal is to have an IDE-independent live coding workflow known from the javascript / npm world e.g. "vue-cli serve" ([see](https://cli.vuejs.org/guide/cli-service.html)) which starts a dev-webserver and allows for hot code reloading when changes are detected. It should basically do the same what Eclipse "Build automatically" is doing, but without Eclipse. So I can use any text editor VSCode, vim etc.

A workflow could look like:

```
cd mybndworkspace
bnd dev mywebapp/launch.bndrun
```

or multiple `.bndrun` files

```
cd mybndworkspace
bnd dev mywebapp/launch.bndrun mywebapp/launch2.bndrun
```

The `dev` command initially checks if any project needs rebuilding, and if yes it does a full build of the workspace before launching the bndrun files. Otherwise the bndrun files are launched immediately and the workspace is watched for changes and then rebuilt automatically.

This allows e.g. to use another editor for changing java files.


or just continous build and doing the run in a separate shell process

```
cd mybndworkspace
bnd build --watch & cd mywebapp; bnd run launch.bndrun
```


This is basically. a combination of the three existing commands:

```
bnd compile
bnd build
bnd run
```

The current code is borrowed from the existing class `ProjectLauncher.LiveCoding` and adapted it for compile-build.  `ProjectLauncher.LiveCoding` is only for .bndrun and  detects changes in .bnd / .bndrun or built .jar files and re-installs them. This is fine. What is missing is the same for a compile-build loop which creates the jars which are then detected by `ProjectLauncher.LiveCoding`

## build and parallel build 

The `build` and the new `dev` command got a (still experimental) `-p, --parallel` option which can build a workspace in parallel. 


## Web Apps and tutorials in mind

I am coming from a Web-application background and my goal is the make building web-applications with bnd much easier. I think most of the parts are there already.

So the goal of this new dev command is actually a bnd tutorial which starts with the following commands to:

1. create a workspace based on a template fragment for a simple web-app
2. run the dev command to run the app and start developing

```
bnd add workspace -f demo-webapp -f osgi myworkspace
cd myworkspace
bnd dev launch.bndrun
```

## Current Status

added a new command:

```
bnd dev [.bndrun...]
```

This mimics the same as `bnd build --watch & bnd run myappbundle/launch.bndrun` on the command line. It spawns n threads - **one** for continous build on changes and **n** for running one or multiple .bndrun files which reloads the rebuilt bundles.

```
bns help dev

NAME
  dev                         - Live coding. Run 1..n .bndrun files in the OSGi
                                launcher, and continously rebuild all projects
                                in the workspace when changes are detected. If
                                no bndrun is specified, the current project is
                                used for the run specification. An initial full
                                build is done when one project not built is
                                detected.

SYNOPSIS
   dev [options] <[bndrun...]>

OPTIONS

   [ -e, --exclude <string;> ] - Exclude files by pattern
   [ -f, --force ]            - Force non-incremental
   [ -p, --parallel ]         - Do the initial full build in parallel
                                (Experimental)
   [ -P, --project <string> ] - Path to another project than the current
                                project. Only valid if no bndrun is specified
   [ -s, --synctime <long> ]  -
   [ -t, --test ]             - Build for test
   [ -v, --verbose ]          - prints more processing information
   [ -V, --verify ]           - Verify all the dependencies before launching
                                (runpath, runbundles)
   [ -w, --workspace <string> ] - Use the following workspace
```

As a quick reference here is how to do this using a full java command using the `bnd.jar`

```
java -jar '/path/to/biz.aQute.bnd.jar' -b /path/to/bndworkspace dev mywebapp/launch.bndrun
```
