### PR TITLE
Add sync baseline version step in postrelease workflow

### DIFF
--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -121,6 +121,9 @@ jobs:
         sed 's/baseline.version:.*/baseline.version: ${{ github.event.inputs.V1 }}/' cnf/build.bnd >tmp
         cat tmp
         mv tmp cnf/build.bnd
+    
+    - name: sync baseline version to docs
+      run: bash docs/scripts/sync-baseline-version.sh
 
     - name: create PR
       run: |


### PR DESCRIPTION
Add step to sync baseline version to documentation.

This ensures that when cnf/build.bnd is updated, the corresponding docs/_data/bnd_version.yml is also updated and included in the PR.