### PR TITLE
Allow overriding HTTPClient request headers

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
@@ -899,4 +899,53 @@ public class HttpClientTest {
 			}
 		}
 	}
+
+	@Test
+	public void testPluginCannotOverrideExplicitUserAgent() throws Exception {
+
+		// 1. no overriding of User-Agent
+		try (Processor p = new Processor()) {
+
+			// try to customize the user-agent, which should not work
+			p.setProperty("-plugin.my-override-useragent", "aQute.bnd.url.ConnectionSettings;match=\""
+				+ httpServer.getBaseURI() + "/*\";User-Agent=\"My own User Agent\"");
+
+			try (HttpClient client = new HttpClient()) {
+				client.setRegistry(p);
+
+				// this sets explicit User-Agent via .headers()
+				String response = client.build()
+					.headers("User-Agent", "Use me!")
+					.get(String.class)
+					.go(httpServer.getBaseURI("user-agent"));
+
+				assertThat(response).contains("Use me!");
+			}
+
+		}
+	}
+
+	@Test
+	public void testPluginCanSetUserAgent() throws Exception {
+
+		try (Processor p = new Processor()) {
+
+			// now customize the user-agent, which now should work
+			p.setProperty("-plugin.my-override-useragent", "aQute.bnd.url.ConnectionSettings;match=\""
+				+ httpServer.getBaseURI() + "/*\";User-Agent=\"My own User Agent\"");
+
+			try (HttpClient client = new HttpClient()) {
+				client.setRegistry(p);
+
+				// because .headersIfAbsent() only sets the default if not set
+				// otherwise
+				String response = client.build()
+					.headersIfAbsent("User-Agent", "Don't use me!")
+					.get(String.class)
+					.go(httpServer.getBaseURI("user-agent"));
+
+				assertThat(response).contains("My own User Agent");
+			}
+		}
+	}
 }

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -567,6 +567,7 @@ public class HttpClient implements Closeable, URLConnector {
 					Dates.formatMillis(Dates.RFC_7231_DATE_TIME, request.ifUnmodifiedSince));
 			}
 
+			setHeadersIfAbsent(request.headersIfAbsent, con);
 			setHeaders(request.headers, con);
 
 			configureHttpConnection(request.verb, hcon);
@@ -724,6 +725,21 @@ public class HttpClient implements Closeable, URLConnector {
 				stream = stream.peek((k, v) -> logger.debug("set header {}={}", k, v));
 			}
 			stream.forEachOrdered(con::setRequestProperty);
+		}
+
+		private void setHeadersIfAbsent(Map<String, String> headers, URLConnection con) {
+			MapStream<String, String> stream = MapStream.ofNullable(headers);
+			if (logger.isDebugEnabled()) {
+				stream = stream.peek((k, v) -> logger.debug("set header {}={}", k, v));
+			}
+			stream.forEachOrdered((k, v) -> {
+				String existing = con.getRequestProperty(k);
+				// don't override headers which are already set
+				// e.g. via -plugin aQute.bnd.url.ConnectionSettings
+				if (existing == null) {
+					con.setRequestProperty(k, v);
+				}
+			});
 		}
 
 		private Object convert(Type type, File in, TaggedData tag) throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpRequest.java
