### PR TITLE
add warn marker for Non-empty, non-contained pck

### DIFF
--- a/bndtools.builder/src/org/bndtools/builder/decorator/ui/PackageDecorator.java
+++ b/bndtools.builder/src/org/bndtools/builder/decorator/ui/PackageDecorator.java
@@ -2,12 +2,14 @@ package org.bndtools.builder.decorator.ui;
 
 import java.io.File;
 
+import org.bndtools.api.BndtoolsConstants;
 import org.bndtools.api.ILogger;
 import org.bndtools.api.Logger;
 import org.bndtools.build.api.IProjectDecorator.BndProjectInfo;
 import org.bndtools.builder.BndtoolsBuilder;
 import org.bndtools.core.ui.icons.Icons;
 import org.bndtools.utils.swt.SWTConcurrencyUtil;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -145,6 +147,7 @@ public class PackageDecorator extends LabelProvider implements ILightweightLabel
 							.containsFQN(pkgName)) {
 							if (!excluded.equals(text)) {
 								pkgResource.setPersistentProperty(packageDecoratorKey, excluded);
+								createMarker(project, pkgResource, pkgName);
 								changed = true;
 							}
 							continue;
@@ -168,5 +171,14 @@ public class PackageDecorator extends LabelProvider implements ILightweightLabel
 				.getDecoratorManager()
 				.update(packageDecoratorId));
 		}
+	}
+
+	private static void createMarker(IProject project, IResource pkgResource, String pkgName) throws CoreException {
+		IMarker marker = pkgResource.createMarker(BndtoolsConstants.MARKER_BND_PATH_PROBLEM);
+		marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+		marker.setAttribute(IMarker.MESSAGE, "Non-empty, non-contained package: " + pkgName
+			+ " (Add package to -privatepackage or Export-Package in bnd.bnd)");
+		marker.setAttribute(IMarker.LOCATION, project.getName());
+		marker.setAttribute(IMarker.SOURCE_ID, BndtoolsConstants.CORE_PLUGIN_ID);
 	}
 }


### PR DESCRIPTION
Adds an additional WARNING marker in Eclipse Problems View for packages which get the little red icon , indicating that the package is non-empty but is neither in -privatepackage or Export-Package

The goal is that this kind of problem gets noticed easier, because in a large workspace with deeply nested packages (and maybe package presentation "hierarchical") it is hard to notice. 


## Example

For a package like this 

<img width="197" height="38" alt="image" src="https://github.com/user-attachments/assets/7f779ed2-71ec-4cae-af71-d3ac76622bcc" />

you now also get a warning like this :

<img width="1703" height="67" alt="image" src="https://github.com/user-attachments/assets/934c193c-adc3-4a7e-a394-ebf1abd49287" />

**Bndtools Path Problem Marker**
```
Non-empty, non-contained package: my.package.foo (Add package to private or exported packages in bnd.bnd)
```

Suggestions for better wording welcome. The current message is based on an existing comment in the code.
