### PR TITLE
MavenBndRepo: Add converter for index between text and pom.xml (+ context menu in Repo Browser)

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/IndexFile.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,7 +79,7 @@ class IndexFile {
 	final IMavenRepo							repo;
 	private final Processor						domain;
 	private final Macro							replacer;
-	private final boolean						isPom;
+	final boolean								isPom;
 
 	final Reporter								reporter;
 	final PromiseFactory						promiseFactory;
@@ -457,7 +458,7 @@ class IndexFile {
 
 	private void save(Set<Archive> add, Set<Archive> remove) throws Exception {
 		if (isPom) {
-			POMIndexFile.savePom(indexFile, archives);
+			POMIndexFile.savePom(indexFile, sort(archives.keySet()));
 		} else {
 			saveText(add, remove);
 		}
@@ -507,6 +508,38 @@ class IndexFile {
 			return update(toAdd).thenAccept(b -> save(toAdd, toRemove));
 		});
 		sync(serializer);
+	}
+
+	void convertTextXml() {
+		Promise<Boolean> serializer = serialize(() -> {
+
+			if (isPom) {
+				try (Formatter f = new Formatter()) {
+					sort(archives.keySet()).forEach(archive -> f.format("%s\n", archive));
+					IO.store(f.toString(), indexFile);
+				}
+
+			} else {
+				POMIndexFile.savePom(indexFile, sort(archives.keySet()));
+			}
+			lastModified = indexFile.lastModified();
+			return null;
+		});
+		sync(serializer);
+
+	}
+
+	private static List<Archive> sort(Set<Archive> archives) {
+
+		// Compute archives from current state (update() already applied
+		// changes)
+		return archives.stream()
+			.sorted(Comparator.comparing((Archive a) -> a.revision.program.group)
+				.thenComparing(a -> a.revision.program.artifact)
+				.thenComparing(Comparator.comparing(a -> a.extension))
+				.thenComparing(Comparator.comparing(a -> a.classifier))
+				.thenComparing(a -> a.revision.version.toString()))
+			.collect(toList());
 	}
 
 	private Archive toArchive(String s, boolean macro) {

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -916,6 +916,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 							.size());
 						f.format("Storage                      : %s\n", localRepo);
 						f.format("Index                        : %s\n", index.indexFile);
+						f.format("Format                        : %s\n", index.isPom ? "pom.xml" : "text");
 						f.format("Release repos                : \n    %s\n", storage.getReleaseRepositories()
 							.stream()
 							.filter(Objects::nonNull)

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -136,6 +136,10 @@ public class MbrUpdater {
 		return changes;
 	}
 
+	void convertTextXml() throws Exception {
+		repo.index.convertTextXml();
+	}
+
 	private String format(MultiMap<Archive, MavenVersion> overlap) {
 		Justif j = new Justif(140, 50, 60, 70, 80, 90, 100, 110);
 		j.formatter()

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/POMIndexFile.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/POMIndexFile.java
@@ -1,13 +1,9 @@
 package aQute.bnd.repository.maven.provider;
 
-import static java.util.stream.Collectors.toList;
-
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -15,7 +11,6 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import org.osgi.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -89,7 +84,7 @@ abstract class POMIndexFile {
 		return text != null ? text.trim() : null;
 	}
 
-	static void savePom(File indexFile, Map<Archive, Resource> archives)
+	static void savePom(File indexFile, List<Archive> sortedArchives)
 		throws Exception {
 		// Read existing project-level metadata to preserve user values
 		String projectGroupId = "bnd.index";
@@ -120,17 +115,6 @@ abstract class POMIndexFile {
 				logger.debug("Could not read existing pom.xml metadata, using defaults", e);
 			}
 		}
-
-		// Compute archives from current state (update() already applied
-		// changes)
-		List<Archive> sortedArchives = archives.keySet()
-			.stream()
-			.sorted(Comparator.comparing((Archive a) -> a.revision.program.group)
-				.thenComparing(a -> a.revision.program.artifact)
-				.thenComparing(Comparator.comparing(a -> a.extension))
-				.thenComparing(Comparator.comparing(a -> a.classifier))
-				.thenComparing(a -> a.revision.version.toString()))
-			.collect(toList());
 
 		// Ensure parent directory exists
 		File parent = indexFile.getParentFile();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -53,6 +53,9 @@ class RepoActions {
 		map.put("Update Revisions :: To higher MAJOR revision", () -> {
 			upgradeRevisions(major);
 		});
+		map.put("Convert :: Text <--> pom.xml", () -> {
+			convertTextXmlRevisions();
+		});
 
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MICRO revision", () -> {
 			clipboard.copy(preview(micro));
@@ -261,6 +264,15 @@ class RepoActions {
 				repo.refresh();
 			}
 
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	private void convertTextXmlRevisions() {
+		try {
+			mbr.convertTextXml();
+			repo.refresh();
 		} catch (Exception e) {
 			throw Exceptions.duck(e);
 		}


### PR DESCRIPTION
This is a continuation of https://github.com/bndtools/bnd/pull/7137

Add right-click context menue to bndtools repo browser (on a repo entry), to convert repository index between plain text and pom.xml formats. Introduces IndexFile.convertTextXml() and a static IndexFile.sort(...) to produce a deterministic ordering of archives; POMIndexFile.savePom(...) signature changed to accept a sorted List<Archive> and no longer performs sorting. MbrUpdater and RepoActions expose a new conversion action, and MavenBndRepository now prints the index format in its diagnostics.

<img width="386" height="251" alt="image" src="https://github.com/user-attachments/assets/7639450f-797c-4fa1-bd8a-0b94114d0562" />

1. Right click on a Repo of type MavenBndRepository
2. Click `Text <--> pom.xml`

This will toggle the current index of the repository from (one GAV per line) text to pom.xml or vice versa.

The format is also shown in the tooltip of the repo (Refresh Workspace might be needed)

<img width="339" height="112" alt="image" src="https://github.com/user-attachments/assets/a4b3be6b-860b-4976-b952-906f23fc3071" />

