### PR TITLE
Persist and manage workspace template fragment indexes

### DIFF
--- a/bndtools.core/src/bndtools/preferences/BndPreferences.java
+++ b/bndtools.core/src/bndtools/preferences/BndPreferences.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.bndtools.api.NamedPlugin;
 import org.bndtools.headless.build.manager.api.HeadlessBuildManager;
@@ -20,6 +21,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 
 import aQute.bnd.build.Workspace;
+import aQute.bnd.wstemplates.FragmentTemplateEngine;
 import bndtools.Plugin;
 import bndtools.central.Central;
 import bndtools.team.TeamUtils;
@@ -42,6 +44,7 @@ public class BndPreferences {
 	private static final String		PREF_BUILDBEFORELAUNCH			= "buildBeforeLaunch";
 	private static final String		PREF_ENABLE_TEMPLATE_REPO		= "enableTemplateRepo";
 	private static final String		PREF_TEMPLATE_REPO_URI_LIST		= "templateRepoUriList";
+	private static final String		PREF_WORKSPACE_TEMPLATE_INDEXES	= "workspaceTemplateIndexes";
 	private static final String		PREF_EXPLORER_PROMPT			= "prompt";
 	private static final String		PREF_PARALLEL					= "parallel";
 
@@ -63,6 +66,7 @@ public class BndPreferences {
 		store.setDefault(PREF_ENABLE_TEMPLATE_REPO, false);
 		store.setDefault(PREF_TEMPLATE_REPO_URI_LIST,
 			"https://raw.githubusercontent.com/bndtools/bundle-hub/master/index.xml.gz");
+		store.setDefault(PREF_WORKSPACE_TEMPLATE_INDEXES, FragmentTemplateEngine.DEFAULT_INDEX);
 		store.setDefault(PREF_WORKSPACE_OFFLINE, false);
 		store.setDefault(PREF_PARALLEL, false);
 		store.setDefault(PREF_USE_ALIAS_REQUIREMENTS, true);
@@ -208,6 +212,29 @@ public class BndPreferences {
 				sb.append(' ');
 		}
 		store.setValue(PREF_TEMPLATE_REPO_URI_LIST, sb.toString());
+	}
+
+	public List<String> getWorkspaceTemplateIndexes() {
+		return parseUriList(store.getString(PREF_WORKSPACE_TEMPLATE_INDEXES));
+	}
+
+	public void setWorkspaceTemplateIndexes(List<String> uris) {
+		store.setValue(PREF_WORKSPACE_TEMPLATE_INDEXES, formatUriList(uris));
+	}
+
+	static List<String> parseUriList(String urisStr) {
+		if (urisStr == null || urisStr.isBlank())
+			return Collections.emptyList();
+		return Arrays.stream(urisStr.trim()
+			.split("\\s+"))
+			.filter(s -> !s.isBlank())
+			.collect(Collectors.toList());
+	}
+
+	static String formatUriList(List<String> uris) {
+		return uris.stream()
+			.filter(s -> s != null && !s.isBlank())
+			.collect(Collectors.joining(" "));
 	}
 
 	public IPreferenceStore getStore() {

--- a/bndtools.core/src/bndtools/preferences/ui/ReposPreferencePage.java
+++ b/bndtools.core/src/bndtools/preferences/ui/ReposPreferencePage.java
@@ -39,12 +39,16 @@ public class ReposPreferencePage extends PreferencePage implements IWorkbenchPre
 	private List<String>	templateRepos;
 	private TableViewer		vwrRepos;
 
+	private List<String>	workspaceTemplateIndexes;
+	private TableViewer		vwrIndexes;
+
 	@Override
 	public void init(IWorkbench workbench) {
 		BndPreferences prefs = new BndPreferences();
 
 		enableTemplateRepo = prefs.getEnableTemplateRepo();
 		templateRepos = new ArrayList<>(prefs.getTemplateRepoUriList());
+		workspaceTemplateIndexes = new ArrayList<>(prefs.getWorkspaceTemplateIndexes());
 	}
 
 	@Override
@@ -124,6 +128,51 @@ public class ReposPreferencePage extends PreferencePage implements IWorkbenchPre
 			}
 		});
 
