### PR TITLE
Re-resolve .bndrun files for bndtools development in Eclipse

### DIFF
--- a/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.aarch64.bndrun
@@ -48,7 +48,6 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
-	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
 	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\

--- a/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
+++ b/bndtools.core/bndtools.cocoa.macosx.x86_64.bndrun
@@ -46,7 +46,6 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
-	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
 	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\

--- a/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
+++ b/bndtools.core/bndtools.gtk.linux.x86_64.bndrun
@@ -45,7 +45,6 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
-	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
 	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\

--- a/bndtools.core/bndtools.shared.bndrun
+++ b/bndtools.core/bndtools.shared.bndrun
@@ -116,7 +116,7 @@
 	bnd.identity;id='org.apache.felix.scr';version='[0,2.1.16)',\
 	bnd.identity;id='osgi.*',\
 	bnd.identity;id='org.osgi.*.annotations',\
-	bnd.identity;id='biz.aQute.bndlib';version='[7.0.0,7.0.1)',\
+	bnd.identity;id='biz.aQute.bndlib';version='[7.0.0,${baseline.version})',\
 	bnd.identity;id='org.hamcrest';version='[3.0.0,4)'
 
 

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -44,7 +44,6 @@
 	bndtools.m2e.debug.fragment;version=snapshot,\
 	bndtools.pde;version=snapshot,\
 	bndtools.release;version=snapshot,\
-	com.google.errorprone.annotations;version='[2.38.0,2.38.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	com.google.guava;version='[33.4.8,33.4.9)',\
 	com.google.guava.failureaccess;version='[1.0.3,1.0.4)',\


### PR DESCRIPTION
- resolve all .bndruns
- ensure blacklist always excludes biz.aQute.bndlib from 7.0.0 up to latest bnd release (which is defined in the baseline.version in cnf/build.bnd). The reason for this exclusion is that we want to use the latest snapshot for resolving, but our Eclipse Repos also contain bndlib 7.0.0 which leads to resolver problems because the resolver gets stuck between multiple versions of bndlib