### PR TITLE
Add optional imports for Guava / Error Prone 

### DIFF
--- a/org.bndtools.templating/bnd.bnd
+++ b/org.bndtools.templating/bnd.bnd
@@ -17,8 +17,8 @@
 	org.antlr:ST4:jar:complete;maven-scope=provided,\
 	com.github.spullara.mustache.java:compiler;maven-scope=provided,\
 	com.google.guava;version="[33.4.8,33.4.9)";maven-scope=provided,\
-	org.jspecify.jspecify;version='[1.0.0,2.0.0)';maven-scope=provided
-
+	com.google.guava.failureaccess;version=latest;maven-scope=provided
+	
 -testpath: \
 	slf4j.api,\
 	slf4j.simple,\
@@ -32,7 +32,7 @@
 	aQute.libg.*,\
 	com.github.mustachejava.*,\
 	com.google.common.*,\
-	org.jspecify.*
+	
 	
 Bundle-ActivationPolicy: lazy
 
@@ -41,6 +41,8 @@ Import-Package: \
  com.google.appengine.*;resolution:=optional,\
  com.google.apphosting.*;resolution:=optional,\
  android.os.*;resolution:=optional,\
+ !org.jspecify.*,\
+ !com.google.errorprone.annotations.*,\
  ${eclipse.importpackage},\
  *
 


### PR DESCRIPTION
Closes #7022

## Guava

- Removed `org.jspecify.jspecify` and  `com.google.errorprone.annotations` 
- following packages are now private-package (instead of Import-Package)

```
com.google.common.util.concurrent.internal.*
```

Hopefully makes life easier for https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3579#issuecomment-3693797403


Full  MANIFEST.MF (Print view from JAR viewer):

```
[MANIFEST]

Automatic-Module-Name                   org.bndtools.templating
Bundle-ActivationPolicy                 lazy
Bundle-Copyright                        Copyright (c) Neil Bartlett (2009, 2025) and others. All Rights Reserved.
Bundle-Developers                       bjhargrave;email="bj@hargrave.dev";name="BJ Hargrave";organization=IBM;organizationUrl="https://developer.ibm.com";roles=developer;timezone="America/New_York";url="https://github.com/bjhargrave"
                                        chrisrueger;email="chrisrueger@gmail.com";name="Christoph Rueger";organization="Synesty GmbH";organizationUrl="https://synesty.com/";roles=developer;timezone="Europe/Berlin"
                                        peterkir;email="peter@klib.io";name="Peter Kirschner";organization="Kirschners GmbH";organizationUrl="https://peterkir.github.io/";roles=developer;timezone="Europe/Berlin";url="https://peterkir.github.io"
                                        pkriens;email="Peter.Kriens@aQute.biz";name="Peter Kriens";organization=Bndtools;organizationUrl="https://github.com/bndtools";roles="architect,developer";timezone=1
                                        rotty3000;email="raymond.auge@liferay.com";name="Ray Augé";organization="Liferay Inc.";organizationUrl="https://www.liferay.com";roles=developer;timezone="America/New_York";url="https://rotty3000.github.io"
Bundle-DocURL                           https://bndtools.org/
Bundle-License                          (Apache-2.0 OR EPL-2.0);description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
Bundle-ManifestVersion                  2
Bundle-Name                             org.bndtools.templating
Bundle-SCM                              connection=scm:git:https://github.com/bndtools/bnd.git
                                        developerConnection=scm:git:git@github.com:bndtools/bnd.git
                                        tag=7.3.0-SNAPSHOT
                                        url=https://github.com/bndtools/bnd
Bundle-SymbolicName                     org.bndtools.templating
Bundle-Vendor                           Bndtools https://bndtools.org/
Bundle-Version                          7.3.0.202512290835-SNAPSHOT
Export-Package                          org.bndtools.templating.util;version="1.0.0";uses:="org.osgi.service.metatype"
                                        org.bndtools.templating;version="2.0.0";uses:="aQute.service.reporter,org.eclipse.core.runtime,org.osgi.framework,org.osgi.service.metatype,org.osgi.util.promise"
Git-Descriptor                          7.3.0.DEV-96-gf5db14361
Git-SHA                                 f5db14361114564f2162531fbcfb160e2aac43fe
Import-Package                          aQute.bnd.exceptions;version="[3.0,4)"
                                        aQute.bnd.osgi;version="[7.6,8)"
                                        aQute.service.reporter;version="[1.3,2)"
                                        android.os;resolution:=optional
                                        com.google.appengine.api.utils;resolution:=optional
                                        com.google.appengine.api;resolution:=optional
                                        com.google.apphosting.api;resolution:=optional
                                        javax.crypto
                                        javax.crypto.spec
                                        javax.swing
                                        javax.swing.border
                                        javax.swing.event
                                        javax.swing.text
                                        javax.swing.tree
                                        org.eclipse.core.runtime;bundle-symbolic-name="org.eclipse.core.runtime";bundle-version="[3.30,4)"
                                        org.osgi.framework;version="[1.8,2)"
                                        org.osgi.service.metatype;version="[1.3,2)"
                                        org.osgi.util.promise;version="[1.3,2)"
                                        sun.misc;resolution:=optional
Manifest-Version                        1.0
Private-Package                         aQute.lib.io;version="4.5.0"
                                        aQute.lib.stringrover;version="1.2.0"
                                        aQute.libg.glob;version="1.6.0"
                                        com.github.mustachejava
                                        com.github.mustachejava.codes
                                        com.github.mustachejava.reflect
                                        com.github.mustachejava.reflect.guards
                                        com.github.mustachejava.resolver
                                        com.github.mustachejava.util
                                        com.google.common.base
                                        com.google.common.base.internal
                                        com.google.common.cache
                                        com.google.common.collect
                                        com.google.common.graph
                                        com.google.common.hash
                                        com.google.common.io
                                        com.google.common.math
                                        com.google.common.primitives
                                        com.google.common.util.concurrent
                                        com.google.common.util.concurrent.internal
                                        org.bndtools.templating.engine.mustache
                                        org.bndtools.templating.engine.st
                                        org.stringtemplate.v4
                                        org.stringtemplate.v4.compiler
                                        org.stringtemplate.v4.debug
                                        org.stringtemplate.v4.gui
                                        org.stringtemplate.v4.misc
                                        st4hidden.org.antlr.runtime
                                        st4hidden.org.antlr.runtime.misc
                                        st4hidden.org.antlr.runtime.tree
Provide-Capability                      osgi.service;objectClass:List<String>="org.bndtools.templating.TemplateEngine";uses:="org.bndtools.templating"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.3.0)(!(version>=2.0.0)))"
SPDX-License-Identifier                 (Apache-2.0 OR EPL-2.0)
Service-Component                       OSGI-INF/org.bndtools.templating.engine.mustache.xml
                                        OSGI-INF/org.bndtools.templating.engine.st.xml


```

