### PR TITLE
fix gpg signing

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -13,6 +13,7 @@ if [[ -n "${GPG_PRIVATE_KEY}" && -n "${GPG_PASSPHRASE}" ]]; then
 
     echo -e "#\n# list secret keys\n#\n"
     gpg --list-secret-keys --keyid-format LONG
+    export GPG_TTY=$(tty)
 fi
 
 # build

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -46,6 +46,9 @@ Bundle-Version:         ${base.version}.${tstamp}-SNAPSHOT
 -groupid:               biz.aQute.bnd
 -pom:                   version=${if;${def;-snapshot};${versionmask;===;${@version}}-${def;-snapshot};${versionmask;===s;${@version}}}
 -maven-release:         pom;path=JAR,javadoc;-classpath="${project.buildpath}"
+
+gpg: gpg --homedir ${def;USERHOME;~}/.gnupg --pinentry-mode loopback
+
 # -snapshot unset (commented out) is a snapshot build. (e.g. 6.0.0-SNAPSHOT)
 # -snapshot set to a value (e.g. RC1) is a release build with the value as the Maven version qualifier. (e.g. 6.0.0-RC1)
 # -snapshot set to the empty string is a release build with no Maven version qualifier. (e.g. 6.0.0)


### PR DESCRIPTION
`gpg: signing failed: Inappropriate ioctl for device` via
export GPG_TTY=$(tty)