### PR TITLE
P2Export: Try to fix Update ECF P2 Update Site not recognized during installation

### DIFF
--- a/biz.aQute.repository/src/aQute/p2/export/P2Export.java
+++ b/biz.aQute.repository/src/aQute/p2/export/P2Export.java
@@ -139,6 +139,46 @@ class P2Export {
 			"p2.compresssed", true, //
 			"pgp.publicKeys", pgp_publicKeys);
 
+		Set<String> addedUpdateUrls = new HashSet<>();
+		Tag references = new Tag(repository, "references");
+		if (update != null) {
+			addedUpdateUrls.add(update);
+			new Tag(references, "repository")//
+				.addAttribute("uri", update)
+				.addAttribute("url", update)
+				.addAttribute("type", 1)
+				.addAttribute("options", 0);
+			new Tag(references, "repository")//
+				.addAttribute("uri", update)
+				.addAttribute("url", update)
+				.addAttribute("type", 0)
+				.addAttribute("options", 0);
+		}
+
+		p2.content.units.stream()
+			.distinct()
+			.sorted()
+			.forEach(iu -> {
+
+				if (iu instanceof Feature f) {
+					if (f.update != null && addedUpdateUrls.add(f.update)) {
+						new Tag(references, "repository")//
+							.addAttribute("uri", f.update)
+							.addAttribute("url", f.update)
+							.addAttribute("type", 1)
+							.addAttribute("options", 1);
+						new Tag(references, "repository")//
+							.addAttribute("uri", f.update)
+							.addAttribute("url", f.update)
+							.addAttribute("type", 0)
+							.addAttribute("options", 1);
+					}
+
+				}
+			});
+
+		size(references);
+
 		Tag mappings = new Tag(repository, "mappings");
 		new Tag(mappings, "rule")//
 			.addAttribute("filter", "(&(classifier=osgi.bundle))")
@@ -483,6 +523,11 @@ class P2Export {
 			tUpdate.addAttribute("url", feature.update);
 			if (feature.updateLabel != null)
 				tUpdate.addAttribute("label", feature.updateLabel);
+
+			Tag tDiscovery = new Tag(url, "discovery");
+			tDiscovery.addAttribute("url", feature.update);
+			if (feature.updateLabel != null)
+				tDiscovery.addAttribute("label", feature.updateLabel);
 		}
 
 		Tag requires = new Tag(f, "requires");

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/bndtools.ecf.feature.bndrun
@@ -3,19 +3,19 @@ Bundle-Name:            Bndtools ECF Remote Services
 Bundle-Description:     ECF Remote Services integration for Bndtools
 Bundle-Category         bndtools
 Bundle-Copyright: Copyright Composent, Inc. others, 2025
-update: https://download.eclipse.org/rt/ecf/latest/site.p2/
+update: https://download.eclipse.org/rt/ecf/3.16.5/site.p2/
 update.label: ECF Update Site
 
 Require-Capability \
-    feature;name=org.eclipse.ecf.core.feature;version="[0.0.0,1000)",\
+    feature;name=org.eclipse.ecf.core.feature;version="[1.7.0,2)",\
     feature;name=bndtools.main.feature,\
-    feature;name=org.eclipse.ecf.discovery.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.discovery.jmdns.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.osgi.services.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.provider.generic.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.provider.generic.remoteservice.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.remoteservice.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.remoteservice.sdk.bndtools.feature;version="[0.0.0,1000)",\
-    feature;name=org.eclipse.ecf.sharedobject.feature;version="[0.0.0,1000)"
+    feature;name=org.eclipse.ecf.discovery.feature;version="[1.1.0,2)",\
+    feature;name=org.eclipse.ecf.discovery.jmdns.feature;version="[1.1.0,2)",\
+    feature;name=org.eclipse.ecf.osgi.services.feature;version="[2.7.100,3)",\
+    feature;name=org.eclipse.ecf.provider.generic.feature;version="[1.2.0,2)",\
+    feature;name=org.eclipse.ecf.provider.generic.remoteservice.feature;version="[1.3.0,2)",\
+    feature;name=org.eclipse.ecf.remoteservice.feature;version="[2.7.0,3)",\
+    feature;name=org.eclipse.ecf.remoteservice.sdk.bndtools.feature;version="[3.16.5,4)",\
+    feature;name=org.eclipse.ecf.sharedobject.feature;version="[1.2.0,2)"
     
     

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.main.xml
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.main.xml
@@ -486,6 +486,7 @@ version(s), and exceptions or additional permissions here}."
   You may add additional accurate notices of copyright ownership.]]></license>
   <url>
     <update url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
+    <discovery url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
   </url>
   <requires>
     <import feature="org.eclipse.platform.feature.group" version="4.25.0" match="equivalent"/>

--- a/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.pde.xml
+++ b/biz.aQute.repository/testdata/p2-publish/ws-1/p1/expected-feature.pde.xml
@@ -4,6 +4,7 @@
   <license url="https://opensource.org/licenses/Apache-2.0"><![CDATA[Simple license description]]></license>
   <url>
     <update url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
+    <discovery url="https://bndtools.jfrog.io/bndtools/update-latest" label="Bndtools Update Site"/>
   </url>
   <requires>
     <import feature="bndtools.main.feature.feature.group" version="7.0.0.0000-SNAPSHOT" match="perfect"/>


### PR DESCRIPTION
Closes #6841 

add more p2 update site references

- to artifacts.xml as <references> same as in content.xml
- to feature.xml as <discovery> tag

Let's see if that helps.