### PR TITLE
Exclude aQute.launcher.agent and pre packages

### DIFF
--- a/biz.aQute.launcher/bnd.bnd
+++ b/biz.aQute.launcher/bnd.bnd
@@ -28,6 +28,11 @@
 	aQute.launcher.plugin
 -includeresource: \
 	${p}.pre.jar=pre.jar
+	
+Import-Package: \
+		!aQute.launcher.agent,\
+		!aQute.launcher.pre,\
+		*;version="${range;[==,+)}"
 
 -builderignore: testresources
 


### PR DESCRIPTION
Closes #6476

exclude aQute.launcher.agent and aQute.launcher.pre while importing all other packages. This ensures those internal launcher packages are not considered for OSGi imports as no other bundle exports them


The MANIFEST of biz.aQute.launcher.jar now looks like this:

Notice the packages `aQute.launcher.agent` and `aQute.launcher.pre` are not there anymore.


```
[MANIFEST]

Automatic-Module-Name                   biz.aQute.launcher
Bundle-Copyright                        Copyright (c) aQute SARL (2000, 2026) and others. All Rights Reserved.
Bundle-Developers                       bjhargrave;email="bj@hargrave.dev";name="BJ Hargrave";organization=IBM;organizationUrl="https://developer.ibm.com";roles=developer;timezone="America/New_York";url="https://github.com/bjhargrave"
                                        chrisrueger;email="chrisrueger@gmail.com";name="Christoph Rueger";organization="Synesty GmbH";organizationUrl="https://synesty.com/";roles=developer;timezone="Europe/Berlin"
                                        peterkir;email="peter@klib.io";name="Peter Kirschner";organization="Kirschners GmbH";organizationUrl="https://peterkir.github.io/";roles=developer;timezone="Europe/Berlin";url="https://peterkir.github.io"
                                        pkriens;email="Peter.Kriens@aQute.biz";name="Peter Kriens";organization=Bndtools;organizationUrl="https://github.com/bndtools";roles="architect,developer";timezone=1
                                        rotty3000;email="raymond.auge@liferay.com";name="Ray Augé";organization="Liferay Inc.";organizationUrl="https://www.liferay.com";roles=developer;timezone="America/New_York";url="https://rotty3000.github.io"
Bundle-DocURL                           https://bnd.bndtools.org/
Bundle-License                          (Apache-2.0 OR EPL-2.0);description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
Bundle-ManifestVersion                  2
Bundle-Name                             biz.aQute.launcher
Bundle-SCM                              connection=scm:git:https://github.com/bndtools/bnd.git
                                        developerConnection=scm:git:git@github.com:bndtools/bnd.git
                                        tag=7.3.0-SNAPSHOT
                                        url=https://github.com/bndtools/bnd
Bundle-SymbolicName                     biz.aQute.launcher
Bundle-Vendor                           Bndtools https://bndtools.org/
Bundle-Version                          7.3.0.202602180824-SNAPSHOT
Git-Descriptor                          7.3.0.DEV-221-g066cc267c-dirty
Git-SHA                                 066cc267ce17f54bfa88eaa73938e1e13554eca2
Import-Package                          aQute.bnd.build;version="[4.7,5)"
                                        aQute.bnd.exceptions;version="[3.0,4)"
                                        aQute.bnd.header;version="[2.7,3)"
                                        aQute.bnd.help.instructions;version="[1.8,2)"
                                        aQute.bnd.osgi;version="[7.6,8)"
                                        aQute.service.reporter;version="[1.3,2)"
                                        org.osgi.framework.connect;version="[1.0,2)"
                                        org.osgi.framework.dto;version="[1.8,2)"
                                        org.osgi.framework.launch;version="[1.2,2)"
                                        org.osgi.framework.startlevel;version="[1.0,2)"
                                        org.osgi.framework.wiring;version="[1.2,2)"
                                        org.osgi.framework;version="[1.8,2)"
                                        org.osgi.resource;version="[1.0,2)"
                                        org.osgi.service.permissionadmin;version="[1.2,2)"
                                        org.slf4j;version="[2.0,3)"
Launcher-Plugin                         aQute.launcher.plugin.ProjectLauncherImpl
Manifest-Version                        1.0
Private-Package                         aQute.launcher
                                        aQute.launcher.constants
                                        aQute.launcher.minifw
                                        aQute.launcher.plugin
                                        aQute.lib.bundles;version="5.0.1"
                                        aQute.lib.collections;version="4.3.0"
                                        aQute.lib.hex;version="1.4.0"
                                        aQute.lib.io;version="4.5.0"
                                        aQute.lib.startlevel;version="1.0.0"
                                        aQute.lib.stringrover;version="1.2.0"
                                        aQute.lib.strings;version="1.12.0"
                                        aQute.lib.utf8properties;version="4.2.0"
                                        aQute.libg.cryptography;version="1.3.0"
                                        aQute.libg.glob;version="1.6.0"
                                        aQute.libg.parameters;version="1.1.0"
                                        aQute.libg.qtokens;version="1.3.0"
                                        aQute.libg.tuple;version="1.0"
                                        aQute.libg.uri;version="3.5.0"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
SPDX-License-Identifier                 (Apache-2.0 OR EPL-2.0)

```


