### PR TITLE
Update baseline version to 7.3.0

### DIFF
--- a/docs/_data/bnd_version.yml
+++ b/docs/_data/bnd_version.yml
@@ -1,1 +1,1 @@
-baseline_version: "7.2.1"
+baseline_version: "7.3.0"


### PR DESCRIPTION
Closes #7229

This should update the version in some docs from 7.2.1 to 7.3.0  in all .md files where the following variable is used:

```
{{ site.data.bnd_version.baseline_version }}
```