### PR TITLE
Do not concat Bundle-Activator when already defined

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -3187,6 +3187,86 @@ public class BuilderTest {
 		}
 	}
 
+	/**
+	 * Check that the defined activator is found, and not concatenated by the
+	 * Bundle-Activator annotation in TypeInVersionedPackage
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testBundleActivatorShouldNotBeConcatenated() throws Exception {
+		Builder bmaker = new Builder();
+		try {
+			bmaker.setProperty("Bundle-Activator", "test.activator.Activator");
+			bmaker.setProperty("build", "xyz"); // for @Version annotation
+			bmaker.setProperty("Private-Package", "test.*");
+			bmaker.setProperty("-bundleannotations",
+				"test.annotationheaders.attrs.std.activator.TypeInVersionedPackage");
+			// bmaker.setProperty("-dsannotations", "!*");
+			// bmaker.setProperty("-metatypeannotations", "!*");
+			bmaker.setClasspath(new File[] {
+				new File("bin_test")
+			});
+			bmaker.setProperty("-fixupmessages.export",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
+			bmaker.setProperty("-fixupmessages.directive",
+				"Unknown directive foobar: in Export-Package, allowed directives are uses:,mandatory:,include:,exclude:,-import:, and 'x-*'");
+
+			Jar jar = bmaker.build();
+			report("testBundleActivatorShouldNotBeConcatenated", bmaker, jar);
+
+			Attributes main = jar.getManifest()
+				.getMainAttributes();
+			assertEquals("test.activator.Activator", main.getValue(Constants.BUNDLE_ACTIVATOR));
+			assertFalse(
+				bmaker
+					.check(
+						"The Bundle-Activator header only supports a single type. The following types were found: test.activator.Activator,test.annotationheaders.attrs.std.activator.TypeInVersionedPackage. This usually happens when a macro resolves to multiple types"));
+		} finally {
+			bmaker.close();
+		}
+	}
+
+	/**
+	 * Check that the Bundle-Activator annotation in TypeInVersionedPackage
+	 * defines the Bundle-Activator of our bundle.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testBundleActivatorFromAnnotation() throws Exception {
+		Builder bmaker = new Builder();
+		try {
+			// bmaker.setProperty("Bundle-Activator",
+			// "test.activator.Activator");
+			bmaker.setProperty("build", "xyz"); // for @Version annotation
+			bmaker.setProperty("Private-Package", "test.*");
+			bmaker.setProperty("-bundleannotations",
+				"test.annotationheaders.attrs.std.activator.TypeInVersionedPackage,*");
+			bmaker.setClasspath(new File[] {
+				new File("bin_test")
+			});
+			bmaker.setProperty("-fixupmessages.export",
+				"The annotation aQute.bnd.annotation.Export applied to package test.versionpolicy.api is deprecated and will be removed in a future release. The org.osgi.annotation.bundle.Export should be used instead");
+			bmaker.setProperty("-fixupmessages.directive",
+				"Unknown directive foobar: in Export-Package, allowed directives are uses:,mandatory:,include:,exclude:,-import:, and 'x-*'");
+
+			Jar jar = bmaker.build();
+			// assertTrue(bmaker.check());
+			report("testBundleActivatorFromAnnotation", bmaker, jar);
+
+			Attributes main = jar.getManifest()
+				.getMainAttributes();
+			assertEquals("test.annotationheaders.attrs.std.activator.TypeInVersionedPackage",
+				main.getValue(Constants.BUNDLE_ACTIVATOR));
+
+			assertFalse(bmaker.check(
+				"The Bundle-Activator header only supports a single type*"));
+		} finally {
+			bmaker.close();
+		}
+	}
+
 	@Test
 	public void testImportVersionRange() throws Exception {
 		assertVersionEquals("[1.1,2.0)", "[1.1,2.0)");


### PR DESCRIPTION
Closes #6867

fixes a problem that `Verifier.verifyActivator()` throws an error "The Bundle-Activator header only supports a single type. The following types were found" when the bnd instructions already define a Bundle-Activator but a processed jar also contributed a Bundle-Activator (e.g. via `@Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")` annotation). 

see [org.apache.logging.log4j.util.Activator](https://github.com/apache/logging-log4j2/blob/2.x/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java#L49)

<img width="1826" height="436" alt="image" src="https://github.com/user-attachments/assets/1278883c-39bb-4d0a-9e4a-6df249185e9f" />


Before this fix the Bundle-Activator header was concatenated to the existing `Bundle-Activator` header in the outer bnd of the bundle and thus resulted in multiple values (separated by comma). But for Bundle-Activator this does not make sense as it supports only a single value, as there can only be one single Bundle-Activator in the manifest - which is correctly complained about by `Verifier.verifyActivator()`.

This PR fixes the root cause where the multiple-values are created, so that `Verifier.verifyActivator()` does not complain anymore.

This for example happened with `-includeresource` of a Bundle (unrolling or lib:=true) or other ways where bnd scans classes of jar files.

I also identified some other Bundle headers in which should also only contain a single value and not be concatenated.

