### PR TITLE
Docs: Getting Started: add CLI installation to frontpage

### DIFF
--- a/docs/_chapters/120-install.md
+++ b/docs/_chapters/120-install.md
@@ -19,21 +19,35 @@ bnd is not a single product, it is a library (bndlib) used in many different sof
 That said, there is also a command line version of bnd, providing an easy way to try out its many features. You can install bnd through [brew][1] on MacOS.
 
 You can also run bnd command as executable jar, which can be downloaded from [JFrog][7]:
+
 ```bash
-java -jar biz.aQute.bnd-{VERSION}.jar <command>
+# Install bnd CLI
+$ curl -L -o biz.aQute.bnd-7.1.0.jar \
+	https://bndtools.jfrog.io/artifactory/update-latest/biz/aQute/bnd/biz.aQute.bnd/7.1.0/biz.aQute.bnd-7.1.0.jar
+$ alias bnd='java -jar "$PWD/biz.aQute.bnd-7.1.0.jar"'
+
+# Run commands
+bnd <command>
+
+# Example
+bnd help
 ```
 
+
 ## Libraries
-The binaries are available on [JFrog][7]. The latest version can be found at:
 
-	https://bndtools.jfrog.io/bndtools/libs-snapshot/biz/aQute/bnd/biz.aQute.bnd/
+The binaries are available on JFrog:
 
