### PR TITLE
DS: Add tests for inner-class constructor injection

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/component/constructorinjection/ConstructorInjectionErrorOnNonStaticInnerClassComponent.java
+++ b/biz.aQute.bndlib.tests/test/test/component/constructorinjection/ConstructorInjectionErrorOnNonStaticInnerClassComponent.java
@@ -1,0 +1,14 @@
+package test.component.constructorinjection;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConstructorInjectionErrorOnNonStaticInnerClassComponent.class)
+public class ConstructorInjectionErrorOnNonStaticInnerClassComponent {
+
+	@Component(service = ConstructorInjectionErrorOnNonStaticInnerClassComponentInner.class)
+	public class ConstructorInjectionErrorOnNonStaticInnerClassComponentInner {
+		// this should fail because a component on a non-static inner class
+		// cannot be instantiated by DS, because it has no way to get the outer
+		// instance
+	}
+}

--- a/biz.aQute.bndlib.tests/test/test/component/constructorinjection/ConstructorInjectionStaticInnerClassComponent.java
+++ b/biz.aQute.bndlib.tests/test/test/component/constructorinjection/ConstructorInjectionStaticInnerClassComponent.java
@@ -1,0 +1,13 @@
+package test.component.constructorinjection;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConstructorInjectionStaticInnerClassComponent.class)
+public class ConstructorInjectionStaticInnerClassComponent {
+
+	@Component(service = ConstructorInjectionStaticInnerClassComponentInner.class)
+	public static class ConstructorInjectionStaticInnerClassComponentInner {
+		// this static inner class component should work because it can be
+		// instantiated by DS
+	}
+}


### PR DESCRIPTION
Closes #7078 and successor of #7082

Add two test component classes and corresponding tests to verify DS constructor-injection behavior for inner classes. New classes: ConstructorInjectionErrorOnNonStaticInnerClassComponent (non-static inner should fail) and ConstructorInjectionStaticInnerClassComponent (static inner should succeed). Update DSAnnotationTest.java to import Pattern, add tests that build jars, assert expected failure for non-static inner class, assert success for static inner class, and validate generated OSGI-INF XML. Also include a minor whitespace fix and additional XML assertions for the existing default no-arg constructor test.

## Background

After using bnd 7.3.0-SNAPSHOT of #7082 a project of mine suddenly showed errors. It turns out we have put a `@Component` on a non-static inner class. 

At first [I thought](https://github.com/bndtools/bnd/issues/7078#issuecomment-3849010269) PR #7082 was wrong. But it turns out it is correct. Our code is wrong:

```

@Component(service = ConstructorInjectionErrorOnNonStaticInnerClassComponent.class)
public class ConstructorInjectionErrorOnNonStaticInnerClassComponent {

	@Component(service = ConstructorInjectionErrorOnNonStaticInnerClassComponentInner.class)
        @HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=app-context)")
        @HttpWhiteboardResource(pattern = "/templates/*", prefix = "/src/main/resource/apps/templates")
	public class ConstructorInjectionErrorOnNonStaticInnerClassComponentInner {
	}
}

```

This is impossible for DS to instantiate , as it has no outer instance. 
I guess we did not notice this until today, because the `@Component` is not really needed, and the only thing we need are the `@HttpWhiteboard` annotations. But since there was no error, we just didn't care. The app was working as expected. 

Now the error shows and we can react:
- either we remove the `@Component`
- or make the inner class `static`

