### PR TITLE
Support tester.customservice property.

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
@@ -2,6 +2,7 @@ package aQute.tester.junit.platform;
 
 import static aQute.junit.constants.TesterConstants.TESTER_CONTINUOUS;
 import static aQute.junit.constants.TesterConstants.TESTER_CONTROLPORT;
+import static aQute.junit.constants.TesterConstants.TESTER_CUSTOMSERVICE;
 import static aQute.junit.constants.TesterConstants.TESTER_DIR;
 import static aQute.junit.constants.TesterConstants.TESTER_NAMES;
 import static aQute.junit.constants.TesterConstants.TESTER_PORT;
@@ -88,11 +89,17 @@ public class Activator implements BundleActivator, Runnable {
 		this.context = context;
 		active = true;
 
+		boolean isCustomService = Boolean.valueOf(context.getProperty(TESTER_CUSTOMSERVICE));
 		if (!Boolean.valueOf(context.getProperty(TESTER_SEPARATETHREAD))
-			&& Boolean.valueOf(context.getProperty("launch.services"))) {
+			&& (isCustomService || Boolean.valueOf(context.getProperty("launch.services")))) {
 			// can't register services on mini framework
 			Hashtable<String, String> ht = new Hashtable<>();
-			ht.put("main.thread", "true");
+			if (isCustomService) {
+				ht.put("junit.tester", "true");
+			}
+			else {
+				ht.put("main.thread", "true");
+			}
 			ht.put(Constants.SERVICE_DESCRIPTION, "JUnit tester");
 			context.registerService(Runnable.class.getName(), this, ht);
 		} else {

--- a/biz.aQute.tester/src/aQute/junit/constants/TesterConstants.java
+++ b/biz.aQute.tester/src/aQute/junit/constants/TesterConstants.java
@@ -66,4 +66,11 @@ public interface TesterConstants {
 	 * well to use this special thread to run all tests on.
 	 */
 	String	TESTER_SEPARATETHREAD	= "tester.separatethread";
+
+	/**
+	 * Register the tester {@link java.lang.Runnable} as a service with the
+	 * attribute {@code junit.tester=true}. User code may then obtain the
+	 * service and run then tests when convenient.
+	 */
+	String  TESTER_CUSTOMSERVICE     = "tester.customservice";
 }


### PR DESCRIPTION
For https://github.com/bndtools/bnd/issues/6960.

I've written it so that if you set `tester.customservice`, you get a service with `junit.tester=true`. Also, if you set `tester.customservice` you don't need to also set `launch.services`.

Test forthcoming.