### PR TITLE
[Security] Maven Repositories: Add Trusted Checksum Verification

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,6 +58,7 @@ import aQute.libg.reporter.slf4j.Slf4jReporter;
 import aQute.maven.api.Archive;
 import aQute.maven.provider.MavenBackingRepository;
 import aQute.maven.provider.MavenRepository;
+import aQute.maven.provider.TrustedChecksums;
 import aQute.service.reporter.Reporter;
 
 /**
@@ -75,6 +77,7 @@ public class BndPomRepository extends BaseRepository
 	private String				name;
 	private Reporter			reporter			= new Slf4jReporter(BndPomRepository.class);
 	private File				localRepo;
+	private MavenRepository					storage;
 	private InnerRepository		repoImpl;
 	private List<Archive>		archives;
 	private BridgeRepository	bridge;
@@ -82,8 +85,8 @@ public class BndPomRepository extends BaseRepository
 	private String				query;
 	private String				queryUrl;
 	private ScheduledFuture<?>	pomPoller;
-
 	private String				status;
+	private TrustedChecksums				trustedChecksums;
 
 	public BndPomRepository() {
 		prepared = Memoize.supplier(this::preparePromise);
@@ -156,6 +159,7 @@ public class BndPomRepository extends BaseRepository
 			status("Neither pom, archive nor query property are set");
 		}
 
+
 		return Processor.getPromiseFactory()
 			.submit(this::prepareAsync);
 	}
@@ -169,6 +173,9 @@ public class BndPomRepository extends BaseRepository
 			HttpClient client = registry.getPlugin(HttpClient.class);
 			localRepo = IO.getFile(configuration.local(MAVEN_REPO_LOCAL));
 			File location = workspace.getFile(getLocation());
+
+			this.trustedChecksums = loadTrustedChecksumFile(workspace);
+			this.trustedChecksums.open();
 
 			String releaseUrl = configuration.releaseUrl();
 			if (releaseUrl == null) {
@@ -188,26 +195,39 @@ public class BndPomRepository extends BaseRepository
 			List<MavenBackingRepository> snapshot = MavenBackingRepository.create(snapshotUrl, reporter, localRepo,
 				client);
 
-			MavenRepository repository = new MavenRepository(localRepo, name, release, snapshot, client.promiseFactory()
+			storage = new MavenRepository(localRepo, name, release, snapshot, client.promiseFactory()
 				.executor(), reporter);
+			storage.setTrustedChecksums(trustedChecksums);
 
 			boolean transitive = configuration.transitive(true);
 			boolean dependencyManagement = configuration.dependencyManagement(false);
 
 			if (pomFiles != null) {
-				repoImpl = new PomRepository(repository, client, location, transitive, dependencyManagement)
+				repoImpl = new PomRepository(storage, client, location, transitive, dependencyManagement)
 					.uris(pomFiles);
 			} else if (archives != null) {
-				repoImpl = new PomRepository(repository, client, location, transitive, dependencyManagement)
+				repoImpl = new PomRepository(storage, client, location, transitive, dependencyManagement)
 					.archives(archives);
 			} else if (query != null) {
-				repoImpl = new SearchRepository(repository, location, query, queryUrl, workspace, client, transitive,
+				repoImpl = new SearchRepository(storage, location, query, queryUrl, workspace, client, transitive,
 					dependencyManagement);
 			} else {
-				repository.close();
+				storage.close();
 				return false;
 			}
+
+			// Generate trusted checksums file if recording is enabled
+			if (configuration.checksumRecord() && repoImpl instanceof PomRepository pr) {
+				try {
+					TrustedChecksums.createTrustedChecksumFile(storage, trustedChecksums.getFile(), pr.archives);
+				} catch (Exception e) {
+					reporter.exception(e, "Failed to record trusted checksums file");
+					// Don't fail init() if optional recording fails
+				}
+			}
+
 			bridge = new BridgeRepository(repoImpl);
+
 
 			startPoll();
 			return true;
@@ -482,6 +502,16 @@ public class BndPomRepository extends BaseRepository
 			cb.copy(gavs);
 		});
 
+		menu.put("Generate Trusted Checksums File", () -> {
+			if (repoImpl instanceof PomRepository pr) {
+				try {
+					TrustedChecksums.createTrustedChecksumFile(storage, trustedChecksums.getFile(), pr.archives);
+				} catch (Exception e) {
+					throw Exceptions.duck(e);
+				}
+			}
+
+		});
 
 		if (target.length == 2) {
 			// Revision Action: 0 = bns, 1 = version
@@ -509,7 +539,22 @@ public class BndPomRepository extends BaseRepository
 		if (!init()) {
 			return getStatus();
 		}
-		return bridge.tooltip(target);
+
+		try (Formatter f = new Formatter()) {
+			f.format("BndPomRepository             : %s\n", getName());
+			f.format("Tags                         : %s\n", getTags());
+			File trustedChecksumsFile = trustedChecksums.getFile();
+			if (trustedChecksumsFile.exists()) {
+				f.format("Trusted Checksums File   : %s\n", trustedChecksumsFile);
+			}
+
+			String tooltipBase = bridge.tooltip(target);
+			f.format("Resources                    : %s\n", tooltipBase);
+
+
+			return f.toString();
+		}
+
 	}
 
 	@Override
@@ -544,5 +589,14 @@ public class BndPomRepository extends BaseRepository
 			.getOther(Archive.JAR_EXTENSION, Archive.SOURCES_CLASSIFIER);
 	}
 
+	private TrustedChecksums loadTrustedChecksumFile(Workspace workspace) {
+		String checksumFile = configuration.checksumFile();
+		if (checksumFile == null || checksumFile.isBlank()) {
+			return new TrustedChecksums(null);
+		}
+		File file = workspace.getFile(checksumFile);
+		return new TrustedChecksums(file);
+
+	}
 
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/PomConfiguration.java
@@ -61,6 +61,17 @@ public interface PomConfiguration {
 	String pom();
 
 	/**
+	 * The path to the trusted checksum file corresponding to index file
+	 */
+	String checksumFile();
+
+	/**
+	 * If <code>true</code> the checksumFile will be automatically generated on
+	 * initialization.
+	 */
+	boolean checksumRecord();
+
+	/**
 	 * The name of the repo. Required.
 	 */
 	String name();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.2.0")
+@Version("2.3.0")
 package aQute.bnd.repository.maven.pom.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Configuration.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Configuration.java
