### PR TITLE
Bundle Graph: Show first contributing package

### DIFF
--- a/bndtools.core/src/bndtools/views/bundlegraph/BundleGraphView.java
+++ b/bndtools.core/src/bndtools/views/bundlegraph/BundleGraphView.java
@@ -101,7 +101,7 @@ public class BundleGraphView extends ViewPart {
 	private Supplier<BundleGraphModel>			modelSupplier		= null;
 	private final Set<BundleNode>		selected		= new LinkedHashSet<>();
 	private ExpansionMode				mode			= ExpansionMode.ONLY_SELECTED;
-	private boolean						autoRender				= true;
+	private boolean						showFirstPackage	= false;
 	private EdgeFilter					edgeFilter				= EdgeFilter.ALL;
 
 	// UI
@@ -109,7 +109,7 @@ public class BundleGraphView extends ViewPart {
 	private TableViewer					selectedViewer;
 	private Text						filterText;
 	private Combo						modeCombo;
-	private Button						autoRenderCheck;
+	private Button						showFirstPackageCheck;
 	private Browser						browser;
 	private boolean						browserReady;
 	private SashForm					sash;
@@ -395,19 +395,20 @@ public class BundleGraphView extends ViewPart {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				mode = ExpansionMode.values()[modeCombo.getSelectionIndex()];
-				if (autoRender) {
-					rerender();
-				}
+				rerender();
 			}
 		});
 
-		autoRenderCheck = new Button(optRow, SWT.CHECK);
-		autoRenderCheck.setText("Auto-render");
-		autoRenderCheck.setSelection(true);
-		autoRenderCheck.addSelectionListener(new SelectionAdapter() {
+		showFirstPackageCheck = new Button(optRow, SWT.CHECK);
+		showFirstPackageCheck.setText("Show edge package");
+		showFirstPackageCheck.setToolTipText(
+			"Shows the first contributing package on an edge. This is helpful for debugging why two bundles are connected.");
+		showFirstPackageCheck.setSelection(false);
+		showFirstPackageCheck.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				autoRender = autoRenderCheck.getSelection();
+				showFirstPackage = showFirstPackageCheck.getSelection();
+				rerender();
 			}
 		});
 
@@ -503,9 +504,7 @@ public class BundleGraphView extends ViewPart {
 				@Override
 				public void completed(org.eclipse.swt.browser.ProgressEvent event) {
 					browserReady = true;
-					if (autoRender) {
-						rerender();
-					}
+					rerender();
 					applyZoom(currentZoomPercent); // ensures JS scale matches
 					// UI state
 				}
@@ -652,9 +651,7 @@ public class BundleGraphView extends ViewPart {
 		}
 		refreshAvailable();
 		selectedViewer.setInput(new ArrayList<>(selected));
-		if (autoRender) {
-			rerender();
-		}
+		rerender();
 	}
 
 	// ---- Private helpers ----
@@ -687,9 +684,7 @@ public class BundleGraphView extends ViewPart {
 		}
 		if (changed) {
 			selectedViewer.setInput(new ArrayList<>(selected));
-			if (autoRender) {
-				rerender();
-			}
+			rerender();
 		}
 	}
 
@@ -703,9 +698,7 @@ public class BundleGraphView extends ViewPart {
 		}
 		if (changed) {
 			selectedViewer.setInput(new ArrayList<>(selected));
-			if (autoRender) {
-				rerender();
-			}
+			rerender();
 		}
 	}
 
