### PR TITLE
Effective view: fix some macros not expanded

### DIFF
--- a/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
+++ b/bndtools.core/src/bndtools/editor/BndSourceEffectivePage.java
@@ -561,7 +561,7 @@ public class BndSourceEffectivePage extends FormPage {
 				// Define tooltip size constants
 				final int TOOLTIP_WIDTH = 700;
 				final int TOOLTIP_HEIGHT = 300;
-				
+
 				Composite container = new Composite(parent, SWT.NONE);
 
 				if (parent instanceof Shell) {
@@ -773,6 +773,8 @@ public class BndSourceEffectivePage extends FormPage {
 				return super.getUnexpandedProperty(key);
 			}
 		};
+		p.setBase(editModel.getOwner()
+			.getBase());
 		return p;
 	}
 


### PR DESCRIPTION
Closes #6957
e.g. now expands : example.cat: ${cat;example.txt}

The missing piece was that the base for the processor was not set correctly, so the file for filebased macros were not found. 

Now the effective view shows the value in the column and also on hovering:

<img width="988" height="298" alt="image" src="https://github.com/user-attachments/assets/c604830c-03db-40a6-bb7b-1d16463c6d12" />
