### PR TITLE
Remove test-bnd module from in-build pom.xml

### DIFF
--- a/maven-plugins/bnd-indexer-maven-plugin/src/it/in-build/pom.xml
+++ b/maven-plugins/bnd-indexer-maven-plugin/src/it/in-build/pom.xml
@@ -14,7 +14,6 @@
 	<packaging>pom</packaging>
 
 	<modules>
-		<module>../test-bnd</module>
 		<module>../test-snapshot</module>
 	</modules>
 


### PR DESCRIPTION
This is replacement PR for https://github.com/bndtools/bnd/pull/7021 (which was in the wrong branch)

This is a (maybe a temporary) fix for https://github.com/bndtools/bnd/issues/7020 to make the master build work again. 

## Description

The test-bnd module reference was removed from the modules section in the in-build pom.xml

This fixes the failing test in https://github.com/bndtools/bnd/issues/7020

But not sure this is really the best solution, since it might fix only a symptom, and not the root cause. But maybe it serves as a base for discussion.

## Analysis

The cause seemed to be that maven-plugins/bnd-indexer-maven-plugin/src/it/test-bnd builds a fake bnd v1.50.0 bundle.

```
[INFO] Reactor Summary:
[INFO] 
[INFO] bnd 1.50.0 ......................................... SUCCESS [  0.272 s]
[INFO] org.apache.aries.async 0.0.1-SNAPSHOT .............. SUCCESS [  0.006 s]
[INFO] in-build 0.0.1 ..................................... FAILURE [  0.081 s]

```

And then the test in-build/pom.xml find this bnd 1.50.0 from the reactor instead of the remote maven central, and thus fails.

But I don't know why it suddenly happens and did not happen earlier.
Not sure my fix here is only fighting symptoms.

@timothyjward , since you worked on related PRs (see description of https://github.com/bndtools/bnd/issues/7020), maybe you have an idea.

Or mayb @bjhargrave has thoughts too since you did a larger PR related to the tests https://github.com/bndtools/bnd/pull/5252