### PR TITLE
-maven-release;sign: allow to specify keyname

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -215,6 +215,10 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 						.isEmpty()) {
 						releaser.setPassphrase(instructions.passphrase);
 					}
+					if (instructions.keyname != null && !instructions.keyname.trim()
+						.isEmpty()) {
+						releaser.setKeyname(instructions.keyname);
+					}
 					if (instructions.snapshot >= 0)
 						releaser.setBuild(instructions.snapshot, null);
 
@@ -479,6 +483,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 		Attrs sign = p.remove("sign");
 		if (sign != null) {
+			release.keyname = sign.get("keyname");
 			release.passphrase = sign.get("passphrase");
 		}
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/ReleaseDTO.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/ReleaseDTO.java
@@ -48,5 +48,6 @@ public class ReleaseDTO extends DTO {
 	public SourceDTO		sources		= new SourceDTO();
 	public List<ExtraDTO>	extra		= new ArrayList<>();
 	public long				snapshot	= -1;
+	public String			keyname;
 	public String			passphrase;
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.1.0")
+@Version("2.2.0")
 package aQute.bnd.repository.maven.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/maven/api/Release.java
+++ b/biz.aQute.repository/src/aQute/maven/api/Release.java
@@ -62,4 +62,11 @@ public interface Release extends Closeable {
 	 * @param passphrase the passphrase
 	 */
 	void setPassphrase(String passphrase);
+
+	/**
+	 * Set the name / ID of the signing key.
+	 *
+	 * @param keyname the name / ID of the key (e.g. in the gpg keystore)
+	 */
+	void setKeyname(String keyname);
 }

--- a/biz.aQute.repository/src/aQute/maven/api/package-info.java
+++ b/biz.aQute.repository/src/aQute/maven/api/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.8.0")
+@Version("1.9.0")
 package aQute.maven.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/maven/provider/Releaser.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/Releaser.java
@@ -31,6 +31,7 @@ class Releaser implements Release {
 	protected boolean					localOnly;
 	protected MavenBackingRepository	repo;
 	private Properties					context;
+	private String						keyname;
 	private String						passphrase;
 
 	Releaser(MavenRepository home, Revision revision, MavenBackingRepository repo, Properties context)
@@ -178,7 +179,10 @@ class Releaser implements Release {
 
 		File sign = new File(home.toLocalFile(archive.localPath)
 			.getAbsolutePath() + ".asc");
-		int result = Signer.sign(f, context.getProperty("gpg", "gpg"), passphrase.equals("DEFAULT") ? null : passphrase,
+		String key = (keyname != null) ? keyname : null;
+		String pass = passphrase.equals("DEFAULT") ? null : passphrase;
+		int result = Signer.sign(f, context.getProperty("gpg", "gpg"), key,
+			pass,
 			sign);
 		if (result == 0) {
 			repo.store(sign, archive.remotePath + ".asc");
@@ -250,4 +254,8 @@ class Releaser implements Release {
 		this.passphrase = passphrase;
 	}
 
+	@Override
+	public void setKeyname(String keyname) {
+		this.keyname = keyname;
+	}
 }

--- a/biz.aQute.repository/src/aQute/maven/provider/SnapshotReleaser.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/SnapshotReleaser.java
@@ -97,4 +97,11 @@ public class SnapshotReleaser extends Releaser {
 		// ignore
 	}
 
+	/*
+	 * Snapshots are never signed
+	 */
+	@Override
+	public void setKeyname(String keyname) {
+		// ignore
+	}
 }

--- a/biz.aQute.repository/src/aQute/maven/provider/packageinfo
+++ b/biz.aQute.repository/src/aQute/maven/provider/packageinfo
@@ -1,1 +1,1 @@
-version 2.6
+version 2.7

--- a/docs/_instructions/_ext/maven_release.md
+++ b/docs/_instructions/_ext/maven_release.md
@@ -30,6 +30,7 @@ Though this instruction is not specific for a plugin, it was developed in conjun
                        ( ';path=' ( 'JAR' | PATH ) )?
     sign            ::= 'sign'
                        ( ';passphrase=' VALUE )?
+                       ( ';keyname=' VALUE )?
 
 If `sources` or `javadoc` has the attribute `force=true`, either one will be release to the maven repository even if no `releaseUrl` or `snapshotUrl` is set or `maven-release=local`. 
 
@@ -55,13 +56,17 @@ For example:
 
 # Signing
 
-If the instruction contains the sign attribute  and release build is detected the repository tries to apply [gnupg](https://gnupg.org/) via a command process to create `.asc` files for all deployed artifacts. This requires a Version of [gnupg](https://gnupg.org/) installed on your build system. By default it uses the `gpg` command. If the `passphrase` is configured, it will hand it over to the command as standard input. The command will be constructed as follows: `gpg --batch --passphrase-fd 0 --output <filetosign>.asc --detach-sign --armor <filetosign>`. Some newer gnupg versions will ignore the passphrase via standard input for the first try and ask again with password screen. This will crash the process. Have a look [here](https://stackoverflow.com/questions/19895122/how-to-use-gnupgs-passphrase-fd-argument) to teach gnupg otherwise. The command can be exchanged or amended with additional options by defining a property named `gpg` in your workspace (e.g. `build.bnd` or somewhere in the ext directory).
+If the instruction contains the sign attribute  and release build is detected the repository tries to apply [gnupg](https://gnupg.org/) via a command process to create `.asc` files for all deployed artifacts. This requires a Version of [gnupg](https://gnupg.org/) installed on your build system. By default it uses the `gpg` command. If the `passphrase` is configured, it will hand it over to the command as standard input, same for the `keyname`. 
+
+The command will be constructed as follows: 
+
+`gpg --batch --local-user <keyname> --passphrase-fd 0 --output <filetosign>.asc --detach-sign --armor <filetosign>`. Some newer gnupg versions will ignore the passphrase via standard input for the first try and ask again with password screen. This will crash the process. Have a look [here](https://stackoverflow.com/questions/19895122/how-to-use-gnupgs-passphrase-fd-argument) to teach gnupg otherwise. The command can be exchanged or amended with additional options by defining a property named `gpg` in your workspace (e.g. `build.bnd` or somewhere in the ext directory).
 
 Example config could look like:
 
 ```
 # use the env macro to avoid to set the passphrase somehwere in your project
--maven-release: pom,sign;passphrase=${env;GNUPG_PASSPHRASE}
+-maven-release: pom,sign;keyname=${env;GNUPG_KEYNAME}, passphrase=${env;GNUPG_PASSPHRASE}
 gpg: gpg --homedir /mnt/n/tmp/gpg/.gnupg --pinentry-mode loopback
 ```
 


### PR DESCRIPTION
This makes the signing more flexible by allowing to specify the name of the key (`keyname`), especially if you have multiple keys in your gpg keystore. This isually the case on local dev environments.

e.g. `-maven-release: pom,sign;keyname=${env;GNUPG_KEYNAME}, passphrase=${env;GNUPG_PASSPHRASE}`