+		Group indexGroup = new Group(composite, SWT.NONE);
+		indexGroup.setText("Workspace Template Indexes");
+		indexGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		indexGroup.setLayout(new GridLayout(2, false));
+
+		Label lblIndexes = new Label(indexGroup, SWT.NONE);
+		lblIndexes.setText("Index URLs (index.bnd) offered as workspace template fragments in the New Bnd Workspace wizard:");
+		lblIndexes.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
+
+		final Table tblIndexes = new Table(indexGroup, SWT.BORDER | SWT.MULTI);
+		vwrIndexes = new TableViewer(tblIndexes);
+		vwrIndexes.setContentProvider(ArrayContentProvider.getInstance());
+		vwrIndexes.setLabelProvider(new URLLabelProvider(tblIndexes.getDisplay()));
+		vwrIndexes.setInput(workspaceTemplateIndexes);
+
+		GridData gdIndexes = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		gdIndexes.widthHint = 260;
+		gdIndexes.heightHint = 80;
+		tblIndexes.setLayoutData(gdIndexes);
+
+		final AddRemoveButtonBarPart addRemoveIndexPart = new AddRemoveButtonBarPart();
+		Control addRemoveIndexPanel = addRemoveIndexPart.createControl(indexGroup, SWT.FLAT | SWT.VERTICAL);
+		addRemoveIndexPanel.setLayoutData(new GridData(SWT.FILL, SWT.TOP, false, false));
+		addRemoveIndexPart.setRemoveEnabled(false);
+		addRemoveIndexPart.addListener(new AddRemoveListener() {
+			@Override
+			public void addSelected() {
+				doAddIndex();
+			}
+
+			@Override
+			public void removeSelected() {
+				doRemoveIndex();
+			}
+		});
+		vwrIndexes.addSelectionChangedListener(event -> addRemoveIndexPart.setRemoveEnabled(!vwrIndexes.getSelection()
+			.isEmpty()));
+		tblIndexes.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if (e.keyCode == SWT.DEL && e.stateMask == 0)
+					doRemoveIndex();
+			}
+		});
+
 		return composite;
 	}
 
@@ -152,6 +201,30 @@ public class ReposPreferencePage extends PreferencePage implements IWorkbenchPre
 		validate();
 	}
 
+	private void doAddIndex() {
+		URLDialog dialog = new URLDialog(getShell(), "Add workspace template index URL", false);
+		if (dialog.open() == Window.OK) {
+			URI location = dialog.getLocation();
+
+			String locationStr = location.toString();
+			workspaceTemplateIndexes.add(locationStr);
+			vwrIndexes.add(locationStr);
+		}
+	}
+
+	private void doRemoveIndex() {
+		int[] selectedIndexes = vwrIndexes.getTable()
+			.getSelectionIndices();
+		if (selectedIndexes == null)
+			return;
+		List<Object> selected = new ArrayList<>(selectedIndexes.length);
+		for (int index : selectedIndexes) {
+			selected.add(workspaceTemplateIndexes.get(index));
+		}
+		workspaceTemplateIndexes.removeAll(selected);
+		vwrIndexes.remove(selected.toArray());
+	}
+
 	private void validate() {
 		String error = null;
 		if (enableTemplateRepo) {
@@ -174,6 +247,7 @@ public class ReposPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		prefs.setEnableTemplateRepo(enableTemplateRepo);
 		prefs.setTemplateRepoUriList(templateRepos);
+		prefs.setWorkspaceTemplateIndexes(workspaceTemplateIndexes);
 
 		return true;
 	}

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -1,10 +1,9 @@
 package bndtools.wizards.newworkspace;
 
-import static aQute.bnd.wstemplates.FragmentTemplateEngine.DEFAULT_INDEX;
-
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
@@ -61,6 +60,7 @@ import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateInfo;
 import aQute.bnd.wstemplates.FragmentTemplateEngine.TemplateUpdater;
 import bndtools.Plugin;
 import bndtools.central.Central;
+import bndtools.preferences.BndPreferences;
 import bndtools.shared.ConfirmDialogWithTextarea;
 import bndtools.util.ui.UI;
 
@@ -88,9 +88,11 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 		try {
 			Job job = Job.create("load index", mon -> {
 				try {
-					templates.read(new URL(DEFAULT_INDEX))
-						.unwrap()
-						.forEach(templates::add);
+					for (String uri : new BndPreferences().getWorkspaceTemplateIndexes()) {
+						templates.read(new URL(uri))
+							.unwrap()
+							.forEach(templates::add);
+					}
 					Parameters p = workspace.getMergedParameters(Constants.WORKSPACE_TEMPLATES);
 					templates.read(p)
 						.forEach(templates::add);
@@ -109,7 +111,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 					Plugin.getDefault()
 						.getLog()
 						.log(new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0,
-							"failed to read default index " + DEFAULT_INDEX, e));
+							"failed to read template index", e));
 				}
 			});
 			job.schedule();
