### PR TITLE
docs: allow 'since' and other custom frontmatter

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/ManualGenerator.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/ManualGenerator.java
@@ -10,8 +10,10 @@ import java.nio.file.Files;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import aQute.bnd.help.Syntax;
+import aQute.bnd.unmodifiable.Sets;
 import aQute.lib.getopt.CommandLine;
 import aQute.lib.getopt.Description;
 import aQute.lib.getopt.Options;
@@ -132,8 +134,28 @@ class ManualGenerator {
 				f.format("class: %s\n", overrideFrontmatter.getOrDefault("class", "Header"));
 			}
 			f.format("summary: |\n   %s\n", overrideFrontmatter.getOrDefault("summary", sx.getLead()));
+
+			String since = overrideFrontmatter.getOrDefault("since", null);
+			if (since != null) {
+				f.format("since: %s\n", since);
+			}
+
 			f.format(
 				"note: AUTO-GENERATED FILE - DO NOT EDIT. You can add manual content via same filename in ext folder. ");
+
+			// add custom frontmatter tags
+			Set<String> frontterNoOverwrite = Sets.of("layout", "title", "class", "summary", "note", "since");
+			overrideFrontmatter.entrySet()
+				.stream()
+				.filter(e -> !frontterNoOverwrite.contains(e.getKey()))
+				.forEach(entry -> {
+					String key = entry.getKey();
+					String value = entry.getValue();
+					if (value != null && !value.isBlank()) {
+						f.format("%n%s: %s%n", key, value);
+					}
+				});
+
 			f.format("\n---\n\n");
 
 

--- a/docs/_instructions/_ext/generate.md
+++ b/docs/_instructions/_ext/generate.md
@@ -3,7 +3,7 @@ layout: default
 class: Project
 title: "-generate srcs ';output=' DIR ( ';' ( system | generate | classpath))* ..."
 summary: Generate sources 
-since: 5.1
+since: 5.1.0
 ---
 
 Virtually all the work bnd is concerned about happens in generating the JAR file. The key idea is to _pull_ resources in the JAR, instead of the more traditional _push_ model of other builders. This works well, except for _generating source code_. This generating step must happen before the compiler is called, and the compiler is generally called before bnd becomes active. 

--- a/docs/_instructions/_ext/noee.md
+++ b/docs/_instructions/_ext/noee.md
@@ -2,7 +2,7 @@
 layout: default
 class: Ant
 title: -noee  BOOLEAN
-since: 2.3
+since: 2.3.0
 summary:  Donot add an automatic requirement on an EE capability based on the class format.
 ---
 

--- a/docs/_instructions/_ext/nosubstitution.md
+++ b/docs/_instructions/_ext/nosubstitution.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: -nosubstitution
-since: 7.2
+since: 7.2.0
 ---
 
 See [Subsitution](/chapters/170-versioning.html#substitution) to learn more about package Substition (a key aspect of OSGi allowing that a package can be both exported and imported).

--- a/docs/_instructions/_ext/stalecheck.md
+++ b/docs/_instructions/_ext/stalecheck.md
@@ -3,7 +3,7 @@ layout: default
 class: Project
 title: -stalecheck srcs ';newer=' depends ( ';' ( warning | error | command ))* ...
 summary: Perform a stale check of files and directories before building a jar 
-since: 4.3
+since: 4.3.0
 ---
 
 If you work in Bndtools then there is normally little to worry about, bndtools keeps everything up to dated all the time. 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -24,8 +24,13 @@
 						{% include pagination.htm %}
 						
 						{% if page.class %}
-							<div class="pageclass" onclick="window.location.href='/chapters/790-reference.html';">
-								{{page.class}}
+						<div class="pageclass" onclick="window.location.href='/chapters/790-reference.html';">
+							{{page.class}}
+						</div>
+						{% endif %}
+						{% if page.since %}
+							<div class="pageclass page-since-tag" title="The content below assumes bndtools version {{ page.since }}.">
+								<a href="https://github.com/bndtools/bnd/wiki/Changes-in-{{ page.since }}" target="_blank">Since {{ page.since }}</a>
 							</div>
 						{% endif %}
 					</div>

--- a/docs/css/style.scss
+++ b/docs/css/style.scss
@@ -269,3 +269,14 @@ div[class*="language-"] button{
   right: 5px;
 }
 
+.page-since-tag{
+  margin-top: 2px
+}
+
+.page-since-tag a {
+  color: white;
+}
+
+.pageclass.page-since-tag{
+  background-color: #aaaaaa;
+}


### PR DESCRIPTION
in the docs this shows a little greyish tag with a version number and a link to the release notes. we have a similar mechanism on the bndtools.org page

<img width="1282" height="228" alt="image" src="https://github.com/user-attachments/assets/b87d8623-ea21-45ed-b45d-5919670e49e8" />
