### PR TITLE
Template Fragment Installation: Clarify 3rd-party template fragment warnings

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
@@ -201,11 +201,12 @@ public class AddCommands {
 
 		if (!thirdParty.isEmpty()) {
 			bnd.out.format("Your selection would install " + thirdParty.size()
-				+ " fragments from 3rd-party authors (including required dependency fragments): %n");
+				+ " template fragments from 3rd-party authors (including required dependency fragments): %n");
 			showTemplatesFragments(thirdParty);
 
 			boolean confirmed = showConfirmation(
-				"Are you sure you trust the authors and want to continue fetching the content?");
+				"These fragments may contain build instructions (e.g., .bnd files) that are executed with the next build. "
+					+ "Only continue if you fully trust the authors and the content.");
 
 			if (!confirmed) {
 				// not confirmed. cancel selected
@@ -227,7 +228,7 @@ public class AddCommands {
 	private boolean showConfirmation(String question) {
 		try (Scanner scanner = new Scanner(System.in)) {
 			while (true) {
-				bnd.out.format("%n%s (yes/no): ", question);
+				bnd.out.format("%n%s%nDo you want to proceed? (yes/no): ", question);
 				String input = scanner.nextLine()
 					.trim()
 					.toLowerCase();

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -138,8 +138,10 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 
 		String title = "Install 3rd-Party templates";
 		String message = String.format("Your selection would install %s"
-			+ " templates from 3rd-party authors (including required dependency fragments): %n"
-			+ "%nAre you sure you trust the authors and want to continue fetching the content?", num3rdParty);
+			+ " template fragments from 3rd-party authors (including required dependency fragments): %n"
+			+ "%nThese fragments may contain build instructions (e.g., .bnd files) that are executed with the next build.%n"
+			+ "Only continue if you fully trust the authors and the content.%n%n" + "Do you want to proceed?",
+			num3rdParty);
 		StringBuilder details = new StringBuilder();
 		try (Formatter f = new Formatter(details);) {
 			thirdParty.forEach(ti -> f.format("%n%s - %s (Repo: %s) %n", ti.name(), ti.description(),

--- a/docs/_chapters/620-template-fragments.md
+++ b/docs/_chapters/620-template-fragments.md
@@ -27,10 +27,11 @@ Official templates from the [bndtools Github organisation](https://github.com/bn
 Non-official templates from 3rd-party authors are shown with a yellow exclamation mark. 
 
 
-> ##### Note: Check templates before installation
-> Make sure you carefully check templates beforehand, since this is content from potentially untrusted sources which is downloaded to your computer.
-> You should double click on an entry to open the Github repostory of that template in your browser. 
-> This allows you to examine the content which is about to be downloaded to your workspace when you press finish. If you select at least one 3rd-Party template a confirmatin popup asks you to confirm, if you trust the authors. 
+> ##### Security Note: Check templates before installation
+> Make sure you carefully check fragment templates (including `required` dependency fragments) beforehand, since this is content from potentially untrusted sources which is downloaded to your computer. These fragments may contain build instructions (e.g., `${system}` macro in `.bnd`, `.bndrun` files) that are executed with the next build.
+> Bnd CLI and bndtools will display a confirmation dialog before installing 3rd-party fragment temmplates.
+> You should double click on an template entry to open the Github repostory of that template in your browser.
+> This allows you to examine the content which is about to be downloaded to your workspace when you press finish.
 {: .block-warning }
 
 The [workspace](/chapters/123-tour-workspace.html) is already prepared for this model of fragments. The [merged instructions][2] mean that 


### PR DESCRIPTION
Update user-facing prompts in AddCommands.java and NewWorkspaceWizard.java to improve clarity and safety. The text now adds an explicit warning that these fragments may contain build instructions (e.g., .bnd files) which are executed on the next build, asking users to proceed only if they fully trust the authors/content.

## Example CLI


```shell
bnd add fragment "IndexedMavenRepository"

Your selection would install 1 template fragments from 3rd-party authors (including required dependency fragments): 
IndexedMavenRepository - Provide an OSGi repository derived from a subset of one or more maven repositories
  - Repo: https://github.com/mnlipp/de.mnl.osgi/tree/master/de.mnl.osgi.bnd.repository/workspace-template 

These fragments may contain build instructions (e.g., .bnd files) that are executed with the next build. Only continue if you fully trust the authors and the content.
Do you want to proceed? (yes/no): 

# Yes

Added 1 template fragment(s): 
IndexedMavenRepository - Provide an OSGi repository derived from a subset of one or more maven repositories
  - Repo: https://github.com/mnlipp/de.mnl.osgi/tree/master/de.mnl.osgi.bnd.repository/workspace-template 

# No

No template fragments installed with workspace, because user did not confirm the installation.

```


## Example bndtools

<img width="541" height="357" alt="image" src="https://github.com/user-attachments/assets/9987706b-bc3f-4cf6-b470-774f0bf0de6c" />
