### PR TITLE
Fix baseline error

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/package-info.java
@@ -1,4 +1,4 @@
-@Version("7.6.0")
+@Version("8.0.0")
 package aQute.bnd.osgi;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Fixes master build because we increased the bnd baseline version to 7.2.1

