### PR TITLE
deprecate sonatype release mode for 7.3.0

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -1217,11 +1217,16 @@ public class Project extends Processor {
 		release(new ReleaseParameter(name, test, false));
 	}
 
+	@Deprecated(forRemoval = true, since = "7.3.0")
 	public static class ReleaseParameter {
+		@Deprecated
 		public String	name;
+		@Deprecated
 		public boolean	test;
+		@Deprecated
 		public boolean	lastBundleInWorkspace;
 
+		@Deprecated(forRemoval = true, since = "7.3.0")
 		public ReleaseParameter(String name, boolean test, boolean lastBundleInWorkspace) {
 			this.name = name;
 			this.test = test;
@@ -1229,6 +1234,10 @@ public class Project extends Processor {
 		}
 	}
 
+	/**
+	 * Do not use this method.
+	 */
+	@Deprecated(forRemoval = true, since = "7.3.0")
 	public void release(ReleaseParameter relParam) throws Exception, IOException {
 		List<RepositoryPlugin> releaseRepos = getReleaseRepos(relParam.name);
 		if (releaseRepos.isEmpty()) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/SonatypeMode.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/SonatypeMode.java
@@ -1,5 +1,6 @@
 package aQute.bnd.repository.maven.provider;
 
+@Deprecated(forRemoval = true, since = "7.3.0")
 public enum SonatypeMode {
 
 	/*
@@ -23,6 +24,7 @@ public enum SonatypeMode {
 		this.value = value;
 	}
 
+	@Deprecated
 	@Override
 	public String toString() {
 		return value;

--- a/docs/_plugins/maven.md
+++ b/docs/_plugins/maven.md
@@ -33,7 +33,7 @@ A configuration can look like this:
 			index=${.}/release.maven; \
 			name="Release"
 
-#### Release to Maven Central via Sonatype Central Portal
+#### Release to Maven Central via Sonatype Central Portal (deprecated for removal in 7.3.0)
 
 Maven Central now offers publishing through the [Sonatype Central Portal](https://central.sonatype.com/), which provides a streamlined publishing process. The MavenBndRepository plugin supports this with the `sonatypeMode` configuration property.
 


### PR DESCRIPTION
Preparation for #7027 (see https://github.com/bndtools/bnd/issues/7027#issuecomment-3724450223 )

as discussed today. The current implementation was a dead end and we will move it to another part of the build. It was needed to release bnd itself but should not be used anywhere outside