@@ -44,6 +44,18 @@ public interface Configuration {
 	String index(String deflt);
 
 	/**
+	 * The path to the trusted checksum file corresponding to index file
+	 *
+	 */
+	String checksumFile();
+
+	/**
+	 * If <code>true</code> the checksumFile will be automatically generated on
+	 * initialization.
+	 */
+	boolean checksumRecord();
+
+	/**
 	 * Content added to the index file. Content maybe one line without CR/LF as
 	 * long as there is a comma or whitespace separating the GAVs. Further same
 	 * format as the index file.

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -2,6 +2,7 @@ package aQute.bnd.repository.maven.provider;
 
 import static aQute.bnd.osgi.Constants.BSN_SOURCE_SUFFIX;
 import static aQute.bnd.service.tags.Tags.parse;
+import static aQute.maven.provider.TrustedChecksums.createTrustedChecksumFile;
 
 import java.io.Closeable;
 import java.io.File;
@@ -92,6 +93,7 @@ import aQute.maven.api.Revision;
 import aQute.maven.provider.MavenBackingRepository;
 import aQute.maven.provider.MavenRepository;
 import aQute.maven.provider.PomGenerator;
+import aQute.maven.provider.TrustedChecksums;
 import aQute.service.reporter.Reporter;
 
 /**
@@ -133,6 +135,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 	private final AtomicReference<Throwable>	open							= new AtomicReference<>();
 	Optional<Workspace>							workspace;
 	private AtomicBoolean						polling							= new AtomicBoolean(false);
+	private TrustedChecksums					trustedChecksums;
 
 	/**
 	 * Put result
@@ -708,6 +711,9 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				}
 			}
 
+			File indexFile = getIndexFile();
+			this.trustedChecksums = loadTrustedChecksumFile(indexFile);
+			this.trustedChecksums.open();
 
 			for (MavenBackingRepository mbr : release) {
 				if (mbr.isRemote()) {
@@ -731,8 +737,8 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				storageMvn.setSonatypePublisherUrl(sonatypeReleaseUrl);
 				storageMvn.setSonatypePublishSnapshotUrl(sonatypeSnapshotUrl);
 			}
+			storageMvn.setTrustedChecksums(trustedChecksums);
 
-			File indexFile = getIndexFile();
 			Processor domain = (registry != null) ? registry.getPlugin(Processor.class) : null;
 			String source = configuration.source();
 			if (source != null) {
@@ -754,6 +760,18 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 				}
 			}
 
+
+			// Generate trusted checksums file if recording is enabled
+			if (configuration.checksumRecord()) {
+				try {
+					TrustedChecksums.createTrustedChecksumFile(storage, trustedChecksums.getFile(),
+						index.getArchives());
+				} catch (Exception e) {
+					reporter.exception(e, "Failed to record trusted checksums file");
+					// Don't fail init() if optional recording fails
+				}
+			}
+
 			startPoll();
 			logger.debug("initing {}", this);
 			workspace.ifPresent(ws -> ws.refresh(this));
@@ -763,6 +781,20 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 			status = Exceptions.getDisplayTypeName(e) + " " + Exceptions.causes(e);
 			return false;
 		}
+	}
+
+	private TrustedChecksums loadTrustedChecksumFile(File indexFile) {
+		String checksumFile = configuration.checksumFile();
+
+		File trustedChecksumFile;
+		if (checksumFile != null) {
+			trustedChecksumFile = IO.getFile(base, checksumFile);
+		} else {
+			File indexDir = indexFile.getParentFile() != null ? indexFile.getParentFile() : base;
+			trustedChecksumFile = IO.getFile(indexDir, indexFile.getName() + ".checksums");
+		}
+
+		return new TrustedChecksums(trustedChecksumFile);
 	}
 
 	private void validateUris(List<MavenBackingRepository> release, Formatter f) {
@@ -911,13 +943,21 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 					if (status != null)
 						f.format("STATUS = %s", status);
 					else {
+						String status = getStatus();
 						f.format("MavenBndRepository           : %s\n", getName());
+						if (status != null) {
+							f.format("Status           : %s\n", status);
+						}
 						f.format("Tags                         : %s\n", getTags());
 						f.format("Revisions                    : %s\n", index.getArchives()
 							.size());
 						f.format("Storage                      : %s\n", localRepo);
 						f.format("Index                        : %s\n", index.indexFile);
 						f.format("Format                        : %s\n", index.isPom ? "pom.xml" : "text");
+						File trustedChecksumsFile = trustedChecksums.getFile();
+						if (trustedChecksumsFile.exists()) {
+							f.format("Trusted Checksums File                         : %s\n", trustedChecksumsFile);
+						}
 						f.format("Release repos                : \n    %s\n", storage.getReleaseRepositories()
 							.stream()
 							.filter(Objects::nonNull)
@@ -1141,6 +1181,15 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 
 	public HttpClient getClient() {
 		return client;
+	}
+
+	void createTrustedChecksumsFile() {
+		try {
+			createTrustedChecksumFile(storage, trustedChecksums.getFile(), index.archives.keySet());
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+
 	}
 
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MbrUpdater.java
@@ -140,6 +140,10 @@ public class MbrUpdater {
 		repo.index.convertTextXml();
 	}
 
+	void createTrustedChecksumsFile() throws Exception {
+		repo.createTrustedChecksumsFile();
+	}
+
 	private String format(MultiMap<Archive, MavenVersion> overlap) {
 		Justif j = new Justif(140, 50, 60, 70, 80, 90, 100, 110);
 		j.formatter()

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/RepoActions.java
@@ -56,7 +56,9 @@ class RepoActions {
 		map.put("Convert :: Text <--> pom.xml", () -> {
 			convertTextXmlRevisions();
 		});
-
+		map.put("Create Trusted Checksums file", () -> {
+			createTrustedChecksumsFile();
+		});
 		map.put("Update Revisions :: Dry run to clipboard - Update to higher MICRO revision", () -> {
 			clipboard.copy(preview(micro));
 		});
@@ -272,6 +274,15 @@ class RepoActions {
 	private void convertTextXmlRevisions() {
 		try {
 			mbr.convertTextXml();
+			repo.refresh();
+		} catch (Exception e) {
+			throw Exceptions.duck(e);
+		}
+	}
+
+	private void createTrustedChecksumsFile() {
+		try {
+			mbr.createTrustedChecksumsFile();
 			repo.refresh();
 		} catch (Exception e) {
 			throw Exceptions.duck(e);

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.3.0")
+@Version("2.4.0")
 package aQute.bnd.repository.maven.provider;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/src/aQute/maven/provider/DigestValidator.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/DigestValidator.java
@@ -1,0 +1,54 @@
+package aQute.maven.provider;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import aQute.lib.io.IO;
+
+class DigestValidator {
+
+	// MD5(xercesImpl-2.9.0.jar)= 33ec8d237cbaceeffb2c2a7f52afd79a
+	// SHA1(xercesImpl-2.9.0.jar)= 868c0792233fc78d8c9bac29ac79ade988301318
+
+	final static Pattern DIGEST_POLLUTED = Pattern.compile("(.+=\\s*)?(?<digest>([0-9A-F][0-9A-F])+)\\s*",
+		Pattern.CASE_INSENSITIVE);
+
+	/**
+	 * Validates that a file digest matches a remote digest.
+	 *
+	 * @param file the file being validated (deleted if validation fails)
+	 * @param fileDigest the computed file digest
+	 * @param remoteDigest the remote digest to compare against
+	 * @throws IllegalArgumentException if digests don't match and deletes file
+	 */
+	static void checkDigest(File file, String fileDigest, String remoteDigest) {
+		if (remoteDigest == null)
+			return;
+
+		Matcher m = DIGEST_POLLUTED.matcher(remoteDigest);
+		if (m.matches())
+			remoteDigest = m.group("digest");
+
+		try {
+			int start = 0;
+			while (start < remoteDigest.length() && Character.isWhitespace(remoteDigest.charAt(start)))
+				start++;
+
+			for (int i = 0; i < fileDigest.length(); i++) {
+				if (start + i < remoteDigest.length()) {
+					char us = fileDigest.charAt(i);
+					char them = remoteDigest.charAt(start + i);
+					if (us == them || Character.toLowerCase(us) == Character.toLowerCase(them))
+						continue;
+				}
+				throw new IllegalArgumentException(
+					"Invalid content checksum " + fileDigest + " for " + file + "; expected " + remoteDigest);
+			}
+
+		} catch (Exception e) {
+			IO.delete(file);
+			throw e;
+		}
+	}
+}

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenBackingRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenBackingRepository.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import aQute.bnd.http.HttpClient;
@@ -36,14 +35,14 @@ public abstract class MavenBackingRepository implements Closeable {
 	// MD5(xercesImpl-2.9.0.jar)= 33ec8d237cbaceeffb2c2a7f52afd79a
 	// SHA1(xercesImpl-2.9.0.jar)= 868c0792233fc78d8c9bac29ac79ade988301318
 
-	final static Pattern					DIGEST_POLLUTED	= Pattern
-		.compile("(.+=\\s*)?(?<digest>([0-9A-F][0-9A-F])+)\\s*", Pattern.CASE_INSENSITIVE);
+	final static Pattern					DIGEST_POLLUTED	= DigestValidator.DIGEST_POLLUTED;
 
 	final Map<Revision, RevisionMetadata>	revisions		= new ConcurrentHashMap<>();
 	final Map<Program, ProgramMetadata>		programs		= new ConcurrentHashMap<>();
 	final String							id;
 	final File								local;
 	final Reporter							reporter;
+
 
 	public MavenBackingRepository(File root, String base, Reporter reporter) throws Exception {
 		this.local = root;
@@ -64,33 +63,7 @@ public abstract class MavenBackingRepository implements Closeable {
 	public abstract TaggedData fetch(String path, File file, boolean force) throws Exception;
 
 	protected void checkDigest(String fileDigest, String remoteDigest, File file) {
-		if (remoteDigest == null)
-			return;
-
-		Matcher m = DIGEST_POLLUTED.matcher(remoteDigest);
-		if (m.matches())
-			remoteDigest = m.group("digest");
-
-		try {
-			int start = 0;
-			while (start < remoteDigest.length() && Character.isWhitespace(remoteDigest.charAt(start)))
-				start++;
-
-			for (int i = 0; i < fileDigest.length(); i++) {
-				if (start + i < remoteDigest.length()) {
-					char us = fileDigest.charAt(i);
-					char them = remoteDigest.charAt(start + i);
-					if (us == them || Character.toLowerCase(us) == Character.toLowerCase(them))
-						continue;
-				}
-				throw new IllegalArgumentException(
-					"Invalid content checksum " + fileDigest + " for " + file + "; expected " + remoteDigest);
-			}
-
-		} catch (Exception e) {
-			IO.delete(file);
-			throw e;
-		}
+		DigestValidator.checkDigest(file, fileDigest, remoteDigest);
 	}
 
 	public abstract void store(File file, String path) throws Exception;

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
@@ -50,6 +50,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 	private SonatypeMode						sonatypeMode	= SonatypeMode.NONE;
 	private String								sonatypeReleaseUrl	= null;
 	private String								sonatypeSnapshotUrl	= null;
+	private TrustedChecksums					trustedChecksums;
 
 	public MavenRepository(File base, String id, List<MavenBackingRepository> release,
 		List<MavenBackingRepository> snapshot, Executor executor, Reporter reporter) throws Exception {
@@ -204,6 +205,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 			case UNMODIFIED :
 			case UPDATED :
 			default :
+				checkTrustedChecksum(archive, file);
 				return file;
 		}
 	}
@@ -255,7 +257,9 @@ public class MavenRepository implements IMavenRepo, Closeable {
 
 	@Override
 	public File toLocalFile(Archive archive) {
-		return toLocalFile(archive.localPath);
+		File file = toLocalFile(archive.localPath);
+		checkTrustedChecksum(archive, file);
+		return file;
 	}
 
 	@Override
@@ -433,6 +437,19 @@ public class MavenRepository implements IMavenRepo, Closeable {
 
 	public String getSonatypePublishSnapshotUrl() {
 		return sonatypeSnapshotUrl;
+	}
+
+	public void setTrustedChecksums(TrustedChecksums trustedChecksums) {
+		this.trustedChecksums = trustedChecksums;
+	}
+
+
+	private boolean checkTrustedChecksum(Archive archive, File file) {
+		if (trustedChecksums == null || archive == null || file == null || !file.isFile()) {
+			return false;
+		}
+
+		return trustedChecksums.checkTrustedChecksum(archive, file);
 	}
 
 }

--- a/biz.aQute.repository/src/aQute/maven/provider/TrustedChecksums.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/TrustedChecksums.java
@@ -1,0 +1,233 @@
+package aQute.maven.provider;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import aQute.lib.date.Dates;
+import aQute.lib.io.IO;
+import aQute.lib.strings.Strings;
+import aQute.libg.cryptography.MD5;
+import aQute.libg.cryptography.SHA1;
+import aQute.libg.cryptography.SHA256;
+import aQute.libg.cryptography.SHA512;
+import aQute.maven.api.Archive;
+import aQute.maven.api.IMavenRepo;
+
+/**
+ * Helper for handling trusted checksum verification for Maven artifacts
+ */
+public final class TrustedChecksums {
+
+	private final File						sidecarFile;
+	private Map<Archive, ArtifactChecksum>	index	= Map.of();
+	private volatile boolean							indexExists				= false;
+	private final Map<TrustedChecksumCacheKey, Boolean>	trustedChecksumCache	= new ConcurrentHashMap<>();
+
+	public TrustedChecksums(File trustedChecksumFile) {
+		this.sidecarFile = trustedChecksumFile;
+	}
+
+	public File getFile() {
+		return this.sidecarFile;
+	}
+
+	/**
+	 * Fetches a checksum for an Archive. Returns <code>null</code> if no entry
+	 * exists.
+	 *
+	 * @param archive
+	 * @return the ArtifactChecksum or <code>null</code> if not found.
+	 */
+	public ArtifactChecksum get(Archive archive) {
+		if (!indexExists)
+			return null;
+		return index.get(archive);
+	}
+
+	/**
+	 * Validates a downloaded artifact against a configured trusted checksum.
+	 *
+	 * @param archive the repository artifact archive
+	 * @param file the downloaded artifact file
+	 * @return {@code true} if a trusted checksum exists for the artifact and
+	 *         the file successfully matches it; {@code false} if no trusted
+	 *         checksum is configured
+	 * @throws TrustedChecksumException if checksum calculation fails or the
+	 *             file does not match the configured trusted checksum. In the
+	 *             mismatch case the file is deleted before the exception is
+	 *             thrown.
+	 */
+	public boolean checkTrustedChecksum(Archive archive, File file) {
+		if (!indexExists)
+			return false;
+
+		ArtifactChecksum expected = get(archive);
+		if (expected == null) {
+			return false;
+		}
+
+		TrustedChecksumCacheKey key = TrustedChecksumCacheKey.from(archive, file, expected);
+
+		// cache expensive computeHash
+		Boolean cached = trustedChecksumCache.get(key);
+		if (cached != null) {
+			return cached;
+		}
+
+		// Reuse existing checkDigest() with format: "algorithm=hash"
+		try {
+			String fileHash = computeHash(file, expected.hashType());
+			DigestValidator.checkDigest(file, fileHash, expected.hash());
+			trustedChecksumCache.put(key, Boolean.TRUE);
+			return true;
+		} catch (Exception e) {
+			throw new TrustedChecksumException(e.getMessage(), e);
+		}
+	}
+
+	public void open() throws IOException {
+		if (sidecarFile == null || !sidecarFile.isFile()) {
+			return;
+		}
+		indexExists = true;
+		Collection<ArtifactChecksum> set = read(IO.collect(sidecarFile));
+		index = set.stream()
+			.collect(Collectors.toMap(acs -> acs.archive(), acs -> acs));
+
+	}
+
+	public static void createTrustedChecksumFile(IMavenRepo repo, File checksumFile, Collection<Archive> archives)
+		throws Exception {
+
+		if (checksumFile == null || archives == null) {
+			return;
+		}
+
+		if (checksumFile.isDirectory()) {
+			throw new IllegalArgumentException("Trusted Checksum file must not be a directory: " + checksumFile);
+		}
+
+		try (FileOutputStream fos = new FileOutputStream(
+			checksumFile);
+			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(fos, StandardCharsets.UTF_8))) {
+
+			writer.write("# Generated (" + Dates.formatMillis(DateTimeFormatter
+				.ofPattern("yyyy/MM/dd HH:mm:ss", Locale.ROOT)
+				.withZone(Dates.UTC_ZONE_ID), new Date().getTime())
+				+ "): Trusted Checksums for each GAV in the maven index");
+			writer.newLine();
+
+			List<Archive> sorted = archives.stream()
+				.sorted(java.util.Comparator.comparing(Archive::toString))
+				.toList();
+
+			for (Archive arch : sorted) {
+				File localFile = repo.toLocalFile(arch);
+				String line = arch.toString() + "=sha1:" + SHA1.digest(localFile)
+					.asHex();
+				writer.write(line);
+				writer.newLine();
+			}
+			writer.flush();
+		}
+	}
+
+	/**
+	 * Parses the content of a .checksums file and returns the ArtifactCheckSum
+	 * entries.
+	 *
+	 * @param source content of the trusted checksum file as a String
+	 * @return the parsed de-duplicated ArtifactChecksum entries
+	 */
+	public static List<ArtifactChecksum> read(String source) {
+		Set<ArtifactChecksum> archives = Strings.splitLinesAsStream(source)
+			.map(s -> ArtifactChecksum.parse(s))
+			.filter(Objects::nonNull)
+			.collect(Collectors.toCollection(LinkedHashSet::new));
+		return List.copyOf(archives);
+	}
+
+	record ArtifactChecksum(Archive archive, String hashType, String hash) {
+		public static ArtifactChecksum parse(String line) {
+
+			line = line.trim();
+
+			if (line.startsWith("#") || line.isEmpty())
+				return null;
+
+			String[] parts = line.split("=", 2);
+			if (parts.length != 2) {
+				throw new IllegalArgumentException("Invalid checksum line format: " + line);
+			}
+
+			Archive archive = Archive.valueOf(parts[0].trim());
+
+			String rhs = parts[1].trim();
+			int colon = rhs.indexOf(':');
+			if (colon < 0) {
+				throw new IllegalArgumentException("Missing hash type separator: " + line);
+			}
+
+			String hashType = rhs.substring(0, colon)
+				.trim();
+			String hash = rhs.substring(colon + 1)
+				.trim();
+
+			return new ArtifactChecksum(archive, hashType, hash);
+		}
+	}
+
+	public static String computeHash(File file, String hashType) throws Exception {
+		return switch (hashType.toLowerCase()) {
+			case "sha-256", "sha256" -> SHA256.digest(file)
+				.asHex();
+			case "sha-512", "sha512" -> SHA512.digest(file)
+				.asHex();
+			case "md5" -> MD5.digest(file)
+				.asHex();
+			case "sha1", "sha-1" -> SHA1.digest(file)
+				.asHex();
+			default -> throw new IllegalArgumentException("Unsupported hash type: " + hashType);
+		};
+	}
+
+	@Override
+	public String toString() {
+		return sidecarFile != null ? String.valueOf(sidecarFile) : "-";
+	}
+
+
+	public static class TrustedChecksumException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		public TrustedChecksumException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+	}
+
+	private record TrustedChecksumCacheKey(Archive archive, File file, long lastModified, long length,
+		String hashType,
+		String expectedHash) {
+		public static TrustedChecksumCacheKey from(Archive archive, File file, ArtifactChecksum expected) {
+			return new TrustedChecksumCacheKey(archive, file.getAbsoluteFile(), file.lastModified(), file.length(),
+				expected.hashType(), expected.hash());
+		}
+	}
+}

--- a/biz.aQute.repository/src/aQute/maven/provider/packageinfo
+++ b/biz.aQute.repository/src/aQute/maven/provider/packageinfo
@@ -1,1 +1,1 @@
-version 2.8
+version 2.9.0

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/MavenBndRepoTest.java
@@ -78,6 +78,8 @@ public class MavenBndRepoTest {
 	File								remote;
 	File								staging;
 	File								index;
+	File								trustedChecksumsFile;
+	File								trustedChecksumsFileFailing;
 
 	private MavenBndRepository			repo;
 	private FakeNexus					fnx;
@@ -89,12 +91,16 @@ public class MavenBndRepoTest {
 		remote = IO.getFile(tmp, "remote");
 		staging = IO.getFile(tmp, "staging");
 		index = IO.getFile(tmp, "index");
+		trustedChecksumsFile = IO.getFile(tmp, "index.checksums");
+		trustedChecksumsFileFailing = IO.getFile(tmp, "index.failing.checksums");
 		remote.mkdirs();
 		local.mkdirs();
 		staging.mkdirs();
 
 		IO.copy(IO.getFile("testresources/mavenrepo"), remote);
 		IO.copy(IO.getFile("testresources/mavenrepo/index.maven"), index);
+		IO.copy(IO.getFile("testresources/mavenrepo/index.maven.checksums"), trustedChecksumsFile);
+		IO.copy(IO.getFile("testresources/mavenrepo/index.maven.failing.checksums"), trustedChecksumsFileFailing);
 
 		Config config = new Config();
 		fnx = new FakeNexus(config, remote);
@@ -1518,6 +1524,37 @@ public class MavenBndRepoTest {
 				.trim())
 	        .as("plain jar dependency for org.osgi.dto must exist without <type> or <classifier>")
 	        .isEqualTo("org.osgi.dto");
+	}
+
+	@Test
+	public void testGetTrustedCheckPass() throws Exception {
+		Map<String, String> map = new HashMap<>();
+		map.put("releaseUrl", remote.toURI()
+			.toString());
+		map.put("checksumFile", trustedChecksumsFile.toString());
+
+		config(map);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0"), null);
+		assertNotNull(file);
+		assertTrue(file.isFile());
+
+		File file2 = repo.get("commons-cli:commons-cli", new Version("1.2"), null);
+		assertNotNull(file2);
+		assertTrue(file2.isFile());
+	}
+
+	@Test
+	public void testGetTrustedCheckFail() throws Exception {
+		Map<String, String> map = new HashMap<>();
+		map.put("releaseUrl", remote.toURI()
+			.toString());
+		map.put("checksumFile", trustedChecksumsFileFailing.toString());
+		config(map);
+		File file = repo.get("commons-cli:commons-cli", new Version("1.0"), null);
+		assertFalse(file.isFile());
+
+		File file2 = repo.get("commons-cli:commons-cli", new Version("1.2"), null);
+		assertFalse(file2.isFile());
 	}
 
 }

--- a/biz.aQute.repository/test/aQute/maven/provider/TrustedChecksumsTest.java
+++ b/biz.aQute.repository/test/aQute/maven/provider/TrustedChecksumsTest.java
@@ -1,0 +1,45 @@
+package aQute.maven.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import aQute.maven.api.Archive;
+import aQute.maven.provider.TrustedChecksums.ArtifactChecksum;
+
+public class TrustedChecksumsTest {
+	@Test
+	public void testParseValidChecksum() throws Exception {
+	    String line = "org.example:artifact:1.0=sha256:abc123def456";
+	    ArtifactChecksum ac = ArtifactChecksum.parse(line);
+	    assertEquals(Archive.valueOf("org.example:artifact:1.0"), ac.archive());
+	    assertEquals("sha256", ac.hashType());
+	    assertEquals("abc123def456", ac.hash());
+	}
+
+	@Test
+	public void testParseValidChecksum2() throws Exception {
+		// check if trimming works correctly
+		String source = " #comment line \n" + " org.example:artifact:1.0 = sha256 : abc123def456  ";
+		List<ArtifactChecksum> list = TrustedChecksums.read(source);
+		assertThat(list).hasSize(1);
+
+		ArtifactChecksum ac = list.get(0);
+		assertEquals(Archive.valueOf("org.example:artifact:1.0"), ac.archive());
+		assertEquals("sha256", ac.hashType());
+		assertEquals("abc123def456", ac.hash());
+	}
+
+	@Test
+	public void testParseInvalidFormat() throws Exception {
+	    String invalidLine = "invalid_format_no_equals";
+	    assertThrows(IllegalArgumentException.class, () ->
+	        ArtifactChecksum.parse(invalidLine)
+	    );
+	}
+}
+

--- a/biz.aQute.repository/testresources/mavenrepo/index.maven.checksums
+++ b/biz.aQute.repository/testresources/mavenrepo/index.maven.checksums
@@ -1,0 +1,3 @@
+# Hello Comment
+commons-cli:commons-cli:1.0=sha1:6dac9733315224fc562f6268df58e92d65fd0137
+commons-cli:commons-cli:1.2=sha1:2bf96b7aa8b611c177d329452af1dc933e14501c

--- a/biz.aQute.repository/testresources/mavenrepo/index.maven.failing.checksums
+++ b/biz.aQute.repository/testresources/mavenrepo/index.maven.failing.checksums
@@ -1,0 +1,3 @@
+# Hello Comment
+commons-cli:commons-cli:1.0=sha1:should_fail
+commons-cli:commons-cli:1.2=sha1:should_fail

--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -944,6 +944,8 @@
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="readOnly" type="boolean" description="" default="false" />
 		    <property name="index" type="string" description="The path to the index file (relative to build.bnd, or an absolute path)" default="${.}/central.maven" />
+		    <property name="checksumFile" type="string" description="Points to the trusted checksum file for Trusted Checksum verification. (relative to build.bnd)" default="cnf/ext/central.maven.checksums" />
+		    <property name="checksumRecord" type="boolean" description="Record (generate) trusted checksums during initialization" default="false" />
 		    <property name="source" type="string" description="Content added to the index file. Content maybe one line without CR/LF as long as there is a comma or whitespace separating the GAVs. Further same format as the index file." />
 		    <property name="noupdateOnRelease" type="boolean" description="Do not update the index when a file is released" />
 		    <property name="poll_time" type="int" description="Sets the time in seconds when to check for changes in the pom-files" default="5" />
@@ -973,7 +975,9 @@
 		    <property name="local" type="string" description="The path to the local repository" default="~/.m2/repository" />
 		    <property name="revision" type="string" description="Coordinates of a maven revision. I.e. group:artifactid[:c]:version. Can be a comma separated list of GAVs." />
 		    <property name="location" type="string" description="Points to a file that is used as the cache. It will be in OSGi format." />
-		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files. (relative to build.bnd, or an absolute path)" default="${.}/pom.xml" />
+		    <property name="pom" type="string" description="Points to a pom.xml file. This is exclusive with revision. Can be a comma separated list of files. (relative to build.bnd)" default="${.}/pom.xml" />
+		    <property name="checksumFile" type="string" description="Points to the trusted checksum file for Trusted Checksum verification. (relative to build.bnd, or an absolute path)" default="cnf/ext/trusted.checksums" />
+		    <property name="checksumRecord" type="boolean" description="Record (generate) trusted checksums during initialization" default="false" />
 		    <property name="query" type="string" description="The query used to search Maven Central Search." />
 		    <property name="queryUrl" type="string" description="The url of the Maven Central Search."  />
 		    <property name="transitive" type="boolean" description="Allow transitive dependencies" />

--- a/docs/_plugins/maven.md
+++ b/docs/_plugins/maven.md
@@ -75,20 +75,22 @@ The class name of the plugin is `aQute.bnd.repository.maven.provider.MavenBndRep
 | `readOnly`       | `true`|`false` | `false` | If set to _truthy_ then this repository is read only.|
 | `name`           | `NAME`| `Maven` | The name of the repository.|
 | `index`          | `PATH`| `cnf/<name>.mvn` | The path to the _index_ file. The index file is a list of Maven _coordinates_ (text with one GAV per line or pom.xml).|
+| `checksumFile`   | `PATH`| `<index-dir>/<index-filename>.checksums` | The path to the trusted checksum file relative to `build.bnd`. If not specified, defaults to a `.checksums` sidecar file next to the index file. See [Trusted Checksum Verification](#trusted-checksum-verification).|
+| `checksumRecord`   | `boolean` | `false` | When set to `true`, the repository automatically generates (records) the trusted checksum file during initialization. Checksums are computed for all artifacts currently listed in the index file and written to the default sidecar location (`<index>.checksums`) or the path specified by `checksumFile`. Non-fatal errors during recording are logged but do not prevent the repository from initializing. |
 | `tags`           | `STRING`|  | Comma separated list of tags. (e.g. resolve, baseline, release) Use a placeholder like &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution. The `resolve` tag is picked up by the [-runrepos](/instructions/runrepos.html) instruction.|
 | `source`         | `STRING`| `org.osgi:org.osgi.service.log:1.3.0 org.osgi:org.osgi.service.log:1.2.0` | A space, comma, semicolon, or newline separated GAV string. |
 | `noupdateOnRelease` | `true|false` | `false` | If set to _truthy_ then this repository will not update the `index` when a non-snapshot artifact is released.|
 | `poll.time`      | `integer` | 5 seconds | Number of seconds between checks for changes to the `index` file. If the value is negative or the workspace is in batch/CI mode, then no polling takes place.|
 | `multi`          | `NAME`|        | Comma separated list of extensions to be searched for indexing containing bundles. For example, a zip file could comprise further bundles. Hence, this zip artifact can be referenced in this plugin for indexing the internal JARs. |
 
-If no `releaseUrl` nor a `snapshotUrl` are specified then the repository is _local only_. 
+If no `releaseUrl` nor a `snapshotUrl` are specified then the repository is _local only_.
 
 For finding archives, both URLs are used. For releasing, only the first or the `stagingUrl` is used.
 
 ## Index file
 
-The `index` file specifies a view on the remote repository, it _scopes_ it. Since we use the bnd repositories to resolve against, it is impossible to resolve against the world. The index file falls under source control, it is stored in the source control management system. This guarantees that at any time the project is checked out it has the same views on its repository. This is paramount to prevent build breackages due to changes in repositories. 
-The index file supports two formats: 
+The `index` file specifies a view on the remote repository, it _scopes_ it. Since we use the bnd repositories to resolve against, it is impossible to resolve against the world. The index file falls under source control, it is stored in the source control management system. This guarantees that at any time the project is checked out it has the same views on its repository. This is paramount to prevent breaking builds due to changes in repositories.
+The index file supports two formats:
 
 - a) text file with one GAV per line or
 - b) Maven _pom.xml_ content (note that not the full maven pom.xml features are supported. Mainly the `<dependency>` entries are relevant).
@@ -148,9 +150,9 @@ An example `pom.xml` index file which is supported by MavenBndRepository looks l
 </project>
 ```
 
-As stated earlier: Not all maven `pom.xml` features are supported. Mainly the `<dependency>` entries are relevant. The parser is very simple and `pom.xml` is just meant to be an alternative format format for the text file. 
+As stated earlier: Not all maven `pom.xml` features are supported. Mainly the `<dependency>` entries are relevant. The parser is very simple and `pom.xml` is just meant to be an alternative format for the text file.
 
-One advantage of using the `pom.xml` format over the flat text file is that `pom.xml` is understood by more tooling. For example Dependabot can automatically update `pom.xml` files, but not the flat text file. 
+One advantage of using the `pom.xml` format over the flat text file is that `pom.xml` is understood by more tooling. For example Dependabot can automatically update `pom.xml` files, but not the flat text file.
 
 
 ## Local Repository
@@ -182,6 +184,106 @@ The Maven Bnd Repository uses the bnd Http Client. See the [-connection-settings
 ## Tagging
 
 This plugin supports Tagging via the `tags` configuration property. See [Tagging of repository plugins](/plugins/#tagging-of-repository-plugins) for more details.
+
+## Trusted Checksum Verification
+
+The Maven Bnd Repository supports trusted checksum verification to protect against tampered or corrupted artifacts. When a checksum file is present, every artifact fetched from the repository is validated against the expected checksum before use. If the checksum does not match, the local file is deleted and an exception is thrown.
+
+### The .checksums File
+
+The checksum file is a plain-text sidecar file that lists the expected checksum for each artifact coordinate in the index. By convention, bnd looks for a file with the same name as the index file plus the `.checksums` extension. For example, if your index is `cnf/central.maven`, bnd will automatically look for `cnf/central.maven.checksums`.
+
+You can override this location with the checksumFile configuration property:
+
+```
+-plugin.central = \
+	aQute.bnd.repository.maven.provider.MavenBndRepository; \
+		releaseUrl=https://repo.maven.apache.org/maven2/; \
+		index=${.}/central.maven; \
+		checksumFile=${.}/trusted/central.checksums; \
+		name="Central"
+```
+
+If neither a default nor an explicit checksum file exists, checksum verification is silently skipped and the repository operates normally.
+
+### File Format
+
+Each line in the `.checksums` file specifies one artifact coordinate and its expected checksum in the form:
+
+```
+<GAV>=<hashType>:<hexDigest>
+```
+
+where `<GAV>` uses the same coordinate syntax as the index file and `<hashType>` is one of `sha1`, `sha-1`, `sha256`, `sha-256`, `sha512`, `sha-512`, or `md5`.
+
+Lines starting with # are treated as comments. Empty lines are ignored.
+
+**Example central.maven.checksums:**
+
+```
+# Trusted checksums for central.maven
+commons-cli:commons-cli:1.0=sha1:6dac9733315224fc562f6268df58e92d65fd0137
+commons-cli:commons-cli:1.2=sha1:2bf96b7aa8b611c177d329452af1dc933e14501c
+org.osgi:osgi.core:6.0.0=sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+```
+
+### Generating the Checksums File
+
+The `checksumRecord` configuration option enables automatic generation of the trusted checksum file during repository initialization. This is useful for CI/CD pipelines and build automation where you want to "bootstrap" or audit the checksums without manual intervention.
+
+**Configuration:**
+
+```
+-plugin.central =
+	aQute.bnd.repository.maven.provider.MavenBndRepository;
+	releaseUrl=https://repo.maven.apache.org/maven2/;
+	index=${.}/central.maven;
+	checksumRecord=true;
+	name="Central"
+```
+
+**Workflow:**
+
+1. Repository initialization runs (during workspace startup or build)
+2. Index file is loaded and all artifacts are discovered
+3. If `checksumRecord=true`, bnd iterates through each artifact
+4. Computes a checksum (SHA-1 by default) for each locally available artifact
+5. Writes the checksums to the `.checksums` sidecar file (or custom location)
+6. Repository becomes ready for use
+
+**Use Cases:**
+
+- **Local development:** Enable `checksumRecord=true` locally when you need to generate or update the checksum file. After building, review the changes to `index.checksums` and commit to version control if satisfied.
+- **Controlled checksum updates:** Use an environment variable like `CHECKSUMS_RECORD` to selectively enable recording only when intentional (e.g., `checksumRecord=${if;${env;CHECKSUMS_RECORD};false}`). Leave disabled in regular CI builds to prevent unintended modifications to the checksum file.
+- **Onboarding new artifacts:** When adding new dependencies to the index, enable recording on a local build to bootstrap the initial checksum file.
+
+**Notes:**
+
+- Recording happens **after** repository initialization completes, ensuring all artifacts are available
+- Only artifacts that have been downloaded to the local repository can have their checksums recorded
+- Remote-only artifacts (not yet downloaded) are skipped during recording
+- The generated file uses SHA-1 by default (matching the format created by the IDE's "Create Trusted Checksums file" action)
+- If the checksum file already exists, it will be **overwritten** with the current state
+- **Best practice:** Leave `checksumRecord=false` in standard CI builds. Enable it only when you intend to update and review the checksum file before committing.
+- To use recorded checksums for verification on subsequent builds, ensure `checksumFile` is configured or the default `.checksums` sidecar is in place
+
+### Generating checksums file in Bndtools
+
+Additionally the Bndtools Eclipse Plugin provides a context menu action on the repository to generate the checksum file automatically. Right-click the repository entry and choose "Create Trusted Checksums file". This computes a `sha1` checksum for every artifact currently in the index and writes the result to the default sidecar location (`<index>.checksums`).
+
+After generating the file, review it and commit it to version control alongside your index file. This ensures that everyone on your team (and CI) uses the same trusted checksums.
+
+### Expected Behavior
+
+|                              Situation                             |                               Behavior                              |
+|:------------------------------------------------------------------:|:-------------------------------------------------------------------:|
+| No checksum file exists                                            | Default: No verification is performed; artifacts are used as-is.                  |
+| `.checksums` file exists but has no entry for an artifact              | That artifact is not verified; it is used as-is.                    |
+| Checksum file exists and artifact matches the expected hash        | Artifact is used normally.                                          |
+| Checksum file exists but  artifact does not match the expected hash | The local file is deleted and a `TrustedChecksumException` is thrown. The artifact appears as if it does not exist / could not be downloaded and thus will not resolve. Removing the artifact entry from the checksum file and a rebuild should re-download the artifact |
+
+This design means you can incrementally add entries to the checksum file: only artifacts explicitly listed are verified. Artifacts not listed in the file are passed through without verification.
+
 
 ## IDEs
 

--- a/docs/_plugins/pomrepo.md
+++ b/docs/_plugins/pomrepo.md
@@ -40,7 +40,7 @@ Opening the `Run` tab of the bndrun editor on this file will show you all transi
 ## Searching
 
 
-**DEPRECATION:** The searching feature below will be deprecated in bnd 7.2.0 for removal in bnd 8.0. 
+**DEPRECATION:** The searching feature below will be deprecated in bnd 7.2.0 for removal in bnd 8.0.
 The reason is that this search is considered "legacy" (see https://status.maven.org/), and also is often instable recently.
 
 Maven Central supports a [searching facility](https://blog.sonatype.com/2011/06/you-dont-need-a-browser-to-use-maven-central/) based on Solr. For example, you want all the artifacts of a given group id. In that case you could use the following Bnd Pom Repository plugin:
@@ -67,6 +67,7 @@ The query must return a JSON response.
 | `revision`       | `GAV...` |      | A comma separated list of Maven coordinates. The GAV will be searched in the normal way. For further information about Coordinates & Terminology please see MavenBndRepositoryPlugin|
 | `pom`            | `URI...` |      | A comma separated list of URLs to POM files.|
 | `location`       | `PATH` | `cnf/cache/pom-<name>.xml` | Optional cached index of the parsed POMs. |
+| `checksumFile`   | `PATH`|  | The path to the trusted checksum file relative to `build.bnd`. See [Trusted Checksum Verification](#trusted-checksum-verification).|
 | `query`          | `STRING` |      | A Solr query string. This is the part after `?` and must be properly URL encoded|
 | `queryUrl`       | `URI` | `https://search.maven.org/solrsearch/select` | Optional URL to the search engine.|
 | `name`           | `STRING`|       | Required name of the repo.|
@@ -107,6 +108,11 @@ This plugin supports Tagging via the `tags` configuration property. See [Tagging
 ## IDEs
 
 The repository view in the IDE will show detailed information when you hover the mouse over the the repository entry, the program entry, or the revision entry.
+
+## Trusted Checksum Verification
+
+The Bnd Pom Repository supports trusted checksum verification to protect against tampered or corrupted artifacts.
+See the section in [MavenBndRepository - Trusted Checksum Verification](maven.md#trusted-checksum-verification) for more details.
 
 ## Caveats
 


### PR DESCRIPTION
Closes #7236 

This pull request introduces **optional** support for trusted checksum verification in the Maven repository providers (MavenBndRepository and BndPomRepository). The main goal is to ensure that downloaded artifacts **can** validated against a trusted checksum file, improving the integrity and security of repository operations. The changes include new configuration options, core logic for managing and verifying trusted checksums, and integration into repository workflows and UI actions.


```
-plugin.central =
	aQute.bnd.repository.maven.provider.MavenBndRepository;
	releaseUrl=https://repo.maven.apache.org/maven2/;
	index=${.}/central.maven;
	checksumRecord=true;
	checksumFile=${.}/central.maven.checksums; \
	name="Central"
```

Above the following settings are new:

```
	checksumRecord=true;
	checksumFile=${.}/central.maven.checksums; \

```



**Trusted Checksum Support and Verification:**

* Added a new `TrustedChecksums` class to manage trusted checksum files, load and cache checksums, verify artifact integrity, and generate trusted checksum files. This includes logic for reading, writing, and validating checksums for Maven artifacts.
* Implemented a `DigestValidator` helper class to centralize digest comparison logic, replacing duplicate code and improving maintainability.
* Integrated trusted checksum verification into `MavenRepository` and `MavenBackingRepository`, so that artifact retrieval and local file access now check against trusted checksums when available. [[1]](diffhunk://#diff-27dada18e4f368e9d7479a5f0fa8d92bd449ed51f95d3198db47af2bebed99f7R53) [[2]](diffhunk://#diff-27dada18e4f368e9d7479a5f0fa8d92bd449ed51f95d3198db47af2bebed99f7R208) [[3]](diffhunk://#diff-27dada18e4f368e9d7479a5f0fa8d92bd449ed51f95d3198db47af2bebed99f7L258-R262) [[4]](diffhunk://#diff-27dada18e4f368e9d7479a5f0fa8d92bd449ed51f95d3198db47af2bebed99f7R442-R454) [[5]](diffhunk://#diff-2a026ba5e884180d6b32fa7b7d3c7c802d18391403b3d26876f79c6b0b4a0e1cL39-R46) [[6]](diffhunk://#diff-2a026ba5e884180d6b32fa7b7d3c7c802d18391403b3d26876f79c6b0b4a0e1cL67-R66)

**Configuration and Initialization:**

* Extended the `Configuration` interface to allow specifying a trusted checksum file path, and updated repository initialization to load and use the trusted checksum file. [[1]](diffhunk://#diff-7c358ff940c0b6c70cf070423b249590f79afc9c257f3380139fdf1e46d288bfR46-R51) [[2]](diffhunk://#diff-3543c94c5c19a9e5c48bfb1d5c749588b7eda893e5f27a469720562d505debd9R138) [[3]](diffhunk://#diff-3543c94c5c19a9e5c48bfb1d5c749588b7eda893e5f27a469720562d505debd9R714-R716) [[4]](diffhunk://#diff-3543c94c5c19a9e5c48bfb1d5c749588b7eda893e5f27a469720562d505debd9R774-R787)
* Added logic to generate a trusted checksum file from the current repository state, and exposed this as a repository action in the UI. [[1]](diffhunk://#diff-3543c94c5c19a9e5c48bfb1d5c749588b7eda893e5f27a469720562d505debd9R1174-R1182) [[2]](diffhunk://#diff-9798d76a25282bc3dff5647b6739f82970d66f20f02645d60e6bad8333fc1b91R143-R146) [[3]](diffhunk://#diff-de9ed602c96913740754cd7b37d9bf2e964eb9f6ea738e5df236dd313ad15d63L59-R61) [[4]](diffhunk://#diff-de9ed602c96913740754cd7b37d9bf2e964eb9f6ea738e5df236dd313ad15d63R283-R291)

**Reporting and Versioning:**

* Enhanced repository tooltips and reporting to display the status and location of the trusted checksums file when present.
* Updated package versioning to reflect the new feature. [[1]](diffhunk://#diff-21636d027d198bdc24b6964ed6fdeb8fbbafee6914b8580ebd31350f5a52f69dL1-R1) [[2]](diffhunk://#diff-d604f29b488deaf301c6542129d8b8216fd535aed1ec31968af3f56f72ce8a6dL1-R1)

## Screenshots

<img width="386" height="229" alt="image" src="https://github.com/user-attachments/assets/d93f63b0-a58e-4978-bf7e-48c35a16cd0d" />

<img width="817" height="673" alt="image" src="https://github.com/user-attachments/assets/dc14b721-1057-412d-9ef2-1ed96c3fc5d9" />

<img width="709" height="86" alt="image" src="https://github.com/user-attachments/assets/35fadbd6-443f-495a-b7da-02ff176084ba" />

When a Checksum does not match it looks like this:

<img width="1674" height="149" alt="image" src="https://github.com/user-attachments/assets/03605c23-e08e-4cf6-bbcf-4b75127244e2" />

The file basically does not exist anymore (the failing check deletes it), so the jar cannot be used / resolved etc.

