### PR TITLE
Add `repo deps` command to export Maven GAVs for dash-licenses

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/RepoCommand.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/RepoCommand.java
@@ -56,6 +56,7 @@ import aQute.bnd.osgi.Verifier;
 import aQute.bnd.osgi.repository.ResourcesRepository;
 import aQute.bnd.osgi.repository.XMLResourceGenerator;
 import aQute.bnd.osgi.resource.ResourceUtils;
+import aQute.bnd.repository.maven.provider.MavenBndRepository;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.service.RepositoryPlugin;
 import aQute.bnd.service.RepositoryPlugin.PutOptions;
@@ -81,6 +82,7 @@ import aQute.lib.json.JSONCodec;
 import aQute.lib.strings.Strings;
 import aQute.libg.cryptography.SHA1;
 import aQute.libg.glob.Glob;
+import aQute.maven.api.Archive;
 
 public class RepoCommand {
 	private final static Logger	logger	= LoggerFactory.getLogger(RepoCommand.class);
@@ -888,6 +890,90 @@ public class RepoCommand {
 			r.toPom(out, po);
 		} finally {
 			out.close();
+		}
+	}
+
+	@Description("Export the Maven coordinates (GAVs) of all artifacts in the Maven repositories as a flat, "
+		+ "newline-separated list. Macros in the repository index files (e.g. ${junit.version}) are resolved. "
+		+ "The output is directly consumable by the Eclipse Dash License Tool (dash-licenses), for example:\n"
+		+ "  bnd repo deps -o deps.txt\n"
+		+ "  java -jar org.eclipse.dash.licenses-<version>.jar deps.txt -summary DEPENDENCIES")
+	@Arguments(arg = {})
+	interface DepsOptions extends Options {
+		@Description("Output file (default: the console)")
+		String output();
+
+		@Description("A glob expression on the repository name; default is all Maven repositories")
+		Glob from();
+
+		@Description("Exclude artifacts whose 'group:artifact:version' coordinate matches any of the given glob "
+			+ "expressions (e.g. '-e biz.aQute.bnd:*' to drop your own bundles). May be repeated.")
+		String[] exclude();
+
+		@Description("Emit ClearlyDefined ids (maven/mavencentral/<group>/<artifact>/<version>) instead of Maven GAVs")
+		boolean clearlydefined();
+	}
+
+	/**
+	 * Read the Maven repositories of the workspace and export the coordinates of
+	 * all of their artifacts as a flat list, suitable as input for the Eclipse
+	 * Dash License Tool. This bridges the bnd workspace model (curated Maven
+	 * repository index files) to license/IP analysis tooling.
+	 *
+	 * @throws Exception
+	 */
+	@Description("Export the Maven GAVs of all artifacts in the Maven repositories for license/IP analysis (dash-licenses)")
+	public void _deps(DepsOptions opts) throws Exception {
+		Glob from = opts.from();
+
+		List<Glob> excludes = new ArrayList<>();
+		if (opts.exclude() != null) {
+			for (String e : opts.exclude()) {
+				excludes.add(new Glob(e));
+			}
+		}
+
+		// Deduplicate and sort. Distinct classifiers (sources, javadoc) and the
+		// pom share a single revision, so collecting the revision coordinate
+		// collapses them into one entry per artifact.
+		Set<String> coordinates = new TreeSet<>();
+
+		for (RepositoryPlugin repo : repos) {
+			if (!(repo instanceof MavenBndRepository maven))
+				continue;
+
+			if (from != null && !from.matches(repo.getName()))
+				continue;
+
+			for (Archive archive : maven.getArchives()) {
+				String gav = archive.revision.toString(); // group:artifact:version
+
+				boolean excluded = false;
+				for (Glob g : excludes) {
+					if (g.matches(gav)) {
+						excluded = true;
+						break;
+					}
+				}
+				if (excluded)
+					continue;
+
+				if (opts.clearlydefined()) {
+					coordinates.add("maven/mavencentral/" + archive.revision.group + "/" + archive.revision.artifact
+						+ "/" + archive.revision.version);
+				} else {
+					coordinates.add(gav);
+				}
+			}
+		}
+
+		String text = Strings.join("\n", coordinates);
+
+		String sout = opts.output();
+		if (sout == null || "console".equals(sout)) {
+			bnd.out.println(text);
+		} else {
+			IO.store(text + "\n", bnd.getFile(sout));
 		}
 	}
 

