### PR TITLE
gradle: Properly configure sourceSet compile and runtime classpaths

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -238,7 +238,7 @@ public class BndPlugin implements Plugin<Project> {
 			/* Set up source sets */
 			SourceSetContainer sourceSets = sourceSets(project);
 			/* bnd uses the same directory for java and resources. */
-			sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME, sourceSet -> {
+			SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME, sourceSet -> {
 				ConfigurableFileCollection srcDirs;
 				try {
 					srcDirs = objects.fileCollection()
@@ -249,25 +249,23 @@ public class BndPlugin implements Plugin<Project> {
 				File destinationDir = bndProject.getSrcOutput();
 				sourceSet.getJava()
 					.setSrcDirs(srcDirs);
+				sourceSet.getJava()
+					.getDestinationDirectory()
+					.fileValue(destinationDir);
 				sourceSet.getResources()
 					.setSrcDirs(srcDirs);
-				sourceSet.getJava()
+				sourceSet.getResources()
 					.getDestinationDirectory()
 					.fileValue(destinationDir);
 				sourceSet.getOutput()
 					.setResourcesDir(destinationDir);
-				TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(),
-					AbstractCompile.class, t -> {
-						t.getDestinationDirectory()
-							.fileValue(destinationDir);
-						FileCollection jarLibraryElements = jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
-						t.setClasspath(jarLibraryElements.plus(t.getClasspath()));
-					});
-				generateInputAction.ifPresent(compileTask::configure);
-				sourceSet.getOutput()
-					.dir(Maps.of("builtBy", compileTask.getName()), destinationDir);
-				TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
-				generateInputAction.ifPresent(processResourcesTask::configure);
+				sourceSet.setCompileClasspath(jarLibraryElements(project, sourceSet.getCompileClasspathConfigurationName()));
+				sourceSet.setRuntimeClasspath(objects.fileCollection()
+					.from(sourceSet.getOutput(), jarLibraryElements(project, sourceSet.getRuntimeClasspathConfigurationName())));
+				generateInputAction.ifPresent(action -> {
+					tasks.named(sourceSet.getCompileJavaTaskName()).configure(action);
+					tasks.named(sourceSet.getProcessResourcesTaskName()).configure(action);
+				});
 			});
 			sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME, sourceSet -> {
 				ConfigurableFileCollection srcDirs = objects.fileCollection()
@@ -275,22 +273,20 @@ public class BndPlugin implements Plugin<Project> {
 				File destinationDir = bndProject.getTestOutput();
 				sourceSet.getJava()
 					.setSrcDirs(srcDirs);
+				sourceSet.getJava()
+					.getDestinationDirectory()
+					.fileValue(destinationDir);
 				sourceSet.getResources()
 					.setSrcDirs(srcDirs);
-				sourceSet.getJava()
+				sourceSet.getResources()
 					.getDestinationDirectory()
 					.fileValue(destinationDir);
 				sourceSet.getOutput()
 					.setResourcesDir(destinationDir);
-				TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(),
-					AbstractCompile.class, t -> {
-						t.getDestinationDirectory()
-							.fileValue(destinationDir);
-						FileCollection jarLibraryElements = jarLibraryElements(t, sourceSet.getCompileClasspathConfigurationName());
-						t.setClasspath(jarLibraryElements.plus(t.getClasspath()));
-					});
-				sourceSet.getOutput()
-					.dir(Maps.of("builtBy", compileTask.getName()), destinationDir);
+				sourceSet.setCompileClasspath(objects.fileCollection()
+					.from(mainSourceSet.getOutput(), jarLibraryElements(project, sourceSet.getCompileClasspathConfigurationName())));
+				sourceSet.setRuntimeClasspath(objects.fileCollection()
+					.from(sourceSet.getOutput(), mainSourceSet.getOutput(), jarLibraryElements(project, sourceSet.getRuntimeClasspathConfigurationName())));
 			});
 			/* Configure srcDirs for any additional languages */
 			project.afterEvaluate(p -> {
@@ -305,26 +301,20 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					Provider<Directory> destinationDir = sourceSet.getJava()
-						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
 					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
 						try {
 							TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileTaskName(name),
-								AbstractCompile.class, t -> {
-									t.getDestinationDirectory()
-										.value(destinationDir);
-									t.getInputs()
-										.files(processResourcesTask)
-										.withPropertyName(processResourcesTask.getName());
-								});
-							generateInputAction.ifPresent(compileTask::configure);
+								AbstractCompile.class, t -> t.getInputs()
+									.files(processResourcesTask)
+									.withPropertyName(processResourcesTask.getName())
+							);
 							sourceDirectorySet.setSrcDirs(sourceSet.getJava()
 								.getSrcDirs());
 							sourceDirectorySet.getDestinationDirectory()
-								.value(destinationDir);
-							sourceSet.getOutput()
-								.dir(Maps.of("builtBy", compileTask.getName()), destinationDir);
+								.value(sourceSet.getJava()
+									.getDestinationDirectory());
+							generateInputAction.ifPresent(compileTask::configure);
 						} catch (UnknownDomainObjectException e) {
 							// no such task
 						}
@@ -341,25 +331,19 @@ public class BndPlugin implements Plugin<Project> {
 								sourceDirectorySets.put(name, sourceDirectorySet);
 							}
 						});
