### PR TITLE
Update error message for DS component class requirements

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
@@ -4586,7 +4586,7 @@ public class DSAnnotationTest {
 			// expect error because class has no noArg constructor and
 			if (!b.check(
 				Pattern.quote(
-					"test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor] The DS component class test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor must declare a public no-arg constructor, or a public constructor annotated with @Activate.")))
+					"test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor] The DS component class test.component.DSAnnotationTest$ConstructorInjectionMissingDefaultNoArgConstructor must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with @Activate. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.")))
 				fail();
 		}
 	}
@@ -4605,7 +4605,7 @@ public class DSAnnotationTest {
 			// cannot be instantiated
 			if (!b.check(
 				Pattern.quote(
-					"The DS component class test.component.constructorinjection.ConstructorInjectionErrorOnNonStaticInnerClassComponent$ConstructorInjectionErrorOnNonStaticInnerClassComponentInner must declare a public no-arg constructor, or a public constructor annotated with @Activate")))
+					"The DS component class test.component.constructorinjection.ConstructorInjectionErrorOnNonStaticInnerClassComponent$ConstructorInjectionErrorOnNonStaticInnerClassComponentInner must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with @Activate. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.")))
 				fail();
 		}
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/component/DSAnnotationReader.java
@@ -183,7 +183,7 @@ public class DSAnnotationReader extends ClassDataCollector {
 			DeclarativeServicesAnnotationError details = new DeclarativeServicesAnnotationError(
 				implementationClass.getFQN(), null, null, ErrorType.INVALID_COMPONENT_TYPE);
 			details.addError(analyzer,
-				"[%s] The DS component class %s must declare a public no-arg constructor, or a public constructor annotated with @Activate.",
+				"[%s] The DS component class %s must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with @Activate. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.",
 				details.location(), implementationClass.getFQN());
 		}
 

--- a/docs/_chapters/200-components.md
+++ b/docs/_chapters/200-components.md
@@ -59,7 +59,7 @@ A DS component class must have **either**:
 If your component class has a constructor with parameters but no `@Activate` annotation, bnd will generate an error:
 
 ```
-The DS component class {className} must declare a public no-arg constructor, or a public constructor annotated with @Activate.
+The DS component class {className} must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with @Activate. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.
 ```
 
 **Examples of valid components:**

--- a/docs/_chapters/920-faq.md
+++ b/docs/_chapters/920-faq.md
@@ -125,7 +125,7 @@ Starting with bnd 7.3.0, bnd enforces the DS specification requirement that comp
 
 If you see this error:
 ```
-The DS component class {className} must declare a public no-arg constructor, or a public constructor annotated with @Activate.
+The DS component class {className} must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with @Activate. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.
 ```
 
 You need to either add a public no-arg constructor, use `@Activate` on your constructor, ensure your class is public, or make inner classes static.


### PR DESCRIPTION
Clarify error message as pointed out in https://github.com/bndtools/bnd/pull/7082#issuecomment-3911285753 (original issue https://github.com/bndtools/bnd/issues/7078 )

> The DS component class {className} must be publicly accessible and have either a public no-arg constructor or a public constructor annotated with `@Activate`. Non-public classes, including public inner classes enclosed in non-public classes, are not supported.