### PR TITLE
deprecate -testterminate

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
@@ -91,10 +91,18 @@ public abstract class ProjectTester {
 		launcher.setCwd(dir);
 	}
 
+	/**
+	 * @deprecated forRemoval since = "8.0.0"
+	 */
+	@Deprecated
 	public boolean getTerminate() {
 		return terminate;
 	}
 
+	/**
+	 * @deprecated forRemoval since = "8.0.0"
+	 */
+	@Deprecated
 	public void setTerminate(boolean terminate) {
 		this.terminate = terminate;
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -302,6 +302,10 @@ public interface Constants {
 	String		TESTPACKAGES								= "-testpackages";
 	String		TESTPATH									= "-testpath";
 	String		TESTCONTINUOUS								= "-testcontinuous";
+	/**
+	 * @deprecated forRemoval since = "8.0.0"
+	 */
+	@Deprecated
 	String		TESTTERMINATE								= "-testterminate";
 	String		TESTSOURCES									= "-testsources";
 	String		TESTUNRESOLVED								= "-testunresolved";


### PR DESCRIPTION
mark the unused instruction as deprecated as suggested in PR #7158