### PR TITLE
docs: fix link from previous PR

### DIFF
--- a/docs/_chapters/800-headers.md
+++ b/docs/_chapters/800-headers.md
@@ -3,9 +3,9 @@ title: Headers
 layout: default
 ---
 
-<div>
-
 Learn the basics of bnd headers on the [Generating JARs](/chapters/160-jars.html) page. 
+
+<div>
 
 <dl class="property-index">
 

--- a/docs/_chapters/825-instructions-ref.md
+++ b/docs/_chapters/825-instructions-ref.md
@@ -3,9 +3,10 @@ title: Instruction Index
 layout: default
 ---
 
+Learn the basics of bnd instructions in the [Instruction reference](/chapters/820-instructions.html).
+
 <div>
 
-Learn the basics of bnd instructions in the [Instruction reference](/chapters/820-instructions.html).
 
 <table class="property-index">
     <thead>

--- a/docs/_chapters/855-macros-ref.md
+++ b/docs/_chapters/855-macros-ref.md
@@ -3,9 +3,9 @@ title: Macro Index
 layout: default
 ---
 
-<div>
-
 Learn the basics of bnd macros in the [Macro reference](/chapters/850-macros.html).
+
+<div>
 
 <dl class="property-index">
 


### PR DESCRIPTION
it seems you cannot place markdown links inside html tags