### PR TITLE
Try to make BndPlugin compatible with the Gradle configuration cache

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndWorkspacePlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndWorkspacePlugin.java
@@ -48,6 +48,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 	private static final Pattern		OPTION_P			= Pattern.compile("--(?<option>\\w+)(?:=(?<value>\\S+)?)?");
 	private static final Pattern		TASKNAME_SPLITTER	= Pattern.compile(":");
 	private static final Set<String>	SPECIAL_FOLDERS		= Sets.of("buildSrc", "gradle");
+	public static final String 			BND_WORKSPACE_PROPERTY = "bndWorkspace";
 
 	/**
 	 * Default public constructor.
@@ -221,7 +222,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 			ExtraPropertiesExtension ext = project.getExtensions()
 				.getExtraProperties();
 			ext.set("bnd_cnf", cnf);
-			ext.set("bndWorkspace", workspace);
+			ext.set(BND_WORKSPACE_PROPERTY, workspace);
 			project.getPluginManager()
 				.apply(BndWorkspacePlugin.class);
 		});
@@ -256,7 +257,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 			bnd_cnf = Workspace.CNFDIR;
 			ext.set("bnd_cnf", bnd_cnf);
 		}
-		Workspace bndWorkspace = (Workspace) workspace.findProperty("bndWorkspace");
+		Workspace bndWorkspace = (Workspace) workspace.findProperty(BND_WORKSPACE_PROPERTY);
 		if (Objects.isNull(bndWorkspace)) {
 			// if not passed from settings
 			Workspace.setDriver(Constants.BNDDRIVER_GRADLE);
@@ -267,7 +268,7 @@ public class BndWorkspacePlugin implements Plugin<Object> {
 			bndWorkspace = new Workspace(rootDir, bnd_cnf);
 			bndWorkspace.setOffline(gradle.getStartParameter()
 				.isOffline());
-			ext.set("bndWorkspace", bndWorkspace);
+			ext.set(BND_WORKSPACE_PROPERTY, bndWorkspace);
 			bndWorkspaceConfigure(bndWorkspace, gradle);
 		}
 

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBndPlugin.groovy
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/test/groovy/aQute/bnd/gradle/TestBndPlugin.groovy
@@ -37,7 +37,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "build", "release")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "build", "release")
 				.forwardOutput()
 				.build()
 
@@ -89,7 +89,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "echo", "bndproperties", ":tasks")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "echo", "bndproperties", ":tasks")
 				.forwardOutput()
 				.build()
 
@@ -108,7 +108,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--continue", ":test.simple:resolve", ":test.simple:resolve2")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--continue", ":test.simple:resolve", ":test.simple:resolve2")
 				.forwardOutput()
 				.buildAndFail()
 
@@ -176,7 +176,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--continue", ":test.simple:export", ":test.simple:runbundles", ":test.simple:export2", ":test.simple:export3")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--continue", ":test.simple:export", ":test.simple:runbundles", ":test.simple:export2", ":test.simple:export3")
 				.forwardOutput()
 				.build()
 
@@ -233,7 +233,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", ":tasks")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", ":tasks")
 				.forwardOutput()
 				.build()
 
@@ -250,7 +250,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "build", "release")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "build", "release")
 				.forwardOutput()
 				.build()
 
@@ -297,7 +297,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "build", "release")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "build", "release")
 				.forwardOutput()
 				.build()
 
@@ -344,7 +344,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "build", "release")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "build", "release")
 				.forwardOutput()
 				.build()
 
@@ -396,7 +396,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "check", "--exclude-task", "testrun.testOSGi2")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "check", "--exclude-task", "testrun.testOSGi2")
 				.forwardOutput()
 				.build()
 
@@ -435,7 +435,7 @@ class TestBndPlugin extends Specification {
 		when:
 		result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2")
 				.forwardOutput()
 				.buildAndFail()
 
@@ -445,7 +445,7 @@ class TestBndPlugin extends Specification {
 		when:
 		result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2", "--tests=test.simple.Test")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2", "--tests=test.simple.Test")
 				.forwardOutput()
 				.build()
 
@@ -455,7 +455,7 @@ class TestBndPlugin extends Specification {
 		when:
 		result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2", "--tests=test.simple.ProjectNameTest")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "testrun.testOSGi2", "--tests=test.simple.ProjectNameTest")
 				.forwardOutput()
 				.build()
 
@@ -474,7 +474,7 @@ class TestBndPlugin extends Specification {
 		when:
 		def result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "build", "release")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "build", "release")
 				.forwardOutput()
 				.build()
 
@@ -505,7 +505,7 @@ class TestBndPlugin extends Specification {
 		when:
 		result = TestHelper.getGradleRunner()
 				.withProjectDir(testProjectDir)
-				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--parallel", "--stacktrace", "--debug", "clean")
+				.withArguments("-Pbnd_plugin=${pluginClasspath}", "--configuration-cache", "--parallel", "--stacktrace", "--debug", "clean")
 				.forwardOutput()
 				.build()
 


### PR DESCRIPTION
For https://github.com/bndtools/bnd/issues/6970.

`BndPlugin` itself can now be serialized, which is a start.

Unfortunately this isn't enough, because it adds actions to various tasks (using `doFirst()` or `doLast()`) which necessarily use the `aQute.bnd.build.Project`.