### PR TITLE
Include 6 in junit.platform import version range

### DIFF
--- a/biz.aQute.tester.junit-platform/bnd.bnd
+++ b/biz.aQute.tester.junit-platform/bnd.bnd
@@ -12,10 +12,17 @@ Bundle-Description: \
 # The dependency on aQute packages is only for the
 # launcher side. When launched, those dependencies
 # are not necessary
+# with the line 
+# org.junit.platform.commons.util;status=INTERNAL;version="[6,7)";resolution:=optional, \
+# more ActivatorJUnitPlatformLatestTest work with JUni6, but 
+# ActivatorJUnitPlatformEarliestTest all tests fail
+# TODO We need to find a new solution how to support JUnit6.
+# I doubt that  biz.aQute.tester.junit-platform can support JUnit5 and JUnit6
 Import-Package: \
 	aQute.*;resolution:=optional,\
 	junit.*;version="${range;[==,5);${junit3.version}}";resolution:=optional,\
 	org.apache.felix.service.command;resolution:=optional,\
+	org.junit.platform.commons.util;status=INTERNAL;version="[6,7)";resolution:=optional, \
 	org.junit.platform.*;version="${range;[==,7);${junit.platform.tester.version}}",\
 	org.junit.*;version="${range;[==,+);${junit4.tester.version}}";resolution:=optional,\
 	*

--- a/cnf/ext/junit.bnd
+++ b/cnf/ext/junit.bnd
@@ -20,8 +20,8 @@ junit4.eclipse.version=4.13.2
 # of junit-platform and the version we're building against.
 junit.jupiter.eclipse.version=5.10.1
 junit.platform.eclipse.version=1.10.1
-junit.jupiter.version=5.14.2
-junit.platform.version=1.14.2
+junit.jupiter.version=6.0.2
+junit.platform.version=6.0.2
 opentest4j.version=1.3.0
 assertj.version=3.24.2
 awaitility.version=4.2.0

