### PR TITLE
more lenient osgi.ee=JavaSE for unknown JDKs

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Clazz.java
@@ -199,7 +199,7 @@ public class Clazz {
 			this.major = ordinal() + 45;
 			String version = Integer.toString(ordinal() + 1);
 			this.ee = "JavaSE-" + version;
-			this.filter = "(&(osgi.ee=JavaSE)(version=" + version + "))";
+			this.filter = eeFilter(version);
 		}
 
 		JAVA(String ee, String filter) {
@@ -247,6 +247,28 @@ public class Clazz {
 
 		public String getEE() {
 			return ee;
+		}
+
+		/**
+		 * Returns an eeFilter String also supporting yet unknown JDKs (lenient)
+		 */
+		public static String buildEEFilterLenient(int major) {
+
+			// lenient: We try to return a useful filter
+			// even for yet unknown JDKs
+			int version = major - 45;
+			if ((version < 0)) {
+				return eeFilter("UNKNOWN");
+			} else if (version >= (JAVA.values.length - 1)) {
+				// yet UNKNOWN
+				return eeFilter(Integer.toString(version));
+			}
+
+			return format(major).getFilter();
+		}
+
+		private static String eeFilter(String version) {
+			return "(&(osgi.ee=JavaSE)(version=" + version + "))";
 		}
 
 		public String getFilter() {
@@ -2025,6 +2047,11 @@ public class Clazz {
 
 	public JAVA getFormat() {
 		return JAVA.format(classFile.major_version);
+
+	}
+
+	public int getMajorVersion() {
+		return classFile.major_version;
 
 	}
 


### PR DESCRIPTION
Closes #6858

**Experimental:**

For a yet to bnd unknown JDK (e.g. JDK-10000) Instead of

```
Require-Capability: osgi.ee;filter:="(osgi.ee=UNKNOWN)"
```

we now create

Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=9955))"

for a  .class file with u2 major_version 10000 (9955 == 10000 - 45)