and the contained `biz.aQute.launcher.pre.jar` like this:

```
[MANIFEST]

Bundle-Copyright                        Copyright (c) aQute SARL (2000, 2026) and others. All Rights Reserved.
Bundle-Developers                       bjhargrave;email="bj@hargrave.dev";name="BJ Hargrave";organization=IBM;organizationUrl="https://developer.ibm.com";roles=developer;timezone="America/New_York";url="https://github.com/bjhargrave"
                                        chrisrueger;email="chrisrueger@gmail.com";name="Christoph Rueger";organization="Synesty GmbH";organizationUrl="https://synesty.com/";roles=developer;timezone="Europe/Berlin"
                                        peterkir;email="peter@klib.io";name="Peter Kirschner";organization="Kirschners GmbH";organizationUrl="https://peterkir.github.io/";roles=developer;timezone="Europe/Berlin";url="https://peterkir.github.io"
                                        pkriens;email="Peter.Kriens@aQute.biz";name="Peter Kriens";organization=Bndtools;organizationUrl="https://github.com/bndtools";roles="architect,developer";timezone=1
                                        rotty3000;email="raymond.auge@liferay.com";name="Ray Augé";organization="Liferay Inc.";organizationUrl="https://www.liferay.com";roles=developer;timezone="America/New_York";url="https://rotty3000.github.io"
Bundle-DocURL                           https://bnd.bndtools.org/
Bundle-License                          (Apache-2.0 OR EPL-2.0);description="This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0, or the Eclipse Public License 2.0.";link="https://opensource.org/licenses/Apache-2.0,https://opensource.org/licenses/EPL-2.0"
Bundle-ManifestVersion                  2
Bundle-Name                             biz.aQute.launcher.pre
Bundle-SCM                              connection=scm:git:https://github.com/bndtools/bnd.git
                                        developerConnection=scm:git:git@github.com:bndtools/bnd.git
                                        tag=7.3.0-SNAPSHOT
                                        url=https://github.com/bndtools/bnd
Bundle-SymbolicName                     biz.aQute.launcher.pre
Bundle-Vendor                           Bndtools https://bndtools.org/
Bundle-Version                          7.3.0.202602180739-SNAPSHOT
Git-Descriptor                          7.3.0.DEV-220-g6b083e3e7-dirty
Git-SHA                                 6b083e3e78d549c4c7caf880901233db8f169bcb
Manifest-Version                        1.0
Premain-Class                           aQute.launcher.agent.LauncherAgent
Private-Package                         aQute.launcher.agent
                                        aQute.launcher.pre
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
SPDX-License-Identifier                 (Apache-2.0 OR EPL-2.0)
```


Furthermore the range of all remaining `Import-Package`s was changed to `${range;[==,+)}`