### PR TITLE
Handle P2 Repo features in bundle graph drag & drop

### DIFF
--- a/bndtools.core/src/bndtools/views/bundlegraph/BundleGraphDropAdapter.java
+++ b/bndtools.core/src/bndtools/views/bundlegraph/BundleGraphDropAdapter.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -26,10 +27,19 @@ import org.eclipse.swt.dnd.DropTargetEvent;
 import org.eclipse.swt.dnd.TransferData;
 import org.eclipse.ui.part.ResourceTransfer;
 
+import aQute.bnd.repository.p2.provider.P2Repository;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.version.Version;
+import aQute.p2.provider.Feature;
+import aQute.p2.provider.Feature.Includes;
+import aQute.p2.provider.Feature.Plugin;
+import bndtools.model.repo.FeatureFolderNode;
+import bndtools.model.repo.FeatureVersionNode;
+import bndtools.model.repo.IncludedBundleItem;
+import bndtools.model.repo.IncludedFeatureItem;
 import bndtools.model.repo.RepositoryBundle;
 import bndtools.model.repo.RepositoryBundleVersion;
+import bndtools.model.repo.RepositoryFeature;
 import bndtools.views.bundlegraph.model.BundleEdge;
 import bndtools.views.bundlegraph.model.BundleGraphModel;
 import bndtools.views.bundlegraph.model.BundleNode;
@@ -219,13 +229,169 @@ class BundleGraphDropAdapter extends ViewerDropAdapter {
 				wholeRepos.add((RepositoryPlugin) element);
 			} else if (element instanceof IResource) {
 				categorize((IResource) element, bndrunFiles, projects);
-			} else if (element instanceof IAdaptable) {
+			}
+			else if (element instanceof RepositoryFeature repofeature) {
+				try {
+
+					RepositoryPlugin repo = repofeature.getRepo();
+					if (repo instanceof P2Repository p2repo) {
+
+						Feature feature = repofeature.getFeature();
+						addFeatureRecursive(repoBundles, repoVersions, p2repo, feature, new HashSet<>());
+
+					}
+				} catch (Exception e) {
+					logger.logWarning("Failed to drop feature: " + repofeature, e);
+				}
+			}
+			else if (element instanceof FeatureVersionNode fvn) {
+				RepositoryPlugin repo = fvn.getRepo();
+				List<FeatureFolderNode> featureFolders = getFeatureChildren(fvn);
+				for (FeatureFolderNode featureFolderNode : featureFolders) {
+					addFeatureFolderNode(repoBundles, repoVersions, repo, featureFolderNode);
+				}
+			}
+			else if (element instanceof FeatureFolderNode ffn) {
+				RepositoryPlugin repo = ffn.getParent()
+					.getRepo();
+				addFeatureFolderNode(repoBundles, repoVersions, repo, ffn);
+
+			}
+			else if (element instanceof IncludedFeatureItem ifi) {
+				addIncludedFeatureItem(repoBundles, repoVersions, ifi);
+			}
+			else if (element instanceof IncludedBundleItem ibi) {
+				RepositoryPlugin repo = ibi.getParent()
+					.getParent()
+					.getRepo();
+				Plugin plugin = ibi.getPlugin();
+				RepositoryBundle bundle = new RepositoryBundle(repo, plugin.id);
+				repoBundles.add(bundle);
+			}
+			else if (element instanceof IAdaptable) {
 				IResource resource = ((IAdaptable) element).getAdapter(IResource.class);
 				if (resource != null) {
 					categorize(resource, bndrunFiles, projects);
 				}
 			}
 		}