@@ -742,9 +735,7 @@ public class BundleGraphView extends ViewPart {
 		this.model = new SimpleBundleGraphModel(newNodes, newEdges, newJarMap);
 		refreshAvailable();
 		selectedViewer.setInput(new ArrayList<>(selected));
-		if (autoRender) {
-			rerender();
-		}
+		rerender();
 	}
 
 	private void addDependencies() {
@@ -752,9 +743,7 @@ public class BundleGraphView extends ViewPart {
 		boolean changed = selected.addAll(closure);
 		if (changed) {
 			selectedViewer.setInput(new ArrayList<>(selected));
-			if (autoRender) {
-				rerender();
-			}
+			rerender();
 		}
 	}
 
@@ -763,9 +752,7 @@ public class BundleGraphView extends ViewPart {
 		boolean changed = selected.addAll(closure);
 		if (changed) {
 			selectedViewer.setInput(new ArrayList<>(selected));
-			if (autoRender) {
-				rerender();
-			}
+			rerender();
 		}
 	}
 
@@ -787,7 +774,8 @@ public class BundleGraphView extends ViewPart {
 				break;
 		}
 		// Pass the user-selected (primary) set so the renderer can style them differently
-		lastMermaidDef = MermaidRenderer.toMermaid(model, subset, new LinkedHashSet<>(selected), edgeFilter);
+		lastMermaidDef = MermaidRenderer.toMermaid(model, subset, new LinkedHashSet<>(selected), edgeFilter,
+			showFirstPackage);
 		// Escape backticks for JS template literal
 		String escaped = lastMermaidDef.replace("\\", "\\\\")
 			.replace("`", "\\`");
@@ -813,9 +801,7 @@ public class BundleGraphView extends ViewPart {
 		selected.retainAll(newModel.nodes());
 		refreshAvailable();
 		selectedViewer.setInput(new ArrayList<>(selected));
-		if (autoRender) {
-			rerender();
-		}
+		rerender();
 	}
 
 	/**
@@ -881,9 +867,7 @@ public class BundleGraphView extends ViewPart {
 		Set<BundleEdge> recomputedEdges = ManifestDependencyCalculator.calculateEdges(mergedJarMap);
 		this.model = new SimpleBundleGraphModel(mergedNodes, recomputedEdges, mergedJarMap);
 		refreshAvailable();
-		if (autoRender) {
-			rerender();
-		}
+		rerender();
 	}
 
 	/**
@@ -895,9 +879,7 @@ public class BundleGraphView extends ViewPart {
 		boolean changed = selected.addAll(incoming.nodes());
 		if (changed) {
 			selectedViewer.setInput(new ArrayList<>(selected));
-			if (autoRender) {
-				rerender();
-			}
+			rerender();
 		}
 	}
 

--- a/bndtools.core/src/bndtools/views/bundlegraph/ManifestDependencyCalculator.java
+++ b/bndtools.core/src/bndtools/views/bundlegraph/ManifestDependencyCalculator.java
@@ -112,6 +112,9 @@ public final class ManifestDependencyCalculator {
 		// we emit an edge to each exporter.
 		// (importer, exporter) → list of per-package optional flags
 		Map<BundleNode, Map<BundleNode, List<Boolean>>> edgeOptionals = new LinkedHashMap<>();
+		// (importer, exporter) → first contributing package name
+		Map<BundleNode, Map<BundleNode, String>> edgeFirstPackage = new LinkedHashMap<>();
+
 		for (Map.Entry<BundleNode, Map<String, Boolean>> entry : importsWithOptional.entrySet()) {
 			BundleNode importer = entry.getKey();
 			for (Map.Entry<String, Boolean> pkgEntry : entry.getValue().entrySet()) {
@@ -122,6 +125,10 @@ public final class ManifestDependencyCalculator {
 						edgeOptionals.computeIfAbsent(importer, k -> new LinkedHashMap<>())
 							.computeIfAbsent(exporter, k -> new ArrayList<>())
 							.add(isOptional);
+						// Record the first package that established this
+						// (importer, exporter) edge
+						edgeFirstPackage.computeIfAbsent(importer, k -> new LinkedHashMap<>())
+							.putIfAbsent(exporter, pkg);
 					}
 				}
 			}
@@ -136,7 +143,9 @@ public final class ManifestDependencyCalculator {
 				List<Boolean> flags = toEntry.getValue();
 				boolean edgeIsOptional = flags.stream()
 					.allMatch(b -> b);
-				edges.add(new BundleEdge(from, to, edgeIsOptional));
+				String firstPkg = edgeFirstPackage.getOrDefault(from, Collections.emptyMap())
+					.getOrDefault(to, "");
+				edges.add(new BundleEdge(from, to, edgeIsOptional, firstPkg));
 			}
 		}
 		return edges;

--- a/bndtools.core/src/bndtools/views/bundlegraph/model/BundleEdge.java
+++ b/bndtools.core/src/bndtools/views/bundlegraph/model/BundleEdge.java
@@ -1,15 +1,55 @@
 package bndtools.views.bundlegraph.model;
 
+import java.util.Objects;
+
 /**
  * Represents a directed dependency edge between two bundle nodes.
  * <p>
- * An edge {@code (from, to)} means bundle {@code from} depends on bundle {@code to} (i.e., {@code from} imports at
- * least one package that {@code to} exports). The edge is considered <em>optional</em> when every
- * {@code Import-Package} entry that gave rise to this edge carries {@code resolution:=optional}; if at least one
- * contributing import is mandatory, the edge is mandatory.
+ * An edge {@code (from, to)} means bundle {@code from} depends on bundle
+ * {@code to} (i.e., {@code from} imports at least one package that {@code to}
+ * exports). The edge is considered <em>optional</em> when every
+ * {@code Import-Package} entry that gave rise to this edge carries
+ * {@code resolution:=optional}; if at least one contributing import is
+ * mandatory, the edge is mandatory.
  *
  * @param from the importing bundle
  * @param to the exporting bundle (the dependency)
- * @param optional {@code true} when every import that created this edge is {@code resolution:=optional}
+ * @param optional {@code true} when every import that created this edge is
+ *            {@code resolution:=optional}
+ * @param contributingPackage the first package name that gave rise to this edge
+ *            (may be empty, never {@code null})
  */
-public record BundleEdge(BundleNode from, BundleNode to, boolean optional) {}
+public record BundleEdge(BundleNode from, BundleNode to, boolean optional, String contributingPackage) {
+
+	public BundleEdge(BundleNode from, BundleNode to, boolean optional, String contributingPackage) {
+		this.from = Objects.requireNonNull(from, "from");
+		this.to = Objects.requireNonNull(to, "to");
+		this.optional = optional;
+		this.contributingPackage = contributingPackage != null ? contributingPackage : "";
+	}
+
+	/**
+	 * Convenience constructor for callers that do not track a contributing
+	 * package.
+	 */
+	public BundleEdge(BundleNode from, BundleNode to, boolean optional) {
+		this(from, to, optional, "");
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(from, optional, to);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		BundleEdge other = (BundleEdge) obj;
+		return Objects.equals(from, other.from) && optional == other.optional && Objects.equals(to, other.to);
+	}
+}

--- a/bndtools.core/src/bndtools/views/bundlegraph/render/MermaidRenderer.java
+++ b/bndtools.core/src/bndtools/views/bundlegraph/render/MermaidRenderer.java
@@ -1,6 +1,5 @@
 package bndtools.views.bundlegraph.render;
 
-import java.util.Collections;
 import java.util.Set;
 
 import bndtools.views.bundlegraph.model.BundleEdge;
@@ -14,59 +13,38 @@ public final class MermaidRenderer {
 
 	private MermaidRenderer() {}
 
-	/**
-	 * Produces a Mermaid {@code graph LR} definition for the given node subset. All nodes are rendered with the same
-	 * style. Only edges where both endpoints are in the subset are included.
-	 *
-	 * @param model the full graph model
-	 * @param subset the nodes to include in the diagram
-	 * @return Mermaid graph definition string
-	 */
-	public static String toMermaid(BundleGraphModel model, Set<BundleNode> subset) {
-		return toMermaid(model, subset, Collections.emptySet(), EdgeFilter.ALL);
-	}
+
 
 	/**
-	 * Produces a Mermaid {@code graph LR} definition for the given node subset, visually distinguishing "primary"
-	 * (user-selected seed) nodes from "secondary" (closure) nodes.
-	 * <p>
-	 * Primary nodes get a solid, highlighted border; secondary nodes get a dashed, muted border. Mandatory dependency
-	 * edges are rendered as solid arrows ({@code -->}); optional-only edges (where every contributing
-	 * {@code Import-Package} entry carried {@code resolution:=optional}) are rendered as dotted arrows ({@code -.->}).
-	 * Only edges where both endpoints are in the subset are included.
-	 *
-	 * @param model the full graph model
-	 * @param subset all nodes to include in the diagram (primary ∪ secondary)
-	 * @param primaryNodes the user-selected seed nodes (subset of {@code subset})
-	 * @return Mermaid graph definition string
-	 */
-	public static String toMermaid(BundleGraphModel model, Set<BundleNode> subset, Set<BundleNode> primaryNodes) {
-		return toMermaid(model, subset, primaryNodes, EdgeFilter.ALL);
-	}
-
-	/**
-	 * Produces a Mermaid {@code graph LR} definition for the given node subset, visually distinguishing "primary"
-	 * (user-selected seed) nodes from "secondary" (closure) nodes, and filtering edges according to
+	 * Produces a Mermaid {@code graph LR} definition for the given node subset,
+	 * visually distinguishing "primary" (user-selected seed) nodes from
+	 * "secondary" (closure) nodes, and filtering edges according to
 	 * {@code edgeFilter}.
 	 * <p>
-	 * Primary nodes get a solid, highlighted border; secondary nodes get a dashed, muted border. Mandatory dependency
-	 * edges are rendered as solid arrows ({@code -->}); optional-only edges are rendered as dotted arrows
+	 * Primary nodes get a solid, highlighted border; secondary nodes get a
+	 * dashed, muted border. Mandatory dependency edges are rendered as solid
+	 * arrows ({@code -->}); optional-only edges are rendered as dotted arrows
 	 * ({@code -.->}). The {@code edgeFilter} controls which edges are included:
 	 * <ul>
 	 * <li>{@link EdgeFilter#ALL} – all edges (mandatory and optional)</li>
-	 * <li>{@link EdgeFilter#ONLY_MANDATORY} – only edges that are not all-optional</li>
-	 * <li>{@link EdgeFilter#ONLY_OPTIONAL} – only edges that are all-optional</li>
+	 * <li>{@link EdgeFilter#ONLY_MANDATORY} – only edges that are not
+	 * all-optional</li>
+	 * <li>{@link EdgeFilter#ONLY_OPTIONAL} – only edges that are
+	 * all-optional</li>
 	 * </ul>
 	 * Only edges where both endpoints are in the subset are included.
 	 *
 	 * @param model the full graph model
 	 * @param subset all nodes to include in the diagram (primary ∪ secondary)
-	 * @param primaryNodes the user-selected seed nodes (subset of {@code subset})
+	 * @param primaryNodes the user-selected seed nodes (subset of
+	 *            {@code subset})
 	 * @param edgeFilter controls which dependency edges to include
+	 * @param showFirstPackage if <code>true</code> the first contributing
+	 *            package on an edge is shown
 	 * @return Mermaid graph definition string
 	 */
 	public static String toMermaid(BundleGraphModel model, Set<BundleNode> subset, Set<BundleNode> primaryNodes,
-		EdgeFilter edgeFilter) {
+		EdgeFilter edgeFilter, boolean showFirstPackage) {
 
 		// Collect active edges (filtered by edgeFilter, both endpoints in subset)
 		java.util.List<BundleEdge> activeEdges = new java.util.ArrayList<>();
@@ -128,13 +106,20 @@ public final class MermaidRenderer {
 		}
 
 		for (BundleEdge edge : activeEdges) {
-			// Arrow direction: 'to' exports something that 'from' imports → arrow points to --> from
+			// Arrow direction: 'to' exports something that 'from' imports →
+			// arrow points to --> from
 			String arrow = edge.optional() ? ".->" : "-->";
+			String firstPkg = edge.contributingPackage();
 			sb.append("    ")
 				.append(nodeId(edge.to()))
 				.append(" ")
-				.append(arrow)
-				.append(" ")
+				.append(arrow);
+			if (showFirstPackage && firstPkg != null && !firstPkg.isEmpty()) {
+				sb.append("|")
+					.append(escape(firstPkg))
+					.append("|");
+			}
+			sb.append(" ")
 				.append(nodeId(edge.from()))
 				.append("\n");
 		}

--- a/bndtools.core/test/bndtools/views/bundlegraph/GraphClosuresTest.java
+++ b/bndtools.core/test/bndtools/views/bundlegraph/GraphClosuresTest.java
@@ -2,6 +2,7 @@ package bndtools.views.bundlegraph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
@@ -193,5 +194,74 @@ public class GraphClosuresTest {
 		assertTrue(result.contains(b));
 		assertTrue(result.contains(c));
 		assertEquals(3, result.size());
+	}
+
+	@Test
+	public void nullContributingPackageIsNormalizedToEmptyString() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		BundleEdge edge = new BundleEdge(a, b, false, null);
+		assertNotNull(edge.contributingPackage(), "contributingPackage must never be null");
+		assertEquals("", edge.contributingPackage(), "null contributingPackage should be normalized to empty string");
+	}
+
+	@Test
+	public void equalsIgnoresContributingPackage() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		BundleEdge edgeWithPkg = new BundleEdge(a, b, false, "com.example.api");
+		BundleEdge edgeNoPkg = new BundleEdge(a, b, false);
+
+		assertEquals(edgeWithPkg, edgeNoPkg,
+			"Edges with same from/to/optional but different contributingPackage should be equal");
+	}
+
+	@Test
+	public void hashCodeIgnoresContributingPackage() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		BundleEdge edgeWithPkg = new BundleEdge(a, b, false, "com.example.api");
+		BundleEdge edgeNoPkg = new BundleEdge(a, b, false);
+
+		assertEquals(edgeWithPkg.hashCode(), edgeNoPkg.hashCode(),
+			"Hash codes must be equal when from/to/optional are the same");
+	}
+
+	@Test
+	public void edgesWithDifferentOptionalAreNotEqual() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		BundleEdge mandatory = new BundleEdge(a, b, false, "com.example.api");
+		BundleEdge optional = new BundleEdge(a, b, true, "com.example.api");
+
+		assertNotEquals(mandatory, optional, "Edges with different optional flag must not be equal");
+	}
+
+	@Test
+	public void edgesWithDifferentFromAreNotEqual() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+		BundleNode c = node("bundle.c");
+
+		BundleEdge edgeAB = new BundleEdge(a, b, false);
+		BundleEdge edgeCB = new BundleEdge(c, b, false);
+
+		assertNotEquals(edgeAB, edgeCB, "Edges with different 'from' nodes must not be equal");
+	}
+
+	@Test
+	public void edgesWithDifferentToAreNotEqual() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+		BundleNode c = node("bundle.c");
+
+		BundleEdge edgeAB = new BundleEdge(a, b, false);
+		BundleEdge edgeAC = new BundleEdge(a, c, false);
+
+		assertNotEquals(edgeAB, edgeAC, "Edges with different 'to' nodes must not be equal");
 	}
 }

