### PR TITLE
Exclude CONTRIBUTING.md and DEV_README.md from workflows

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -9,12 +9,16 @@ on:
     - '!docs/**'
     - '!.github/**'
     - '.github/**/*ci*'
+    - '!CONTRIBUTING.md'
+    - '!DEV_README.md'
   pull_request:
     paths:
     - '**'
     - '!docs/**'
     - '!.github/**'
     - '.github/**/*ci*'
+    - '!CONTRIBUTING.md'
+    - '!DEV_README.md'
 
 env:
   LC_ALL: en_US.UTF-8

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -10,12 +10,16 @@ on:
     - '!docs/**'
     - '!.github/**'
     - '.github/**/*rebuild*'
+    - '!CONTRIBUTING.md'
+    - '!DEV_README.md'
   pull_request:
     paths:
     - '**'
     - '!docs/**'
     - '!.github/**'
     - '.github/**/*rebuild*'
+    - '!CONTRIBUTING.md'
+    - '!DEV_README.md'
 
 env:
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
Updated cibuild.yml and rebuild.yml to ignore changes to CONTRIBUTING.md and DEV_README.md, preventing unnecessary workflow runs when these documentation files are modified.