### PR TITLE
Draft: Set resources destination dir at a higher level.

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -254,8 +254,9 @@ public class BndPlugin implements Plugin<Project> {
 				sourceSet.getJava()
 					.getDestinationDirectory()
 					.fileValue(destinationDir);
-				sourceSet.getOutput()
-					.setResourcesDir(destinationDir);
+				sourceSet.getResources()
+					.getDestinationDirectory()
+					.fileValue(destinationDir);
 				TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(),
 					AbstractCompile.class, t -> {
 						t.getDestinationDirectory()


### PR DESCRIPTION
This is what I meant in https://github.com/bndtools/bnd/issues/6896#issuecomment-3532261102.

Unfortunately it makes some tests fail. I'll try to investigate later.

Obviously not ready for merge yet, commit not signed off, etc.