--- a/bndtools.core/test/bndtools/views/bundlegraph/ManifestDependencyCalculatorTest.java
+++ b/bndtools.core/test/bndtools/views/bundlegraph/ManifestDependencyCalculatorTest.java
@@ -217,4 +217,73 @@ public class ManifestDependencyCalculatorTest {
 		assertEquals(2, edges.stream().filter(e -> e.from().equals(a)).count(),
 			"Exactly two edges from bundle.a (one per exporter of the split package)");
 	}
+
+	// ---- Tests for contributingPackage field ----
+
+	@Test
+	public void contributingPackageIsSetOnEdge() throws Exception {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		// b exports com.example.api; a imports it
+		Map<BundleNode, File> nodeToJar = new HashMap<>();
+		nodeToJar.put(a, createJar("bundle.a", null, "com.example.api"));
+		nodeToJar.put(b, createJar("bundle.b", "com.example.api", null));
+
+		Set<BundleEdge> edges = ManifestDependencyCalculator.calculateEdges(nodeToJar);
+
+		assertEquals(1, edges.size(), "Should be exactly one edge");
+		BundleEdge edge = edges.iterator()
+			.next();
+		assertEquals("com.example.api", edge.contributingPackage(),
+			"The contributing package should be the imported/exported package");
+	}
+
+	@Test
+	public void contributingPackageIsFirstImportedPackageWhenMultipleMatch() throws Exception {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		// b exports two packages; a imports both — contributingPackage should
+		// be the first one processed
+		Map<BundleNode, File> nodeToJar = new HashMap<>();
+		// Use a LinkedHashMap-friendly ordering: first entry in Import-Package
+		// is pkg.one
+		nodeToJar.put(a, createJar("bundle.a", null, "pkg.one,pkg.two"));
+		nodeToJar.put(b, createJar("bundle.b", "pkg.one,pkg.two", null));
+
+		Set<BundleEdge> edges = ManifestDependencyCalculator.calculateEdges(nodeToJar);
+
+		assertEquals(1, edges.size(), "Should be exactly one edge between a and b");
+		BundleEdge edge = edges.iterator()
+			.next();
+		// contributingPackage is the first package that established the edge
+		assertFalse(edge.contributingPackage()
+			.isEmpty(), "Contributing package should not be empty when packages are matched");
+		assertTrue(edge.contributingPackage()
+			.equals("pkg.one")
+			|| edge.contributingPackage()
+				.equals("pkg.two"),
+			"Contributing package should be one of the matched packages");
+	}
+
+	@Test
+	public void contributingPackageNotNullForOptionalEdge() throws Exception {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		// b exports com.example.api; a imports it as optional
+		Map<BundleNode, File> nodeToJar = new HashMap<>();
+		nodeToJar.put(a, createJar("bundle.a", null, "com.example.api;resolution:=optional"));
+		nodeToJar.put(b, createJar("bundle.b", "com.example.api", null));
+
+		Set<BundleEdge> edges = ManifestDependencyCalculator.calculateEdges(nodeToJar);
+
+		assertEquals(1, edges.size());
+		BundleEdge edge = edges.iterator()
+			.next();
+		assertTrue(edge.optional(), "Edge should be optional");
+		assertEquals("com.example.api", edge.contributingPackage(),
+			"Contributing package should be set even for optional edges");
+	}
 }

