### PR TITLE
Fix NPE in RepoCollector initialization during Project construction

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ProjectTest.java
@@ -870,6 +870,25 @@ public class ProjectTest {
 		}
 	}
 
+	/**
+	 * Test for https://github.com/bndtools/bnd/issues/7303 that no NPE is
+	 * thrown.
+	 */
+	@Test
+	public void testRepoCollectorNoNPEWorkspaceOpenNotCalled() throws Exception {
+
+		try (Workspace ws = getWorkspace(IO.getFile("testresources/ws-repocollector"), "cnf").setOffline(false);
+			Project project = ws.getProject("p1");
+		) {
+			List<String> errors = project.getErrors();
+			List<String> warnings = project.getWarnings();
+
+			assertThat(errors).hasSize(0);
+			assertThat(warnings).hasSize(0);
+		}
+
+	}
+
 	@Test
 	public void testRepoCollectorNonJar() throws Exception {
 		try (Workspace ws = getWorkspace(IO.getFile("testresources/ws-repononjar"));
@@ -1308,6 +1327,16 @@ public class ProjectTest {
 	private Workspace getWorkspace(File file) throws Exception {
 		IO.copy(file, tmp);
 		return new Workspace(tmp);
+	}
+
+	/**
+	 * This method calles the 2-arg constructor of Workspace, which was
+	 * important for a bugfix, because this constructor does not call
+	 * Workspace.open()
+	 */
+	private Workspace getWorkspace(File file, String bndDir) throws Exception {
+		IO.copy(file, tmp);
+		return new Workspace(tmp, bndDir);
 	}
 
 	private Workspace getWorkspace(String dir) throws Exception {

--- a/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/bnd.bnd
+++ b/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/bnd.bnd
@@ -1,0 +1,1 @@
+-nobundles=true

--- a/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/build.bnd
+++ b/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/build.bnd
@@ -1,0 +1,5 @@
+-plugin.1.Central: \
+  aQute.bnd.repository.maven.provider.MavenBndRepository; \
+    name = Central; \
+    releaseUrl = https://repo.maven.apache.org/maven2/; \
+    index = ./cnf/deps.maven

--- a/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/deps.maven
+++ b/biz.aQute.bndlib.tests/testresources/ws-repocollector/cnf/deps.maven
@@ -1,0 +1,1 @@
+org.ow2.asm:asm:9.10

--- a/biz.aQute.bndlib.tests/testresources/ws-repocollector/p1/bnd.bnd
+++ b/biz.aQute.bndlib.tests/testresources/ws-repocollector/p1/bnd.bnd
@@ -1,0 +1,2 @@
+-buildpath: org.ow2.asm:asm;version=9.10
+-include= jar:${fileuri;${repo;org.ow2.asm:asm;9.10}}!/META-INF/MANIFEST.MF

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -191,12 +191,12 @@ public class Project extends Processor {
 		super(workspace);
 		this.workspace = workspace;
 		setFileMustExist(false);
+		repoCollector = new RepoCollector(this);
 		if (buildFile != null)
 			setProperties(buildFile);
 
 		// For backward compatibility reasons, we also read
 		readBuildProperties();
-		repoCollector = new RepoCollector(this);
 		addClose(repoCollector);
 	}
 
@@ -3249,7 +3249,7 @@ public class Project extends Processor {
 				.stream()
 				.mapToInt(arg -> arg.length() + 3) // +1 for space, +2 for potential quotes
 				.sum();
-			
+
 			// Windows command line limit is ~8191 characters
 			// Use arg file if we're getting close (allow some margin)
 			if (cmdLineLength > 6000) {
@@ -3282,7 +3282,7 @@ public class Project extends Processor {
 	private File createJavacArgumentFile(Command javac) throws Exception {
 		File argFile = IO.createTempFile(getTarget(), "javac-args", ".txt");
 		List<String> args = javac.getArguments();
-		
+
 		try (PrintWriter writer = new PrintWriter(argFile, "UTF-8")) {
 			// Skip the first argument (javac executable path)
 			for (int i = 1; i < args.size(); i++) {
@@ -3296,7 +3296,7 @@ public class Project extends Processor {
 				writer.println(arg);
 			}
 		}
-		
+
 		return argFile;
 	}
 


### PR DESCRIPTION
Closes #7303 

Move RepoCollector initialization before setProperties() in Project constructor to ensure it's available when properties are being processed. This fixes issue #7303 where an NPE could occur when using the 2-arg Workspace constructor (which doesn't call open()). Adds test case with repocollector workspace to verify the fix.