### PR TITLE
P2: create optional features category

### DIFF
--- a/org.bndtools.p2/bndtools.ecf.feature.bndrun
+++ b/org.bndtools.p2/bndtools.ecf.feature.bndrun
@@ -1,7 +1,7 @@
 Bundle-SymbolicName: bndtools.ecf.feature
 Bundle-Name:            Bndtools ECF Remote Services
 Bundle-Description:     ECF Remote Services integration for Bndtools
-Bundle-Category         bndtools
+Bundle-Category         bndtools-optional
 Bundle-Copyright: Copyright Composent, Inc. others, 2025
 update: https://download.eclipse.org/rt/ecf/latest/site.p2/
 update.label: ECF Update Site

--- a/org.bndtools.p2/bndtools.m2e.feature.bndrun
+++ b/org.bndtools.p2/bndtools.m2e.feature.bndrun
@@ -3,7 +3,7 @@ Bundle-Name:    Bndtools m2e
 Bundle-Description:       m2e integration for Bndtools
 Bundle-Copyright: Copyright Gregory Amerson others, 2016
 
-Bundle-Category bndtools
+Bundle-Category bndtools-optional
 
 Require-Capability \
     feature;name=org.eclipse.m2e.feature;version=2.0.0, \

--- a/org.bndtools.p2/bndtools.pde.feature.bndrun
+++ b/org.bndtools.p2/bndtools.pde.feature.bndrun
@@ -1,7 +1,7 @@
 Bundle-SymbolicName: bndtools.pde.feature
 Bundle-Name:            Bndtools PDE
 Bundle-Description:     PDE integration for Bndtools
-Bundle-Category         bndtools
+Bundle-Category         bndtools-optional
 Bundle-Copyright: Copyright Elias N Vasylenko and others, 2017
 
 Require-Capability \

--- a/org.bndtools.p2/features.bnd
+++ b/org.bndtools.p2/features.bnd
@@ -20,5 +20,8 @@ update.label    =   Bndtools Update Site
 -categories \
     bndtools; \
         label = Bndtools; \
-        description = Bndtools, OSGi Development Tools for Eclipse based on bnd.
+        description = Bndtools, OSGi Development Tools for Eclipse based on bnd. You need to select this.,\
+    bndtools-optional; \
+        label = Bndtools - Optionals; \
+        description = Optional features for bndtools. Select them individually when needed.
         


### PR DESCRIPTION
This displays 2 entries in the bndtools p2 installation dialog where the main entry contains only the bndtools core feature. And the other one contains fetures for m2e, pde and ecf, which are not always required.

<img width="1014" height="799" alt="image" src="https://github.com/user-attachments/assets/922b9041-5bfa-41c0-a7ca-f86664d0c4e0" />


This makes installation easier and avoids potential problems with optional features. It's not that those problems are less important to adress, but it makes installation of the main bndtools plugin easier (the 90% happy path)



Related to #6983 and #6974 