### PR TITLE
[maven][resolve] Provide a better logging experience for maven users when resolving

### DIFF
--- a/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Bndrun.java
@@ -104,11 +104,35 @@ public class Bndrun extends Run {
 		return resolve(failOnChanges, writeOnChanges, runbundlesListFormatter);
 	}
 
+	/**
+	 * Use the resolver to calculate the <code>-runbundles</code> required to
+	 * execute the bndrun configuration.
+	 * <p>
+	 * Use the return value with {@link Run#setProperty(String, String)} with
+	 * key {@link Constants#RUNBUNDLES}
+	 *
+	 * @param failOnChanges if the build should fail when changes to the
+	 *            <code>-runbundles</code> are detected
+	 * @param writeOnChanges if the bndrun file should be updated when changes
+	 *            to the <code>-runbundles</code> are detected are detected
+	 * @param logger the logger to use to report the resolve operation
+	 * @return the calculated <code>-runbundles</code>
+	 * @throws Exception
+	 */
+	public String resolve(boolean failOnChanges, boolean writeOnChanges, ResolverLogger logger) throws Exception {
+		return resolve(failOnChanges, writeOnChanges, runbundlesListFormatter, null);
+	}
+
 	public <T> T resolve(boolean failOnChanges, boolean writeOnChanges,
 		Converter<T, Collection<? extends HeaderClause>> runbundlesFormatter) throws Exception {
+		return resolve(failOnChanges, writeOnChanges, runbundlesFormatter, null);
+	}
+
+	public <T> T resolve(boolean failOnChanges, boolean writeOnChanges,
+		Converter<T, Collection<? extends HeaderClause>> runbundlesFormatter, ResolverLogger logger) throws Exception {
 
 		checkValidate();
-		RunResolution resolution = RunResolution.resolve(this, this, null);
+		RunResolution resolution = RunResolution.resolve(this, this, null, logger);
 
 		if (!resolution.isOK()) {
 			throw resolution.exception;
@@ -118,8 +142,12 @@ public class Bndrun extends Run {
 	}
 
 	public RunResolution resolve(ResolutionCallback... callbacks) throws Exception {
+		return resolve(null, callbacks);
+	}
+
+	public RunResolution resolve(ResolverLogger logger, ResolutionCallback... callbacks) throws Exception {
 		checkValidate();
-		RunResolution resolution = RunResolution.resolve(this, this, Arrays.asList(callbacks))
+		RunResolution resolution = RunResolution.resolve(this, this, Arrays.asList(callbacks), logger)
 			.reportException();
 		if (!resolution.isOK()) {
 			if (resolution.exception instanceof ResolutionException re) {

--- a/biz.aQute.resolve/src/biz/aQute/resolve/Slf4jResolverLogger.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/Slf4jResolverLogger.java
@@ -1,0 +1,51 @@
+package biz.aQute.resolve;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Slf4jResolverLogger extends ResolverLogger {
+
+	private static final Logger logger = LoggerFactory.getLogger(Slf4jResolverLogger.class);
+
+	@Override
+	public void log(int level, String msg, Throwable throwable) {
+		super.log(level, msg, throwable);
+		if (throwable == null) {
+			switch (level) {
+				case LOG_DEBUG :
+					logger.debug(msg);
+					break;
+				case LOG_ERROR :
+					logger.error(msg);
+					break;
+				case LOG_INFO :
+					logger.info(msg);
+					break;
+				case LOG_WARNING :
+					logger.warn(msg);
+					break;
+				default :
+					logger.warn("Unknown log level {}. Log message was {}", level, msg);
+					break;
+			}
+		} else {
+			switch (level) {
+				case LOG_DEBUG :
+					logger.debug(msg, throwable);
+					break;
+				case LOG_ERROR :
+					logger.error(msg, throwable);
+					break;
+				case LOG_INFO :
+					logger.info(msg, throwable);
+					break;
+				case LOG_WARNING :
+					logger.warn(msg, throwable);
+					break;
+				default :
+					logger.warn("Unknown log level {}. Log message was {}", level, msg, throwable);
+					break;
+			}
+		}
+	}
+}

--- a/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
+++ b/biz.aQute.resolve/src/biz/aQute/resolve/package-info.java
@@ -1,4 +1,4 @@
-@Version("9.2.0")
+@Version("9.3.0")
 package biz.aQute.resolve;
 
 import org.osgi.annotation.versioning.Version;

--- a/maven-plugins/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven-plugins/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -22,6 +22,8 @@ import aQute.bnd.osgi.Resource;
 import aQute.bnd.unmodifiable.Sets;
 import aQute.lib.io.IO;
 import biz.aQute.resolve.ResolveProcess;
+import biz.aQute.resolve.ResolverLogger;
+import biz.aQute.resolve.Slf4jResolverLogger;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.execution.MavenSession;
@@ -154,8 +156,8 @@ public class ExportMojo extends AbstractMojo {
 	private Operation getOperation() {
 		return (file, bndrun, run) -> {
 			if (resolve) {
-				try {
-					String runBundles = run.resolve(failOnChanges, false);
+				try (ResolverLogger rl = new Slf4jResolverLogger()) {
+					String runBundles = run.resolve(failOnChanges, false, rl);
 					if (run.isOk()) {
 						logger.info("{}: {}", Constants.RUNBUNDLES, runBundles);
 						run.setProperty(Constants.RUNBUNDLES, runBundles);

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -18,6 +18,8 @@ import aQute.bnd.unmodifiable.Sets;
 import aQute.lib.io.IO;
 import aQute.lib.utf8properties.UTF8Properties;
 import biz.aQute.resolve.ResolveProcess;
+import biz.aQute.resolve.ResolverLogger;
+import biz.aQute.resolve.Slf4jResolverLogger;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -159,8 +161,8 @@ public class ResolverMojo extends AbstractMojo {
 
 	private Operation getOperation() {
 		return (file, runName, run) -> {
-			try {
-				String result = run.resolve(failOnChanges, writeOnChanges);
+			try (ResolverLogger rl = new Slf4jResolverLogger()) {
+				String result = run.resolve(failOnChanges, writeOnChanges, rl);
 				logger.info("{}: {}", Constants.RUNBUNDLES, result);
 			} catch (ResolutionException re) {
 				logger.error(ResolveProcess.format(re, reportOptional));

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
@@ -26,6 +26,8 @@ import aQute.bnd.unmodifiable.Sets;
 import aQute.bnd.version.VersionRange;
 import biz.aQute.resolve.ResolutionCallback;
 import biz.aQute.resolve.ResolveProcess;
+import biz.aQute.resolve.ResolverLogger;
+import biz.aQute.resolve.Slf4jResolverLogger;
 import biz.aQute.resolve.RunResolution;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -147,7 +149,7 @@ public class VerifierMojo extends AbstractMojo {
 
 	private Operation getOperation() {
 		return (file, runName, run) -> {
-			try {
+			try (ResolverLogger rl = new Slf4jResolverLogger()) {
 				String originalRunRequires = run.mergeProperties(Constants.RUNREQUIRES);
 
 				Collection<BundleId> expectedRunbundles = run.getRunbundles()
@@ -166,7 +168,7 @@ public class VerifierMojo extends AbstractMojo {
 					.map(Requirement::toString)
 					.collect(Collectors.joining(", ")));
 
-				RunResolution result = run.resolve(new BundleFilter(runBundleReqs));
+				RunResolution result = run.resolve(rl, new BundleFilter(runBundleReqs));
 
 				if (result.isOK()) {
 					List<BundleId> resolved = result.getResolvedRunBundles();

--- a/maven-plugins/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven-plugins/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -17,6 +17,8 @@ import aQute.bnd.unmodifiable.Sets;
 import aQute.lib.strings.Strings;
 import aQute.libg.glob.Glob;
 import biz.aQute.resolve.ResolveProcess;
+import biz.aQute.resolve.ResolverLogger;
+import biz.aQute.resolve.Slf4jResolverLogger;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -196,8 +198,8 @@ public class TestingMojo extends AbstractMojo {
 				return 0;
 			}
 			if (resolve) {
-				try {
-					String runBundles = run.resolve(failOnChanges, false);
+				try (ResolverLogger rl = new Slf4jResolverLogger()) {
+					String runBundles = run.resolve(failOnChanges, false, rl);
 					if (run.isOk()) {
 						logger.info("{}: {}", Constants.RUNBUNDLES, runBundles);
 						run.setProperty(Constants.RUNBUNDLES, runBundles);


### PR DESCRIPTION
This commit updates the bndrun resolve process to be better able to log externally. The main driver for this is from maven plugins which currently get little to no logging from the resolve process. These now use an SLF4J logger to log resolve messages, while still logging to a temporary file to maintain the existing error reporting behaviour.

Fixes #7217