### PR TITLE
P2Export: support update site url per feature

### DIFF
--- a/biz.aQute.repository/src/aQute/p2/export/P2.java
+++ b/biz.aQute.repository/src/aQute/p2/export/P2.java
@@ -260,13 +260,18 @@ class P2 {
 		final BundleId	groupId;
 		final BundleId	jarId;
 		final String	plugin;
+		final String	update;
+		final String	updateLabel;
 
-		Feature(BundleId id, Domain properties, List<Provided> provides, List<Required> requires, String plugin) {
+		Feature(BundleId id, Domain properties, List<Provided> provides, List<Required> requires, String plugin,
+			String updateSiteUrl, String updateLabel) {
 			super(id, properties, provides, requires);
 			this.plugin = plugin;
 			this.requires.addAll(requires);
 			this.groupId = getBundleId(id.getBsn() + ".feature.group", id.getVersion());
 			this.jarId = getBundleId(id.getBsn() + ".feature.jar", id.getVersion());
+			this.update = updateSiteUrl;
+			this.updateLabel = updateLabel;
 		}
 
 		String getProvider() {

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
@@ -1,0 +1,20 @@
+Bundle-Name:            Bndtools ECF Remote Services
+Bundle-Description:     ECF Remote Services integration for Bndtools
+Bundle-Category         bndtools
+Bundle-Copyright: Copyright Composent, Inc. others, 2025
+update: https://download.eclipse.org/rt/ecf/latest/site.p2/
+update.label: ECF Update Site
+
+Require-Capability \
+    feature;name=org.eclipse.ecf.core.feature;version="[0.0.0,1000)",\
+    feature;name=bndtools.main.feature,\
+    feature;name=org.eclipse.ecf.discovery.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.discovery.jmdns.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.osgi.services.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.provider.generic.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.provider.generic.remoteservice.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.remoteservice.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.remoteservice.sdk.bndtools.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.sharedobject.feature;version="[0.0.0,1000)"
+    
+    

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.main.xml
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.main.xml
@@ -484,6 +484,9 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.]]></license>
+  <url>
+    <update url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
+  </url>
   <requires>
     <import feature="org.eclipse.platform.feature.group" version="4.25.0" match="equivalent"/>
   </requires>

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.pde.xml
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.pde.xml
@@ -2,6 +2,9 @@
   <description url="https://bnd.bndtools.org/"><![CDATA[PDE integration for Bndtools]]></description>
   <copyright><![CDATA[Copyright bndtools]]></copyright>
   <license url="https://opensource.org/licenses/Apache-2.0"><![CDATA[Simple license description]]></license>
+  <url>
+    <update url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
+  </url>
   <requires>
     <import feature="bndtools.main.feature.feature.group" version="7.0.0" match="perfect"/>
     <import feature="org.eclipse.pde.feature.group" version="3.14.1300" match="equivalent"/>

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/features.bnd
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/features.bnd
@@ -14,7 +14,8 @@ Bundle-Copyright:       Copyright bndtools
 features        = \
         bndtools.main.feature.bndrun, \
         bndtools.m2e.feature.bndrun, \
-        bndtools.pde.feature.bndrun
+        bndtools.pde.feature.bndrun,\
+        bndtools.ecf.feature.bndrun
 
 update          =   https://bndtools.jfrog.io/bndtools/update-latest
 update.label    =   Bndtools Update Site


### PR DESCRIPTION
Now you can override the update URL per feature and it is now also added to feature.xml and content.xml This makes it easier to install features which require a specific update site to be available in Eclipse without the user having to add the site manually.

e.g. feature.xml

```
 <url>
    <update url="https://download.eclipse.org/rt/ecf/latest/site.p2/" label="ECF Update Site"/>
  </url>
```

and also to content.xml `<references>` e.g.

```
<references size="4">
    <repository uri="https://bndtools.jfrog.io/bndtools/update-latest" url="https://bndtools.jfrog.io/bndtools/update-latest" type="1" options="0"/>
    <repository uri="https://bndtools.jfrog.io/bndtools/update-latest" url="https://bndtools.jfrog.io/bndtools/update-latest" type="0" options="0"/>
    <repository uri="https://download.eclipse.org/rt/ecf/latest/site.p2/" url="https://download.eclipse.org/rt/ecf/latest/site.p2/" type="1" options="1"/>
    <repository uri="https://download.eclipse.org/rt/ecf/latest/site.p2/" url="https://download.eclipse.org/rt/ecf/latest/site.p2/" type="0" options="1"/>
  </references>

```