### PR TITLE
effective view: fix incorrectly merged props and add support for decorated instructions

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -1602,11 +1602,20 @@ public class BndEditModel {
 	}
 
 	public static String getStem(String header) {
+		String stem;
 		int n = header.indexOf('.');
 		if (n < 0)
-			return header;
+			stem = header;
+		else
+			stem = header.substring(0, n);
 
-		return header.substring(0, n);
+		// remove any trailing +, ++ (decorated instructions)
+		int m = stem.indexOf('+');
+		if (m < 0)
+			return stem;
+		else
+			return stem.substring(0, m);
+
 	}
 
 	@SuppressWarnings("unchecked")

--- a/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/help/Syntax.java
@@ -1134,4 +1134,8 @@ public class Syntax implements Constants {
 		return ret.toLowerCase()
 			.replace("-", "_");
 	}
+
+	public static boolean isInstruction(String key) {
+		return key.startsWith("-");
+	}
 }

--- a/bndtools.core/src/bndtools/editor/completion/BndHover.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndHover.java
@@ -1,5 +1,8 @@
 package bndtools.editor.completion;
 
+import static aQute.bnd.help.Syntax.isInstruction;
+import static aQute.bnd.osgi.Constants.MERGED_HEADERS;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,7 +22,6 @@ import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Shell;
 
-import aQute.bnd.header.Parameters;
 import aQute.bnd.help.Syntax;
 import aQute.bnd.osgi.Processor;
 
@@ -102,7 +104,6 @@ public class BndHover extends DefaultTextHover implements ITextHoverExtension, I
 		StringBuilder sb = new StringBuilder();
 
 		if (syntax != null) {
-
 			sb.append(syntax.getLead());
 			String values = syntax.getValues();
 			if (values != null && !values.isBlank()) {
@@ -112,12 +113,16 @@ public class BndHover extends DefaultTextHover implements ITextHoverExtension, I
 			sb.append("\nExample: ");
 			sb.append(syntax.getExample());
 		}
-		Parameters decorated = properties.decorated(key);
-		if (!decorated.isEmpty()) {
+
+		String value = isInstruction(key) || MERGED_HEADERS.contains(key) ? properties.decorated(key)
+			.toString()
+			: properties.get(key);
+
+		if (!value.isEmpty()) {
 			sb.append("\n")
 				.append(key)
 				.append("=")
-				.append(decorated);
+				.append(value);
 		}
 
 		List<String> errors = properties.getErrors();


### PR DESCRIPTION
Closes #6893

- only show properties as "merged" which are in Constants.MERGED_HEADERS

## Merged Properties and instructions

Now MERGED_HEADERS and instructions (properties starting with `-` as in `-buildpath`) are properly merged. 
E.g.

For 

```
version: 1.2.3
version.eclipse.base: 2.64.0-dev.646364
version.gecko: 1.2.1-dev.652527
version.shared: 1.3.1
```

<img width="602" height="972" alt="image" src="https://github.com/user-attachments/assets/656c47be-d484-45b2-9ecf-affaa0ea8451" />

the single 'version' is now not merged anymore. (because it is NOT contained in `Constants.MERGED_HEADERS`)

While 

```
-buildpath: foo
-buildpath.a: bar
```

is still merged

<img width="530" height="282" alt="image" src="https://github.com/user-attachments/assets/31c8fa44-7206-4c04-a5c2-9ab2efe0f9b4" />

because it is contained in `Constants.MERGED_HEADERS`

https://github.com/bndtools/bnd/blob/cbc7b063f023d0b17eec2397912355c0a4ad119c/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java#L611


## Decorated instructions

This PR also handles [decorated instructions](https://bnd.bndtools.org/chapters/820-instructions.html#decorated-instructions) and displays them properly merged. 

e.g.

```
-foo       a, b, c;skip=true, d
-foo+      b;skip=true,c;skip=false
-foo+.d    d;skip=true
```

is now displayed as 

```
-foo: a,b;skip=true,c;skip=false,d;skip=true
```

<img width="772" height="312" alt="image" src="https://github.com/user-attachments/assets/7df908a1-0c6f-4b3e-8cb0-cb699bad2118" />


Note: I also fixed the hover feature in source and effective view which had the same issue