@@ -27,6 +27,7 @@ public class HttpRequest<T> {
 	Object				upload;
 	Type				download;
 	Map<String, String>	headers			= new HashMap<>();
+	Map<String, String>	headersIfAbsent	= new HashMap<>();
 	long				timeout			= -1;
 	HttpClient			client;
 	String				ifNoneMatch;
@@ -163,10 +164,18 @@ public class HttpRequest<T> {
 	}
 
 	/**
-	 * Add header to request
+	 * Add an explicit header to request
 	 */
 	public HttpRequest<T> headers(String key, String value) {
 		headers.put(key, value);
+		return this;
+	}
+
+	/**
+	 * Add a default header which is only set if not otherwise set.
+	 */
+	public HttpRequest<T> headersIfAbsent(String key, String value) {
+		headersIfAbsent.put(key, value);
 		return this;
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("2.1.0")
 package aQute.bnd.http;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/SearchRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/SearchRepository.java
@@ -104,7 +104,7 @@ class SearchRepository extends InnerRepository {
 				logger.debug("Searching {}", query);
 
 				SearchResult result = client.build()
-					.headers("User-Agent", "Bnd")
+					.headersIfAbsent("User-Agent", "Bnd")
 					.useCache(cacheFile, DEFAULT_MAX_STALE)
 					.get(SearchResult.class)
 					.go(url);

--- a/biz.aQute.repository/src/aQute/maven/nexus/provider/Nexus.java
+++ b/biz.aQute.repository/src/aQute/maven/nexus/provider/Nexus.java
@@ -82,7 +82,7 @@ public class Nexus {
 	public HttpRequest<Object> request() {
 		return client.build()
 			.headers("Accept", "application/json")
-			.headers("User-Agent", "bnd");
+			.headersIfAbsent("User-Agent", "bnd");
 	}
 
 	public List<URI> files() throws Exception {
@@ -317,7 +317,7 @@ public class Nexus {
 		URI upload = getUri().resolve("service/local/staging/deployByRepositoryId/" + repositoryId + "/" + remotePath);
 		TaggedData go = client.build()
 			.upload(file)
-			.headers("User-Agent", "Bnd")
+			.headersIfAbsent("User-Agent", "Bnd")
 			.headers("Content-Type", "application/xml")
 			.asTag()
 			.put()
@@ -346,7 +346,7 @@ public class Nexus {
 	public TaggedData fetchStaging(String repositoryId, String remotePath, boolean force) throws Exception {
 		URI uri = getUri().resolve("service/local/staging/deployByRepositoryId/" + repositoryId + "/" + remotePath);
 		return client.build()
-			.headers("User-Agent", "Bnd")
+			.headersIfAbsent("User-Agent", "Bnd")
 			.asTag()
 			.get()
 			.go(uri);
@@ -355,7 +355,7 @@ public class Nexus {
 	public TaggedData deleteStaging(String repositoryId, String remotePath) throws Exception {
 		URI uri = getUri().resolve("service/local/staging/deployByRepositoryId/" + repositoryId + "/" + remotePath);
 		return client.build()
-			.headers("User-Agent", "Bnd")
+			.headersIfAbsent("User-Agent", "Bnd")
 			.asTag()
 			.delete()
 			.go(uri);

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRemoteRepository.java
@@ -14,11 +14,11 @@ import org.osgi.util.promise.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.http.HttpRequestException;
 import aQute.bnd.service.url.State;
 import aQute.bnd.service.url.TaggedData;
-import aQute.bnd.exceptions.Exceptions;
 import aQute.libg.cryptography.MD5;
 import aQute.libg.cryptography.SHA1;
 import aQute.libg.uri.URIUtil;
@@ -63,7 +63,7 @@ public class MavenRemoteRepository extends MavenBackingRepository {
 	private Promise<TaggedData> fetch(String path, File file, int retries, long delay, boolean force) throws Exception {
 		logger.debug("Fetching {}", path);
 		return client.build()
-			.headers("User-Agent", "Bnd")
+			.headersIfAbsent("User-Agent", "Bnd")
 			.useCache(file, force ? -1 : DEFAULT_MAX_STALE)
 			.asTag()
 			.async(new URL(base + path))

--- a/docs/_instructions/_ext/connection_settings.md
+++ b/docs/_instructions/_ext/connection_settings.md
@@ -154,6 +154,26 @@ getting a remote file.
 or in the `eclipse.ini` file or through some other means. In that case, make sure not specify the `<trust/>` nor `<verify/>` element 
 in a `connection-settings.xml`. The reason is that once you specify those element, the built-in Java mechanism is replaced with bnd code.
 
+## Overriding HTTP Request Headers
+
+The internal `HTTPClient` sets some HTTP requests headers by default, for example `"User-Agent=bnd"`.
+To customize the HTTP headers, you can use a plugin. 
+
+**Example: Customize User-Agent**
+
+
+
+```
+# e.g. in your /cnf/build.bnd
+-plugin.my-override-useragent: \
+  aQute.bnd.url.ConnectionSettings; \
+    match="https://repo.maven.apache.org/maven2/*"; \
+    User-Agent="My own User Agent"
+```
+
+With this configuration each HTTP requests by bnd (e.g. when downloading a dependency from Maven Central) will use that User-Agent instead of the default one. 
+
+
 
 [1]: https://bnd.discourse.group/t/using-client-certificate-for-server-authentication/85
 


### PR DESCRIPTION
Closes #7228


This pull request improves the handling and documentation of HTTP request headers in the `HttpClient` class. The main change ensures that custom headers provided by plugins are not overridden by default headers, and the documentation now explains how to customize headers such as `User-Agent`.

**HTTP Header Handling Improvements:**

* Modified `setHeaders` in `HttpClient.java` to only set a request property if it has not already been set, preventing default headers from overwriting custom ones provided by plugins.

**Documentation Updates:**

* Added a new section to the documentation explaining how to override HTTP request headers (such as `User-Agent`) using a plugin in your build configuration.