### PR TITLE
bump felix resolver 2.0.0 to 2.0.4

### DIFF
--- a/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/central.mvn
+++ b/biz.aQute.bndall.tests/resources/launchpad/ws1/cnf/central.mvn
@@ -4,7 +4,7 @@ org.apache.felix:org.apache.felix.framework:6.0.5
 org.apache.felix:org.apache.felix.gogo.command:1.0.2
 org.apache.felix:org.apache.felix.gogo.runtime:1.1.0
 org.apache.felix:org.apache.felix.gogo.shell:1.1.0
-org.apache.felix:org.apache.felix.resolver:2.0.0
+org.apache.felix:org.apache.felix.resolver:2.0.4
 org.apache.felix:org.apache.felix.scr:2.1.12
 org.apache.felix:org.apache.felix.inventory:1.0.6
 org.apache.felix:org.apache.felix.logback:1.0.2

--- a/biz.aQute.resolve/testdata/framework-fragment/cnf/central.maven
+++ b/biz.aQute.resolve/testdata/framework-fragment/cnf/central.maven
@@ -16,7 +16,7 @@ org.apache.felix:org.apache.felix.metatype:1.2.1
 org.apache.felix:org.apache.felix.scr:2.1.12
 org.apache.felix:org.apache.felix.systemready:0.4.0
 org.apache.felix:org.apache.felix.utils:1:11:0
-org.apache.felix:org.apache.felix.resolver:2.0.0
+org.apache.felix:org.apache.felix.resolver:2.0.4
 
 org.osgi:osgi.annotation:7.0.0
 org.osgi:osgi.cmpn:7.0.0

--- a/cnf/ext/central.mvn
+++ b/cnf/ext/central.mvn
@@ -61,7 +61,7 @@ org.apache.felix:org.apache.felix.framework:7.0.5
 org.apache.felix:org.apache.felix.gogo.command:1.0.2
 org.apache.felix:org.apache.felix.gogo.runtime:1.1.6
 org.apache.felix:org.apache.felix.gogo.shell:1.1.0
-org.apache.felix:org.apache.felix.resolver:2.0.0
+org.apache.felix:org.apache.felix.resolver:2.0.4
 org.apache.felix:org.apache.felix.scr:2.1.12
 org.apache.felix:org.apache.felix.inventory:1.0.6
 org.apache.felix:org.apache.felix.logback:1.0.6


### PR DESCRIPTION
2.0.4
----

** Improvement
    * [[FELIX-6398](https://issues.apache.org/jira/browse/FELIX-6398)] - Update framework packages to osgi.core 8 (https://github.com/apache/felix-dev/commit/00c952340e51b9748d84cc63d1048d833f0a3cff)

2.0.2
-----

** Bug
    * [[FELIX-6140](https://issues.apache.org/jira/browse/FELIX-6140)] - possible deadlock in ResolverImpl.EnhancedExecutor.await() (https://github.com/apache/felix-dev/commit/ffdf3dd51b172c1e770c6894d9420c8f58afe377)
    * [[FELIX-6212](https://issues.apache.org/jira/browse/FELIX-6212)] - Issues with uses capability checking with split packages and reexport (https://github.com/apache/felix-dev/commit/a13ea8ea177933e2911b14e1de55fff4e5196927, https://github.com/apache/felix-dev/commit/990e9d499a7ab9ad93af68c4be37ad9cd2d29067 ) 

see changelog: https://github.com/apache/felix-dev/blob/master/resolver/doc/changelog.txt