-If you are a maven user, you can find many version in central. The coordinates are:
+- [Releases and Release Candidates (RC)](https://bndtools.jfrog.io/artifactory/update-latest/biz/aQute/bnd/biz.aQute.bnd/)
+- [SNAPSHOT releases](https://bndtools.jfrog.io/bndtools/libs-snapshot/biz/aQute/bnd/biz.aQute.bnd/) (e.g. the latest from current master branch)
+
+
+If you are a maven user, you can find many versions in central. The coordinates are:
 
 		<dependency>
 			<groupId>biz.aQute.bnd</groupId>
 			<artifactId>biz.aQute.bndlib</artifactId>
-			<version>....</version>
+			<version>7.1.0</version>
 		</dependency>
 
 

--- a/docs/_layouts/front.html
+++ b/docs/_layouts/front.html
@@ -31,18 +31,40 @@
 
 			<div class="code-tabs">
 				<div class="tab-buttons">
-					<button class="tab-button active" onclick="openTab(event, 'tab-wrap')">bnd CLI wrap</button>
-					<button class="tab-button" onclick="openTab(event, 'tab-cli')">bnd CLI advanced</button>
+					<button class="tab-button" onclick="openTab(event, 'tab-install-cli')">Install bnd CLI</button>
+					<button class="tab-button active" onclick="openTab(event, 'tab-wrap')">bnd CLI JAR wrapping</button>
+					<button class="tab-button" onclick="openTab(event, 'tab-cli')">bnd CLI JAR wrapping
+						advanced</button>
 					<button class="tab-button" onclick="openTab(event, 'tab-maven')">Maven</button>
 					<button class="tab-button" onclick="openTab(event, 'tab-gradle')">Gradle</button>
 					<button class="tab-button" onclick="openTab(event, 'tab-workspace')">Build Workspace and
 						Projects</button>
+					<button class="tab-button" onclick="openTab(event, 'tab-eclipse')">Eclipse plugin</button>
+				</div>
+
+				<div id="tab-install-cli" class="tab-content">
+					<div class="language-shell highlighter-rouge">
+						<div class="highlight">
+							<pre class="highlight"><code># Install bnd CLI (precondition for the other examples)
+$ curl -L -o biz.aQute.bnd-7.1.0.jar \
+	https://bndtools.jfrog.io/artifactory/update-latest/biz/aQute/bnd/biz.aQute.bnd/7.1.0/biz.aQute.bnd-7.1.0.jar
+$ alias bnd='java -jar "$PWD/biz.aQute.bnd-7.1.0.jar"'
+</code></pre>
+						</div>
+						This installs the bnd CLI and makes the 'bnd' command available in your shell.
+					</div>
+					<p><strong>Reference:</strong>
+						<a href="{{ '/chapters/120-install.html#command-line' | prepend: site.baseurl }}">bnd CLI
+							installation</a> |
+						<a href="{{ '/chapters/400-commands.html' | prepend: site.baseurl }}">bnd CLI documentatiion</a>
+					</p>
 				</div>
 
 				<div id="tab-wrap" class="tab-content active">
 					<div class="language-shell highlighter-rouge">
 						<div class="highlight">
 							<pre class="highlight"><code># Quick wrap - automatically generates OSGi metadata
+# download an example jar to wrap
 $ curl -L -o activation.jar \
 	https://repo1.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.jar
 $ bnd wrap activation.jar
@@ -50,7 +72,9 @@ $ bnd wrap activation.jar
 						</div>
 						The result is a new jar file with OSGi metadata (<i>META-INF/MANIFEST.MF</i>).
 					</div>
-					<p><a href="{{ '/commands/wrap.html' | prepend: site.baseurl }}">bnd wrap command documentation</a>
+					<p><strong>Reference:</strong>
+						<a href="{{ '/commands/wrap.html' | prepend: site.baseurl }}">bnd wrap command documentation</a>
+						|
 					</p>
 				</div>
 
@@ -58,20 +82,26 @@ $ bnd wrap activation.jar
 					<div class="language-shell highlighter-rouge">
 						<div class="highlight">
 							<pre class="highlight"><code># Use a bnd file for more control
+# download an example jar to wrap
 $ curl -L -o activation.jar \
 	https://repo1.maven.org/maven2/javax/activation/activation/1.1.1/activation-1.1.1.jar
+
+# a activation.bnd file to specify OSGi metadata
 $ cat > activation.bnd &lt;&lt;EOF
 -classpath: activation.jar
 Export-Package: *;version=1.1.1
 Bundle-Version: 1.1.1
 EOF
+
+# Generate the OSGi bundle
 $ bnd activation.bnd
 </code></pre>
 						</div>
 						The result is a new jar file with OSGi metadata (<i>META-INF/MANIFEST.MF</i>).
 					</div>
-					<p><a href="{{ '/chapters/125-tour-features.html' | prepend: site.baseurl }}">bnd CLI advanced JAR
-							wrapping tutorial</a></p>
+					<p><strong>Reference:</strong>
+						<a href="{{ '/chapters/125-tour-features.html' | prepend: site.baseurl }}">bnd CLI advanced JAR
+							wrapping tutorial</a> |
 				</div>
 
 				<div id="tab-maven" class="tab-content">
@@ -107,8 +137,10 @@ $ bnd activation.bnd
 						</div>
 						This will automatically generate OSGi metadata (META-INF/MANIFEST.MF) during the Maven build.
 					</div>
-					<p><a href="https://github.com/bndtools/bnd/blob/master/maven-plugins/bnd-maven-plugin/README.md">Maven
-							plugin documentation</a></p>
+					<p><strong>Reference:</strong>
+						<a href="https://github.com/bndtools/bnd/blob/master/maven-plugins/bnd-maven-plugin/README.md">Maven
+							plugin documentation</a>
+					</p>
 				</div>
 
 				<div id="tab-gradle" class="tab-content">
@@ -132,9 +164,11 @@ jar {
 						</div>
 						This will automatically generate OSGi metadata (META-INF/MANIFEST.MF) during the Gradle build.
 					</div>
-					<p><a
+					<p><strong>Reference:</strong>
+						<a
 							href="https://github.com/bndtools/bnd/tree/master/gradle-plugins#create-a-task-of-the-bundle-type">Gradle
-							plugin documentation</a></p>
+							plugin documentation</a>
+					</p>
 				</div>
 
 				<div id="tab-workspace" class="tab-content">
@@ -148,25 +182,22 @@ $ bnd add workspace -f demo-webapp -f osgi myworkspace
 # Navigate to the workspace
 $ cd myworkspace
 
-# Build all projects
-$ bnd build
-
 # Start a live-coding / hot reload dev server to run the application during development in an editor
 $ bnd dev launch.bndrun
 
-# or alternatively just run the application withhout hot-reloading:
+# or alternatively just build and run the application without hot-reloading:
+$ bnd build
 $ bnd run launch.bndrun
-
 </code></pre>
 						</div>
 					</div>
 
-					<p>This creates a complete OSGi workspace that works identically across Eclipse, Gradle, Maven, and
+					<p>This creates a complete bnd workspace that works identically across Eclipse, Gradle, Maven, and
 						the command line.</p>
 					<p><strong>Learn more:</strong> <a
 							href="{{ '/chapters/123-tour-workspace.html' | prepend: site.baseurl }}">Workspace and
 							Projects Tour</a></p>
-					<p><strong>Command reference:</strong>
+					<p><strong>Reference:</strong>
 						<a href="{{ '/commands/add.html' | prepend: site.baseurl }}">bnd add</a> |
 						<a href="{{ '/commands/build.html' | prepend: site.baseurl }}">bnd build</a> |
 						<a href="{{ '/commands/dev.html' | prepend: site.baseurl }}">bnd dev</a> |
@@ -174,6 +205,16 @@ $ bnd run launch.bndrun
 					</p>
 
 				</div>
+
+				<div id="tab-eclipse" class="tab-content">
+					<p>The bndtools plugin for Eclipse provides tight integration with the bnd build system. It allows you
+						to create, build, and run OSGi projects directly from within Eclipse.</p>
+						<p><strong>Reference:</strong>
+							<a href="https://bndtools.org/">Bndtools Plugin Documentation</a>
+						</p>
+						<p><strong>Get started:</strong> <a
+								href="https://bndtools.org/workspace.html">Bndtools Workspace Tutorial</a></p>
+
 			</div>
 		</li>
 


### PR DESCRIPTION
<img width="2244" height="1116" alt="image" src="https://github.com/user-attachments/assets/7e0bb82f-a362-41e5-877b-348d2fac1a56" />

- add CLI install tab
- add Eclipse plugin tab

