### PR TITLE
Effective view: show macro errors

### DIFF
--- a/bndtools.core/src/bndtools/editor/completion/BndHover.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndHover.java
@@ -1,5 +1,6 @@
 package bndtools.editor.completion;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bndtools.api.editor.IBndEditor;
@@ -117,6 +118,13 @@ public class BndHover extends DefaultTextHover implements ITextHoverExtension, I
 				.append(key)
 				.append("=")
 				.append(decorated);
+		}
+
+		List<String> errors = properties.getErrors();
+		if (errors != null && !errors.isEmpty()) {
+			sb.append("\n\n");
+			sb.append("Errors: ");
+			sb.append(errors);
 		}
 
 		String text = sb.toString();


### PR DESCRIPTION
Closes #6875 

- make macro errors visible in an errors column
- show macro errors on hovering (works in normal Source view and effective source view)

In Effective Table view

<img width="2218" height="1136" alt="image" src="https://github.com/user-attachments/assets/1aa12845-049c-4bb6-b454-43d9aa6d06a0" />

And in Source view (normal source view and also effective source view)

Hover over the key:

<img width="816" height="322" alt="image" src="https://github.com/user-attachments/assets/816f6052-1352-469a-9853-b56331a3dec4" />

or hover over a marked text of the expression you want to evaluate

<img width="942" height="244" alt="image" src="https://github.com/user-attachments/assets/aacecddd-d691-4a53-9990-552fb5e6c8c0" />