@@ -422,6 +424,13 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 							} else {
 								result.unwrap()
 									.forEach(templates::add);
+								String uriStr = uri.toString();
+								BndPreferences prefs = new BndPreferences();
+								List<String> indexes = new ArrayList<>(prefs.getWorkspaceTemplateIndexes());
+								if (!indexes.contains(uriStr)) {
+									indexes.add(uriStr);
+									prefs.setWorkspaceTemplateIndexes(indexes);
+								}
 								ui.write(() -> model.templates = templates.getAvailableTemplates());
 							}
 						} catch (Exception e) {

--- a/bndtools.core/test/bndtools/preferences/BndPreferencesTest.java
+++ b/bndtools.core/test/bndtools/preferences/BndPreferencesTest.java
@@ -1,0 +1,41 @@
+package bndtools.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class BndPreferencesTest {
+
+	@Test
+	public void parse_null_or_blank_yields_empty_list() {
+		assertEquals(List.of(), BndPreferences.parseUriList(null));
+		assertEquals(List.of(), BndPreferences.parseUriList(""));
+		assertEquals(List.of(), BndPreferences.parseUriList("   \t  "));
+	}
+
+	@Test
+	public void parse_splits_on_any_whitespace_and_trims() {
+		assertEquals(List.of("a", "b", "c"), BndPreferences.parseUriList("  a   b \t c "));
+	}
+
+	@Test
+	public void parse_keeps_a_single_value() {
+		assertEquals(List.of("https://example.org/index.bnd"),
+			BndPreferences.parseUriList("https://example.org/index.bnd"));
+	}
+
+	@Test
+	public void format_joins_with_single_space_and_drops_blanks() {
+		assertEquals("a b c", BndPreferences.formatUriList(Arrays.asList("a", "", "b", "   ", "c")));
+		assertEquals("", BndPreferences.formatUriList(List.of()));
+	}
+
+	@Test
+	public void round_trip_preserves_entries() {
+		List<String> uris = List.of("https://a/index.bnd", "file:/tmp/b/index.bnd");
+		assertEquals(uris, BndPreferences.parseUriList(BndPreferences.formatUriList(uris)));
+	}
+}


### PR DESCRIPTION
Fixes #7276

Add a bndtools.core preference `workspaceTemplateIndexes` (default FragmentTemplateEngine.DEFAULT_INDEX) to persist extra -workspace-templates indexes. The New Bnd Workspace wizard now loads them from this preference instead of hard-coding DEFAULT_INDEX and persists indexes added via the '+' button. A "Workspace Template Indexes" group on the Templates preference page manages them (Add/Remove), mirroring the templateRepoUriList UI. The list can be pre-seeded via e.g. Oomph: /instance/bndtools.core/workspaceTemplateIndexes.