### PR TITLE
biz.aQute.bnd.annotation: compile with java 8

### DIFF
--- a/biz.aQute.bnd.annotation/bnd.bnd
+++ b/biz.aQute.bnd.annotation/bnd.bnd
@@ -1,5 +1,13 @@
 # Set javac settings from JDT prefs
--include: ${workspace}/cnf/includes/jdt.bnd
+-include: ~${workspace}/cnf/includes/jdt.bnd
+
+# #7005: Keep this bundle compatible with Java 8 as long as possible. All other code is min. Java 17
+# It is because some libraries reference bnd annotations
+# like aQute.bnd.annotation.Cardinality, aQute.bnd.annotation.Resolution, aQute.bnd.annotation.spi.ServiceConsumer
+# directly in source code (e.g. https://github.com/apache/logging-log4j2/blob/752d023795fc518a38ecae73bb6455e2723cecea/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java)
+# but they need to stay compatible with java 8.
+javac.source = 8
+javac.target = 8
 
 Bundle-Description:     bnd Annotations Library
 

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/ConsumerType.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/ConsumerType.java
@@ -18,8 +18,10 @@ import java.lang.annotation.Target;
  * For an elaborate and simple explanation, see {@link ProviderType}.
  * </p>
  * Deprecated because being replaced by OSGi annotations
+ *
+ * @deprecated forRemoval since = "7.0.0"
  */
-@Deprecated(forRemoval = true, since = "7.0.0")
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/ProviderType.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/ProviderType.java
@@ -60,8 +60,10 @@ import java.lang.annotation.Target;
  * this interface" for @noimplement marked interfaces.
  * </p>
  * Deprecated because replaced by OSGi annotations
+ *
+ * @deprecated forRemoval since = "7.0.0"
  */
-@Deprecated(forRemoval = true, since = "7.0.0")
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)

--- a/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/Version.java
+++ b/biz.aQute.bnd.annotation/src/aQute/bnd/annotation/Version.java
@@ -8,8 +8,10 @@ import java.lang.annotation.Target;
 
 /**
  * Deprecated because made superfluous by OSGi annotations
+ *
+ * @deprecated forRemoval since = "7.0.0"
  */
-@Deprecated(forRemoval = true, since = "7.0.0")
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.CLASS)
 @Target({


### PR DESCRIPTION
Closes #7005

remove Java 9+ features: It was simply the attributes of the `@Deprecated` annotation. So we just put that into the comment and use plain `@Deprecated` which is Java8 compatible.

Then enforced compilation with java8

TODO: Not sure if we really want to do this or what the drawbacks are. Maybe with [bnd 8.0.0](https://github.com/bndtools/bnd/wiki/WIP-ideas-%E2%80%90-bnd-8.0.0-breaking-changes) we should remove java 8 support fully. 