### PR TITLE
Fix Resolution View stale data on empty loader selection

### DIFF
--- a/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
+++ b/bndtools.core/src/bndtools/views/resolution/ResolutionView.java
@@ -851,6 +851,13 @@ public class ResolutionView extends ViewPart implements ISelectionListener, IRes
 				analysisJob.schedule(500);
 			} else {
 				analysisJob = null;
+				if (display != null && !display.isDisposed()) {
+					display.asyncExec(() -> {
+						if (reqsTree != null && !reqsTree.isDisposed() && capsTable != null && !capsTable.isDisposed()) {
+							setInput(Collections.emptySet(), Collections.emptyMap(), Collections.emptyMap());
+						}
+					});
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Summary:\n- clear Resolution view input when selection yields no loaders\n- prevent stale requirements/capabilities from remaining visible\n\nRoot cause:\nexecuteAnalysis skipped work when loaders became empty but did not clear existing UI input, leaving previous results visible.\n\nValidation:\n- ./gradlew :bndtools.core:compileJava