--- a/bndtools.core/test/bndtools/views/bundlegraph/MermaidRendererTest.java
+++ b/bndtools.core/test/bndtools/views/bundlegraph/MermaidRendererTest.java
@@ -41,7 +41,8 @@ public class MermaidRendererTest {
 	@Test
 	public void emptySubsetProducesMinimalGraph() {
 		BundleGraphModel model = graph(Collections.emptySet(), Collections.emptyMap());
-		String result = MermaidRenderer.toMermaid(model, Collections.emptySet());
+		String result = MermaidRenderer.toMermaid(model, Collections.emptySet(), Collections.emptySet(), EdgeFilter.ALL,
+			false);
 		assertTrue(result.startsWith("graph LR\n"), "Should start with graph LR header");
 	}
 
@@ -51,7 +52,7 @@ public class MermaidRendererTest {
 		Set<BundleNode> nodes = Collections.singleton(a);
 		BundleGraphModel model = graph(nodes, Collections.emptyMap());
 
-		String result = MermaidRenderer.toMermaid(model, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 
 		assertTrue(result.contains("com_example_bundle"), "Node id should replace dots with underscores");
 		assertTrue(result.contains("com.example.bundle"), "Node label should contain original BSN");
@@ -70,7 +71,7 @@ public class MermaidRendererTest {
 		deps.put(a, Collections.singleton(b)); // a depends on b
 
 		BundleGraphModel model = graph(nodes, deps);
-		String result = MermaidRenderer.toMermaid(model, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 
 		// Edge should be: b --> a (b exports something a imports)
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Should have solid edge from b to a");
@@ -91,7 +92,7 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graph(all, deps);
 		// Subset contains only 'a', not 'b'
 		Set<BundleNode> subset = Collections.singleton(a);
-		String result = MermaidRenderer.toMermaid(model, subset);
+		String result = MermaidRenderer.toMermaid(model, subset, Collections.emptySet(), EdgeFilter.ALL, false);
 
 		assertFalse(result.contains("-->") || result.contains(".->"),
 			"No edges when dependency endpoint not in subset");
@@ -106,7 +107,7 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graph(nodes, Collections.emptyMap());
 
 		// subset == primary: no secondary nodes → no classDef emitted
-		String result = MermaidRenderer.toMermaid(model, nodes, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, nodes, EdgeFilter.ALL, false);
 		assertFalse(result.contains("classDef"), "No classDef when all nodes are primary");
 		assertFalse(result.contains(":::"), "No class assignment when all nodes are primary");
 	}
@@ -122,7 +123,7 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graph(allNodes, Collections.emptyMap());
 
 		Set<BundleNode> primarySet = Collections.singleton(primary);
-		String result = MermaidRenderer.toMermaid(model, allNodes, primarySet);
+		String result = MermaidRenderer.toMermaid(model, allNodes, primarySet, EdgeFilter.ALL, false);
 
 		assertTrue(result.contains("classDef primary"), "Primary classDef should be declared");
 		assertTrue(result.contains("classDef secondary"), "Secondary classDef should be declared");
@@ -138,7 +139,7 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graph(nodes, Collections.emptyMap());
 
 		// Empty primary set → nothing to distinguish, no styling
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet());
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 		assertFalse(result.contains("classDef"), "No classDef when primary set is empty");
 	}
 
@@ -157,7 +158,7 @@ public class MermaidRendererTest {
 		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false));
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
-		String result = MermaidRenderer.toMermaid(model, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge should use solid --> arrow");
 		assertFalse(result.contains(".->"), "Mandatory edge should not use dotted arrow");
 	}
@@ -175,7 +176,7 @@ public class MermaidRendererTest {
 		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, true));
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
-		String result = MermaidRenderer.toMermaid(model, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 		assertTrue(result.contains("bundle_b .-> bundle_a"), "Optional edge should use dotted .-> arrow");
 		assertFalse(result.contains("-->"), "Optional edge should not use solid arrow");
 	}
