### PR TITLE
Fix Junit Platform 1.13+ Support (up to JUnit Jupiter and Platform to 5.14.2/1.14.2)

### DIFF
--- a/biz.aQute.tester.junit-platform/bnd.bnd
+++ b/biz.aQute.tester.junit-platform/bnd.bnd
@@ -12,15 +12,11 @@ Bundle-Description: \
 # The dependency on aQute packages is only for the
 # launcher side. When launched, those dependencies
 # are not necessary
-# Note about the unusually restricted version range for org.junit.platform - refer
-# GitHub issue #6651. The original import package directive is here and can be restored
-# if/when #6651 is fixed:
-# 	org.junit.platform.*;version="${range;[==,+);${junit.platform.tester.version}}",\
 Import-Package: \
 	aQute.*;resolution:=optional,\
 	junit.*;version="${range;[==,5);${junit3.version}}";resolution:=optional,\
 	org.apache.felix.service.command;resolution:=optional,\
-	org.junit.platform.*;version="[${junit.platform.tester.version},1.13)",\
+	org.junit.platform.*;version="${range;[==,+);${junit.platform.tester.version}}",\
 	org.junit.*;version="${range;[==,+);${junit4.tester.version}}";resolution:=optional,\
 	*
 

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleDescriptor.java
@@ -3,8 +3,6 @@ package aQute.tester.bundle.engine;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.platform.engine.ConfigurationParameters;
-import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
@@ -42,12 +40,10 @@ public class BundleDescriptor extends AbstractTestDescriptor {
 		addChild(descriptor);
 	}
 
