### PR TITLE
Template Fragments: Include 3rd-party dependency fragments in the warning

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
@@ -167,9 +167,7 @@ public class AddCommands {
 	}
 
 	private void showTemplatesFragments(List<TemplateInfo> availableTemplates) {
-		availableTemplates.forEach(ti -> bnd.out.format("%s - %s%n  - Organisation: %s%n  - Repo: %s %n", ti.name(),
-			ti.description(), ti.id()
-				.organisation(),
+		availableTemplates.forEach(ti -> bnd.out.format("%s - %s%n  - Repo: %s %n", ti.name(), ti.description(),
 			ti.id()
 				.repoUrl()));
 	}
@@ -195,12 +193,15 @@ public class AddCommands {
 			return;
 		}
 
-		List<TemplateInfo> thirdParty = selectedTemplates.stream()
+		List<TemplateInfo> selectedAndRequired = engine.resolveRequirements(selectedTemplates);
+		List<TemplateInfo> thirdParty = selectedAndRequired
+			.stream()
 			.filter(t -> !t.isOfficial())
 			.toList();
 
 		if (!thirdParty.isEmpty()) {
-			bnd.out.format("You have selected " + thirdParty.size() + " fragments from 3rd-party authors: %n");
+			bnd.out.format("Your selection would install " + thirdParty.size()
+				+ " fragments from 3rd-party authors (including required dependency fragments): %n");
 			showTemplatesFragments(thirdParty);
 
 			boolean confirmed = showConfirmation(

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
@@ -450,25 +450,25 @@ public class FragmentTemplateEngine {
 	 * Resolve all required templates recursively. This method processes the
 	 * 'require' field of each template and includes all transitively required
 	 * templates.
-	 * 
+	 *
 	 * @param templates the initial list of templates
 	 * @return a list containing the original templates plus all required
 	 *         templates, with duplicates removed
 	 */
-	List<TemplateInfo> resolveRequirements(List<TemplateInfo> templates) {
+	public List<TemplateInfo> resolveRequirements(List<TemplateInfo> templates) {
 		Set<TemplateID> seen = new HashSet<>();
 		List<TemplateInfo> result = new ArrayList<>();
-		
+
 		for (TemplateInfo template : templates) {
 			resolveRequirements(template, seen, result);
 		}
-		
+
 		return result;
 	}
 
 	/**
 	 * Recursively resolve requirements for a single template.
-	 * 
+	 *
 	 * @param template the template to resolve
 	 * @param seen set of already processed template IDs to prevent circular
 	 *            dependencies
@@ -479,20 +479,20 @@ public class FragmentTemplateEngine {
 		if (seen.contains(template.id())) {
 			return;
 		}
-		
+
 		seen.add(template.id());
-		
+
 		// First, recursively resolve all required templates
 		if (template.require() != null && template.require().length > 0) {
 			for (String requiredId : template.require()) {
 				TemplateID reqId = TemplateID.from(requiredId.trim());
-				
+
 				// Find the required template in our available templates
 				TemplateInfo requiredTemplate = templates.stream()
 					.filter(t -> t.id().equals(reqId))
 					.findFirst()
 					.orElse(null);
-				
+
 				if (requiredTemplate != null) {
 					// Recursively resolve this required template
 					resolveRequirements(requiredTemplate, seen, result);
@@ -502,7 +502,7 @@ public class FragmentTemplateEngine {
 				}
 			}
 		}
-		
+
 		// Add the current template after its dependencies
 		result.add(template);
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.1.0")
+@Version("1.2.0")
 package aQute.bnd.wstemplates;
 
 import org.osgi.annotation.versioning.Version;

--- a/bndtools.core/src/bndtools/shared/ConfirmDialogWithTextarea.java
+++ b/bndtools.core/src/bndtools/shared/ConfirmDialogWithTextarea.java
@@ -1,0 +1,40 @@
+package bndtools.shared;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * A confirmation dialog that displays a scrollable, copy-pasteable details area.
+ */
+public class ConfirmDialogWithTextarea extends MessageDialog {
+
+    private final String details;
+
+    public ConfirmDialogWithTextarea(Shell parentShell, String title, String message, String details) {
+        super(parentShell, title, null, message,
+              MessageDialog.QUESTION,
+              new String[] { "Install", "Cancel" }, 0);
+        this.details = details;
+    }
+
+    @Override
+    protected Control createCustomArea(Composite parent) {
+        Text text = new Text(parent, SWT.BORDER | SWT.MULTI | SWT.READ_ONLY | SWT.V_SCROLL | SWT.H_SCROLL | SWT.WRAP);
+        text.setText(details);
+        GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
+        gd.widthHint = 500;
+        gd.heightHint = 150;
+        text.setLayoutData(gd);
+        return text;
+    }
+
+    /** Returns true if the user clicked "Install" (index 0). */
+    public static boolean open(Shell shell, String title, String message, String details) {
+        ConfirmDialogWithTextarea dialog = new ConfirmDialogWithTextarea(shell, title, message, details);
+        return dialog.open() == 0;
+    }
+}

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -1,12 +1,14 @@
 package bndtools.wizards.newworkspace;
 
 import static aQute.bnd.wstemplates.FragmentTemplateEngine.DEFAULT_INDEX;
-import static org.eclipse.jface.dialogs.MessageDialog.openConfirm;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collections;
+import java.util.Formatter;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.bndtools.core.ui.icons.Icons;
@@ -17,6 +19,7 @@ import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
@@ -58,6 +61,7 @@ import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateInfo;
 import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateUpdater;
 import bndtools.Plugin;
 import bndtools.central.Central;
+import bndtools.shared.ConfirmDialogWithTextarea;
 import bndtools.util.ui.UI;
 
 /**
@@ -125,13 +129,26 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 
 		// show a confirmation dialog
 		// if there is at least one 3rd-party template selected
-		long num3rdParty = model.selectedTemplates.stream()
-			.filter(t -> !t.isOfficial())
-			.count();
 
-		boolean confirmed = num3rdParty == 0 || openConfirm(getShell(), "Install 3rd-Party templates",
-			"You have selected " + num3rdParty + " templates from 3rd-party authors. "
-				+ "Are you sure you trust the authors and want to continue fetching the content?");
+		List<TemplateInfo> selectedAndRequired = templates.resolveRequirements(model.selectedTemplates);
+		List<TemplateInfo> thirdParty = selectedAndRequired.stream()
+			.filter(t -> !t.isOfficial())
+			.toList();
+		long num3rdParty = thirdParty.size();
+
+		String title = "Install 3rd-Party templates";
+		String message = String.format("Your selection would install %s"
+			+ " templates from 3rd-party authors (including required dependency fragments): %n"
+			+ "%nAre you sure you trust the authors and want to continue fetching the content?", num3rdParty);
+		StringBuilder details = new StringBuilder();
+		try (Formatter f = new Formatter(details);) {
+			thirdParty.forEach(ti -> f.format("%n%s - %s (Repo: %s) %n", ti.name(), ti.description(),
+				ti.id()
+					.repoUrl()));
+		}
+
+		boolean confirmed = num3rdParty == 0
+			|| ConfirmDialogWithTextarea.open(getShell(), title, message, details.toString());
 
 		if (!confirmed) {
 			// not confirmed. cancel selected
@@ -148,6 +165,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			return false;
 
 	}
+
 
 	class NewWorkspaceWizardPage extends WizardPage {
 		NewWorkspaceWizardPage() {
@@ -188,6 +206,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 
 			CheckboxTableViewer selectedTemplates = CheckboxTableViewer.newCheckList(container,
 				SWT.BORDER | SWT.FULL_SELECTION);
+			ColumnViewerToolTipSupport.enableFor(selectedTemplates);
 			selectedTemplates.setContentProvider(ArrayContentProvider.getInstance());
 			Table table = selectedTemplates.getTable();
 			table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 6, 10));
@@ -267,9 +286,49 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 
 			});
 
+			TableViewerColumn requiresColumn = new TableViewerColumn(selectedTemplates, SWT.NONE);
+			requiresColumn.getColumn()
+				.setText("Requires");
+			requiresColumn.setLabelProvider(new ColumnLabelProvider() {
+
+				@Override
+				public String getText(Object element) {
+					if (element instanceof TemplateInfo ti) {
+						List<TemplateInfo> reqs = NewWorkspaceWizard.this.templates
+							.resolveRequirements(Collections.singletonList(ti));
+
+						long num3rdParty = reqs != null && reqs.size() > 1 ? reqs.stream()
+							.filter(rti -> !rti.isOfficial())
+							.count() : 0;
+
+						return reqs != null && reqs.size() > 1
+							? String.valueOf(reqs.size() - 1)
+								+ (num3rdParty > 0 ? " (" + num3rdParty + " 3rd Party)" : "")
+							: "0";
+					}
+					return super.getText(element);
+				}
+
+				@Override
+				public String getToolTipText(Object element) {
+					if (element instanceof TemplateInfo ti) {
+
+						List<TemplateInfo> reqs = NewWorkspaceWizard.this.templates
+							.resolveRequirements(Collections.singletonList(ti));
+						return reqs != null && reqs.size() > 1 ? "will be also installed: " + reqs.stream()
+							.filter(rti -> !rti.equals(ti))
+							.map(rti -> rti.name())
+							.collect(Collectors.joining(", "))
+							: "No dependencies";
+					}
+					return super.getToolTipText(element);
+				}
+			});
+
 			tableLayout.addColumnData(new ColumnWeightData(1, 200, false));
 			tableLayout.addColumnData(new ColumnWeightData(10, 460, true));
 			tableLayout.addColumnData(new ColumnWeightData(20, 100, true));
+			tableLayout.addColumnData(new ColumnWeightData(30, 50, true));
 
 			Button addButton = new Button(container, SWT.PUSH);
 			addButton.setText("+");


### PR DESCRIPTION
This hardens security of the Fragment template installation process.

Add recursive requirement resolution to FragmentTemplateEngine (made resolveRequirements public) and use it in AddCommands and NewWorkspaceWizard so prompts/counts include transitively required templates. Update prompt text to list third-party fragments (with repo info) and clarify that required dependency fragments are included. Also bump wstemplates package version to 1.2.0 and add minor formatting/import adjustments.

<img width="539" height="303" alt="image" src="https://github.com/user-attachments/assets/63b7d453-7c16-46d9-a34a-89d448083618" />

Also we now show a "Requires" column which shows the dependencies (required transitive dependent templates) which will also be installed. 

<img width="961" height="394" alt="image" src="https://github.com/user-attachments/assets/edae09d4-b2b0-41b5-9569-22aea6522480" />

<img width="461" height="114" alt="image" src="https://github.com/user-attachments/assets/5a3a66d8-637c-4277-9495-2be385a168e5" />

