### PR TITLE
Macro: fix for dollar escaping

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -145,12 +145,27 @@ public class Macro {
 				}
 			} else if (c1 == begin)
 				nesting++;
-			else if (c1 == '\\' && index < line.length() - 1
-				&& (line.charAt(index) == '$' || line.charAt(index) == ';')) {
-				// remove the escape backslash and interpret the dollar or ;
-				// as a literal
-				variable.append(line.charAt(index));
-				index++;
+			else if (c1 == '\\') {
+				int backslashCount = 1;
+				while (index < line.length() && line.charAt(index) == '\\') {
+					backslashCount++;
+					index++;
+				}
+				if (index < line.length() && (line.charAt(index) == '$' || line.charAt(index) == ';')) {
+					if (backslashCount % 2 == 0) {
+						// Even number of backslashes => macro starts
+						variable.append("\\".repeat(backslashCount / 2));
+						continue outer;
+					} else {
+						// Odd number of backslashes => escape the $
+						variable.append("\\".repeat(backslashCount / 2));
+						variable.append(line.charAt(index));
+						index++;
+						continue outer;
+					}
+				} else {
+					variable.append("\\".repeat(backslashCount));
+				}
 				continue outer;
 			} else if (c1 == '$' && index < line.length() - 2 && !inMacro) {
 				char c2 = line.charAt(index);


### PR DESCRIPTION
For now this is a base for discussion of my comment https://github.com/bndtools/bnd/issues/6894#issuecomment-3463694757

It fixes a parsing problem for escaped dollar characters in macros.
But the problem is that - while this works for the testcase - this fix is never used in real-life because java Properties parsing drops backslashes in the first place (see spec https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Properties.html#load(java.io.Reader)) 

> The method does not treat a backslash character, \, before a non-valid escape character as an error; the backslash is silently dropped. For example, in a Java string the sequence "\z" would cause a compile time error. In contrast, this method silently drops the backslash. Therefore, this method treats the two character sequence "\b" as equivalent to the single character 'b'.

Since I have no idea how to handle this I keep this PR as draft. 