### PR TITLE
fix #7145

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -46,7 +46,7 @@ echo -e "#\n# build bnd and bndtools\n#\n"
     -Dmaven.repo.local=dist/m2 \
     -Dbnd.sonatype.release.description=${GITHUB_JOB}_${GITHUB_RUN_NUMBER} \
     --continue \
-    :build "$@"
+    build "$@"
 
 echo -e "#\n# build gradle plugins\n#\n"
 ./gradlew --no-daemon -Dmaven.repo.local=dist/m2 --continue :gradle-plugins:build


### PR DESCRIPTION
```
./gradlew \
    --no-daemon \
    -Dmaven.repo.local=dist/m2 \
    -Dbnd.sonatype.release.description=${GITHUB_JOB}_${GITHUB_RUN_NUMBER} \
    --continue \
    :build "$@"
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/9.2.0/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build 
Configuration on demand is an incubating feature.                                                                                                                                                        

> Configure project :gradle-plugins:biz.aQute.bnd.gradle
Signing plugin detected. Will automatically sign the published artifacts.

[Incubating] Problems report is available at: file:///C:/bnd/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Cannot locate tasks that match ':build' as task 'build' is ambiguous in root project 'bnd'. Candidates are: 'buildEnvironment', 'buildScanPublishPrevious', 'buildscriptDependencies'.
```