--- a/docs/_commands/_ext/repo.md
+++ b/docs/_commands/_ext/repo.md
@@ -1,0 +1,87 @@
+
+## deps — license/IP analysis with the Eclipse Dash License Tool
+
+The `deps` sub-command exports the Maven coordinates (GAVs) of **all artifacts in
+the workspace's Maven repositories** as a flat, newline-separated list. Macros in
+the repository index files (e.g. `${junit.version}` in `cnf/ext/central.mvn`) are
+resolved through the workspace, so the output reflects the actual, curated set of
+third-party dependencies the workspace pulls in.
+
+The output format is exactly what the
+[Eclipse Dash License Tool](https://github.com/eclipse-dash/dash-licenses)
+(`dash-licenses`) consumes, which makes it the bridge between the bnd workspace
+model and Eclipse IP / license vetting.
+
+### Examples
+
+Write the GAV list of every Maven repository to a file:
+
+```
+bnd repo deps -o deps.txt
+```
+
+Feed it to the Dash License Tool to produce a `DEPENDENCIES` summary that marks
+each artifact as `approved` or `restricted`:
+
+```
+bnd repo deps -o deps.txt
+java -jar org.eclipse.dash.licenses-<version>.jar deps.txt -summary DEPENDENCIES
+```
+
+Pipe directly via stdin (`-` means stdin to the Dash tool):
+
+```
+bnd repo deps | java -jar org.eclipse.dash.licenses-<version>.jar -
+```
+
+Restrict to a single repository (glob on the repository name) and drop your own
+bundles from the report:
+
+```
+bnd repo deps --from "Maven Central" -e "biz.aQute.bnd:*" -e "org.bndtools:*"
+```
+
+Emit ClearlyDefined ids instead of Maven GAVs:
+
+```
+bnd repo deps --clearlydefined
+```
+
+### Running it from Gradle
+
+There is no dedicated Gradle task for the command (neither the bnd build nor the
+bnd Gradle plugin exposes arbitrary `bnd` CLI sub-commands as tasks), but it is
+trivial to wrap in a `JavaExec` task:
+
+```gradle
+tasks.register("ipDashDeps", JavaExec) {
+    group = "verification"
+    description = "Export workspace Maven GAVs for the Eclipse Dash License Tool"
+    classpath = files("…/biz.aQute.bnd.jar")   // the bnd executable jar
+    mainClass = "aQute.bnd.main.bnd"
+    args = ["repo", "-w", projectDir.toString(), "deps", "-e", "biz.aQute.bnd:*", "-o", "${projectDir}/deps.txt"]
+}
+```
+
+Notes:
+
+- In a workspace that uses the **bnd Gradle plugin**, bnd is already on the
+  buildscript classpath, so instead of a hard-coded `files(...)` path resolve it as
+  a dependency — e.g. a dedicated `configurations { bndcli }` with
+  `dependencies { bndcli "biz.aQute.bnd:biz.aQute.bnd:<version>" }` and
+  `classpath = configurations.bndcli`.
+- `--workspace` (`-w`) is a parent `repo` option, so it comes *before* `deps` in
+  `args`.
+- To get a one-shot `./gradlew licenseCheck`, add a second `JavaExec`/`Exec` task
+  that depends on `ipDashDeps` and runs
+  `org.eclipse.dash.licenses-<version>.jar deps.txt -summary DEPENDENCIES`.
+
+### Notes
+
+- Only repositories backed by `MavenBndRepository` are exported; OSGi/P2
+  repositories are skipped because they have no Maven coordinates.
+- Source, javadoc and pom variants collapse into a single entry per artifact, and
+  the list is de-duplicated and sorted.
+- This command only *produces* the dependency list; the actual license vetting is
+  performed by `dash-licenses`. See its README for `-review`/`-token`/`-project`
+  options to automatically open Eclipse IP review requests.


### PR DESCRIPTION
Exports the macro-resolved Maven coordinates of all artifacts in the workspace's Maven repositories as a flat list, consumable by the Eclipse Dash License Tool. Includes --from/--exclude/--clearlydefined options and documentation.