### PR TITLE
Refactor release task counting in BndPlugin

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
@@ -13,10 +13,9 @@ public abstract class ReleaseCounterService
 
     private final AtomicInteger remaining = new AtomicInteger(0);
 
-    /** Call during configuration for each enabled release task */
-    public void registerReleaseTask() {
-        remaining.incrementAndGet();
-    }
+	public void setInitialCount(int n) {
+		remaining.set(n);
+	}
 
     /**
 	 * Call during execution by each release task. Returns true exactly once:


### PR DESCRIPTION
Moved release task counting from configuration time to execution graph readiness. The initial count of enabled release tasks is now set when the task graph is ready, improving accuracy and compatibility with parallel execution and configuration cache.