### PR TITLE
sha1: add missing hex param

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -3283,9 +3283,16 @@ public class Analyzer extends Processor {
 				throw new FileNotFoundException("From sha1, not found " + args[1]);
 
 			IO.copy(r.openInputStream(), digester);
+
+			boolean hex = args.length > 2 && args[2].equals("hex");
+			if (hex)
+				return Hex.toHexString(digester.digest()
+					.digest());
+
 			return Base64.encodeBase64(digester.digest()
 				.digest());
 		}
+
 	}
 
 	public Descriptor getDescriptor(String descriptor) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Macro.java
@@ -1931,6 +1931,10 @@ public class Macro {
 
 	static final String _jsHelp = "${js [;<js expr>...]}";
 
+	/**
+	 * @deprecated javascript script engine removed in Java 15
+	 */
+	@Deprecated
 	public Object _js(String[] args) throws Exception {
 		verifyCommand(args, _jsHelp, null, 2, Integer.MAX_VALUE);
 


### PR DESCRIPTION
and deprecate ${js} macro because of removed script engine

Preparation for https://github.com/bndtools/bnd/pull/6948