### PR TITLE
DS: Error on missing public noArg constructor and no Activate

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
@@ -3876,7 +3876,7 @@ public class DSAnnotationTest {
 	}
 
 	@Component
-	static class VolatileField {
+	public static class VolatileField {
 		@Reference
 		private volatile LogService	log1;
 		@Reference
@@ -3915,7 +3915,7 @@ public class DSAnnotationTest {
 	}
 
 	@Component
-	static class FinalDynamicCollectionField {
+	public static class FinalDynamicCollectionField {
 		@Reference(policy = ReferencePolicy.DYNAMIC)
 		private final List<LogService>					logs1	= new CopyOnWriteArrayList<>();
 
@@ -3977,7 +3977,7 @@ public class DSAnnotationTest {
 	}
 
 	@Component
-	static class FieldCardinality {
+	public static class FieldCardinality {
 		@Reference
 		private List<LogService>				log1;
 		@Reference
@@ -4043,7 +4043,7 @@ public class DSAnnotationTest {
 	}
 
 	@Component
-	static class MismatchedUnbind {
+	public static class MismatchedUnbind {
 		@Reference
 		void setLogService10(LogService ls) {}
 
@@ -4101,14 +4101,14 @@ public class DSAnnotationTest {
 	}
 
 	@Component(service = Map.class)
-	static class NotAMap1 {}
+	public static class NotAMap1 {}
 
 	@Component(service = HashMap.class)
-	static class NotAMap2 {}
+	public static class NotAMap2 {}
 
 	@SuppressWarnings("serial")
 	@Component(service = HashMap.class)
-	static class NotAMap3 extends TreeMap<String, String> {
+	public static class NotAMap3 extends TreeMap<String, String> {
 
 		/**
 		 *
@@ -4125,7 +4125,7 @@ public class DSAnnotationTest {
 
 	@SuppressWarnings("serial")
 	@Component(service = Map.class)
-	static class IsAMap1 extends HashMap<String, String> {
+	public static class IsAMap1 extends HashMap<String, String> {
 
 		/**
 		 *
@@ -4134,7 +4134,7 @@ public class DSAnnotationTest {
 	}
 
 	@SuppressWarnings("serial")
-	static class MyHashMap1<K, V> extends HashMap<K, V> {
+	public static class MyHashMap1<K, V> extends HashMap<K, V> {
 
 		/**
 		 *
@@ -4144,7 +4144,7 @@ public class DSAnnotationTest {
 
 	@SuppressWarnings("serial")
 	@Component(service = HashMap.class)
-	static class IsAMap2 extends MyHashMap1<String, String> {
+	public static class IsAMap2 extends MyHashMap1<String, String> {
 
 		/**
 		 *
@@ -4165,7 +4165,7 @@ public class DSAnnotationTest {
 
 	@SuppressWarnings("serial")
 	@Component(service = Map.class)
-	static class IsAMap3 extends MyHashMap2<String, String> {
+	public static class IsAMap3 extends MyHashMap2<String, String> {
 
 		/**
 		 *
@@ -4177,7 +4177,7 @@ public class DSAnnotationTest {
 
 	@SuppressWarnings("serial")
 	@Component(service = Map.class)
-	static class IsAMap3a extends MyHashMap2<String, String> implements Marker {
+	public static class IsAMap3a extends MyHashMap2<String, String> implements Marker {
 
 		/**
 		 *
@@ -4186,7 +4186,7 @@ public class DSAnnotationTest {
 	}
 
 	@Component(service = Map.class)
-	static class IsAMap4 implements MyMap<String, String> {
+	public static class IsAMap4 implements MyMap<String, String> {
 
 		@Override
 		public int size() {
@@ -4561,6 +4561,65 @@ public class DSAnnotationTest {
 			// generate the desired reference name from the parameter name.
 			xt.assertAttribute(LogService.class.getName(), "scr:component/reference[@name='log']/@interface");
 			xt.assertAttribute("1", "scr:component/reference[@name='log']/@parameter");
+
+		}
+	}
+
+	@Component
+	public static class ConstructorInjectionMissingDefaultNoArgConstructor {
+
+		public ConstructorInjectionMissingDefaultNoArgConstructor(BundleContext bundleContext) {
+
+		}
+	}
+
+	@Test
+	public void testConstructorInjectionErrorOnMissingDefaultNoArgConstructor() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.DSANNOTATIONS,
+				"test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor");
+			b.setProperty("Private-Package", "test.component");
+			b.addClasspath(new File("bin_test"));
+
+			Jar jar = b.build();
+			// expect error because class has no noArg constructor and
+			b.check(
+				"test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor] The DS component class test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor must declare a public no-arg constructor, or a public constructor annotated with @Activate.");
+		}
+	}
+
+	@Component
+	public static class ConstructorInjectionDefaultNoArgConstructor {
+
+		public ConstructorInjectionDefaultNoArgConstructor() {
+
+		}
+
+		public ConstructorInjectionDefaultNoArgConstructor(BundleContext bundleContext) {
+
+		}
+	}
+
+	@Test
+	public void testConstructorInjectionDefaultNoArgConstructor() throws Exception {
+		try (Builder b = new Builder()) {
+			b.setProperty(Constants.DSANNOTATIONS,
+				"test.component.DSAnnotationTest$ConstructorInjectionDefaultNoArgConstructor");
+			b.setProperty("Private-Package", "test.component");
+			b.addClasspath(new File("bin_test"));
+
+			Jar jar = b.build();
+			assertOk(b);
+
+			Resource r = jar.getResource(
+				"OSGI-INF/test.component.DSAnnotationTest$ConstructorInjectionDefaultNoArgConstructor.xml");
+			assertNotNull(r);
+			r.write(System.err);
+			XmlTester xt = new XmlTester(r.openInputStream(), "scr", "http://www.osgi.org/xmlns/scr/v1.3.0");
+			xt.assertCount(0, "scr:component/properties");
+			xt.assertCount(0, "scr:component/property");
+			xt.assertAttribute("test.component.DSAnnotationTest$ConstructorInjectionDefaultNoArgConstructor",
+				"scr:component/implementation/@class");
 
 		}
 	}

--- a/biz.aQute.bndlib.tests/test/test/component/WildcardComponents.java
+++ b/biz.aQute.bndlib.tests/test/test/component/WildcardComponents.java
@@ -22,7 +22,7 @@ import aQute.lib.io.IO;
  */
 public class WildcardComponents {
 	@Component
-	static class WildcardTestComponent {}
+	public static class WildcardTestComponent {}
 
 	/**
 	 * Test to see if we ignore scala.ScalaObject as interface


### PR DESCRIPTION
Closes #7078

Bnd will now throw an error if a class with a `@Component` annotation 
- does not have a public no-arg constructor 
- and no `@Activate` annotation

Why?

This makes bnd more compliant with the DS Spec: https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.component.html#service.component-constructor.injection

> If the constructor has a parameter count that does not match the value of the init attribute in the component element, then the constructor must not be considered. If the value of the init attribute is 0, the default value, then the public no-parameter constructor must be used.



The error looks like this:
```
The DS component class MyClass must declare a public no-arg constructor, or a public constructor annotated with @Activate.
```

e.g. for classes like:

```
@Component
public class ConstructorInjectionMissingDefaultNoArgConstructor {

   public ConstructorInjectionMissingDefaultNoArgConstructor(BundleContext bundleContext) {

   }
}
```

or 

```
@Component
class ConstructorInjectionMissingDefaultNoArgConstructor {

}
```

The latter has an implicit no-arg constructor, but since the class is package private, the constructor is not considered public by java.

This error will make builds fail. 
In bndtools Eclipse plugin this will result in an error and a marker at the Class. 

<img width="783" height="139" alt="image" src="https://github.com/user-attachments/assets/51a4d90e-0bed-4622-bad0-55de3a39f9d8" />


<img width="791" height="297" alt="image" src="https://github.com/user-attachments/assets/da65b99f-6cc8-4598-84c0-2c6af19f21ed" />


In each case no .jar is created and no XML DS Component XML is created.

## Why the  Breaking change label

- Added the `breakingchange` label to make people aware and to remind me to mention it in the next release notes. 
- But this might not be a breaking change per se.
- This PR makes bnd more compliant with the DS Spec https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.component.html#service.component-constructor.injection

> If the constructor has a parameter count that does not match the value of the init attribute in the component element, then the constructor must not be considered. If the value of the init attribute is 0, the default value, then the public no-parameter constructor must be used.


So basically bnd will behave more strict so that it does **not** always generate a DS Component XML Descriptor anymore. It will throw an error lke:

```
The DS component class MyClass must declare a public no-arg constructor, or a public constructor annotated with @Activate.
```

The new thing **public** no-arg constructor.
Before this PR bnd just required a **no-arg constructor** and generate a XML component descriptor. 
This would be an invalid component descriptor which would fail at runtime, because e.g. Felix SCR [explicitly looks for public constructors](https://github.com/apache/felix-dev/blob/2282645785948c7acc5d6a5c1c9359cb8eb3a34c/scr/src/main/java/org/apache/felix/scr/impl/inject/internal/ComponentConstructorImpl.java#L98). 

So although this is a behavioral change, it must not be considered breaking, because it basically makes bnd more spec compliant. 

