### PR TITLE
docs: add cross links for headers/instructions/macros

### DIFF
--- a/docs/_chapters/160-jars.md
+++ b/docs/_chapters/160-jars.md
@@ -4,49 +4,46 @@ title: Generating JARs
 layout: default
 ---
 
-This is about generating JARs
+This is about generating OSGi JARs - one of the main tasks of bnd.
 
-This is a simple example of wrapping a jar with bnd. The basic idea is to create a recipe (a .bnd file) that collects the different resources in the right way.
+This is a simple example of [wrapping a jar with bnd](/chapters/390-wrapping.html) (wrapping means: taking a non-OSGi jar and use `bnd` to add OSGi meta data to its MANIFEST.MF to get a proper OSGi `.jar`). 
 
-For example, you want to wrap the WebSocket server from https://github.com/TooTallNate/Java-WebSocket. Download the binary and the sources in Websocket.jar, Websocket-src.zip. Once you have these files, the following code will create the org.websocket bundle
+The basic idea is to create a recipe (a `.bnd` file) that collects the different resources in the right way to create the new output `.jar` including the OSGi meta data in `MANIFEST.MF`.
 
+For example, you want to wrap the WebSocket server from https://github.com/TooTallNate/Java-WebSocket/releases/tag/Java-WebSocket-1.3.4. Download the [binary](https://github.com/TooTallNate/Java-WebSocket/releases/download/Java-WebSocket-1.3.4/Java-WebSocket-1.3.4.jar) (Java-WebSocket-1.3.4.jar) and the [sources](https://github.com/TooTallNate/Java-WebSocket/releases/download/Java-WebSocket-1.3.4/Java-WebSocket-1.3.4-sources.jar) in Java-WebSocket-1.3.4-sources.jar. 
+
+## Project
+
+Once you have these files, create a folder e.g. `mkdir wrappers` and add `bnd.bnd` file in the project to create the `org.websocket.jar` bundle.
+
+    # bnd.bnd
     # Wrapped version of Github project TooTallNate/Java-WebSocket
     Bundle-SymbolicName: org.websocket
     Bundle-DocURL: https://github.com/TooTallNate/Java-WebSocket
     Bundle-License: https://github.com/TooTallNate/Java-WebSocket/blob/8ef67b46ecc927d5521849dcc2d85d10f9789c20/LICENSE
-    Bundle-Description: This repository contains a barebones \ 
-     WebSocket server and client implementation written \ 
-     in 100% Java. The underlying classes are implemented \ 
-     using the Java ServerSocketChannel and SocketChannel \ 
-     classes, which allows for a non-blocking event-driven model \ 
-     (similar to the WebSocket API for web browsers). \ 
-     Implemented WebSocket protocol versions are: Hixie 75, \ 
+    Bundle-Description: This repository contains a barebones \
+     WebSocket server and client implementation written \
+     in 100% Java. The underlying classes are implemented \
+     using the Java ServerSocketChannel and SocketChannel \
+     classes, which allows for a non-blocking event-driven model \
+     (similar to the WebSocket API for web browsers). \
+     Implemented WebSocket protocol versions are: Hixie 75, \
      Hixie 76, Hybi 10, and Hybi 17
 
-    # websocket does not define a version yet :-(
-    Bundle-Version: 1.0.2
+    # version taken from the downloaded file above
+    Bundle-Version: 1.3.4
 
-    -includeresource: @jar/WebSocket.jar, OSGI-OPT/src=@jar/WebSocket-src.zip
+    -includeresource: @Java-WebSocket-1.3.4.jar, OSGI-OPT/src=@Java-WebSocket-1.3.4-sources.jar
     -exportcontents: org.java_websocket
 
