### PR TITLE
P2Export optimizations

### DIFF
--- a/biz.aQute.repository/test/aQute/p2/export/P2PublisherTest.java
+++ b/biz.aQute.repository/test/aQute/p2/export/P2PublisherTest.java
@@ -45,7 +45,7 @@ class P2PublisherTest {
 			File[] build = p.build();
 			assertTrue(p.check());
 
-			File file = p.getFile("generated/p1.jar");
+			File file = p.getFile("generated/bndtools.jar");
 			try (Jar jar = new Jar(file);
 
 				Jar artifacts = new Jar("artifacts.jar", jar.getResource("artifacts.jar")

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bnd.bnd
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bnd.bnd
@@ -21,7 +21,7 @@ pubkey=FAKE PUBLIC KEY
 
 -export features.bnd; \
     type=p2; \
-    name=p1.jar;\
+    name=bndtools.jar;\
     sign=true;\
     sign_key=${key};\
     sign_passphrase=${passphrase};\

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.ecf.feature
 Bundle-Name:            Bndtools ECF Remote Services
 Bundle-Description:     ECF Remote Services integration for Bndtools
 Bundle-Category         bndtools

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.m2e.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.m2e.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.m2e.feature
 Bundle-Name:    Bndtools m2e
 Bundle-Description:       m2e integration for Bndtools
 

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.main.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.main.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.main.feature
 Bundle-Name:            Bndtools
 Bundle-Description:     OSGi Development Tools for Eclipse based on bnd.
 Bundle-Category         bndtools

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.pde.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.pde.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.pde.feature
 Bundle-Name:            Bndtools PDE
 Bundle-Description:     PDE integration for Bndtools
 Bundle-Category         bndtools

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/features.bnd
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/features.bnd
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: org.bndtools.p2
 Bundle-Version  7.0.0
 Bundle-License:  \
     ASL-2.0;\


### PR DESCRIPTION
- add proper manifest in p2 bundle
- remove the hack
- add p2.index file
- put pgp.publicKeys once in <repository> instead of redundantly in each artifact. makes the xml file smaller