@@ -194,7 +195,8 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
 		// includeOptional=false → dotted arrow should be suppressed, and both nodes hidden (no connected edges)
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY,
+			false);
 		assertFalse(result.contains("bundle_b .-> bundle_a"), "Optional edge should be hidden with EdgeFilter.ONLY_MANDATORY");
 		assertFalse(result.contains("-->"), "No solid arrow either");
 		assertFalse(result.contains("bundle_a"), "Disconnected node a should be hidden");
@@ -215,7 +217,8 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
 		// mandatory edge must still appear when ONLY_MANDATORY filter is active
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY,
+			false);
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge must still be shown");
 	}
 
@@ -235,7 +238,8 @@ public class MermaidRendererTest {
 		edges.add(new BundleEdge(a, c, true));  // a→c optional-only
 
 		BundleGraphModel model = graphWithEdges(nodes, edges);
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY,
+			false);
 
 		// mandatory edge must be present
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge should still be shown");
@@ -259,7 +263,7 @@ public class MermaidRendererTest {
 		edges.add(new BundleEdge(a, c, true));  // a→c optional
 
 		BundleGraphModel model = graphWithEdges(nodes, edges);
-		String result = MermaidRenderer.toMermaid(model, nodes);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge b→a should use solid arrow");
 		assertTrue(result.contains("bundle_c .-> bundle_a"), "Optional edge c→a should use dotted arrow");
@@ -281,7 +285,8 @@ public class MermaidRendererTest {
 		edges.add(new BundleEdge(a, c, true));  // a→c optional-only
 
 		BundleGraphModel model = graphWithEdges(nodes, edges);
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_OPTIONAL);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_OPTIONAL,
+			false);
 
 		// optional edge must be present, mandatory edge must be hidden
 		assertTrue(result.contains("bundle_c .-> bundle_a"), "Optional-only edge should be shown");
