### PR TITLE
Fix P2 based on previous PR

### DIFF
--- a/org.bndtools.p2/bnd.bnd
+++ b/org.bndtools.p2/bnd.bnd
@@ -1,6 +1,8 @@
 # Set javac settings from JDT prefs
 -include: ${workspace}/cnf/includes/jdt.bnd, ${workspace}/cnf/includes/bndtools.bnd
 
+-fixupmessages: Eclipse: The Bundle
+Bundle-SymbolicName: org.bndtools.p2.dummy
 p2.version: ${base.version}.${first;${def;-snapshot;DEV};REL}
 timestamp: ${tstamp}
 
@@ -38,6 +40,7 @@ pluginnames: ${-dependson},\
 	org.osgi.util.promise
 
 plugins: ${map;repo;${template;pluginnames;${@};latest}}
+-maven-release:         pom
 
 -resourceonly: true
 

--- a/org.bndtools.p2/bndtools.ecf.feature.bndrun
+++ b/org.bndtools.p2/bndtools.ecf.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.ecf.feature
 Bundle-Name:            Bndtools ECF Remote Services
 Bundle-Description:     ECF Remote Services integration for Bndtools
 Bundle-Category         bndtools

--- a/org.bndtools.p2/bndtools.m2e.feature.bndrun
+++ b/org.bndtools.p2/bndtools.m2e.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.m2e.feature
 Bundle-Name:    Bndtools m2e
 Bundle-Description:       m2e integration for Bndtools
 Bundle-Copyright: Copyright Gregory Amerson others, 2016

--- a/org.bndtools.p2/bndtools.main.feature.bndrun
+++ b/org.bndtools.p2/bndtools.main.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.main.feature
 Bundle-Name:            Bndtools
 Bundle-Description:     OSGi Development Tools for Eclipse based on bnd.
 Bundle-Category         bndtools

--- a/org.bndtools.p2/bndtools.pde.feature.bndrun
+++ b/org.bndtools.p2/bndtools.pde.feature.bndrun
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: bndtools.pde.feature
 Bundle-Name:            Bndtools PDE
 Bundle-Description:     PDE integration for Bndtools
 Bundle-Category         bndtools

--- a/org.bndtools.p2/features.bnd
+++ b/org.bndtools.p2/features.bnd
@@ -1,3 +1,4 @@
+Bundle-SymbolicName: org.bndtools.p2
 Bundle-License:  \
     (ASL-2.0 or EPL-2.0);\
         file="license.txt";\
@@ -7,7 +8,6 @@ Bundle-License:  \
 Bundle-DocURL:          https://bnd.bndtools.org/
 Bundle-Vendor           bnd
 Bundle-Copyright:       Copyright bndtools
-
 
 features        = \
         bndtools.main.feature.bndrun, \


### PR DESCRIPTION
Now the org.bndtools.p2 has properly created META-INF folder (follow up of https://github.com/bndtools/bnd/pull/6826 )