### PR TITLE
Do no longer consider distribution management repos by default

### DIFF
--- a/maven-plugins/bnd-baseline-maven-plugin/README.md
+++ b/maven-plugins/bnd-baseline-maven-plugin/README.md
@@ -125,14 +125,16 @@ be disabled as follows:
 
 #### Include Distribution Management 
 
-By default the `bnd-baseline-maven-plugin` will include repositories
-listed in the Distribution Management section of the POM when 
-searching for the baseline. This is usually the right choice as the 
-distribution repository does not normally change between releases.
-This behaviour can be disabled as follows:
+By default the `bnd-baseline-maven-plugin` will not include repositories
+listed in the [Distribution Management section of the POM](https://maven.apache.org/pom.html#Distribution_Management) when 
+searching for the baseline because this is very often only suitable
+for uploading (but not necessarily for downloading).
+If however your distribution management URL can also be used to download
+old versions of your bundles you can explicitly use that as (additional)
+source for old versions via:
 
     <configuration>
-        <includeDistributionManagement>false</includeDistributionManagement>
+        <includeDistributionManagement>true</includeDistributionManagement>
     </configuration>
 
 #### Continue on Error

--- a/maven-plugins/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven-plugins/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -63,7 +63,15 @@ public class BaselineMojo extends AbstractMojo {
 	@Parameter(property = "bnd.baseline.fail.on.missing", defaultValue = "true")
 	private boolean					failOnMissing;
 
-	@Parameter(property = "bnd.baseline.include.distribution.management", defaultValue = "true")
+	/**
+	 * Also use the remote repository given via
+	 * {@code project.distributionManagement.repository.url} for retrieving the
+	 * base artifact.
+	 *
+	 * @see <a href="https://maven.apache.org/pom.html#Repository">POM
+	 *      Reference: Distribution Management -> Repository</a>
+	 */
+	@Parameter(property = "bnd.baseline.include.distribution.management", defaultValue = "false")
 	private boolean					includeDistributionManagement;
 
 	@Parameter(property = "bnd.baseline.full.report", defaultValue = "false")


### PR DESCRIPTION
This often leads to errors which break the build. Therefore this feature should be opt-in

This closes #6945