### PR TITLE
p2: use existing jar to reuse manifest

### DIFF
--- a/biz.aQute.repository/src/aQute/p2/export/P2Export.java
+++ b/biz.aQute.repository/src/aQute/p2/export/P2Export.java
@@ -28,6 +28,7 @@ import org.osgi.framework.namespace.BundleNamespace;
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.Run;
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.header.Parameters;
 import aQute.bnd.osgi.BundleId;
@@ -104,10 +105,20 @@ class P2Export {
 			return null;
 		}
 
-		Jar jar = new Jar(name);
+		File file = Project.getFile(bndrun.getTargetDir(), name);
+		Jar jar;
+		if (file.exists()) {
+			try {
+				jar = Jar.fromResource(name, new FileResource(file));
+			} catch (Exception e) {
+				throw Exceptions.duck(e);
+			}
+		} else {
+			jar = new Jar(name);
+			jar.setDoNotTouchManifest();
+			jar.setManifest((Manifest) null);
+		}
 		jar.setReproducible("true");
-		jar.setDoNotTouchManifest();
-		jar.setManifest((Manifest) null);
 		jar.putResource("content.jar", generateContent(p2));
 		jar.putResource("artifacts.jar", generateArtifacts(p2, jar));
 		return new AbstractMap.SimpleEntry<String, Resource>("p2", new JarResource(jar));

--- a/org.bndtools.p2/bnd.bnd
+++ b/org.bndtools.p2/bnd.bnd
@@ -40,10 +40,10 @@ pluginnames: ${-dependson},\
 plugins: ${map;repo;${template;pluginnames;${@};latest}}
 
 -resourceonly: true
-
 -maven-release: 
 -buildrepo: 
 -releaserepo:
+
 
 # P2 signing:
 # key (name of the key), 


### PR DESCRIPTION
Currently the p2Export jar does not contain a MANIFEST.MF and thus the build fails with "Cannot install /org.bndtools.p2/generated/org.bndtools.p2.jar into Local because Could not create a pom from Maven metainfo properties nor manifest information"

But bnd automatically creates a normal jar (what bnd usually does) with META-INF/MANIFEST.MF. 
BUT: if you give the p2export jar the same filename then the normal jar is overwritten. 

This PR fixes the problem and now simply reuse an existing jar if it already exist. 
That way the result the p2export jar has also `META-INF/MANIFEST.MF` and als `META-INF/maven/*` files if configured.

