### PR TITLE
Fix warnings from last commit

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
@@ -5,6 +5,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 
+/**
+ * A counter helper to determine which task is the last release task.
+ */
 public abstract class ReleaseCounterService
         implements BuildService<BuildServiceParameters.None>, AutoCloseable {
 
@@ -16,9 +19,11 @@ public abstract class ReleaseCounterService
     }
 
     /**
-     * Call during execution by each release task.
-     * Returns true exactly once: for the last release task that runs.
-     */
+	 * Call during execution by each release task. Returns true exactly once:
+	 * for the last release task that runs.
+	 *
+	 * @return <code>true</code> if this is the last task to be released
+	 */
     public boolean isLastReleaseTask() {
         return remaining.decrementAndGet() == 0;
     }


### PR DESCRIPTION
Update release task execution to detect and handle the last bundle in the workspace, using a special ReleaseParameter for Sonatype release scenarios. Non-final bundles use the standard release method.

Add ReleaseCounterService for release task coordination

Introduces ReleaseCounterService to track and coordinate multiple 'release' tasks, ensuring special handling for the last bundle released. Updates BndPlugin to use this shared service for correct release sequencing, improving reliability in multi-bundle workspaces.