### PR TITLE
Switch to the correct BuildContext API

### DIFF
--- a/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -68,7 +68,7 @@ import org.apache.maven.settings.Settings;
 import org.apache.maven.shared.mapping.MappingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonatype.plexus.build.incremental.BuildContext;
+import org.codehaus.plexus.build.BuildContext;
 
 /**
  * Abstract base class for all bnd-maven-plugin mojos.


### PR DESCRIPTION
This avoids rebuilding the jar when nothing has changed, and in projects with subproject, avoids downstream project recompilations.