@@ -304,7 +309,8 @@ public class MermaidRendererTest {
 		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false)); // a→b mandatory
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ONLY_MANDATORY,
+			false);
 		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge should appear");
 		assertFalse(result.contains("bundle_c"), "Isolated node c must not appear");
 	}
@@ -337,7 +343,7 @@ public class MermaidRendererTest {
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 		Set<BundleNode> primarySet = Collections.singleton(assertjCore);
 
-		String result = MermaidRenderer.toMermaid(model, nodes, primarySet, EdgeFilter.ONLY_MANDATORY);
+		String result = MermaidRenderer.toMermaid(model, nodes, primarySet, EdgeFilter.ONLY_MANDATORY, false);
 
 		// The edge touching the primary node must appear
 		assertTrue(result.contains("assertj_core --> net_bytebuddy_byte_buddy")
@@ -362,7 +368,83 @@ public class MermaidRendererTest {
 		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false));
 		BundleGraphModel model = graphWithEdges(nodes, edges);
 
-		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL);
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
 		assertTrue(result.contains("bundle_c"), "Isolated node c must still appear under ALL filter");
+	}
+
+	// ---- Tests for showFirstPackage / contributingPackage ----
+
+	@Test
+	public void contributingPackageShownOnEdgeWhenShowFirstPackageIsTrue() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		Set<BundleNode> nodes = new LinkedHashSet<>();
+		nodes.add(a);
+		nodes.add(b);
+
+		// a depends on b via a mandatory edge with a known contributing package
+		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false, "com.example.api"));
+		BundleGraphModel model = graphWithEdges(nodes, edges);
+
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, true);
+		assertTrue(result.contains("|com.example.api|"),
+			"Contributing package should appear as edge label when showFirstPackage=true");
+	}
+
+	@Test
+	public void contributingPackageHiddenOnEdgeWhenShowFirstPackageIsFalse() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		Set<BundleNode> nodes = new LinkedHashSet<>();
+		nodes.add(a);
+		nodes.add(b);
+
+		// a depends on b via a mandatory edge with a known contributing package
+		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false, "com.example.api"));
+		BundleGraphModel model = graphWithEdges(nodes, edges);
+
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, false);
+		assertFalse(result.contains("|com.example.api|"),
+			"Contributing package should not appear when showFirstPackage=false");
+		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge should still appear");
+	}
+
+	@Test
+	public void emptyContributingPackageNotShownEvenWhenShowFirstPackageIsTrue() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		Set<BundleNode> nodes = new LinkedHashSet<>();
+		nodes.add(a);
+		nodes.add(b);
+
+		// a depends on b with no contributing package (empty string)
+		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, false));
+		BundleGraphModel model = graphWithEdges(nodes, edges);
+
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, true);
+		assertFalse(result.contains("||"), "No empty edge label should be rendered");
+		assertTrue(result.contains("bundle_b --> bundle_a"), "Mandatory edge should still appear");
+	}
+
+	@Test
+	public void contributingPackageShownOnOptionalEdgeWhenShowFirstPackageIsTrue() {
+		BundleNode a = node("bundle.a");
+		BundleNode b = node("bundle.b");
+
+		Set<BundleNode> nodes = new LinkedHashSet<>();
+		nodes.add(a);
+		nodes.add(b);
+
+		// a depends on b via an optional edge with a contributing package
+		Set<BundleEdge> edges = Collections.singleton(new BundleEdge(a, b, true, "com.example.optional"));
+		BundleGraphModel model = graphWithEdges(nodes, edges);
+
+		String result = MermaidRenderer.toMermaid(model, nodes, Collections.emptySet(), EdgeFilter.ALL, true);
+		assertTrue(result.contains("|com.example.optional|"),
+			"Contributing package should appear on optional edge when showFirstPackage=true");
+		assertTrue(result.contains(".->"), "Optional edge should use dotted arrow");
 	}
 }


### PR DESCRIPTION
- Record and optionally display the first package that created a dependency edge.  This makes debugging easier if you want to find out why two bundles are connected. For example I had two bundles with a cycle and it took me a while to pinpoint the responsible package. This should puts it in your face, if you need it. 

<img width="1121" height="665" alt="image" src="https://github.com/user-attachments/assets/06abf7d2-5738-4bd4-b81e-ffb71e9f8265" />


- Replace the former auto-render UI checkbox with a "Show edge package" checkbox in BundleGraphView and simplify rerender logic (always rerender on changes/browser-ready, because this is fast and the auto-render checkbox was not really needed).

- also: Remove toMermaid overloads Remove the convenience overloaded toMermaid methods. Were not really needed

