### PR TITLE
new -nosubstitution instruction to disable package substitution globally (comparable to -noimport:=true)

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -1719,6 +1719,102 @@ public class BuilderTest {
 	}
 
 	@Test
+	public void testSubstitutionEnabled() throws Exception {
+
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.NOSUBSTITUTION, "false");
+			b.setProperty("Export-Package", "org.osgi.util.measurement, org.osgi.service.http;");
+			b.setProperty("Private-Package", "org.osgi.framework, test.refer");
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue("Import-Package");
+			String exports = m.getMainAttributes()
+				.getValue("Export-Package");
+			assertTrue(exports.contains("org.osgi.service.http"));
+			assertTrue(imports.contains("org.osgi.service.http"));
+		}
+
+	}
+
+	@Test
+	public void testSubstitutionDisabled() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.NOSUBSTITUTION, "true");
+			b.setProperty("Export-Package", "org.osgi.util.measurement, org.osgi.service.http;");
+			b.setProperty("Private-Package", "org.osgi.framework, test.refer");
+			b.addClasspath(IO.getFile("jar/osgi.jar"));
+			b.addClasspath(new File("bin_test"));
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue("Import-Package");
+			String exports = m.getMainAttributes()
+				.getValue("Export-Package");
+			assertTrue(exports.contains("org.osgi.service.http"));
+			assertFalse(imports.contains("org.osgi.service.http"));
+		}
+
+	}
+
+	@Test
+	public void testSubstitutionEnabled2() throws Exception {
+
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.NOSUBSTITUTION, "false");
+			b.setProperty("Export-Package", "org.apache.felix.*");
+			b.addClasspath(IO.getFile(
+				"testresources/ws/cnf/repo2/org.apache.felix.configadmin/org.apache.felix.configadmin-1.8.8.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("Private-Package", "org.apache.felix.cm.impl");
+			b.setProperty("-fixupmessages.export",
+				"The annotation aQute.bnd.annotation.Export");
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue("Import-Package");
+			String exports = m.getMainAttributes()
+				.getValue("Export-Package");
+			assertTrue(exports.contains("org.apache.felix.cm;"));
+			assertTrue(imports.contains("org.apache.felix.cm;"));
+		}
+
+	}
+
+	@Test
+	public void testSubstitutionDisabled2() throws Exception {
+
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.NOSUBSTITUTION, "true");
+			b.setProperty("Export-Package", "org.apache.felix.*");
+			b.addClasspath(IO.getFile(
+				"testresources/ws/cnf/repo2/org.apache.felix.configadmin/org.apache.felix.configadmin-1.8.8.jar"));
+			b.addClasspath(new File("bin_test"));
+			b.setProperty("Private-Package", "org.apache.felix.cm.impl");
+			b.setProperty("-fixupmessages.export", "The annotation aQute.bnd.annotation.Export");
+			Jar jar = b.build();
+			assertTrue(b.check());
+
+			Manifest m = jar.getManifest();
+			String imports = m.getMainAttributes()
+				.getValue("Import-Package");
+			String exports = m.getMainAttributes()
+				.getValue("Export-Package");
+			assertTrue(exports.contains("org.apache.felix.cm;"));
+			assertFalse(imports.contains("org.apache.felix.cm;"));
+		}
+
+	}
+
+	@Test
 	public void testNoImportDirective() throws Exception {
 		Builder b = new Builder();
 		try {

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -620,6 +620,10 @@ public class Syntax implements Constants {
 			NOCLASSFORNAME + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
 		new Syntax(NOIMPORTJAVA, "Do not calculate " + IMPORT_PACKAGE + " references for java.* packages.",
 			NOIMPORTJAVA + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
+		new Syntax(NOSUBSTITUTION,
+			"Setting this to true disables package substitution globally (default is false). That means, that bnd does not calculate "
+				+ IMPORT_PACKAGE + " references for packages exported by the current bundle.",
+			NOSUBSTITUTION + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),
 
 		new Syntax(NOEE, "Do not calculate the osgi.ee name space Execution Environment from the class file version.",
 			NOEE + "=true", "true,false", Verifier.TRUEORFALSEPATTERN),

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -1887,6 +1887,14 @@ public class Analyzer extends Processor {
 	 * Not clear anymore ...
 	 */
 	Packages doExportsToImports(Packages exports) {
+
+		if (is(Constants.NOSUBSTITUTION)) {
+			// package substitution disabled completely
+			// means: we do not import at all, any package we export
+			// this is equivalent to Export-Package:*;-noimport:=true
+			return new Packages();
+		}
+
 		// private packages = contained - exported.
 		Set<PackageRef> privatePackages = new HashSet<>(contained.keySet());
 		privatePackages.removeAll(exports.keySet());

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -198,6 +198,7 @@ public interface Constants {
 	String		NOUSES										= "-nouses";
 	String		NOCLASSFORNAME								= "-noclassforname";
 	String		NOIMPORTJAVA								= "-noimportjava";
+	String		NOSUBSTITUTION								= "-nosubstitution";
 	String		NOBUNDLES									= "-nobundles";
 	String		NOPARALLEL									= "-noparallel";
 	String		OUTPUTMASK									= "-outputmask";																																						// default
@@ -344,7 +345,7 @@ public interface Constants {
 		CONNECTION_SETTINGS, RUNPROVIDEDCAPABILITIES, WORKINGSET, RUNSTORAGE, REPRODUCIBLE, INCLUDEPACKAGE,
 		CDIANNOTATIONS, REMOTEWORKSPACE, MAVEN_DEPENDENCIES, BUILDERIGNORE, STALECHECK, MAVEN_SCOPE, RUNSTARTLEVEL,
 		RUNOPTIONS, NOCLASSFORNAME, EXPORT_APIGUARDIAN, RESOLVE, DEFINE_CONTRACT, GENERATE, RUNFRAMEWORKRESTART,
-		NOIMPORTJAVA, VERSIONDEFAULTS, LIBRARY, METAINF_SERVICES);
+		NOIMPORTJAVA, NOSUBSTITUTION, VERSIONDEFAULTS, LIBRARY, METAINF_SERVICES);
 
 	// Ignore bundle specific headers. These headers do not make a lot of sense
 	// to inherit

--- a/docs/_chapters/170-versioning.md
+++ b/docs/_chapters/170-versioning.md
@@ -170,6 +170,8 @@ After the bundle has been created and analyzed bnd will see if an exported packa
 
 If a package is imported it will use the version as defined by the version policy.
 
+With the [-nosubstitution: true](/instructions/nosubstitution.html) instruction, this behavior can be disabled globally.
+
 ## Versioning Bundles
 Versioning bundles usually requires bumping the version every time it is placed in a repository. When package versioning is used, the bundle version is only important for tracking an artifact.
 

--- a/docs/_heads/_ext/export_package.md
+++ b/docs/_heads/_ext/export_package.md
@@ -15,7 +15,18 @@ Example:
 Export-Package: !com.*, *
 ```
 
-This example exports all packages except those starting with `com`. You can also use directives such as `-noimport:=true` to control import behavior, and bnd will automatically calculate the `uses:` directive for class space consistency.
+This example exports all packages except those starting with `com`. 
+
+**Note:** By default bnd automatically calculates `Import-Package` references for exported packages. This is called [package substitution](/chapters/170-versioning.html#substitution)
+You can use the `-noimport:=true` directive which instructs bnd to **not** calculate `Import-Package` references for exported packages.
+
+Example:
+
+````
+Export-Package: com.*;-noimport:=true
+```
+
+With the [-nosubstitution: true](/instructions/nosubstitution.html) instruction, this substitution behavior can be disabled globally.
 
 See also: [`-exportcontents`](/instructions/exportcontents.html).
 

--- a/docs/_instructions/_ext/exportcontents.md
+++ b/docs/_instructions/_ext/exportcontents.md
@@ -20,6 +20,17 @@ That is, `Export-Package` will add packages to the bundle, perhaps from (other) 
 
 See the [packages](/macros/packages.html) macro, which is useful in combination with `-exportcontents`.
 
+**Note:** By default bnd automatically calculates `Import-Package` references for exported packages. This is called [package substitution](/chapters/170-versioning.html#substitution)
+You can use the `-noimport:=true` directive which instructs bnd to **not** calculate `Import-Package` references for exported packages.
+
+Example:
+
+````
+-exportcontents: com.*;-noimport:=true
+```
+
+With the [-nosubstitution: true](/instructions/nosubstitution.html) instruction, this substitution behavior can be disabled globally.
+
 ## Use Cases
 
 So `-exportcontent` is appropriate for Maven and Gradle (non-Bnd workspace) builds where the content of the bundle is being managed by normal Maven or Gradle means.

--- a/docs/_instructions/_ext/nosubstitution.md
+++ b/docs/_instructions/_ext/nosubstitution.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: -nosubstitution
+---
+
+See [Subsitution](/chapters/170-versioning.html#substitution) to learn more about package Substition (a key aspect of OSGi allowing that a package can be both exported and imported).
+
+Note, that package substitution behaviour is enabled by default in bnd for backward-compatibilty. But recommended to disable for most cases these days via `-nosubstitution:true`.
+
+
+## Example
+
+```
+-nosubstitution:true
+-exportcontents: *
+Import-Package: *
+```
+
+This ensures that no `Import-Package` is calculated for any package in `Export-Package`. This is equivalent to `Export-Package: *;-noimport:=true` or `-exportcontents: *;-noimport:=true`.
+
+The advantage is that `-nosubstitution:true` is a global switch, thus a developer cannot forget to add `-noimport:=true` in case of a more fine-grained `Export-Package` declaration with multiple packages. 
+
+## Why is it useful?
+
+It is useful for library authors who **never** want to have any exported packages in `Import-Package`.
+Often, library authors who are just using bnd to generate OSGi metadata in their build scripts (e.g. via maven or gradle plugins) but are otherwise unfamiliar with bnd and OSGi, need a simple way to disable this substitution behavior, because it can lead to surprising resolution results (or failures) after deployment (because other bundles providing the same package are pulled in). This is often undesirable in a pure "library" use-case.
+
+This instruction helps making bnd / OSGi adoption easier for library projects just wanting to provide OSGi metadata.

--- a/docs/_instructions/nosubstitution.md
+++ b/docs/_instructions/nosubstitution.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: -nosubstitution
+summary: |
+   Setting this to false disables package substitution globally (default is true). That means, that bnd does not calculate Import-Package references for packages exported by the current bundle.
+note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in ext folder. 
+---
+
+- Example: `-nosubstitution=true`
+
+- Values: `true,false`
+
+- Pattern: `true|false|TRUE|FALSE`
+


### PR DESCRIPTION
Closes #6844

This is about https://bnd.bndtools.org/chapters/170-versioning.html#substitution

Setting this new instruction to `-nosubstitution:true` disables package substitution globally (**default** is `false`). That means, that bnd does not calculate `Import-Package` references for any package in exports.

This is equivalent to `Export-Package: *;-noimport:=true`  or `-exportcontents: *;-noimport:=true`

Note: This is an optional / opt-in feature. Nothing changes if you do not use it. 

## Why is it useful?

This new instruction is useful for library authors who **never** want to have any exported packages in Import-Package ([example](https://github.com/cucumber/cucumber-parent/pull/61/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R257))

## Example

```
-nosubstitution:true
Export-Package: *
Import-Package: *
```

or 

```
-nosubstitution:true
-exportcontents: *
Import-Package: *
```

This ensures that no `Import-Package` is calculated for any package in `Export-Package`


The advantage is that `-nosubstitution:true` is a global switch, thus a developer cannot forget to add `-noimport:=true` in case of a more fine-grained `Export-Package` declaration with multiple packages.

```
-nosubstitution:true
Export-Package: a;-noimport:=true,\
                              b,\ # here -noimport:=true,\ was forgotten
                              c # here -noimport:=true,\ was forgotten
Import-Package: *
```

In the latter example even though `-noimport:=true` directive was forgotten, the `-nosubstitution:true` takes care of it. 

@laeubi could give additional examples on use cases