--- a/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
+++ b/gradle-plugins/biz.aQute.bnd.gradle/build.gradle.kts
@@ -88,7 +88,7 @@ dependencies {
 	implementation("biz.aQute.bnd:biz.aQute.resolve:${version}")
 	runtimeOnly("biz.aQute.bnd:biz.aQute.bnd.embedded-repo:${version}")
 	// keep in sync with cnf/junit.bnd e.g. 'junit.jupiter.version'
-	testImplementation(enforcedPlatform("org.junit:junit-bom:5.14.2"))
+	testImplementation(enforcedPlatform("org.junit:junit-bom:6.0.2"))
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.spockframework:spock-core:${spockVersion}")

--- a/maven-plugins/bnd-plugin-parent/pom.xml
+++ b/maven-plugins/bnd-plugin-parent/pom.xml
@@ -24,7 +24,7 @@
 		<maven.target.version>3.3.9</maven.target.version>
 		<aether.version>1.0.2.v20150114</aether.version>
 		<!-- The following versions should match those in cnf/ext/junit.bnd -->
-		<junit.jupiter.version>5.14.2</junit.jupiter.version>
+		<junit.jupiter.version>6.0.2</junit.jupiter.version>
 		<assertj.version>3.27.6</assertj.version>
 	</properties>
 


### PR DESCRIPTION
Closes #7052

Updated the Import-Package directive to limit org.junit.platform.* to versions below 7, ensuring compatibility with supported JUnit Platform versions including to Junit6. This is because of JUnit6's new version scheme where all versions now start at 6.x : https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0#new-versioning-scheme

This creates the following `Import-Package` for `biz.aQute.tester.junit-platform.jar`

```
[MANIFEST]

Automatic-Module-Name                   biz.aQute.tester.junit-platform
Bundle-Activator                        aQute.tester.junit.platform.Activator
Bundle-Copyright                        Copyright (c) aQute SARL (2000, 2026) and others. All Rights Reserved.
Bundle-Description                      A bnd tester using JUnit Platform. Like biz.aQute.tester, this bundle will add itself to the -runbundles at the end. At startup, this bundle will then look for TestEngine implementations among the loaded bundles and use them to execute the tests. This bundle does NOT contain the necessary TestEngine implementations for JUnit 3, 4 or 5 - it will import them just like any other bundle.
Bundle-Developers                       bjhargrave;email="bj@hargrave.dev";name="BJ Hargrave";organization=IBM;organizationUrl="https://developer.ibm.com";roles=developer;timezone="America/New_York";url="https://github.com/bjhargrave"
                                        chrisrueger;email="chrisrueger@gmail.com";name="Christoph Rueger";organization="Synesty GmbH";organizationUrl="https://synesty.com/";roles=developer;timezone="Europe/Berlin"
                                        peterkir;email="peter@klib.io";name="Peter Kirschner";organization="Kirschners GmbH";organizationUrl="https://peterkir.github.io/";roles=developer;timezone="Europe/Berlin";url="https://peterkir.github.io"
                                        pkriens;email="Peter.Kriens@aQute.biz";name="Peter Kriens";organization=Bndtools;organizationUrl="https://github.com/bndtools";roles="architect,developer";timezone=1
                                        rotty3000;email="raymond.auge@liferay.com";name="Ray Augé";organization="Liferay Inc.";organizationUrl="https://www.liferay.com";roles=developer;timezone="America/New_York";url="https://rotty3000.github.io"
Bundle-DocURL                           https://bnd.bndtools.org/
Bundle-License                          (Apache-2.0 OR EPL-2.0);description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
Bundle-ManifestVersion                  2
Bundle-Name                             biz.aQute.tester.junit-platform
Bundle-SCM                              connection=scm:git:https://github.com/bndtools/bnd.git
                                        developerConnection=scm:git:git@github.com:bndtools/bnd.git
                                        tag=7.3.0-SNAPSHOT
                                        url=https://github.com/bndtools/bnd
Bundle-SymbolicName                     biz.aQute.tester.junit-platform
Bundle-Vendor                           Bndtools https://bndtools.org/
Bundle-Version                          7.3.0.202601141157-SNAPSHOT
Export-Package                          aQute.junit.system;version="7.3.0"
Git-Descriptor                          7.3.0.DEV-136-g5db283c12-dirty
Git-SHA                                 5db283c12d8caa48b1c912e9efc21283291b8d72
Import-Package                          aQute.bnd.build;version="[4.7,5)";resolution:=optional
                                        aQute.bnd.service;version="[4.9,5)";resolution:=optional
                                        aQute.junit.system;version="[7.3,8)";resolution:=optional
                                        javax.xml.stream
                                        junit.framework;version="[3.8,5)";resolution:=optional
                                        org.apache.felix.service.command;version="[1.0,2)";resolution:=optional
                                        org.junit.platform.commons.support;version="[1.10,7)"
                                        org.junit.platform.commons.util;version="[1.10,7)"
                                        org.junit.platform.commons;version="[1.10,7)"
                                        org.junit.platform.engine.discovery;version="[1.10,7)"
                                        org.junit.platform.engine.reporting;version="[1.10,7)"
                                        org.junit.platform.engine.support.descriptor;version="[1.10,7)"
                                        org.junit.platform.engine;version="[1.10,7)"
                                        org.junit.platform.launcher.core;version="[1.10,7)"
                                        org.junit.platform.launcher.listeners;version="[1.10,7)"
                                        org.junit.platform.launcher;version="[1.10,7)"
                                        org.junit;version="[4.10,5)";resolution:=optional
                                        org.opentest4j;version="[1.3,2)"
                                        org.osgi.framework.wiring;version="[1.2,2)"
                                        org.osgi.framework;version="[1.8,2)"
                                        org.osgi.util.tracker;version="[1.5,2)"
Manifest-Version                        1.0
Private-Package                         aQute.lib.hex;version="1.4.0"
                                        aQute.lib.strings;version="1.12.0"
                                        aQute.libg.qtokens;version="1.3.0"
                                        aQute.tester.bundle.engine
                                        aQute.tester.bundle.engine.discovery
                                        aQute.tester.junit.platform
                                        aQute.tester.junit.platform.plugin
                                        aQute.tester.junit.platform.reporting.legacy
                                        aQute.tester.junit.platform.reporting.legacy.xml
                                        aQute.tester.junit.platform.utils
Provide-Capability                      osgi.service;objectClass:List<String>="org.junit.platform.engine.TestEngine";effective:=active
                                        osgi.serviceloader;osgi.serviceloader="org.junit.platform.engine.TestEngine";register:="aQute.tester.bundle.engine.BundleEngine"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))";resolution:=optional
SPDX-License-Identifier                 (Apache-2.0 OR EPL-2.0)
Tester-Plugin                           aQute.tester.junit.platform.plugin.ProjectTesterImpl


```