### PR TITLE
fix org.bndtools.p2 release

### DIFF
--- a/org.bndtools.p2/bnd.bnd
+++ b/org.bndtools.p2/bnd.bnd
@@ -40,10 +40,6 @@ pluginnames: ${-dependson},\
 plugins: ${map;repo;${template;pluginnames;${@};latest}}
 
 -resourceonly: true
--maven-release: 
--buildrepo: 
--releaserepo:
-
 
 # P2 signing:
 # key (name of the key), 


### PR DESCRIPTION
remove the empty instructions to hopefully fix the deployment of org.bndtools.p2 to `dist/m2` and ultimately to jfrog