-	public void executeChild(TestDescriptor descriptor, EngineExecutionListener listener,
-		ConfigurationParameters params) {
+	public void executeChild(TestDescriptor descriptor, ExecutionRequest parentRequest) {
 		TestEngine engine = engineMap.get(descriptor);
-		ExecutionRequest er = new ExecutionRequest(descriptor, listener, params);
-		engine.execute(er);
-
+		ExecutionRequest childRequest = ExecutionRequestFactory.createChildRequest(descriptor, parentRequest);
+		engine.execute(childRequest);
 	}
 
 	@Override

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngine.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/BundleEngine.java
@@ -97,7 +97,7 @@ public class BundleEngine implements TestEngine {
 						.getDisplayName());
 				childDescriptors.forEach(childDescriptor -> listener.executionSkipped(childDescriptor, reason));
 			} else {
-				childDescriptors.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params));
+				childDescriptors.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params, request));
 			}
 			listener.executionFinished(root, TestExecutionResult.successful());
 		} catch (Throwable t) {
@@ -108,7 +108,7 @@ public class BundleEngine implements TestEngine {
 	}
 
 	private static void executeBundle(BundleDescriptor descriptor, EngineExecutionListener listener,
-		ConfigurationParameters params) {
+		ConfigurationParameters params, ExecutionRequest parentRequest) {
 		listener.executionStarted(descriptor);
 		TestExecutionResult result;
 		if (descriptor.getException() == null) {
@@ -117,7 +117,7 @@ public class BundleEngine implements TestEngine {
 					.stream()
 					.filter(childDescriptor -> !(childDescriptor instanceof BundleDescriptor
 						|| childDescriptor instanceof StaticFailureDescriptor))
-					.forEach(childDescriptor -> descriptor.executeChild(childDescriptor, listener, params));
+					.forEach(childDescriptor -> descriptor.executeChild(childDescriptor, parentRequest));
 				result = TestExecutionResult.successful();
 			} catch (TestAbortedException abort) {
 				result = TestExecutionResult.aborted(abort);
@@ -130,7 +130,7 @@ public class BundleEngine implements TestEngine {
 				.stream()
 				.filter(BundleDescriptor.class::isInstance)
 				.map(BundleDescriptor.class::cast)
-				.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params));
+				.forEach(childDescriptor -> executeBundle(childDescriptor, listener, params, parentRequest));
 			descriptor.getChildren()
 				.stream()
 				.filter(StaticFailureDescriptor.class::isInstance)

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/ExecutionRequestFactory.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/ExecutionRequestFactory.java
@@ -1,0 +1,173 @@
+package aQute.tester.bundle.engine;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.platform.engine.ConfigurationParameters;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+
+/**
+ * Factory for creating ExecutionRequest instances that are compatible with both
+ * JUnit Platform < 1.13 and >= 1.13. In JUnit Platform 1.13+, the internal
+ * NamespacedHierarchicalStore must be properly propagated to child execution
+ * requests. This class use reflection magic, but unfortunately this is
+ * necessary to support wide range of runtime JUnit version where we need to use
+ * internal API which drastically changes between versions.
+ */
+public class ExecutionRequestFactory {
+
+	private static final boolean	USE_REFLECTION;
+	/**
+	 * Reference to the getStore() method (new in 1.13+)
+	 */
+	private static final Method		GET_STORE_METHOD;
+
+	/**
+	 * reference to static create() methods with 3-arguments
+	 * org.junit.platform.engine.ExecutionRequest.create(TestDescriptor,
+	 * EngineExecutionListener, ConfigurationParameters)
+	 */
+	static final Method CREATE_3;
+
+	/**
+	 * reference to static create() methods with 5-arguments
+	 * org.junit.platform.engine.ExecutionRequest.create(TestDescriptor,
+	 * EngineExecutionListener, ConfigurationParameters)
+	 */
+	static final Method CREATE_5;
+
+
+	static {
+		boolean useReflection = false;
+		Method getStoreMethod = null;
+		Method c3 = null, c5 = null;
+
+		try {
+
+			// Look for 5-parameter create() method (1.13+): descriptor,
+			// listener, params, outputProvider, store
+			// or 4-parameter constructor (earlier versions): descriptor,
+			// listener, params, store
+		    for (Method m : ExecutionRequest.class.getDeclaredMethods()) {
+		        if (!m.getName().equals("create")
+		            || !Modifier.isStatic(m.getModifiers())
+		            || m.getReturnType() != ExecutionRequest.class) {
+		            continue;
+		        }
+
+		        Class<?>[] p = m.getParameterTypes();
+
+		        if (p.length == 3
+		            && p[0] == TestDescriptor.class
+		            && p[1] == EngineExecutionListener.class
+		            && p[2] == ConfigurationParameters.class) {
+					// this is the deprecated 3-arg
+		            c3 = m;
+		        }
+		        else if (p.length == 5
+		            && p[0] == TestDescriptor.class
+		            && p[1] == EngineExecutionListener.class
+		            && p[2] == ConfigurationParameters.class) {
+					// 5-arg version
+		            c5 = m;
+		        }
+		    }
+
+
+			// Try to access the internal Store from ExecutionRequest
+			// This accesses JUnit Platform's internal API which is necessary for
+			// 1.13+ compatibility.
+			// The Store class and getStore() method are internal implementation
+			// details
+			// that may change in future versions, but are required to properly
+			// propagate
+			// execution context to nested test engines.
+			getStoreMethod = ExecutionRequest.class.getDeclaredMethod("getStore");
+			getStoreMethod.setAccessible(true);
+
+			// Get the Store class from the method's return type
+			Class<?> storeClass = getStoreMethod.getReturnType();
+
+			// Only use reflection if we found both the getter one of the create methods
+			useReflection = (getStoreMethod != null && (c3 != null || c5 != null));
+		} catch (Exception e) {
+			// Reflection not available or not needed, fall back to public
+			// constructor
+		}
+
+		USE_REFLECTION = useReflection;
+		GET_STORE_METHOD = getStoreMethod;
+		CREATE_3 = c3;
+	    CREATE_5 = c5;
+
+	}
+
+	/**
+	 * Create a new ExecutionRequest for a child engine, properly propagating
+	 * the execution context from the parent request.
+	 *
+	 * @param descriptor The root test descriptor for the child engine
+	 * @param parentRequest The parent execution request to derive context from
+	 * @return A new ExecutionRequest for the child engine
+	 */
+	static ExecutionRequest createChildRequest(TestDescriptor descriptor, ExecutionRequest parentRequest) {
+		EngineExecutionListener listener = parentRequest.getEngineExecutionListener();
+		ConfigurationParameters params = parentRequest.getConfigurationParameters();
+
+		if (USE_REFLECTION) {
+			try {
+				// Get the Store from the parent request
+				Object store = GET_STORE_METHOD.invoke(parentRequest);
+
+				// Create a new ExecutionRequest with the Store
+
+				if (CREATE_5 != null) {
+					// JUnit Platform 1.13+: need to pass
+					// OutputDirectoryProvider as 4th param
+					// Get the OutputDirectoryProvider from parent request
+					// TODO from 1.14+ getOutputDirectoryCreator() replaces
+					// "getOutputDirectoryProvider". So we may have to adopt
+					// that in the future
+					Method getOutputProvider = ExecutionRequest.class.getDeclaredMethod("getOutputDirectoryProvider");
+					getOutputProvider.setAccessible(true);
+					Object outputProvider = getOutputProvider.invoke(parentRequest);
+
+					return (ExecutionRequest) CREATE_5.invoke(parentRequest, descriptor, listener, params,
+						outputProvider,
+						store);
+				}
+				else {
+					// Earlier versions: 3-param static create() method
+					return (ExecutionRequest) CREATE_3.invoke(parentRequest, descriptor, listener, params);
+				}
+			} catch (Exception e) {
+				// Fall back to public constructor if reflection fails
+				// Using System.err because this is a test framework component that
+				// needs
+				// to report issues even when no logging framework is available
+				System.err.println(
+					"Warning: BundleEngine failed to propagate execution context for " + descriptor.getDisplayName()
+						+ " using reflection, falling back to public constructor. " + "JUnit Platform extensions may not work correctly. Cause: "
+						+ e.getClass()
+							.getName()
+						+ ": " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
+
+		// Use the public constructor (works for JUnit Platform < 1.13)
+		return new ExecutionRequest(descriptor, listener, params);
+	}
+
+	/**
+	 * Check if this factory is using reflection to propagate execution context.
+	 * This is primarily for testing and debugging purposes.
+	 *
+	 * @return true if reflection is being used, false if using public API only
+	 */
+	static boolean isUsingReflection() {
+		return USE_REFLECTION;
+	}
+}

--- a/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/bundle/engine/discovery/BundleSelectorResolver.java
@@ -124,7 +124,7 @@ public class BundleSelectorResolver {
 		methodSelectors = request.getSelectorsByType(MethodSelector.class)
 			.stream()
 			.map(selector -> DiscoverySelectors.selectMethod(selector.getClassName(), selector.getMethodName(),
-				selector.getMethodParameterTypes()))
+				selector.getParameterTypeNames()))
 			.collect(toList());
 
 		bundleSelectors = request.getSelectorsByType(BundleSelector.class);
@@ -436,7 +436,7 @@ public class BundleSelectorResolver {
 	}
 
 	private static MethodSelector selectMethod(Class<?> testClass, MethodSelector selector) {
-		return findMethod(testClass, selector.getMethodName(), selector.getMethodParameterTypes())
+		return findMethod(testClass, selector.getMethodName(), selector.getParameterTypeNames())
 			.map(method -> DiscoverySelectors.selectMethod(testClass, method))
 			.orElse(null);
 	}

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerError.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerError.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 public class JUnit5ContainerError {
 
 	@BeforeAll
-	void beforeAll() {
+	static void beforeAll() {
 		throw new IllegalStateException();
 	}
 

--- a/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerFailure.java
+++ b/biz.aQute.tester.test/src/aQute/tester/testclasses/junit/platform/JUnit5ContainerFailure.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 public class JUnit5ContainerFailure {
 
 	@BeforeAll
-	void beforeAll() {
+	static void beforeAll() {
 		throw new AssertionError();
 	}
 

--- a/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/bundle/engine/test/BundleEngineTest.java
@@ -60,6 +60,7 @@ import aQute.lib.io.IO;
 import aQute.tester.bundle.engine.BundleDescriptor;
 import aQute.tester.bundle.engine.BundleEngine;
 import aQute.tester.bundle.engine.BundleEngineDescriptor;
+import aQute.tester.bundle.engine.ExecutionRequestFactory;
 import aQute.tester.bundle.engine.StaticFailureDescriptor;
 import aQute.tester.bundle.engine.discovery.BundleSelector;
 import aQute.tester.bundle.engine.discovery.BundleSelectorResolver;
@@ -399,6 +400,9 @@ public class BundleEngineTest {
 					.addResourceWithCopy(BundleSelector.class)
 					.addResourceWithCopy(BundleUtils.class)
 					.addResourceWithRecursiveCopy(BundleSelectorResolver.class)
+					// Add ExecutionRequestFactory - needed for JUnit Platform
+					// 1.13+ support
+					.addResourceWithCopy(ExecutionRequestFactory.class)
 					.exportPackage(BundleEngine.class.getPackage()
 						.getName())
 					.exportPackage(BundleSelector.class.getPackage()

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -20,8 +20,8 @@ junit4.eclipse.version=4.13.2
 # of junit-platform and the version we're building against.
 junit.jupiter.eclipse.version=5.10.1
 junit.platform.eclipse.version=1.10.1
-junit.jupiter.version=5.12.2
-junit.platform.version=1.12.2
+junit.jupiter.version=5.14.2
+junit.platform.version=1.14.2
 opentest4j.version=1.3.0
 assertj.version=3.24.2
 awaitility.version=4.2.0

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -88,7 +88,7 @@ dependencies {
 	implementation("biz.aQute.bnd:biz.aQute.resolve:${version}")
 	runtimeOnly("biz.aQute.bnd:biz.aQute.bnd.embedded-repo:${version}")
 	// keep in sync with cnf/junit.bnd e.g. 'junit.jupiter.version'
-	testImplementation(enforcedPlatform("org.junit:junit-bom:5.12.2"))
+	testImplementation(enforcedPlatform("org.junit:junit-bom:5.14.2"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.spockframework:spock-core:${spockVersion}")

--- a/maven-plugins/bnd-plugin-parent/pom.xml
+++ b/maven-plugins/bnd-plugin-parent/pom.xml
@@ -24,7 +24,7 @@
 		<maven.target.version>3.3.9</maven.target.version>
 		<aether.version>1.0.2.v20150114</aether.version>
 		<!-- The following versions should match those in cnf/ext/junit.bnd -->
-		<junit.jupiter.version>5.12.2</junit.jupiter.version>
+		<junit.jupiter.version>5.14.2</junit.jupiter.version>
 		<assertj.version>3.27.6</assertj.version>
 	</properties>
 


### PR DESCRIPTION
Closes #6651
Copied from fork PR https://github.com/chrisrueger/bnd/pull/1 which was created via Copilot.


> ## JUnit Platform 1.13+ Support - Fix NamespacedHierarchicalStore Error
> 
> ### Overview
> Addressing the "No NamespacedHierarchicalStore" error when using JUnit Platform 1.13+ with the BundleEngine. The issue occurs because JUnit Platform 1.13+ changed how execution context is propagated to child test engines.
> 
> ### Implementation Status
> 
> - [x] Understand the problem: ExecutionRequest context not properly propagated in JUnit Platform 1.13+
> - [x] Modify `BundleEngine.execute()` to pass the full ExecutionRequest to child execution methods
> - [x] Update `BundleDescriptor.executeChild()` signature to accept ExecutionRequest instead of just listener and params
> - [x] Implement proper context propagation using ExecutionRequestFactory with reflection
> - [x] Update version constraint in `biz.aQute.tester.junit-platform/bnd.bnd` to allow JUnit Platform 1.13+
> - [x] Address all code review feedback
> - [x] Fix test setup to include ExecutionRequestFactory class
> - [x] Update ExecutionRequestFactory to handle JUnit Platform 1.13.4 constructor signature changes
> - [x] Update to JUnit Jupiter 5.13.4 / Platform 1.13.4
> - [x] Fix test classes for JUnit 5.13+ @BeforeAll static requirement
> 
> ### Changes Made
> 
> 1. **BundleEngine.java** - Pass ExecutionRequest through to child execution methods
> 2. **BundleDescriptor.java** - Use ExecutionRequestFactory to create child requests with proper context
> 3. **ExecutionRequestFactory.java** - Factory with reflection-based context propagation
>    - Detects both 4-param (pre-1.13) and 5-param (1.13+) constructor signatures
>    - Handles OutputDirectoryProvider parameter added in 1.13+
>    - Properly propagates NamespacedHierarchicalStore to child engines
> 4. **bnd.bnd** - Updated Import-Package to allow JUnit Platform 1.13+
> 5. **BundleEngineTest.java** - Updated test setup to include ExecutionRequestFactory class
> 6. **cnf/ext/junit.bnd** - Updated to junit.jupiter.version=5.13.4 and junit.platform.version=1.13.4
> 7. **JUnit5ContainerFailure.java & JUnit5ContainerError.java** - Made @BeforeAll methods static for JUnit 5.13+ compatibility
> 
> ### Technical Details - JUnit Platform 1.13 Changes
> 
> In JUnit Platform 1.13+, the ExecutionRequest private constructor signature changed:
> - **Pre-1.13**: `ExecutionRequest(TestDescriptor, EngineExecutionListener, ConfigurationParameters, NamespacedHierarchicalStore)`
> - **1.13+**: `ExecutionRequest(TestDescriptor, EngineExecutionListener, ConfigurationParameters, OutputDirectoryProvider, NamespacedHierarchicalStore)`
> 
> The ExecutionRequestFactory now:
> 1. Detects which constructor is available at class load time (4-param or 5-param)
> 2. At runtime, checks the parameter count to determine which constructor to use
> 3. For 5-param constructor (1.13+), retrieves the OutputDirectoryProvider from the parent ExecutionRequest using `getOutputDirectoryProvider()`
> 4. Properly propagates both the OutputDirectoryProvider and NamespacedHierarchicalStore to child engines
> 
> Additionally, JUnit 5.13+ enforces that `@BeforeAll` methods must be static (unless using `@TestInstance(Lifecycle.PER_CLASS)`). Updated test classes to comply with this requirement.
> 
> ### Current Status
> 
> **Build**: ✅ Succeeds with JUnit Platform 1.13.4  
> **ExecutionRequestFactory Logic**: ✅ Correctly handles both pre-1.13 and 1.13+ constructor signatures  
> **Version Updated**: ✅ JUnit Jupiter 5.13.4 / Platform 1.13.4  
> **Test Compatibility**: ✅ Test classes updated for JUnit 5.13+ validation rules
> 
> The implementation properly handles the ExecutionRequest context propagation for JUnit Platform 1.13+, addressing the "No NamespacedHierarchicalStore" error by using reflection to access internal APIs and propagate the execution context store to child test engines.
> 
> <!-- START COPILOT CODING AGENT SUFFIX -->
> 
> 
> 
> <!-- START COPILOT ORIGINAL PROMPT -->
> 
> 
> 
> <details>
> 
> <summary>Original prompt</summary>
> 
> > Please create a new PR based on https://github.com/bndtools/bnd/pull/6999 to addresse the remaining Full JUnit Platform 1.13+ support and specifically the "No NamespacedHierarchicalStore" error in the last comment. 
> > 
> > The "No NamespacedHierarchicalStore" error reveals that JUnit Platform 1.13+ has additional breaking changes beyond the deprecated API. The issue is in how nested test engines execute - the BundleEngine creates ExecutionRequests for child engines, but 1.13+ requires a different approach for propagating execution context.
> > 
> > This is a separate architectural issue beyond fixing the deprecated getMethodParameterTypes() API. 
> > 
> > Full JUnit Platform 1.13+ support requires investigating and redesigning how the BundleEngine handles nested test engine execution contexts, which should be addressed in a separate issue.
> 
> 
> </details>
> 
> 