### PR TITLE
Make workingDirectory's base name match the project name.

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/AbstractBndrun.java
@@ -253,7 +253,7 @@ public abstract class AbstractBndrun extends DefaultTask {
 		DirectoryProperty temporaryDirProperty = objects.directoryProperty()
 			.fileValue(getTemporaryDir());
 		workingDirectory = objects.directoryProperty()
-			.convention(temporaryDirProperty);
+			.convention(temporaryDirProperty.dir(projectName));
 		bundles = objects.fileCollection();
 		SourceSet mainSourceSet = sourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 		targetVersion = project.getTasks()

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -452,6 +452,16 @@ class TestBndPlugin extends Specification {
 		then:
 		result.task(":test.simple:testrun.testOSGi2").outcome == SUCCESS
 
+		when:
+		result = TestHelper.getGradleRunner()
+				.withProjectDir(testProjectDir)
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2", "--tests=test.simple.ProjectNameTest")
+				.forwardOutput()
+				.build()
+
+		then:
+		result.task(":test.simple:testrun.testOSGi2").outcome == SUCCESS
+
 		new File(testReports, "testrun.testOSGi2/TEST-testrun.testOSGi2.xml").isFile()
 	}
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/bnd.bnd
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/bnd.bnd
@@ -13,6 +13,6 @@ Test-Cases: test.simple.Test,test.simple.FailingTest
 -runbundles: \
 	osgi.enroute.junit.wrapper
 
--runproperties:
+-runproperties: testprojectname=${project.name}
 
 -runtrace: true

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/src/test/simple/ProjectNameTest.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/src/test/simple/ProjectNameTest.java
@@ -1,0 +1,11 @@
+package test.simple;
+
+import junit.framework.TestCase;
+
+public class ProjectNameTest extends TestCase {
+
+	public void testProjectName() {
+		String projectNameSysProp = System.getProperty("testprojectname");
+		assertEquals("test.simple", projectNameSysProp);
+	}
+}

--- a/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/testOSGi2.bndrun
+++ b/gradle-plugins/biz.aQute.bnd.gradle/testresources/workspaceplugin9/test.simple/testOSGi2.bndrun
@@ -6,6 +6,6 @@
     test.simple, \
 	osgi.enroute.junit.wrapper
 
--runproperties:
+-runproperties: testprojectname=${project.name}
 
 -runtrace: true


### PR DESCRIPTION
This allows Bnd properties like "p", "project.name", etc. to have the same values they would in Bndtools.

https://github.com/bndtools/bnd/issues/6849