### PR TITLE
skip reorderClause() for Bundle-NativeCode

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/JarTest.java
+++ b/biz.aQute.bndlib.tests/test/test/JarTest.java
@@ -645,6 +645,91 @@ public class JarTest {
 		assertEquals(customHeader, writtenCustomHeader);
 	}
 
+	/**
+	 * Test Bundle-NativeCode is untouched from Jar.reorderClause() for now,
+	 * because this header is special and needs to be parsed differently than
+	 * normal OSGi headers. In the future we could evaluate how to build a
+	 * special reordering for this header.
+	 */
+	@Test
+	public void testWriteManifestBundleNativeCodeNoReordering() throws Exception {
+		Manifest manifest = new Manifest();
+
+		String customHeader = """
+			   natives/linux-amd64/libgluegen_rt.so;
+			   natives/linux-amd64/libjocl.so;
+			   natives/linux-amd64/libnativewindow_awt.so;
+			   natives/linux-amd64/libnewt_drm.so;
+			   natives/linux-amd64/libnativewindow_x11.so;
+			   natives/linux-amd64/libnativewindow_drm.so;
+			   natives/linux-amd64/libnewt_head.so;
+			   natives/linux-amd64/libjogl_mobile.so;
+			   natives/linux-amd64/libjogl_desktop.so;
+			   processor=x86-64; osname=Linux
+			""";
+		manifest.getMainAttributes()
+			.putValue(Constants.BUNDLE_NATIVECODE, customHeader);
+
+		try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
+			Jar.writeManifest(manifest, bout);
+
+			Manifest writtenManifest = new Manifest(new ByteArrayInputStream(bout.toByteArray()));
+			String writtenCustomHeader = writtenManifest.getMainAttributes()
+				.getValue(Constants.BUNDLE_NATIVECODE);
+
+			assertEquals(customHeader.replaceAll("\n", "")
+				.replace(" ", ""),
+				writtenCustomHeader.replaceAll("\n", "")
+					.replace(" ", ""));
+		}
+	}
+
+	/**
+	 * Test Bundle-NativeCode is untouched from Jar.reorderClause() for now,
+	 * because this header is special and needs to be parsed differently than
+	 * normal OSGi headers. In the future we could evaluate how to build a
+	 * special reordering for this header.
+	 */
+	@Test
+	public void testWriteManifestBundleNativeCodeNoReordering2() throws Exception {
+		Manifest manifest = new Manifest();
+
+		String customHeader = """
+			f1;\
+			  osname=Windows95;
+			  processor=x86;
+			  selection-filter='(com.acme.windowing=win32)';
+			  language=en;
+			  osname=Windows98;
+			  language=se,
+			lib/solaris/libhttp.so;
+			  osname=Solaris;
+			  osname = SunOS ;
+			  processor = sparc,
+			lib/linux/libhttp.so;
+			  osname = Linux ;
+			  osversion = 3.1.4;
+			  processor = mips;
+			  selection-filter = '(com.acme.windowing=gtk)',
+			*""";
+		manifest.getMainAttributes()
+			.putValue(Constants.BUNDLE_NATIVECODE, customHeader);
+
+		try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
+			Jar.writeManifest(manifest, bout);
+
+			Manifest writtenManifest = new Manifest(new ByteArrayInputStream(bout.toByteArray()));
+			String writtenCustomHeader = writtenManifest.getMainAttributes()
+				.getValue(Constants.BUNDLE_NATIVECODE);
+
+			assertEquals(customHeader.replaceAll("\n", "")
+				.replace(" ", ""),
+				writtenCustomHeader.replaceAll("\n", "")
+					.replace(" ", ""));
+		}
+	}
+
+
 	@Test
 	public void testWriteManifestComprehensiveAttributeDirectiveOrdering() throws Exception {
 		Manifest manifest = new Manifest();

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Jar.java
@@ -786,7 +786,8 @@ public class Jar implements Closeable {
 			.entrySet()) {
 			String nice = clean((String) entry.getValue());
 			Object key = entry.getKey();
-			if (Constants.OSGI_SYNTAX_HEADERS.contains(key.toString())) {
+			if (Constants.OSGI_SYNTAX_HEADERS.contains(key.toString())
+				&& !Constants.BUNDLE_NATIVECODE.equals(key.toString())) {
 				nice = reorderClause(nice, collator);
 			}
 			mainAttributes.put(key, nice);


### PR DESCRIPTION
Closes #7028

The problem was introduced in https://github.com/bndtools/bnd/pull/6798 and this is a (quick) fix to restore 7.1.0 behavior. 

Also added a testcase so that we have this covered. In the future we could look into a better fix if needed (with the help of @gnodet ), which would require special reorderClause for Bundle-NativeCode, because [this header is special](https://bnd.bndtools.org/heads/bundle_nativecode.html) and cannot be parsed like normal OSGi headers, as Bundle-NativeCode is the only OSGi header with positional elements (paths) before attributes.