### PR TITLE
Effective view: check checkboxes by default

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -135,14 +135,14 @@ public class BndSourceEffectivePage extends FormPage {
 		toggleButton.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
 
 		this.showExpandedValuesButton = toolkit.createButton(body, "Show expanded values", SWT.CHECK);
-		showExpandedValuesButton.setSelection(false);
+		showExpandedValuesButton.setSelection(true);
 		showExpandedValuesButton.setToolTipText("Shows the actual values instead of placeholders.");
 
 		this.showMergedPropertiesButton = toolkit.createButton(body, "Show as merged properties", SWT.CHECK);
 		showMergedPropertiesButton.setToolTipText(
 			"Groups all instructions by the stem of the property, which previews how bnd sees the instructions under the hood.");
-		showMergedPropertiesButton.setSelection(false);
-		showMergedPropertiesButton.setEnabled(false);
+		showMergedPropertiesButton.setSelection(true);
+		showMergedPropertiesButton.setEnabled(true);
 
 		// Create composite for viewers
 		viewersComposite = toolkit.createComposite(body);


### PR DESCRIPTION
Both checkboxes are now checked by default

<img width="522" height="290" alt="image" src="https://github.com/user-attachments/assets/e45d0de8-f5d7-4f0e-890b-3f0cb8c24315" />


I spoke to @peterkir and we realized that we both check both most of the time anyway. So maybe that is a sign for making it the default. 