-					Provider<Directory> destinationDir = sourceSet.getJava()
-						.getClassesDirectory();
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
 					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
 						try {
 							TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileTaskName(name),
-								AbstractCompile.class, t -> {
-									t.getDestinationDirectory()
-										.value(destinationDir);
-									t.getInputs()
-										.files(processResourcesTask)
-										.withPropertyName(processResourcesTask.getName());
-								});
+								AbstractCompile.class, t -> t.getInputs()
+									.files(processResourcesTask)
+									.withPropertyName(processResourcesTask.getName())
+							);
 							sourceDirectorySet.setSrcDirs(sourceSet.getJava()
 								.getSrcDirs());
 							sourceDirectorySet.getDestinationDirectory()
-								.value(destinationDir);
-							sourceSet.getOutput()
-								.dir(Maps.of("builtBy", compileTask.getName()), destinationDir);
+								.value(sourceSet.getJava()
+									.getDestinationDirectory());
 						} catch (UnknownDomainObjectException e) {
 							// no such task
 						}
@@ -376,11 +360,7 @@ public class BndPlugin implements Plugin<Project> {
 			/* Set up dependencies */
 			DependencyHandler dependencies = project.getDependencies();
 			dependencies.add(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, pathFiles(bndProject.getBuildpath()));
-			dependencies.add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, objects.fileCollection()
-				.from(bndProject.getSrcOutput()));
 			dependencies.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, pathFiles(bndProject.getTestpath()));
-			dependencies.add(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, objects.fileCollection()
-				.from(bndProject.getTestOutput()));
 			/* Set up compile tasks */
 			ConfigurableFileCollection javacBootclasspath = objects.fileCollection()
 				.from(decontainer(bndProject.getBootclasspath()));

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndUtils.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndUtils.java
@@ -158,12 +158,11 @@ public class BndUtils {
 	 * attribute, the {@code jar} variant will also be available, making any resources packaged in the jar
 	 * visible.  The provided configuration itself will <strong>NOT</strong> be modified.
 	 *
-	 * @param task The Task.
+	 * @param project The Project.
 	 * @param configurationName The configuration name.
 	 * @return A {@link FileCollection} of the {@code jar} variants of the specified configuration.
 	 */
-	public static FileCollection jarLibraryElements(Task task, String configurationName) {
-		Project project = task.getProject();
+	public static FileCollection jarLibraryElements(Project project, String configurationName) {
 		Configuration configuration = project.getConfigurations()
 			.getByName(configurationName);
 		ArtifactView artifactView = configuration.getIncoming()
@@ -172,10 +171,10 @@ public class BndUtils {
 				try {
 					attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.getObjects()
 						.named(LibraryElements.class, LibraryElements.JAR));
-					task.getLogger()
+					project.getLogger()
 						.info("Using jars for configuration {}:{}", project.getPath(), configurationName);
 				} catch (IllegalArgumentException e) {
-					task.getLogger()
+					project.getLogger()
 						.info("Unable to use jars for configuration {}:{}", project.getPath(), configurationName, e);
 				}
 			});

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BundleTaskExtension.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BundleTaskExtension.java
@@ -209,7 +209,7 @@ public class BundleTaskExtension {
 		outputDirectory = objects.directoryProperty();
 		SourceSet mainSourceSet = sourceSets(project).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
 		setSourceSet(mainSourceSet);
-		classpath(jarLibraryElements(task, mainSourceSet.getCompileClasspathConfigurationName()));
+		classpath(jarLibraryElements(project, mainSourceSet.getCompileClasspathConfigurationName()));
 		properties = objects.mapProperty(String.class, Object.class)
 			.convention(project.provider(this::getGradleProjectProperties));
 		defaultBundleSymbolicName = task.getArchiveBaseName()


### PR DESCRIPTION
This fix is for Bnd Workspace builds.

We use jarLibraryElements to process configurations to require jar elements (instead of output folders). We do this since Bnd can add content to the jar which is sourced from the classpath of the jar task.

So, we now set the sourceSet compile and runtime classpaths using the jarLibraryElements file collection from the compile and runtime classpath configurations, respectively, preceeded with the necessary sourceSet outputs for each classpath.

- main compile: compileClasspath configuration
- main runtime: main output + runtimeClasspath configuration
- test compile: main output + testCompileClasspath configuration
- test runtime: test output + main output + testRuntimeClasspath configuration

We no longer set the classpath or destination dir in the compile task since it will use the related sourceSet compile classpath and destination dir.

We also remove the incorrect setting of the runtimeOnly and testRuntimeOnly configurations.

Fixes https://github.com/bndtools/bnd/issues/7306