+	}
+
+	private void addIncludedFeatureItem(List<RepositoryBundle> repoBundles, List<RepositoryBundleVersion> repoVersions,
+		IncludedFeatureItem ifi) {
+		RepositoryPlugin repo = ifi.getParent()
+			.getParent()
+			.getRepo();
+
+		if (repo instanceof P2Repository p2repo) {
+			Includes includes = ifi.getIncludes();
+
+			try {
+				Object featureObj = p2repo.getFeature(includes.id, includes.version);
+				if (featureObj instanceof Feature feature2) {
+					addFeatureRecursive(repoBundles, repoVersions, p2repo, feature2, new HashSet<>());
+				}
+
+			} catch (Exception e) {
+				logger.logWarning("Failed to drop feature: " + ifi, e);
+			}
+		}
+	}
+
+	/**
+	 * Recursively collects all bundles (plugins) from a feature and all its
+	 * transitively included sub-features.
+	 *
+	 * @param repoBundles collected RepositoryBundle list
+	 * @param repoVersions collected RepositoryBundleVersion list
+	 * @param p2repo the P2 repository to resolve included features
+	 * @param feature the feature to process
+	 * @param visited set of "id:version" strings to prevent infinite loops
+	 */
+	private void addFeatureRecursive(List<RepositoryBundle> repoBundles, List<RepositoryBundleVersion> repoVersions,
+		P2Repository p2repo, Feature feature, Set<String> visited) throws Exception {
+
+		String key = feature.getId() + ":" + feature.getVersion();
+		if (!visited.add(key)) {
+			return; // already processed, avoid cycles
+		}
+
+		// Add this feature's direct plugins
+		addFeature(repoBundles, repoVersions, p2repo, feature);
+
+		// Recurse into included sub-features
+		for (Feature.Includes includes : feature.getIncludes()) {
+			Feature subFeature = p2repo.getFeature(includes.id, includes.version);
+			if (subFeature != null) {
+				addFeatureRecursive(repoBundles, repoVersions, p2repo, subFeature, visited);
+			}
+		}
+	}
+
+	private void addFeature(List<RepositoryBundle> repoBundles, List<RepositoryBundleVersion> repoVersions,
+		RepositoryPlugin repo, Feature feature)
+		throws Exception {
+		List<Plugin> plugins = feature.getPlugins();
+		for (Plugin plugin : plugins) {
+			RepositoryBundle bundle = new RepositoryBundle(repo, plugin.id);
+			if(plugin.version != null) {
+				Version v = Version.parseVersion(plugin.version);
+				repoVersions.add(new RepositoryBundleVersion(bundle, v));
+			}
+			else {
+				repoBundles.add(bundle);
+			}
+		}
+	}
+
+	private void addFeatureFolderNode(List<RepositoryBundle> repoBundles, List<RepositoryBundleVersion> repoVersions,
+		RepositoryPlugin repo,
+		FeatureFolderNode featureFolderNode) {
+		if (FeatureFolderNode.FolderType.INCLUDED_BUNDLES == featureFolderNode.getType()) {
+			List<Object> children = featureFolderNode.getChildren();
+			for (Object child : children) {
+				if (child instanceof IncludedBundleItem ibi) {
+					Plugin plugin = ibi.getPlugin();
+					RepositoryBundle bundle = new RepositoryBundle(repo, plugin.id);
+					repoBundles.add(bundle);
+				}
+
+			}
+		}
+		else if (FeatureFolderNode.FolderType.INCLUDED_FEATURES == featureFolderNode.getType()) {
+			List<Object> children = featureFolderNode.getChildren();
+			for (Object child : children) {
+				if (child instanceof IncludedFeatureItem ifi) {
+					addIncludedFeatureItem(repoBundles, repoVersions, ifi);
+				}
+
+			}
+		}
+	}
+
+	private List<FeatureFolderNode> getFeatureChildren(FeatureVersionNode versionNode) {
+		// Create three folder nodes for the feature hierarchy
+		List<FeatureFolderNode> folders = new ArrayList<>();
+
+		FeatureFolderNode includedFeaturesFolder = new FeatureFolderNode(versionNode,
+			FeatureFolderNode.FolderType.INCLUDED_FEATURES);
+		if (includedFeaturesFolder.hasChildren()) {
+			folders.add(includedFeaturesFolder);
+		}
+
+		FeatureFolderNode requiredFeaturesFolder = new FeatureFolderNode(versionNode,
+			FeatureFolderNode.FolderType.REQUIRED_FEATURES);
+		if (requiredFeaturesFolder.hasChildren()) {
+			folders.add(requiredFeaturesFolder);
+		}
+
+		FeatureFolderNode includedBundlesFolder = new FeatureFolderNode(versionNode,
+			FeatureFolderNode.FolderType.INCLUDED_BUNDLES);
+		if (includedBundlesFolder.hasChildren()) {
+			folders.add(includedBundlesFolder);
+		}
+
+		return folders;
 	}
 
 	private void categorize(IResource resource, List<IFile> bndrunFiles, List<IProject> projects) {


### PR DESCRIPTION
First draft for recent https://github.com/bndtools/bnd/pull/7124 (Support for Eclipse Features in p2 repositories)

Add support for dropping P2 features and feature-related nodes into the bundle graph. The drop adapter now recognizes RepositoryFeature, FeatureVersionNode, FeatureFolderNode, IncludedFeatureItem and IncludedBundleItem (for P2Repository), extracts plugin ids and versions, and populates repoBundles/repoVersions accordingly. New helper methods (addFeature, addFeatureFolderNode, addIncludedFeatureItem, getFeatureChildren) centralize processing of features, included bundles/features and plugin versions. Errors while resolving features from P2Repository are caught and logged.

You can now drop:
- a whole P2Repo (worked already)
- a P2Feature
- an Included Features folder
  -  an Included Feature Item
- an Included Bundles folder
  - an Included Bundle Item


<img width="351" height="210" alt="image" src="https://github.com/user-attachments/assets/68f254b6-ff70-4e00-af17-9f5b696864f9" />


<img width="1324" height="753" alt="image" src="https://github.com/user-attachments/assets/dd4bc253-20ab-454b-8120-1c0734e31469" />