+Either use the [bndtools Eclipse plugin](https://bndtools.org/) or the [bnd CLI](/chapters/400-commands.html) to process the `bnd.bnd` file and let bnd create the .jar. In case of bnd CLI the command is:
 
-The documentation headers are optional but very important, just spent the minute to document them since you'll be grateful later.
+    bnd bnd.bnd
 
-If the target project does not have a version, makeup a version and maintain it. Notice that in general the recipe will only be used once for each version, it is normally not used in continuous integration builds. However, you normally use it to convert the next version of the project. Crisp versioning is important.
-
-The [`-includeresource`](/instructions/includeresource.html) statement unrolls the jars we downloaded in the root of the JAR and in `OSGI-OPT`. Since the source code is in the `src` directory in the  `WebSocket-src.zip` file, we put it in the new JAR under `OSGI-OPT/src`. This convention is supported by all IDEs to give you direct access to the bundle's source code. Since the binary and the source are kept together, you always have the correct source code available, and usually automatically. It is so convenient that once you're used to this it is hard to imagine a life without source code.
-
-The binaries and sources are not in the final jar but bnd does not yet know what needs to be exported. This can be indicated with the [`-exportcontents`](/instructions/exportcontents.html) instruction. It has the same syntax as [`Export-Package`](/heads/export_package.html) but does not copy from the classpath, it only applies the instruction to the content of the final JAR.
-
-## Project
-The easiest way to build these wrappers is to create a project in bndtools called wrappers and create a bnd descriptor for each one. They are then automatically build (look in generated) and you get a lot of help editing the bnd files.
-
-You can also make an ant file but this is not described here (volunteer?). The other possibility is to use bnd from the [[CommandLine]]. In this case the command is:
-
-    bnd websocket.bnd
 
 ## Manifest
-Applying this recipe gives the following manifest in a JAR named `org.websocket.jar`:
+
+Applying this recipe above gives the following `META-INF/MANIFEST.MF` in a JAR named `/generated/org.websocket.jar`:
 
     Manifest-Version: 1.0
     Bnd-LastModified: 1338190175969
@@ -62,14 +59,26 @@ Applying this recipe gives the following manifest in a JAR named `org.websocket.
     Bundle-ManifestVersion: 2
     Bundle-Name: org.websocket
     Bundle-SymbolicName: org.websocket
-    Bundle-Version: 1.0.2
-    Created-By: 1.6.0_27 (Apple Inc.)
-    Export-Package: org.java_websocket;version="1.0.2"
-    Include-Resource: @jar/WebSocket.jar, OSGI-OPT/src=@jar/WebSocket-src.zip
-    Private-Package: org.java_websocket.handshake,org.java_websocket.drafts,
-     org.java_websocket.exceptions,org.java_websocket.util,org.java_websocke
-     t.framing
-    Tool: Bnd-1.51.0
+    Bundle-Version: 1.3.4
+    Export-Package: org.java_websocket;version="1.3.4";uses:="javax.net.ss
+    l"
+    Import-Package: javax.net.ssl
+    Private-Package: org.java_websocket.client,org.java_websocket.drafts,o
+    rg.java_websocket.exceptions,org.java_websocket.framing,org.java_webs
+    ocket.handshake,org.java_websocket.server,org.java_websocket.util
+    Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
+
+
+
+You notice that the `.bnd` file and the `MANIFEST` look similar but the bnd instructions caused bnd to generate headers like `Export-Package` and `Import-Package`. bnd did that by analysing the `.class` files inside `Java-WebSocket-1.3.4.jar` (e.g. by looking at all the `import` statements classes, methods, method parameters and return types).
+
+Note: The documentation headers like `Bundle-Description` are optional but very important, just spent the minute to document them since you'll be grateful later.
+
+If the target project does not have a version, makeup a version and maintain it. Notice that in general the recipe will only be used once for each version, it is normally not used in continuous integration builds. However, you normally use it to convert the next version of the project. Crisp versioning is important.
+
+The [`-includeresource`](/instructions/includeresource.html) statement unrolls the jars we downloaded in the root of the JAR and in `OSGI-OPT`. Since the source code is in the `src` directory in the  `WebSocket-src.zip` file, we put it in the new JAR under `OSGI-OPT/src`. This convention is supported by all IDEs to give you direct access to the bundle's source code. Since the binary and the source are kept together, you always have the correct source code available, and usually automatically. It is so convenient that once you're used to this it is hard to imagine a life without source code.
+
+The binaries and sources are not in the final jar but bnd does not yet know what needs to be exported. This can be indicated with the [`-exportcontents`](/instructions/exportcontents.html) instruction. It has the same syntax as [`Export-Package`](/heads/export_package.html) but does not copy from the classpath, it only applies the instruction to the content of the final JAR.
 
 ## OSGi Header Attribute and Directive Ordering
 
@@ -102,7 +111,7 @@ Notice how:
 
 This consistent ordering provides several benefits:
 
-- **Reproducible builds** - The same input always produces the same output, regardless of the original order
+- **Reproducible builds** - The same input always produces the same output, regardless of the original order (see also [-reproducible](/instructions/reproducible.html))
 - **Easier comparison** - Manifest files can be compared more easily when attributes and directives are consistently ordered
 - **Better readability** - Consistent ordering makes manifest headers easier to read and understand
 
@@ -122,4 +131,31 @@ One of the great features of bnd is to use export version from other versions to
 
     -classpath: dependency.jar, other.jar
 
+# Wrapper project
 
+
+The easiest way to build these wrappers is to create a project in bndtools called `wrappers` and create a main `bnd.bnd` with the following content:
+
+
+```
+-sub: *.bnd
+```
+
+The create a `bnd.bnd` descriptor for each wrapper you need to build. e.g. 
+
+- `websocket.bnd`
+- `someotherlib.bnd`
+
+When the main `bnd.bnd` is processed bnd creates a jar for each sub- .bnd file.
+E.g. 
+
+```
+bnd bnd.bnd
+```
+
+creates a `/generated/websocket.jar` and `/generated/someotherlib.jar`.
+
+
+# All headers
+
+All headers are listed on the [Headers index](/chapters/800-headers.html)

--- a/docs/_chapters/800-headers.md
+++ b/docs/_chapters/800-headers.md
@@ -4,6 +4,9 @@ layout: default
 ---
 
 <div>
+
+Learn the basics of bnd headers on the [Generating JARs](/chapters/160-jars.html) page. 
+
 <dl class="property-index">
 
 <div>

--- a/docs/_chapters/820-instructions.md
+++ b/docs/_chapters/820-instructions.md
@@ -4,6 +4,8 @@ layout: default
 ---
 A bnd instruction is a property that starts with a minus sign ('-'). An instruction instructs bndlib to do something, in general providing parameters to the code. All instructions in bndlib are listed later in this page.
 
+All instructions are listed on the [Instruction index](/chapters/825-instructions-ref.html)
+
 ## Syntax
 
 Almost all bndlib instructions follow the general OSGi syntax. However, the bndlib syntax is in general a bit more relaxed, for example you can use either single quotes (''') or double quotes ('"') while OSGi only allows double quotes. Dangling comma's and some other not exactly correct headers are accepted by bndlib without complaining. Values without quotes are accepted as long as they cannot confuse the general syntax. For example, a value like 1.20 does not have to be quoted since the period ('.') cannot confuse the parser on that place, however, a value like [1.3,4) must be quoted since it contains a comma.

--- a/docs/_chapters/825-instructions-ref.md
+++ b/docs/_chapters/825-instructions-ref.md
@@ -4,6 +4,9 @@ layout: default
 ---
 
 <div>
+
+Learn the basics of bnd instructions in the [Instruction reference](/chapters/820-instructions.html).
+
 <table class="property-index">
     <thead>
         <th>Instruction</th>

--- a/docs/_chapters/850-macros.md
+++ b/docs/_chapters/850-macros.md
@@ -4,7 +4,7 @@ layout: default
 ---
 
 
-A simple macro processor is added to the header processing. Variables allow a single definition of a value, and the use of derivations. Each header is a macro that can be expanded. Notice that headers that do not start with an upper case character will not be copied to the manifest, so they can be used as working variables. Variables are expanded by enclosing the name of the variable in `${<name>}` (curly braces) or `$(<name>)` (parenthesis). Additionally, square brackets \[\], angled brackets <>, double guillemets «», and single guillemets ‹› are also allowed for brackets. If brackets are nested, that is `$[replace;acaca;a(.*)a;[$1]]` will return `[cac]`.
+Bnd has a simple macro processor for the header processing. Variables allow a single definition of a value, and the use of derivations. Each header is a macro that can be expanded. Notice that headers that do not start with an upper case character will not be copied to the manifest, so they can be used as working variables. Variables are expanded by enclosing the name of the variable in `${<name>}` (curly braces) or `$(<name>)` (parenthesis). Additionally, square brackets \[\], angled brackets <>, double guillemets «», and single guillemets ‹› are also allowed for brackets. If brackets are nested, that is `$[replace;acaca;a(.*)a;[$1]]` will return `[cac]`.
 
 There are also a number of macros that perform basic functions. All these functions have the following basic syntax:
 
@@ -21,6 +21,8 @@ For example:
     Bundle-Version= ${version}
     Bundle-Description= This bundle has version ${version}
 
+
+All macros are listed on the [Macro index](/chapters/855-macros-ref.html)
 
 ## Macro patterns
 The default macro pattern is the `${...}` pattern, a dollar sign ('$') followed by a left curly bracket ('{') and closed by a right curly bracket ('}'). However, since bndlib is often used inside other systems it also supports alternative macro patterns:

--- a/docs/_chapters/855-macros-ref.md
+++ b/docs/_chapters/855-macros-ref.md
@@ -4,6 +4,9 @@ layout: default
 ---
 
 <div>
+
+Learn the basics of bnd macros in the [Macro reference](/chapters/850-macros.html).
+
 <dl class="property-index">
 
 <div>


### PR DESCRIPTION
also improve the Generating JARs page and make the example work.