### PR TITLE
gradle: Support gradle 9 in the plugins

### DIFF
--- a/gradle-plugins/README.md
+++ b/gradle-plugins/README.md
@@ -5,10 +5,8 @@ A typical Gradle build is a non-Bnd workspace build.
 A Bnd Workspace build uses the information specified in the Bnd Workspace's `cnf/build.bnd` file and each project's `bnd.bnd` file to configure the Gradle projects and tasks.
 
 The [`biz.aQute.bnd.gradle`][2] jar contains the Bnd Gradle Plugins.
-These plugins require Java 17 and
-at least Gradle 7.3 for Java 17,
-at least Gradle 7.5 for Java 18,
-and at least Gradle 7.6 for Java 19.
+These plugins require Java 17 and at least Gradle 8.0.
+More recent Java versions will require more recent Gradle versions.
 
 This README represents the capabilities and features of the Bnd Gradle Plugins in the branch containing this README.
 So for the `master` branch, this will be the [latest development SNAPSHOT build](#using-the-latest-development-snapshot-build-of-the-bnd-gradle-plugins).

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -1,3 +1,5 @@
+import groovy.lang.GroovySystem
+import org.gradle.util.internal.VersionNumber
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -22,6 +24,10 @@ val bnd_distrepo: String by project
 
 group = bnd_group
 version = bnd_version
+
+val groovyVersion = GroovySystem.getVersion()
+val isGroovy4 = VersionNumber.parse(groovyVersion).major >= 4
+val spockVersion = if (isGroovy4) "2.3-groovy-4.0" else "2.3-groovy-3.0"
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
@@ -80,7 +86,7 @@ dependencies {
 	testImplementation(enforcedPlatform("org.junit:junit-bom:5.12.2"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-	testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+	testImplementation("org.spockframework:spock-core:${spockVersion}")
 }
 
 // Gradle plugin descriptions

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -166,18 +166,23 @@ public class BndPlugin implements Plugin<Project> {
 			configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME)
 				.getArtifacts()
 				.clear();
-			configurations.getByName(Dependency.ARCHIVES_CONFIGURATION)
-				.getArtifacts()
-				.clear();
+			if (!isGradleCompatible("10.0")) { // only for pre 10.0
+				//@SuppressWarnings("deprecation")
+				configurations.getByName(Dependency.ARCHIVES_CONFIGURATION)
+					.getArtifacts()
+					.clear();
+			}
 			/* Set up deliverables */
 			ArtifactHandler artifacts = project.getArtifacts();
 			decontainer(bndProject.getDeliverables()).forEach(deliverable -> {
 				artifacts.add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, deliverable,
 					cpa -> cpa.builtBy(JavaPlugin.JAR_TASK_NAME));
-				artifacts.add(Dependency.ARCHIVES_CONFIGURATION, deliverable,
-					cpa -> cpa.builtBy(JavaPlugin.JAR_TASK_NAME));
+				if (!isGradleCompatible("10.0")) { // only for pre 10.0
+					artifacts.add(Dependency.ARCHIVES_CONFIGURATION, deliverable,
+						cpa -> cpa.builtBy(JavaPlugin.JAR_TASK_NAME));
+				}
 			});
-			FileCollection deliverables = configurations.getByName(Dependency.ARCHIVES_CONFIGURATION)
+			FileCollection deliverables = configurations.getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME)
 				.getArtifacts()
 				.getFiles();
 
@@ -300,19 +305,6 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					if (!isGradleCompatible("8.0")) { // only for pre 8.0
-						@SuppressWarnings("deprecation")
-						Map<String, Object> plugins = new DslObject(sourceSet).getConvention()
-							.getPlugins();
-						plugins.forEach((name, plugin) -> {
-							if (!sourceDirectorySets.containsKey(name)) {
-								Object sds = getter(plugin, name);
-								if (sds instanceof SourceDirectorySet sourceDirectorySet) {
-									sourceDirectorySets.put(name, sourceDirectorySet);
-								}
-							}
-						});
-					}
 					Provider<Directory> destinationDir = sourceSet.getJava()
 						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
@@ -349,19 +341,6 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					if (!isGradleCompatible("8.0")) { // only for pre 8.0
-						@SuppressWarnings("deprecation")
-						Map<String, Object> plugins = new DslObject(sourceSet).getConvention()
-							.getPlugins();
-						plugins.forEach((name, plugin) -> {
-							if (!sourceDirectorySets.containsKey(name)) {
-								Object sds = getter(plugin, name);
-								if (sds instanceof SourceDirectorySet sourceDirectorySet) {
-									sourceDirectorySets.put(name, sourceDirectorySet);
-								}
-							}
-						});
-					}
 					Provider<Directory> destinationDir = sourceSet.getJava()
 						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/Bundle.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/Bundle.java
@@ -28,7 +28,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
  * </pre>
  */
 @CacheableTask
-public class Bundle extends Jar {
+public abstract class Bundle extends Jar {
 	/**
 	 * Create a Bundle task.
 	 * <p>

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestHelper.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestHelper.groovy
@@ -38,24 +38,21 @@ class TestHelper {
 	}
 
 	private static String gradleVersion() {
+		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
+			return "9.1"
+		}
 		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_24)) {
 			return "8.14"
 		}
-		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21) || 
-			JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_22) || 
+		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21) ||
+			JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_22) ||
 			JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_23)) {
 			return "8.10.1"
 		}
 		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_20)) {
 			return "8.1.1"
 		}
-		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_19)) {
-			return "7.6"
-		}
-		if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
-			return "7.5"
-		}
-		return "7.3.2"
+		return "8.0"
 	}
 
 	public static String formatTime(ZipEntry entry) {


### PR DESCRIPTION
This means dropping support for gradle 7 since the support requires the use of deprecated methods removed in gradle 9.

https://github.com/gradle/gradle/issues/34505 causes the 
`TestBundlePlugin."Kotlin Bnd Builder Plugin Test"` to fail when building with Gradle 9.

We will also need to merge this PR before upgrading the gradle version to 9.3 (version targeted for the fix of the above issue) since we will need to remove the use of deprecated methods before we update gradle.