### PR TITLE
Suppress deprecation warnings and update deprecated API calls

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/bnd.java
@@ -1470,6 +1470,7 @@ public class bnd extends Processor {
 	 *
 	 * @throws Exception
 	 */
+	@SuppressWarnings("removal")
 	@Description("Release this project")
 	public void _release(releaseOptions options) throws Exception {
 		Set<Project> projects = new LinkedHashSet<>();

--- a/biz.aQute.bndlib.tests/test/test/AnalysisPluginTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalysisPluginTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 

--- a/biz.aQute.bndlib.tests/test/test/BuilderTest.java
+++ b/biz.aQute.bndlib.tests/test/test/BuilderTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import aQute.bnd.build.model.EE;
 import aQute.bnd.header.Attrs;
@@ -1191,7 +1192,8 @@ public class BuilderTest {
 
 	static class CompilerVersionsArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			FileTree tree = new FileTree();
 			Stream<File> files = tree.stream(new File("compilerversions/src"), "*");
 			return files.filter(File::isDirectory)

--- a/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ClassReferenceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import aQute.bnd.build.model.EE;
 import aQute.bnd.osgi.Builder;
@@ -60,7 +61,8 @@ public class ClassReferenceTest {
 
 	static class CompilerVersionsArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			FileTree tree = new FileTree();
 			Stream<File> files = tree.stream(new File("compilerversions/src"), "*");
 			return files.filter(File::isDirectory)
@@ -79,7 +81,8 @@ public class ClassReferenceTest {
 
 	static class JAVAArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			Clazz.JAVA[] values = Clazz.JAVA.values();
 			return Arrays.stream(values, 0, values.length - 1)
 				.map(Arguments::of);

--- a/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
+++ b/biz.aQute.bndlib.tests/test/test/component/DSAnnotationTest.java
@@ -676,7 +676,7 @@ public class DSAnnotationTest {
 
 	@Component(service = Object.class, configurationPolicy = ConfigurationPolicy.IGNORE, enabled = false, factory = "factory", immediate = false, name = "name", property = {
 		"a=1", "a=2", "b=3"
-	}, properties = "resource.props", servicefactory = false, configurationPid = "configuration-pid", xmlns = "xmlns")
+	}, properties = "resource.props", scope = ServiceScope.SINGLETON, configurationPid = "configuration-pid", xmlns = "xmlns")
 	public static class Explicit_basic implements Serializable, Runnable {
 		private static final long serialVersionUID = 1L;
 

--- a/biz.aQute.bndlib.tests/test/test/model/EETest.java
+++ b/biz.aQute.bndlib.tests/test/test/model/EETest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import aQute.bnd.build.model.EE;
 import aQute.bnd.osgi.Clazz;
@@ -33,7 +34,8 @@ public class EETest {
 
 	static class EEVersionsArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			EE[] values = EE.values();
 			return Arrays.stream(values, 0, values.length - 1)
 				.filter(ee -> ee.getCapabilityName()
@@ -161,7 +163,8 @@ public class EETest {
 
 	static class EEsArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			EE[] values = EE.values();
 			return Arrays.stream(values, 0, values.length - 1)
 				.filter(ee -> ee.getCapabilityName()
@@ -172,7 +175,8 @@ public class EETest {
 
 	static class ModularEEsArgumentsProvider implements ArgumentsProvider {
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+		public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context)
+			throws Exception {
 			EE[] values = EE.values();
 			return Arrays.stream(values, 0, values.length - 1)
 				.filter(ee -> ee.compareTo(EE.JavaSE_1_8) > 0)

--- a/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/ProjectTester.java
@@ -22,6 +22,7 @@ public abstract class ProjectTester {
 	private boolean					continuous	= true;
 	private boolean					terminate	= true;
 
+	@SuppressWarnings("deprecation")
 	public ProjectTester(Project project) throws Exception {
 		this.project = project;
 		launcher = project.getProjectLauncher();

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/pom/provider/BndPomRepository.java
@@ -106,6 +106,7 @@ public class BndPomRepository extends BaseRepository
 		prepared.get(); // start preparation
 	}
 
+	@SuppressWarnings("removal")
 	private Promise<Boolean> preparePromise() {
 		if (configuration.name() == null) {
 			status("Must get a name");

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Configuration.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/Configuration.java
@@ -97,5 +97,6 @@ public interface Configuration {
 	/**
 	 * @return SonatypeMode for this repository none, manual or autopublish
 	 */
+	@SuppressWarnings("removal")
 	SonatypeMode sonatypeMode(String deflt);
 }

--- a/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/maven/provider/MavenBndRepository.java
@@ -662,6 +662,7 @@ public class MavenBndRepository extends BaseRepository implements RepositoryPlug
 			List<MavenBackingRepository> snapshot = new ArrayList<MavenBackingRepository>();
 
 			String releaseUrl = configuration.releaseUrl();
+			@SuppressWarnings("removal")
 			SonatypeMode sonatypeMode = configuration.sonatypeMode(SonatypeMode.NONE.name());
 
 			String stagingUrl = configuration.stagingUrl();

--- a/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
+++ b/biz.aQute.repository/src/aQute/maven/provider/MavenRepository.java
@@ -47,6 +47,7 @@ public class MavenRepository implements IMavenRepo, Closeable {
 	private final boolean						localOnly;
 	private final Map<Revision, Promise<POM>>	poms			= new WeakHashMap<>();
 	private final Reporter						reporter;
+	@SuppressWarnings("removal")
 	private SonatypeMode						sonatypeMode	= SonatypeMode.NONE;
 	private String								sonatypeReleaseUrl	= null;
 	private String								sonatypeSnapshotUrl	= null;
@@ -415,10 +416,12 @@ public class MavenRepository implements IMavenRepo, Closeable {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	public void setSonatypeMode(SonatypeMode sonatypeMode) {
 		this.sonatypeMode = sonatypeMode;
 	}
 
+	@SuppressWarnings("removal")
 	public SonatypeMode getSonatypeMode() {
 		return sonatypeMode;
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/SonatypeDeploymentTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/maven/provider/SonatypeDeploymentTest.java
@@ -154,6 +154,7 @@ public class SonatypeDeploymentTest {
 		Files.writeString(buildBnd.toPath(), content);
 	}
 
+	@SuppressWarnings("removal")
 	private void testDeployment(boolean isSnapshot) throws Exception, IOException {
 		LinkedList<File> releasedFiles = new LinkedList<File>();
 		try (Workspace ws = Workspace.findWorkspace(wsDir)) {

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/Eclipse438FeatureTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/Eclipse438FeatureTest.java
@@ -1,13 +1,14 @@
 package aQute.bnd.repository.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,10 +24,6 @@ import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.lib.io.IO;
 import aQute.p2.packed.Unpack200;
 import aQute.p2.provider.Feature;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Comprehensive test to verify parsing of Eclipse 4.38 P2 repository features.
@@ -57,13 +54,13 @@ public class Eclipse438FeatureTest {
 	public void testEclipse438RepositoryIndexing() throws Exception {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			client.setCache(IO.getFile(tmp, "http-cache"));
-			
+
 			Unpack200 processor = new Unpack200(proc);
 			File indexLocation = new File(tmp, "eclipse-438-index");
-			
+
 			System.out.println("Creating P2 indexer for Eclipse 4.38 repository...");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
-				"Eclipse 4.38");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
+				"Eclipse 4.38")) {}
 
 			// Verify index was created
 			softly.assertThat(indexLocation)
@@ -88,139 +85,137 @@ public class Eclipse438FeatureTest {
 	public void testEclipse438FeatureExtraction() throws Exception {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			client.setCache(IO.getFile(tmp, "http-cache"));
-			
+
 			Unpack200 processor = new Unpack200(proc);
 			File indexLocation = new File(tmp, "eclipse-438-features");
-			
+
 			System.out.println("\n=== Testing Eclipse 4.38 Feature Extraction ===");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
-				"Eclipse 4.38");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
+				"Eclipse 4.38")) {
+				// Get all resources from the repository
+				org.osgi.service.repository.Repository repository = indexer.getBridge()
+					.getRepository();
+				RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
 
-			// Get all resources from the repository
-			org.osgi.service.repository.Repository repository = indexer.getBridge()
-				.getRepository();
-			RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
+				java.util.Collection<Capability> allCaps = repository
+					.findProviders(java.util.Collections.singleton(req))
+					.getOrDefault(req, java.util.Collections.emptyList());
 
-			java.util.Collection<Capability> allCaps = repository
-				.findProviders(java.util.Collections.singleton(req))
-				.getOrDefault(req, java.util.Collections.emptyList());
+				System.out.println("Total capabilities in repository: " + allCaps.size());
 
-			System.out.println("Total capabilities in repository: " + allCaps.size());
+				// Get unique resources
+				java.util.Set<Resource> allResources = ResourceUtils.getResources(allCaps);
+				System.out.println("Total resources in repository: " + allResources.size());
 
-			// Get unique resources
-			java.util.Set<Resource> allResources = ResourceUtils.getResources(allCaps);
-			System.out.println("Total resources in repository: " + allResources.size());
+				// Count and categorize resources by type
+				Map<String, Long> typeCount = allResources.stream()
+					.flatMap(r -> r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
+						.stream())
+					.map(cap -> (String) cap.getAttributes()
+						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
+					.filter(type -> type != null)
+					.collect(Collectors.groupingBy(type -> type, Collectors.counting()));
 
-			// Count and categorize resources by type
-			Map<String, Long> typeCount = allResources.stream()
-				.flatMap(r -> r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
-					.stream())
-				.map(cap -> (String) cap.getAttributes()
-					.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
-				.filter(type -> type != null)
-				.collect(Collectors.groupingBy(type -> type, Collectors.counting()));
+				System.out.println("\nResource types in repository:");
+				typeCount.forEach((type, count) -> System.out.println("  " + type + ": " + count));
 
-			System.out.println("\nResource types in repository:");
-			typeCount.forEach((type, count) -> System.out.println("  " + type + ": " + count));
+				// Verify features exist
+				long featureCount = typeCount.getOrDefault("org.eclipse.update.feature", 0L);
+				softly.assertThat(featureCount)
+					.as("Eclipse 4.38 repository should contain features")
+					.isGreaterThan(0);
 
-			// Verify features exist
-			long featureCount = typeCount.getOrDefault("org.eclipse.update.feature", 0L);
-			softly.assertThat(featureCount)
-				.as("Eclipse 4.38 repository should contain features")
-				.isGreaterThan(0);
+				// Extract features using the getFeatures() method
+				System.out.println("\n=== Extracting features ===");
+				List<Feature> features = indexer.getFeatures();
 
-			// Extract features using the getFeatures() method
-			System.out.println("\n=== Extracting features ===");
-			List<Feature> features = indexer.getFeatures();
-
-			System.out.println("Total features extracted: " + features.size());
-			softly.assertThat(features)
-				.as("Should be able to extract features from repository")
-				.isNotEmpty();
-
-			// Analyze and validate features
-			int validatedCount = 0;
-			int withPlugins = 0;
-			int withIncludes = 0;
-			int withRequires = 0;
-
-			for (Feature feature : features) {
-				// Basic validation
-				softly.assertThat(feature.getId())
-					.as("Feature should have an ID")
-					.isNotNull()
+				System.out.println("Total features extracted: " + features.size());
+				softly.assertThat(features)
+					.as("Should be able to extract features from repository")
 					.isNotEmpty();
 
-				softly.assertThat(feature.getVersion())
-					.as("Feature " + feature.getId() + " should have a version")
-					.isNotNull()
-					.isNotEmpty();
+				// Analyze and validate features
+				int validatedCount = 0;
+				int withPlugins = 0;
+				int withIncludes = 0;
+				int withRequires = 0;
 
-				// Count features with different elements
-				if (!feature.getPlugins()
-					.isEmpty()) {
-					withPlugins++;
-				}
-				if (!feature.getIncludes()
-					.isEmpty()) {
-					withIncludes++;
-				}
-				if (!feature.getRequires()
-					.isEmpty()) {
-					withRequires++;
-				}
+				for (Feature feature : features) {
+					// Basic validation
+					softly.assertThat(feature.getId())
+						.as("Feature should have an ID")
+						.isNotNull()
+						.isNotEmpty();
 
-				// Print details for first few features
-				if (validatedCount < 5) {
-					System.out.println("\nFeature #" + (validatedCount + 1) + ": " + feature.getId());
-					System.out.println("  Version: " + feature.getVersion());
-					System.out.println("  Label: " + feature.getLabel());
-					System.out.println("  Provider: " + feature.getProviderName());
-					System.out.println("  Plugins: " + feature.getPlugins()
-						.size());
-					System.out.println("  Includes: " + feature.getIncludes()
-						.size());
-					System.out.println("  Requires: " + feature.getRequires()
-						.size());
+					softly.assertThat(feature.getVersion())
+						.as("Feature " + feature.getId() + " should have a version")
+						.isNotNull()
+						.isNotEmpty();
 
-					// Print some plugin details
+					// Count features with different elements
 					if (!feature.getPlugins()
 						.isEmpty()) {
-						System.out.println("  Sample plugins:");
-						feature.getPlugins()
-							.stream()
-							.limit(3)
-							.forEach(
-								p -> System.out.println("    - " + p.id + " version=" + p.version));
+						withPlugins++;
 					}
-
-					// Print some included features
 					if (!feature.getIncludes()
 						.isEmpty()) {
-						System.out.println("  Included features:");
-						feature.getIncludes()
-							.stream()
-							.limit(3)
-							.forEach(inc -> System.out
-								.println("    - " + inc.id + " version=" + inc.version
-									+ (inc.optional ? " (optional)" : "")));
+						withIncludes++;
 					}
+					if (!feature.getRequires()
+						.isEmpty()) {
+						withRequires++;
+					}
+
+					// Print details for first few features
+					if (validatedCount < 5) {
+						System.out.println("\nFeature #" + (validatedCount + 1) + ": " + feature.getId());
+						System.out.println("  Version: " + feature.getVersion());
+						System.out.println("  Label: " + feature.getLabel());
+						System.out.println("  Provider: " + feature.getProviderName());
+						System.out.println("  Plugins: " + feature.getPlugins()
+							.size());
+						System.out.println("  Includes: " + feature.getIncludes()
+							.size());
+						System.out.println("  Requires: " + feature.getRequires()
+							.size());
+
+						// Print some plugin details
+						if (!feature.getPlugins()
+							.isEmpty()) {
+							System.out.println("  Sample plugins:");
+							feature.getPlugins()
+								.stream()
+								.limit(3)
+								.forEach(p -> System.out.println("    - " + p.id + " version=" + p.version));
+						}
+
+						// Print some included features
+						if (!feature.getIncludes()
+							.isEmpty()) {
+							System.out.println("  Included features:");
+							feature.getIncludes()
+								.stream()
+								.limit(3)
+								.forEach(inc -> System.out.println("    - " + inc.id + " version=" + inc.version
+									+ (inc.optional ? " (optional)" : "")));
+						}
+					}
+
+					validatedCount++;
 				}
 
-				validatedCount++;
+				System.out.println("\n=== Feature Statistics ===");
+				System.out.println("Total features validated: " + validatedCount);
+				System.out.println("Features with plugins: " + withPlugins);
+				System.out.println("Features with includes: " + withIncludes);
+				System.out.println("Features with requires: " + withRequires);
+
+				// Validate that many features have content
+				softly.assertThat(withPlugins)
+					.as("Many features should contain plugin references")
+					.isGreaterThan(0);
 			}
-
-			System.out.println("\n=== Feature Statistics ===");
-			System.out.println("Total features validated: " + validatedCount);
-			System.out.println("Features with plugins: " + withPlugins);
-			System.out.println("Features with includes: " + withIncludes);
-			System.out.println("Features with requires: " + withRequires);
-
-			// Validate that many features have content
-			softly.assertThat(withPlugins)
-				.as("Many features should contain plugin references")
-				.isGreaterThan(0);
 		}
 	}
 
@@ -231,77 +226,78 @@ public class Eclipse438FeatureTest {
 	public void testEclipse438SpecificFeatures() throws Exception {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			client.setCache(IO.getFile(tmp, "http-cache"));
-			
+
 			Unpack200 processor = new Unpack200(proc);
 			File indexLocation = new File(tmp, "eclipse-438-specific");
-			
+
 			System.out.println("\n=== Testing Specific Eclipse 4.38 Features ===");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
-				"Eclipse 4.38");
-
-			// Get all features to find available ones
-			List<Feature> allFeatures = indexer.getFeatures();
-			softly.assertThat(allFeatures)
-				.as("Repository should contain features")
-				.isNotEmpty();
-
-			// Print first few features for reference
-			System.out.println("\nAvailable features (first 10):");
-			allFeatures.stream()
-				.limit(10)
-				.forEach(f -> System.out.println("  - " + f.getId() + " version " + f.getVersion()));
-
-			// Try to get a specific feature
-			if (!allFeatures.isEmpty()) {
-				Feature firstFeature = allFeatures.get(0);
-				System.out.println("\nTesting getFeature() with: " + firstFeature.getId() + " v" + firstFeature.getVersion());
-				
-				Feature retrieved = indexer.getFeature(firstFeature.getId(), firstFeature.getVersion());
-				
-				softly.assertThat(retrieved)
-					.as("Should be able to retrieve feature by ID and version")
-					.isNotNull();
-
-				if (retrieved != null) {
-					softly.assertThat(retrieved.getId())
-						.as("Retrieved feature should have correct ID")
-						.isEqualTo(firstFeature.getId());
-
-					softly.assertThat(retrieved.getVersion())
-						.as("Retrieved feature should have correct version")
-						.isEqualTo(firstFeature.getVersion());
-
-					System.out.println("Successfully retrieved feature: " + retrieved.getId());
-					System.out.println("  Plugins: " + retrieved.getPlugins()
-						.size());
-					System.out.println("  Includes: " + retrieved.getIncludes()
-						.size());
-				}
-			}
-
-			// Look for platform feature (common in Eclipse releases)
-			Feature platformFeature = allFeatures.stream()
-				.filter(f -> f.getId() != null && f.getId()
-					.contains("org.eclipse.platform"))
-				.findFirst()
-				.orElse(null);
-
-			if (platformFeature != null) {
-				System.out.println("\nFound platform feature: " + platformFeature.getId());
-				System.out.println("  Version: " + platformFeature.getVersion());
-				System.out.println("  Label: " + platformFeature.getLabel());
-				System.out.println("  Plugins: " + platformFeature.getPlugins()
-					.size());
-				System.out.println("  Includes: " + platformFeature.getIncludes()
-					.size());
-
-				softly.assertThat(platformFeature.getId())
-					.as("Platform feature should have ID")
-					.isNotNull();
-
-				softly.assertThat(platformFeature.getPlugins())
-					.as("Platform feature should have plugins")
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
+				"Eclipse 4.38")) {
+				// Get all features to find available ones
+				List<Feature> allFeatures = indexer.getFeatures();
+				softly.assertThat(allFeatures)
+					.as("Repository should contain features")
 					.isNotEmpty();
+
+				// Print first few features for reference
+				System.out.println("\nAvailable features (first 10):");
+				allFeatures.stream()
+					.limit(10)
+					.forEach(f -> System.out.println("  - " + f.getId() + " version " + f.getVersion()));
+
+				// Try to get a specific feature
+				if (!allFeatures.isEmpty()) {
+					Feature firstFeature = allFeatures.get(0);
+					System.out.println(
+						"\nTesting getFeature() with: " + firstFeature.getId() + " v" + firstFeature.getVersion());
+
+					Feature retrieved = indexer.getFeature(firstFeature.getId(), firstFeature.getVersion());
+
+					softly.assertThat(retrieved)
+						.as("Should be able to retrieve feature by ID and version")
+						.isNotNull();
+
+					if (retrieved != null) {
+						softly.assertThat(retrieved.getId())
+							.as("Retrieved feature should have correct ID")
+							.isEqualTo(firstFeature.getId());
+
+						softly.assertThat(retrieved.getVersion())
+							.as("Retrieved feature should have correct version")
+							.isEqualTo(firstFeature.getVersion());
+
+						System.out.println("Successfully retrieved feature: " + retrieved.getId());
+						System.out.println("  Plugins: " + retrieved.getPlugins()
+							.size());
+						System.out.println("  Includes: " + retrieved.getIncludes()
+							.size());
+					}
+				}
+
+				// Look for platform feature (common in Eclipse releases)
+				Feature platformFeature = allFeatures.stream()
+					.filter(f -> f.getId() != null && f.getId()
+						.contains("org.eclipse.platform"))
+					.findFirst()
+					.orElse(null);
+
+				if (platformFeature != null) {
+					System.out.println("\nFound platform feature: " + platformFeature.getId());
+					System.out.println("  Version: " + platformFeature.getVersion());
+					System.out.println("  Label: " + platformFeature.getLabel());
+					System.out.println("  Plugins: " + platformFeature.getPlugins()
+						.size());
+					System.out.println("  Includes: " + platformFeature.getIncludes()
+						.size());
+
+					softly.assertThat(platformFeature.getId())
+						.as("Platform feature should have ID")
+						.isNotNull();
+
+					softly.assertThat(platformFeature.getPlugins())
+						.as("Platform feature should have plugins")
+						.isNotEmpty();
+				}
 			}
 		}
 	}
@@ -313,42 +309,45 @@ public class Eclipse438FeatureTest {
 	public void testEclipse438FeatureProperties() throws Exception {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			client.setCache(IO.getFile(tmp, "http-cache"));
-			
+
 			Unpack200 processor = new Unpack200(proc);
 			File indexLocation = new File(tmp, "eclipse-438-properties");
-			
+
 			System.out.println("\n=== Testing Feature Property Resolution ===");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
-				"Eclipse 4.38");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
+				"Eclipse 4.38")) {
+				List<Feature> features = indexer.getFeatures();
 
-			List<Feature> features = indexer.getFeatures();
-			
-			// Check that properties are resolved (not showing %key references)
-			int resolvedLabels = 0;
-			int resolvedProviders = 0;
+				// Check that properties are resolved (not showing %key
+				// references)
+				int resolvedLabels = 0;
+				int resolvedProviders = 0;
 
-			for (Feature feature : features) {
-				if (feature.getLabel() != null && !feature.getLabel()
-					.startsWith("%")) {
-					resolvedLabels++;
-					if (resolvedLabels <= 3) {
-						System.out.println("Feature " + feature.getId() + " has resolved label: " + feature.getLabel());
+				for (Feature feature : features) {
+					if (feature.getLabel() != null && !feature.getLabel()
+						.startsWith("%")) {
+						resolvedLabels++;
+						if (resolvedLabels <= 3) {
+							System.out
+								.println("Feature " + feature.getId() + " has resolved label: " + feature.getLabel());
+						}
+					}
+
+					if (feature.getProviderName() != null && !feature.getProviderName()
+						.startsWith("%")) {
+						resolvedProviders++;
 					}
 				}
 
-				if (feature.getProviderName() != null && !feature.getProviderName()
-					.startsWith("%")) {
-					resolvedProviders++;
-				}
+				System.out.println("\nFeatures with resolved labels: " + resolvedLabels + "/" + features.size());
+				System.out
+					.println("Features with resolved provider names: " + resolvedProviders + "/" + features.size());
+
+				// Most features should have resolved properties
+				softly.assertThat(resolvedLabels)
+					.as("Many features should have resolved labels")
+					.isGreaterThan(features.size() / 2);
 			}
-
-			System.out.println("\nFeatures with resolved labels: " + resolvedLabels + "/" + features.size());
-			System.out.println("Features with resolved provider names: " + resolvedProviders + "/" + features.size());
-
-			// Most features should have resolved properties
-			softly.assertThat(resolvedLabels)
-				.as("Many features should have resolved labels")
-				.isGreaterThan(features.size() / 2);
 		}
 	}
 
@@ -359,61 +358,60 @@ public class Eclipse438FeatureTest {
 	public void testEclipse438FeatureCapabilities() throws Exception {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			client.setCache(IO.getFile(tmp, "http-cache"));
-			
+
 			Unpack200 processor = new Unpack200(proc);
 			File indexLocation = new File(tmp, "eclipse-438-capabilities");
-			
+
 			System.out.println("\n=== Testing Feature Capabilities in Index ===");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
-				"Eclipse 4.38");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_REPO),
+				"Eclipse 4.38")) {
+				// Get repository and check feature resources
+				org.osgi.service.repository.Repository repository = indexer.getBridge()
+					.getRepository();
+				RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
 
-			// Get repository and check feature resources
-			org.osgi.service.repository.Repository repository = indexer.getBridge()
-				.getRepository();
-			RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
+				java.util.Collection<Capability> allCaps = repository
+					.findProviders(java.util.Collections.singleton(req))
+					.getOrDefault(req, java.util.Collections.emptyList());
 
-			java.util.Collection<Capability> allCaps = repository
-				.findProviders(java.util.Collections.singleton(req))
-				.getOrDefault(req, java.util.Collections.emptyList());
-
-			// Find feature capabilities
-			List<Capability> featureCaps = allCaps.stream()
-				.filter(cap -> "org.eclipse.update.feature"
-					.equals(cap.getAttributes()
+				// Find feature capabilities
+				List<Capability> featureCaps = allCaps.stream()
+					.filter(cap -> "org.eclipse.update.feature".equals(cap.getAttributes()
 						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE)))
-				.collect(Collectors.toList());
+					.collect(Collectors.toList());
 
-			System.out.println("Total feature capabilities: " + featureCaps.size());
+				System.out.println("Total feature capabilities: " + featureCaps.size());
 
-			softly.assertThat(featureCaps)
-				.as("Index should contain feature capabilities")
-				.isNotEmpty();
+				softly.assertThat(featureCaps)
+					.as("Index should contain feature capabilities")
+					.isNotEmpty();
 
-			// Inspect first few feature capabilities
-			int count = 0;
-			for (Capability cap : featureCaps) {
-				if (count++ >= 3)
-					break;
+				// Inspect first few feature capabilities
+				int count = 0;
+				for (Capability cap : featureCaps) {
+					if (count++ >= 3)
+						break;
 
-				Map<String, Object> attrs = cap.getAttributes();
-				System.out.println("\nFeature capability #" + count + ":");
-				System.out.println("  Identity: " + attrs.get(IdentityNamespace.IDENTITY_NAMESPACE));
-				System.out.println("  Version: " + attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE));
-				System.out.println("  Type: " + attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE));
+					Map<String, Object> attrs = cap.getAttributes();
+					System.out.println("\nFeature capability #" + count + ":");
+					System.out.println("  Identity: " + attrs.get(IdentityNamespace.IDENTITY_NAMESPACE));
+					System.out.println("  Version: " + attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE));
+					System.out.println("  Type: " + attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE));
 
-				// Validate required attributes
-				softly.assertThat(attrs.get(IdentityNamespace.IDENTITY_NAMESPACE))
-					.as("Feature capability should have identity")
-					.isNotNull();
+					// Validate required attributes
+					softly.assertThat(attrs.get(IdentityNamespace.IDENTITY_NAMESPACE))
+						.as("Feature capability should have identity")
+						.isNotNull();
 
-				softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
-					.as("Feature capability should have version")
-					.isNotNull();
+					softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
+						.as("Feature capability should have version")
+						.isNotNull();
 
-				softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
-					.as("Feature capability should have type")
-					.isEqualTo("org.eclipse.update.feature");
+					softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
+						.as("Feature capability should have type")
+						.isEqualTo("org.eclipse.update.feature");
+				}
 			}
 		}
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/Eclipse438PlatformFeatureTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/Eclipse438PlatformFeatureTest.java
@@ -1,13 +1,14 @@
 package aQute.bnd.repository.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -19,10 +20,6 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.p2.packed.Unpack200;
 import aQute.p2.provider.Feature;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test Eclipse 4.38 Platform repository to ensure features are
@@ -53,132 +50,135 @@ public class Eclipse438PlatformFeatureTest {
 
 			File indexLocation = new File(tmp, "eclipse-438-platform");
 
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_PLATFORM_REPO),
-				"Eclipse 4.38 Platform Test");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client,
+				new URI(ECLIPSE_438_PLATFORM_REPO), "Eclipse 4.38 Platform Test")) {
+				// Get features from the P2Indexer
+				List<Feature> features = indexer.getFeatures();
 
-			// Get features from the P2Indexer
-			List<Feature> features = indexer.getFeatures();
-
-			softly.assertThat(features)
-				.as("Features list should not be null")
-				.isNotNull();
-
-			softly.assertThat(features)
-				.as("Features list should not be empty")
-				.isNotEmpty();
-
-			// Print all feature IDs to help debug
-			System.out.println("\nAll features in repository:");
-			features.forEach(f -> System.out.println("  - " + f.getId() + " : " + f.getVersion()));
-
-			// Find org.eclipse.sdk feature (which we know exists from the list above)
-			Feature sdkFeature = features.stream()
-				.filter(f -> "org.eclipse.sdk".equals(f.getId()))
-				.findFirst()
-				.orElse(null);
-
-			softly.assertThat(sdkFeature)
-				.as("org.eclipse.sdk feature must be present in features list")
-				.isNotNull();
-
-			if (sdkFeature != null) {
-				softly.assertThat(sdkFeature.getId())
-					.as("Feature ID should be org.eclipse.sdk")
-					.isEqualTo("org.eclipse.sdk");
-
-				softly.assertThat(sdkFeature.getVersion())
-					.as("Feature version should not be null")
+				softly.assertThat(features)
+					.as("Features list should not be null")
 					.isNotNull();
 
-				// Check that version follows Eclipse pattern (should contain 4.38)
-				softly.assertThat(sdkFeature.getVersion())
-					.as("Feature version should contain 4.38")
-					.contains("4.38");
+				softly.assertThat(features)
+					.as("Features list should not be empty")
+					.isNotEmpty();
 
-				System.out.println("Found org.eclipse.sdk feature:");
-				System.out.println("  ID: " + sdkFeature.getId());
-				System.out.println("  Version: " + sdkFeature.getVersion());
-				System.out.println("  Label: " + sdkFeature.getLabel());
-				System.out.println("  Provider: " + sdkFeature.getProviderName());
+				// Print all feature IDs to help debug
+				System.out.println("\nAll features in repository:");
+				features.forEach(f -> System.out.println("  - " + f.getId() + " : " + f.getVersion()));
+
+				// Find org.eclipse.sdk feature (which we know exists from the
+				// list above)
+				Feature sdkFeature = features.stream()
+					.filter(f -> "org.eclipse.sdk".equals(f.getId()))
+					.findFirst()
+					.orElse(null);
+
+				softly.assertThat(sdkFeature)
+					.as("org.eclipse.sdk feature must be present in features list")
+					.isNotNull();
+
+				if (sdkFeature != null) {
+					softly.assertThat(sdkFeature.getId())
+						.as("Feature ID should be org.eclipse.sdk")
+						.isEqualTo("org.eclipse.sdk");
+
+					softly.assertThat(sdkFeature.getVersion())
+						.as("Feature version should not be null")
+						.isNotNull();
+
+					// Check that version follows Eclipse pattern (should
+					// contain 4.38)
+					softly.assertThat(sdkFeature.getVersion())
+						.as("Feature version should contain 4.38")
+						.contains("4.38");
+
+					System.out.println("Found org.eclipse.sdk feature:");
+					System.out.println("  ID: " + sdkFeature.getId());
+					System.out.println("  Version: " + sdkFeature.getVersion());
+					System.out.println("  Label: " + sdkFeature.getLabel());
+					System.out.println("  Provider: " + sdkFeature.getProviderName());
+				}
+
+				// Also check for org.eclipse.platform feature (which exists as
+				// BOTH bundle and feature)
+				Feature platformFeature = features.stream()
+					.filter(f -> "org.eclipse.platform".equals(f.getId()))
+					.findFirst()
+					.orElse(null);
+
+				softly.assertThat(platformFeature)
+					.as("org.eclipse.platform feature must be present in features list (repo has both bundle and feature with this ID)")
+					.isNotNull();
+
+				if (platformFeature != null) {
+					System.out.println("\nFound org.eclipse.platform feature:");
+					System.out.println("  ID: " + platformFeature.getId());
+					System.out.println("  Version: " + platformFeature.getVersion());
+					System.out.println("  Label: " + platformFeature.getLabel());
+					System.out.println("  Provider: " + platformFeature.getProviderName());
+				}
+
+				// Count feature vs bundle resources
+				var bridge = indexer.getBridge();
+				var repository = bridge.getRepository();
+
+				aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
+					IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
+
+				var providers = repository.findProviders(java.util.Collections.singleton(req));
+				java.util.Collection<Capability> allCaps = providers.get(req);
+				java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
+
+				// Look for org.eclipse.platform in raw resources
+				List<Resource> platformResources = allResources.stream()
+					.filter(r -> {
+						List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+						if (identityCaps.isEmpty())
+							return false;
+						Object id = identityCaps.get(0)
+							.getAttributes()
+							.get(IdentityNamespace.IDENTITY_NAMESPACE);
+						return "org.eclipse.platform".equals(id);
+					})
+					.toList();
+
+				System.out.println("\norg.eclipse.platform resources found: " + platformResources.size());
+				platformResources.forEach(r -> {
+					r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
+						.forEach(cap -> {
+							Object type = cap.getAttributes()
+								.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
+							Object label = cap.getAttributes()
+								.get("label");
+							Object providerName = cap.getAttributes()
+								.get("provider-name");
+							System.out.println("  Type: " + type);
+							if (label != null) {
+								System.out.println("    Label: " + label);
+							}
+							if (providerName != null) {
+								System.out.println("    Provider: " + providerName);
+							}
+						});
+				});
+
+				Map<String, Long> resourcesByType = allResources.stream()
+					.flatMap(r -> r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
+						.stream())
+					.map(cap -> (String) cap.getAttributes()
+						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
+					.filter(type -> type != null)
+					.collect(Collectors.groupingBy(type -> type, Collectors.counting()));
+
+				System.out.println("\nResource type distribution:");
+				resourcesByType.forEach((type, count) -> System.out.println("  " + type + ": " + count));
+
+				softly.assertThat(resourcesByType.get("org.eclipse.update.feature"))
+					.as("Index should contain feature resources")
+					.isGreaterThan(0L);
 			}
-
-			// Also check for org.eclipse.platform feature (which exists as BOTH bundle and feature)
-			Feature platformFeature = features.stream()
-				.filter(f -> "org.eclipse.platform".equals(f.getId()))
-				.findFirst()
-				.orElse(null);
-
-			softly.assertThat(platformFeature)
-				.as("org.eclipse.platform feature must be present in features list (repo has both bundle and feature with this ID)")
-				.isNotNull();
-
-			if (platformFeature != null) {
-				System.out.println("\nFound org.eclipse.platform feature:");
-				System.out.println("  ID: " + platformFeature.getId());
-				System.out.println("  Version: " + platformFeature.getVersion());
-				System.out.println("  Label: " + platformFeature.getLabel());
-				System.out.println("  Provider: " + platformFeature.getProviderName());
-			}
-
-			// Count feature vs bundle resources
-			var bridge = indexer.getBridge();
-			var repository = bridge.getRepository();
-
-			aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
-				IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
-
-			var providers = repository.findProviders(java.util.Collections.singleton(req));
-			java.util.Collection<Capability> allCaps = providers.get(req);
-			java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
-
-			// Look for org.eclipse.platform in raw resources
-			List<Resource> platformResources = allResources.stream()
-				.filter(r -> {
-					List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-					if (identityCaps.isEmpty())
-						return false;
-					Object id = identityCaps.get(0)
-						.getAttributes()
-						.get(IdentityNamespace.IDENTITY_NAMESPACE);
-					return "org.eclipse.platform".equals(id);
-				})
-				.toList();
-
-			System.out.println("\norg.eclipse.platform resources found: " + platformResources.size());
-			platformResources.forEach(r -> {
-				r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
-					.forEach(cap -> {
-						Object type = cap.getAttributes()
-							.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
-						Object label = cap.getAttributes()
-							.get("label");
-						Object providerName = cap.getAttributes()
-							.get("provider-name");
-						System.out.println("  Type: " + type);
-						if (label != null) {
-							System.out.println("    Label: " + label);
-						}
-						if (providerName != null) {
-							System.out.println("    Provider: " + providerName);
-						}
-					});
-			});
-
-			Map<String, Long> resourcesByType = allResources.stream()
-				.flatMap(r -> r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE)
-					.stream())
-				.map(cap -> (String) cap.getAttributes()
-					.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
-				.filter(type -> type != null)
-				.collect(Collectors.groupingBy(type -> type, Collectors.counting()));
-
-			System.out.println("\nResource type distribution:");
-			resourcesByType.forEach((type, count) -> System.out.println("  " + type + ": " + count));
-
-			softly.assertThat(resourcesByType.get("org.eclipse.update.feature"))
-				.as("Index should contain feature resources")
-				.isGreaterThan(0L);
 		}
 	}
 
@@ -193,87 +193,87 @@ public class Eclipse438PlatformFeatureTest {
 
 			File indexLocation = new File(tmp, "eclipse-438-platform-2");
 
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_PLATFORM_REPO),
-				"Eclipse 4.38 Platform Test 2");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client,
+				new URI(ECLIPSE_438_PLATFORM_REPO), "Eclipse 4.38 Platform Test 2")) {
+				var bridge = indexer.getBridge();
+				var repository = bridge.getRepository();
 
-			var bridge = indexer.getBridge();
-			var repository = bridge.getRepository();
+				// Find all feature resources
+				aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
+					IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
 
-			// Find all feature resources
-			aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
-				IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
+				var providers = repository.findProviders(java.util.Collections.singleton(req));
+				java.util.Collection<Capability> allCaps = providers.get(req);
+				java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
 
-			var providers = repository.findProviders(java.util.Collections.singleton(req));
-			java.util.Collection<Capability> allCaps = providers.get(req);
-			java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
+				List<Resource> featureResources = allResources.stream()
+					.filter(r -> {
+						List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+						if (identityCaps.isEmpty())
+							return false;
+						Object type = identityCaps.get(0)
+							.getAttributes()
+							.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
+						return "org.eclipse.update.feature".equals(type);
+					})
+					.toList();
 
-			List<Resource> featureResources = allResources.stream()
-				.filter(r -> {
-					List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-					if (identityCaps.isEmpty())
-						return false;
-					Object type = identityCaps.get(0)
-						.getAttributes()
-						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
-					return "org.eclipse.update.feature".equals(type);
-				})
-				.toList();
+				softly.assertThat(featureResources)
+					.as("Should find feature resources in index")
+					.isNotEmpty();
 
-			softly.assertThat(featureResources)
-				.as("Should find feature resources in index")
-				.isNotEmpty();
+				// Find org.eclipse.sdk resource specifically (we know it
+				// exists)
+				Resource sdkResource = featureResources.stream()
+					.filter(r -> {
+						List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+						if (identityCaps.isEmpty())
+							return false;
+						Object id = identityCaps.get(0)
+							.getAttributes()
+							.get(IdentityNamespace.IDENTITY_NAMESPACE);
+						return "org.eclipse.sdk".equals(id);
+					})
+					.findFirst()
+					.orElse(null);
 
-			// Find org.eclipse.sdk resource specifically (we know it exists)
-			Resource sdkResource = featureResources.stream()
-				.filter(r -> {
-					List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-					if (identityCaps.isEmpty())
-						return false;
-					Object id = identityCaps.get(0)
-						.getAttributes()
-						.get(IdentityNamespace.IDENTITY_NAMESPACE);
-					return "org.eclipse.sdk".equals(id);
-				})
-				.findFirst()
-				.orElse(null);
-
-			softly.assertThat(sdkResource)
-				.as("org.eclipse.sdk resource should be in index")
-				.isNotNull();
-
-			if (sdkResource != null) {
-				List<Capability> identityCaps = sdkResource
-					.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-				softly.assertThat(identityCaps)
-					.as("SDK resource should have identity capability")
-					.hasSize(1);
-
-				Capability identity = identityCaps.get(0);
-				Map<String, Object> attrs = identity.getAttributes();
-
-				softly.assertThat(attrs.get(IdentityNamespace.IDENTITY_NAMESPACE))
-					.as("Identity capability should have correct osgi.identity")
-					.isEqualTo("org.eclipse.sdk");
-
-				softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
-					.as("Identity capability should have type org.eclipse.update.feature")
-					.isEqualTo("org.eclipse.update.feature");
-
-				softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
-					.as("Identity capability should have version")
+				softly.assertThat(sdkResource)
+					.as("org.eclipse.sdk resource should be in index")
 					.isNotNull();
 
-				softly.assertThat(attrs.get("label"))
-					.as("Feature should have label attribute")
-					.isNotNull();
+				if (sdkResource != null) {
+					List<Capability> identityCaps = sdkResource.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+					softly.assertThat(identityCaps)
+						.as("SDK resource should have identity capability")
+						.hasSize(1);
 
-				softly.assertThat(attrs.get("provider-name"))
-					.as("Feature should have provider-name attribute")
-					.isNotNull();
+					Capability identity = identityCaps.get(0);
+					Map<String, Object> attrs = identity.getAttributes();
 
-				System.out.println("\norg.eclipse.sdk identity attributes:");
-				attrs.forEach((key, value) -> System.out.println("  " + key + " = " + value));
+					softly.assertThat(attrs.get(IdentityNamespace.IDENTITY_NAMESPACE))
+						.as("Identity capability should have correct osgi.identity")
+						.isEqualTo("org.eclipse.sdk");
+
+					softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
+						.as("Identity capability should have type org.eclipse.update.feature")
+						.isEqualTo("org.eclipse.update.feature");
+
+					softly.assertThat(attrs.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
+						.as("Identity capability should have version")
+						.isNotNull();
+
+					softly.assertThat(attrs.get("label"))
+						.as("Feature should have label attribute")
+						.isNotNull();
+
+					softly.assertThat(attrs.get("provider-name"))
+						.as("Feature should have provider-name attribute")
+						.isNotNull();
+
+					System.out.println("\norg.eclipse.sdk identity attributes:");
+					attrs.forEach((key, value) -> System.out.println("  " + key + " = " + value));
+				}
 			}
 		}
 	}
@@ -290,44 +290,48 @@ public class Eclipse438PlatformFeatureTest {
 
 			File indexLocation = new File(tmp, "eclipse-438-platform-3");
 
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECLIPSE_438_PLATFORM_REPO),
-				"Eclipse 4.38 Platform Test 3");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client,
+				new URI(ECLIPSE_438_PLATFORM_REPO), "Eclipse 4.38 Platform Test 3")) {
+				// Get all features
+				List<Feature> features = indexer.getFeatures();
 
-			// Get all features
-			List<Feature> features = indexer.getFeatures();
+				softly.assertThat(features)
+					.as("Features should be available even when some JARs can't be extracted")
+					.isNotEmpty();
 
-			softly.assertThat(features)
-				.as("Features should be available even when some JARs can't be extracted")
-				.isNotEmpty();
+				// Get all feature resources from index - must use
+				// getResources() directly
+				// to bypass BridgeRepository deduplication which drops
+				// resources with same BSN+version
+				var bridge = indexer.getBridge();
+				aQute.bnd.osgi.repository.ResourcesRepository resourcesRepo = (aQute.bnd.osgi.repository.ResourcesRepository) bridge
+					.getRepository();
+				List<Resource> allResources = resourcesRepo.getResources();
 
-			// Get all feature resources from index - must use getResources() directly
-			// to bypass BridgeRepository deduplication which drops resources with same BSN+version
-			var bridge = indexer.getBridge();
-			aQute.bnd.osgi.repository.ResourcesRepository resourcesRepo = 
-				(aQute.bnd.osgi.repository.ResourcesRepository) bridge.getRepository();
-			List<Resource> allResources = resourcesRepo.getResources();
+				long featureResourceCount = allResources.stream()
+					.filter(r -> {
+						List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+						if (identityCaps.isEmpty())
+							return false;
+						Object type = identityCaps.get(0)
+							.getAttributes()
+							.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
+						return "org.eclipse.update.feature".equals(type);
+					})
+					.count();
 
-			long featureResourceCount = allResources.stream()
-				.filter(r -> {
-					List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-					if (identityCaps.isEmpty())
-						return false;
-					Object type = identityCaps.get(0)
-						.getAttributes()
-						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
-					return "org.eclipse.update.feature".equals(type);
-				})
-				.count();
+				System.out.println("\nFeature statistics:");
+				System.out.println("  Features in index (resources): " + featureResourceCount);
+				System.out.println("  Features returned by getFeatures(): " + features.size());
 
-			System.out.println("\nFeature statistics:");
-			System.out.println("  Features in index (resources): " + featureResourceCount);
-			System.out.println("  Features returned by getFeatures(): " + features.size());
-
-			// The number of Feature objects should match the number of feature resources
-			// This ensures we're creating minimal features for resources that can't be fully extracted
-			softly.assertThat((long) features.size())
-				.as("All feature resources should have corresponding Feature objects")
-				.isEqualTo(featureResourceCount);
+				// The number of Feature objects should match the number of
+				// feature resources
+				// This ensures we're creating minimal features for resources
+				// that can't be fully extracted
+				softly.assertThat((long) features.size())
+					.as("All feature resources should have corresponding Feature objects")
+					.isEqualTo(featureResourceCount);
+			}
 		}
 	}
 }

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/FeaturePropertiesTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/FeaturePropertiesTest.java
@@ -1,7 +1,5 @@
 package aQute.bnd.repository.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -9,15 +7,14 @@ import java.io.InputStream;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.p2.provider.Feature;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test that Feature parser resolves property references from feature.properties

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/FeatureRequirementsInIndexTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/FeatureRequirementsInIndexTest.java
@@ -6,9 +6,11 @@ import java.io.File;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -19,15 +21,10 @@ import org.osgi.resource.Resource;
 import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.osgi.resource.RequirementBuilder;
-import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.lib.io.IO;
 import aQute.p2.packed.Unpack200;
 import aQute.p2.provider.Feature;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test to demonstrate and verify how required features are stored in the P2
@@ -62,167 +59,168 @@ public class FeatureRequirementsInIndexTest {
 
 			System.out.println("\n=== Feature Requirements in P2 Index ===\n");
 
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO), "ECF");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO),
+				"ECF")) {
+				// Get all features
+				List<Feature> features = indexer.getFeatures();
 
-			// Get all features
-			List<Feature> features = indexer.getFeatures();
+				System.out.println("Total features in repository: " + features.size());
 
-			System.out.println("Total features in repository: " + features.size());
+				// Find features that have includes or requires
+				List<Feature> featuresWithIncludes = features.stream()
+					.filter(f -> {
+						try {
+							return !f.getIncludes()
+								.isEmpty();
+						} catch (Exception e) {
+							return false;
+						}
+					})
+					.collect(Collectors.toList());
 
-			// Find features that have includes or requires
-			List<Feature> featuresWithIncludes = features.stream()
-				.filter(f -> {
-					try {
-						return !f.getIncludes()
-							.isEmpty();
-					} catch (Exception e) {
-						return false;
-					}
-				})
-				.collect(Collectors.toList());
+				List<Feature> featuresWithRequires = features.stream()
+					.filter(f -> {
+						try {
+							return !f.getRequires()
+								.isEmpty();
+						} catch (Exception e) {
+							return false;
+						}
+					})
+					.collect(Collectors.toList());
 
-			List<Feature> featuresWithRequires = features.stream()
-				.filter(f -> {
-					try {
-						return !f.getRequires()
-							.isEmpty();
-					} catch (Exception e) {
-						return false;
-					}
-				})
-				.collect(Collectors.toList());
+				System.out.println("Features with includes: " + featuresWithIncludes.size());
+				System.out.println("Features with requires: " + featuresWithRequires.size());
 
-			System.out.println("Features with includes: " + featuresWithIncludes.size());
-			System.out.println("Features with requires: " + featuresWithRequires.size());
-
-			// Get a feature with requirements to examine
-			Feature featureWithReqs = null;
-			if (!featuresWithIncludes.isEmpty()) {
-				featureWithReqs = featuresWithIncludes.get(0);
-			} else if (!featuresWithRequires.isEmpty()) {
-				featureWithReqs = featuresWithRequires.get(0);
-			}
-
-			if (featureWithReqs != null) {
-				System.out.println("\n=== Examining Feature: " + featureWithReqs.getId() + " ===");
-				System.out.println("Version: " + featureWithReqs.getVersion());
-
-				// Show includes (which become requirements)
-				List<Feature.Includes> includes = featureWithReqs.getIncludes();
-				if (!includes.isEmpty()) {
-					System.out.println("\nIncluded features (" + includes.size() + "):");
-					for (Feature.Includes inc : includes) {
-						System.out.println("  - " + inc.id + " version=" + inc.version + (inc.optional ? " (optional)"
-							: ""));
-					}
+				// Get a feature with requirements to examine
+				Feature featureWithReqs = null;
+				if (!featuresWithIncludes.isEmpty()) {
+					featureWithReqs = featuresWithIncludes.get(0);
+				} else if (!featuresWithRequires.isEmpty()) {
+					featureWithReqs = featuresWithRequires.get(0);
 				}
 
-				// Show requires
-				List<Feature.Requires> requires = featureWithReqs.getRequires();
-				if (!requires.isEmpty()) {
-					System.out.println("\nRequired features/plugins (" + requires.size() + "):");
-					for (Feature.Requires req : requires) {
-						if (req.feature != null) {
+				if (featureWithReqs != null) {
+					System.out.println("\n=== Examining Feature: " + featureWithReqs.getId() + " ===");
+					System.out.println("Version: " + featureWithReqs.getVersion());
+
+					// Show includes (which become requirements)
+					List<Feature.Includes> includes = featureWithReqs.getIncludes();
+					if (!includes.isEmpty()) {
+						System.out.println("\nIncluded features (" + includes.size() + "):");
+						for (Feature.Includes inc : includes) {
 							System.out.println(
-								"  - feature: " + req.feature + " version=" + req.version + " match=" + req.match);
-						} else if (req.plugin != null) {
-							System.out.println(
-								"  - plugin: " + req.plugin + " version=" + req.version + " match=" + req.match);
+								"  - " + inc.id + " version=" + inc.version + (inc.optional ? " (optional)" : ""));
 						}
 					}
-				}
 
-				// Convert to OSGi Resource to see how requirements are stored
-				System.out.println("\n=== OSGi Resource Representation ===");
-				Resource resource = featureWithReqs.toResource();
+					// Show requires
+					List<Feature.Requires> requires = featureWithReqs.getRequires();
+					if (!requires.isEmpty()) {
+						System.out.println("\nRequired features/plugins (" + requires.size() + "):");
+						for (Feature.Requires req : requires) {
+							if (req.feature != null) {
+								System.out.println(
+									"  - feature: " + req.feature + " version=" + req.version + " match=" + req.match);
+							} else if (req.plugin != null) {
+								System.out.println(
+									"  - plugin: " + req.plugin + " version=" + req.version + " match=" + req.match);
+							}
+						}
+					}
 
-				// Show identity capability
-				List<Capability> identityCaps = resource.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-				if (!identityCaps.isEmpty()) {
-					Capability identityCap = identityCaps.get(0);
-					System.out.println("\nIdentity Capability:");
-					System.out.println("  Namespace: " + identityCap.getNamespace());
-					System.out.println("  Attributes:");
-					identityCap.getAttributes()
-						.forEach(
-							(key, value) -> System.out.println("    " + key + " = " + value));
-				}
+					// Convert to OSGi Resource to see how requirements are
+					// stored
+					System.out.println("\n=== OSGi Resource Representation ===");
+					Resource resource = featureWithReqs.toResource();
 
-				// Show requirements
-				List<Requirement> requirements = resource.getRequirements("osgi.identity");
-				System.out.println("\nRequirements (" + requirements.size() + "):");
-				for (int i = 0; i < Math.min(5, requirements.size()); i++) {
-					Requirement req = requirements.get(i);
-					System.out.println("\n  Requirement #" + (i + 1) + ":");
-					System.out.println("    Namespace: " + req.getNamespace());
-					System.out.println("    Directives:");
-					req.getDirectives()
-						.forEach((key, value) -> System.out.println("      " + key + " = " + value));
-					if (!req.getAttributes()
-						.isEmpty()) {
-						System.out.println("    Attributes:");
-						req.getAttributes()
+					// Show identity capability
+					List<Capability> identityCaps = resource.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+					if (!identityCaps.isEmpty()) {
+						Capability identityCap = identityCaps.get(0);
+						System.out.println("\nIdentity Capability:");
+						System.out.println("  Namespace: " + identityCap.getNamespace());
+						System.out.println("  Attributes:");
+						identityCap.getAttributes()
+							.forEach((key, value) -> System.out.println("    " + key + " = " + value));
+					}
+
+					// Show requirements
+					List<Requirement> requirements = resource.getRequirements("osgi.identity");
+					System.out.println("\nRequirements (" + requirements.size() + "):");
+					for (int i = 0; i < Math.min(5, requirements.size()); i++) {
+						Requirement req = requirements.get(i);
+						System.out.println("\n  Requirement #" + (i + 1) + ":");
+						System.out.println("    Namespace: " + req.getNamespace());
+						System.out.println("    Directives:");
+						req.getDirectives()
 							.forEach((key, value) -> System.out.println("      " + key + " = " + value));
-					}
-				}
-
-				// Verify requirements in the index
-				System.out.println("\n=== Verifying Requirements in Index ===");
-
-				// Get the resource from the index
-				org.osgi.service.repository.Repository repository = indexer.getBridge()
-					.getRepository();
-
-				// Find the feature resource in the index
-				RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
-				rb.addDirective("filter",
-					String.format("(&(osgi.identity=%s)(type=org.eclipse.update.feature))", featureWithReqs.getId()));
-				Requirement findReq = rb.buildSyntheticRequirement();
-
-				Collection<Capability> matchingCaps = repository
-					.findProviders(java.util.Collections.singleton(findReq))
-					.get(findReq);
-
-				if (matchingCaps != null && !matchingCaps.isEmpty()) {
-					Resource indexedResource = matchingCaps.iterator()
-						.next()
-						.getResource();
-					System.out.println("Found feature in index: " + featureWithReqs.getId());
-
-					List<Requirement> indexedRequirements = indexedResource.getRequirements("osgi.identity");
-					System.out.println("Requirements in indexed resource: " + indexedRequirements.size());
-
-					// Show first few requirements from index
-					for (int i = 0; i < Math.min(3, indexedRequirements.size()); i++) {
-						Requirement req = indexedRequirements.get(i);
-						System.out.println("\n  Indexed Requirement #" + (i + 1) + ":");
-						System.out.println("    Filter: " + req.getDirectives()
-							.get("filter"));
-						String resolution = req.getDirectives()
-							.get("resolution");
-						if (resolution != null) {
-							System.out.println("    Resolution: " + resolution);
+						if (!req.getAttributes()
+							.isEmpty()) {
+							System.out.println("    Attributes:");
+							req.getAttributes()
+								.forEach((key, value) -> System.out.println("      " + key + " = " + value));
 						}
 					}
-				}
 
-				// Verify assertions
-				softly.assertThat(requirements)
-					.as("Feature should have requirements")
-					.isNotEmpty();
+					// Verify requirements in the index
+					System.out.println("\n=== Verifying Requirements in Index ===");
 
-				// Check that included features have proper type filter
-				for (Feature.Includes inc : includes) {
-					boolean found = requirements.stream()
-						.anyMatch(req -> {
-							String filter = req.getDirectives()
-								.get("filter");
-							return filter != null && filter.contains(inc.id)
-								&& filter.contains("type=org.eclipse.update.feature");
-						});
-					softly.assertThat(found)
-						.as("Included feature " + inc.id + " should have requirement with type filter")
-						.isTrue();
+					// Get the resource from the index
+					org.osgi.service.repository.Repository repository = indexer.getBridge()
+						.getRepository();
+
+					// Find the feature resource in the index
+					RequirementBuilder rb = new RequirementBuilder(IdentityNamespace.IDENTITY_NAMESPACE);
+					rb.addDirective("filter", String.format("(&(osgi.identity=%s)(type=org.eclipse.update.feature))",
+						featureWithReqs.getId()));
+					Requirement findReq = rb.buildSyntheticRequirement();
+
+					Collection<Capability> matchingCaps = repository
+						.findProviders(java.util.Collections.singleton(findReq))
+						.get(findReq);
+
+					if (matchingCaps != null && !matchingCaps.isEmpty()) {
+						Resource indexedResource = matchingCaps.iterator()
+							.next()
+							.getResource();
+						System.out.println("Found feature in index: " + featureWithReqs.getId());
+
+						List<Requirement> indexedRequirements = indexedResource.getRequirements("osgi.identity");
+						System.out.println("Requirements in indexed resource: " + indexedRequirements.size());
+
+						// Show first few requirements from index
+						for (int i = 0; i < Math.min(3, indexedRequirements.size()); i++) {
+							Requirement req = indexedRequirements.get(i);
+							System.out.println("\n  Indexed Requirement #" + (i + 1) + ":");
+							System.out.println("    Filter: " + req.getDirectives()
+								.get("filter"));
+							String resolution = req.getDirectives()
+								.get("resolution");
+							if (resolution != null) {
+								System.out.println("    Resolution: " + resolution);
+							}
+						}
+					}
+
+					// Verify assertions
+					softly.assertThat(requirements)
+						.as("Feature should have requirements")
+						.isNotEmpty();
+
+					// Check that included features have proper type filter
+					for (Feature.Includes inc : includes) {
+						boolean found = requirements.stream()
+							.anyMatch(req -> {
+								String filter = req.getDirectives()
+									.get("filter");
+								return filter != null && filter.contains(inc.id)
+									&& filter.contains("type=org.eclipse.update.feature");
+							});
+						softly.assertThat(found)
+							.as("Included feature " + inc.id + " should have requirement with type filter")
+							.isTrue();
+					}
 				}
 			}
 		}

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerExtractFeatureTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerExtractFeatureTest.java
@@ -1,10 +1,11 @@
 package aQute.bnd.repository.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.net.URI;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -13,10 +14,6 @@ import aQute.bnd.osgi.Processor;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.p2.packed.Unpack200;
 import aQute.p2.provider.Feature;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test extractFeatureFromResource functionality in P2Indexer
@@ -41,85 +38,93 @@ public class P2IndexerExtractFeatureTest {
 		try (HttpClient client = new HttpClient(); Processor proc = new Processor()) {
 			// Enable debug logging
 			proc.setTrace(true);
-			
+
 			Unpack200 processor = new Unpack200(proc);
 
 			File indexLocation = new File(tmp, "ecf-index");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO), "ECF Test");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO),
+				"ECF Test")) {
+				// First, check that we have feature resources in the index
+				org.osgi.service.repository.Repository repository = indexer.getBridge()
+					.getRepository();
+				aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
+					org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
 
-			// First, check that we have feature resources in the index
-			org.osgi.service.repository.Repository repository = indexer.getBridge().getRepository();
-			aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
-				org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
-			
-			java.util.Collection<org.osgi.resource.Capability> allCaps = repository.findProviders(
-				java.util.Collections.singleton(req))
-				.getOrDefault(req, java.util.Collections.emptyList());
-			
-			System.out.println("Total capabilities in repository: " + allCaps.size());
-			
-			// Get unique resources
-			java.util.Set<org.osgi.resource.Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
-			System.out.println("Total resources in repository: " + allResources.size());
-			
-			// Count features
-			int featureCount = 0;
-			for (org.osgi.resource.Resource resource : allResources) {
-				java.util.List<org.osgi.resource.Capability> identities = resource.getCapabilities(org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE);
-				for (org.osgi.resource.Capability identity : identities) {
-					Object type = identity.getAttributes().get(org.osgi.framework.namespace.IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
-					if ("org.eclipse.update.feature".equals(type)) {
-						featureCount++;
-						if (featureCount <= 3) {
-							System.out.println("Feature resource " + featureCount + ": " + identity.getAttributes().get(org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE));
-							// Try to extract
-							aQute.bnd.osgi.resource.ResourceUtils.ContentCapability contentCap = aQute.bnd.osgi.resource.ResourceUtils.getContentCapability(resource);
-							if (contentCap == null) {
-								System.out.println("  NO CONTENT CAPABILITY!");
-							} else {
-								System.out.println("  Content URL: " + contentCap.url());
+				java.util.Collection<org.osgi.resource.Capability> allCaps = repository
+					.findProviders(java.util.Collections.singleton(req))
+					.getOrDefault(req, java.util.Collections.emptyList());
+
+				System.out.println("Total capabilities in repository: " + allCaps.size());
+
+				// Get unique resources
+				java.util.Set<org.osgi.resource.Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils
+					.getResources(allCaps);
+				System.out.println("Total resources in repository: " + allResources.size());
+
+				// Count features
+				int featureCount = 0;
+				for (org.osgi.resource.Resource resource : allResources) {
+					java.util.List<org.osgi.resource.Capability> identities = resource
+						.getCapabilities(org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE);
+					for (org.osgi.resource.Capability identity : identities) {
+						Object type = identity.getAttributes()
+							.get(org.osgi.framework.namespace.IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
+						if ("org.eclipse.update.feature".equals(type)) {
+							featureCount++;
+							if (featureCount <= 3) {
+								System.out.println("Feature resource " + featureCount + ": " + identity.getAttributes()
+									.get(org.osgi.framework.namespace.IdentityNamespace.IDENTITY_NAMESPACE));
+								// Try to extract
+								aQute.bnd.osgi.resource.ResourceUtils.ContentCapability contentCap = aQute.bnd.osgi.resource.ResourceUtils
+									.getContentCapability(resource);
+								if (contentCap == null) {
+									System.out.println("  NO CONTENT CAPABILITY!");
+								} else {
+									System.out.println("  Content URL: " + contentCap.url());
+								}
 							}
+							break;
 						}
-						break;
 					}
 				}
-			}
-			
-			System.out.println("Total feature resources found: " + featureCount);
-			softly.assertThat(featureCount)
-				.as("Index should contain feature resources")
-				.isGreaterThan(0);
 
-			// Get all features from the index using the getFeatures() method
-			var features = indexer.getFeatures();
+				System.out.println("Total feature resources found: " + featureCount);
+				softly.assertThat(featureCount)
+					.as("Index should contain feature resources")
+					.isGreaterThan(0);
 
-			System.out.println("Features extracted via getFeatures(): " + features.size());
-			
-			softly.assertThat(features)
-				.as("Index should contain features")
-				.isNotEmpty();
+				// Get all features from the index using the getFeatures()
+				// method
+				var features = indexer.getFeatures();
 
-			// Check that each feature has proper data
-			for (Feature feature : features) {
-				softly.assertThat(feature.getId())
-					.as("Feature should have an ID")
-					.isNotNull()
+				System.out.println("Features extracted via getFeatures(): " + features.size());
+
+				softly.assertThat(features)
+					.as("Index should contain features")
 					.isNotEmpty();
 
-				softly.assertThat(feature.getVersion())
-					.as("Feature should have a version")
-					.isNotNull()
-					.isNotEmpty();
+				// Check that each feature has proper data
+				for (Feature feature : features) {
+					softly.assertThat(feature.getId())
+						.as("Feature should have an ID")
+						.isNotNull()
+						.isNotEmpty();
 
-				// Print first few features for debugging
-				if (features.indexOf(feature) < 3) {
-					System.out.println("Feature: " + feature.getId() + " version=" + feature.getVersion());
-					System.out.println("  Label: " + feature.getLabel());
-					System.out.println("  Plugins: " + feature.getPlugins()
-						.size());
-					System.out.println("  Includes: " + feature.getIncludes()
-						.size());
+					softly.assertThat(feature.getVersion())
+						.as("Feature should have a version")
+						.isNotNull()
+						.isNotEmpty();
+
+					// Print first few features for debugging
+					if (features.indexOf(feature) < 3) {
+						System.out.println("Feature: " + feature.getId() + " version=" + feature.getVersion());
+						System.out.println("  Label: " + feature.getLabel());
+						System.out.println("  Plugins: " + feature.getPlugins()
+							.size());
+						System.out.println("  Includes: " + feature.getIncludes()
+							.size());
+					}
 				}
 			}
 		}
@@ -134,28 +139,29 @@ public class P2IndexerExtractFeatureTest {
 			Unpack200 processor = new Unpack200(proc);
 
 			File indexLocation = new File(tmp, "ecf-index-2");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO), "ECF Test");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO),
+				"ECF Test")) {
+				// Try to get a known feature from the ECF repository
+				// We know this one exists from our previous test
+				Feature feature = indexer.getFeature("org.eclipse.ecf.core.feature", "1.7.0.v20250304-2338");
 
-			// Try to get a known feature from the ECF repository
-			// We know this one exists from our previous test
-			Feature feature = indexer.getFeature("org.eclipse.ecf.core.feature", "1.7.0.v20250304-2338");
+				softly.assertThat(feature)
+					.as("Should be able to retrieve specific feature")
+					.isNotNull();
 
-			softly.assertThat(feature)
-				.as("Should be able to retrieve specific feature")
-				.isNotNull();
+				if (feature != null) {
+					softly.assertThat(feature.getId())
+						.isEqualTo("org.eclipse.ecf.core.feature");
 
-			if (feature != null) {
-				softly.assertThat(feature.getId())
-					.isEqualTo("org.eclipse.ecf.core.feature");
+					softly.assertThat(feature.getVersion())
+						.isEqualTo("1.7.0.v20250304-2338");
 
-				softly.assertThat(feature.getVersion())
-					.isEqualTo("1.7.0.v20250304-2338");
-
-				System.out.println("Retrieved feature: " + feature);
-				System.out.println("  Plugins: " + feature.getPlugins()
-					.size());
-				System.out.println("  Includes: " + feature.getIncludes()
-					.size());
+					System.out.println("Retrieved feature: " + feature);
+					System.out.println("  Plugins: " + feature.getPlugins()
+						.size());
+					System.out.println("  Includes: " + feature.getIncludes()
+						.size());
+				}
 			}
 		}
 	}

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerFeatureTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2IndexerFeatureTest.java
@@ -1,11 +1,12 @@
 package aQute.bnd.repository.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.net.URI;
 import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -16,10 +17,6 @@ import aQute.bnd.http.HttpClient;
 import aQute.bnd.osgi.Processor;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.p2.packed.Unpack200;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test that P2Indexer correctly processes Eclipse features and includes them
@@ -46,92 +43,94 @@ public class P2IndexerFeatureTest {
 			Unpack200 processor = new Unpack200(proc);
 
 			File indexLocation = new File(tmp, "ecf-index");
-			P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO), "ECF Test");
+			try (P2Indexer indexer = new P2Indexer(processor, proc, indexLocation, client, new URI(ECF_P2_REPO),
+				"ECF Test")) {
+				// Get the bridge repository which should contain the indexed
+				// resources
+				var bridge = indexer.getBridge();
+				var repository = bridge.getRepository();
 
-			// Get the bridge repository which should contain the indexed resources
-			var bridge = indexer.getBridge();
-			var repository = bridge.getRepository();
+				// Create a requirement that matches all identity capabilities
+				aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
+					IdentityNamespace.IDENTITY_NAMESPACE);
+				org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
 
-			// Create a requirement that matches all identity capabilities
-			aQute.bnd.osgi.resource.RequirementBuilder rb = new aQute.bnd.osgi.resource.RequirementBuilder(
-				IdentityNamespace.IDENTITY_NAMESPACE);
-			org.osgi.resource.Requirement req = rb.buildSyntheticRequirement();
+				// Find all providers
+				var providers = repository.findProviders(java.util.Collections.singleton(req));
+				java.util.Collection<Capability> allCaps = providers.get(req);
 
-			// Find all providers
-			var providers = repository.findProviders(java.util.Collections.singleton(req));
-			java.util.Collection<Capability> allCaps = providers.get(req);
+				softly.assertThat(allCaps)
+					.as("Index should contain identity capabilities")
+					.isNotEmpty();
 
-			softly.assertThat(allCaps)
-				.as("Index should contain identity capabilities")
-				.isNotEmpty();
+				// Get unique resources
+				java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
 
-			// Get unique resources
-			java.util.Set<Resource> allResources = aQute.bnd.osgi.resource.ResourceUtils.getResources(allCaps);
+				softly.assertThat(allResources)
+					.as("Index should contain resources")
+					.isNotEmpty();
 
-			softly.assertThat(allResources)
-				.as("Index should contain resources")
-				.isNotEmpty();
+				// Find resources with type=org.eclipse.update.feature
+				List<Resource> featureResources = allResources.stream()
+					.filter(r -> {
+						List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+						if (identityCaps.isEmpty())
+							return false;
 
-			// Find resources with type=org.eclipse.update.feature
-			List<Resource> featureResources = allResources.stream()
-				.filter(r -> {
-					List<Capability> identityCaps = r.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-					if (identityCaps.isEmpty())
-						return false;
+						Object type = identityCaps.get(0)
+							.getAttributes()
+							.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
+						return "org.eclipse.update.feature".equals(type);
+					})
+					.toList();
 
-					Object type = identityCaps.get(0)
-						.getAttributes()
-						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE);
-					return "org.eclipse.update.feature".equals(type);
-				})
-				.toList();
+				softly.assertThat(featureResources)
+					.as("Index should contain org.eclipse.update.feature resources")
+					.isNotEmpty();
 
-			softly.assertThat(featureResources)
-				.as("Index should contain org.eclipse.update.feature resources")
-				.isNotEmpty();
+				// Log what we found
+				System.out.println("Total resources in index: " + allResources.size());
+				System.out.println("Feature resources in index: " + featureResources.size());
 
-			// Log what we found
-			System.out.println("Total resources in index: " + allResources.size());
-			System.out.println("Feature resources in index: " + featureResources.size());
-
-			for (Resource feature : featureResources.stream()
-				.limit(5)
-				.toList()) {
-				List<Capability> identityCaps = feature.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
-				if (!identityCaps.isEmpty()) {
-					Capability identityCap = identityCaps.get(0);
-					Object id = identityCap.getAttributes()
-						.get(IdentityNamespace.IDENTITY_NAMESPACE);
-					Object version = identityCap.getAttributes()
-						.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE);
-					System.out.println("  Feature: " + id + " version=" + version);
+				for (Resource feature : featureResources.stream()
+					.limit(5)
+					.toList()) {
+					List<Capability> identityCaps = feature.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+					if (!identityCaps.isEmpty()) {
+						Capability identityCap = identityCaps.get(0);
+						Object id = identityCap.getAttributes()
+							.get(IdentityNamespace.IDENTITY_NAMESPACE);
+						Object version = identityCap.getAttributes()
+							.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE);
+						System.out.println("  Feature: " + id + " version=" + version);
+					}
 				}
-			}
 
-			// Verify at least one feature has proper structure
-			if (!featureResources.isEmpty()) {
-				Resource firstFeature = featureResources.get(0);
-				List<Capability> identityCaps = firstFeature.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
+				// Verify at least one feature has proper structure
+				if (!featureResources.isEmpty()) {
+					Resource firstFeature = featureResources.get(0);
+					List<Capability> identityCaps = firstFeature.getCapabilities(IdentityNamespace.IDENTITY_NAMESPACE);
 
-				softly.assertThat(identityCaps)
-					.as("Feature should have identity capability")
-					.hasSize(1);
+					softly.assertThat(identityCaps)
+						.as("Feature should have identity capability")
+						.hasSize(1);
 
-				Capability identityCap = identityCaps.get(0);
-				softly.assertThat(identityCap.getAttributes()
-					.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
-					.as("Feature identity should have type=org.eclipse.update.feature")
-					.isEqualTo("org.eclipse.update.feature");
+					Capability identityCap = identityCaps.get(0);
+					softly.assertThat(identityCap.getAttributes()
+						.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))
+						.as("Feature identity should have type=org.eclipse.update.feature")
+						.isEqualTo("org.eclipse.update.feature");
 
-				softly.assertThat(identityCap.getAttributes()
-					.get(IdentityNamespace.IDENTITY_NAMESPACE))
-					.as("Feature should have an identity")
-					.isNotNull();
+					softly.assertThat(identityCap.getAttributes()
+						.get(IdentityNamespace.IDENTITY_NAMESPACE))
+						.as("Feature should have an identity")
+						.isNotNull();
 
-				softly.assertThat(identityCap.getAttributes()
-					.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
-					.as("Feature should have a version")
-					.isNotNull();
+					softly.assertThat(identityCap.getAttributes()
+						.get(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE))
+						.as("Feature should have a version")
+						.isNotNull();
+				}
 			}
 		}
 	}

--- a/biz.aQute.repository/test/aQute/p2/provider/FeatureParserTest.java
+++ b/biz.aQute.repository/test/aQute/p2/provider/FeatureParserTest.java
@@ -1,12 +1,13 @@
 package aQute.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.namespace.IdentityNamespace;
@@ -20,10 +21,6 @@ import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.lib.io.IO;
 import aQute.p2.api.Artifact;
 import aQute.p2.packed.Unpack200;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test the Feature parser to ensure it correctly parses Eclipse feature.xml

--- a/biz.aQute.repository/test/aQute/p2/provider/FeatureVersionFilterTest.java
+++ b/biz.aQute.repository/test/aQute/p2/provider/FeatureVersionFilterTest.java
@@ -1,11 +1,12 @@
 package aQute.p2.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.resource.Requirement;
@@ -14,10 +15,6 @@ import org.osgi.resource.Resource;
 import aQute.bnd.osgi.Jar;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.lib.io.IO;
-
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 
 /**
  * Test to verify that Eclipse feature requirement version and match attributes
@@ -44,29 +41,29 @@ public class FeatureVersionFilterTest {
 			      id="test.feature"
 			      label="Test Feature"
 			      version="1.0.0">
-			   
+
 			   <requires>
 			      <!-- perfect: exact version match -->
 			      <import plugin="plugin.perfect" version="1.2.3.qualifier" match="perfect"/>
-			      
+
 			      <!-- equivalent: same major.minor.micro, any qualifier -->
 			      <import plugin="plugin.equivalent" version="1.2.3" match="equivalent"/>
-			      
+
 			      <!-- compatible: same major.minor, micro >= specified -->
 			      <import plugin="plugin.compatible" version="1.2.0" match="compatible"/>
-			      
+
 			      <!-- greaterOrEqual: version >= specified -->
 			      <import plugin="plugin.greaterOrEqual" version="1.0.0" match="greaterOrEqual"/>
-			      
+
 			      <!-- No match specified (defaults to greaterOrEqual) -->
 			      <import plugin="plugin.default" version="2.0.0"/>
-			      
+
 			      <!-- No version specified -->
 			      <import plugin="plugin.noversion"/>
-			      
+
 			      <!-- Feature requirement with version -->
 			      <import feature="feature.compatible" version="1.5.0" match="compatible"/>
-			      
+
 			      <!-- Feature requirement without version -->
 			      <import feature="feature.noversion"/>
 			   </requires>
@@ -192,17 +189,17 @@ public class FeatureVersionFilterTest {
 			      id="test.edge.feature"
 			      label="Test Edge Cases"
 			      version="1.0.0">
-			   
+
 			   <requires>
 			      <!-- Version 0.0.0 (should be treated as no version) -->
 			      <import plugin="plugin.zero" version="0.0.0" match="greaterOrEqual"/>
-			      
+
 			      <!-- Complex qualifier -->
 			      <import plugin="plugin.qualifier" version="1.2.3.v20251201-1234" match="perfect"/>
-			      
+
 			      <!-- Large version numbers -->
 			      <import plugin="plugin.large" version="99.99.99" match="compatible"/>
-			      
+
 			      <!-- Empty match (should default to greaterOrEqual) -->
 			      <import plugin="plugin.emptymatch" version="1.0.0" match=""/>
 			   </requires>

--- a/bndtools.core/src/org/bndtools/core/ui/ExtendedFormEditor.java
+++ b/bndtools.core/src/org/bndtools/core/ui/ExtendedFormEditor.java
@@ -64,10 +64,10 @@ public abstract class ExtendedFormEditor extends FormEditor {
 		super.dispose();
 		if (baseImageDescriptor != null)
 			JFaceResources.getResources()
-				.destroyImage(baseImageDescriptor);
+				.destroy(baseImageDescriptor);
 		if (overlaidTitleImageDescriptor != null)
 			JFaceResources.getResources()
-				.destroyImage(overlaidTitleImageDescriptor);
+				.destroy(overlaidTitleImageDescriptor);
 	}
 
 	public void setOverlayTitleImage(ImageDescriptor overlay) {
@@ -76,17 +76,17 @@ public abstract class ExtendedFormEditor extends FormEditor {
 			firePropertyChange(PROP_TITLE);
 			if (overlaidTitleImageDescriptor != null)
 				JFaceResources.getResources()
-					.destroyImage(overlaidTitleImageDescriptor);
+					.destroy(overlaidTitleImageDescriptor);
 			overlaidTitleImageDescriptor = null;
 		} else {
 			DecorationOverlayIcon newOverlaidDesc = new DecorationOverlayIcon(titleImage, overlay,
 				IDecoration.BOTTOM_LEFT);
 			overlaidTitleImage = JFaceResources.getResources()
-				.createImage(newOverlaidDesc);
+				.create(newOverlaidDesc);
 			firePropertyChange(PROP_TITLE);
 			if (overlaidTitleImageDescriptor != null)
 				JFaceResources.getResources()
-					.destroyImage(overlaidTitleImageDescriptor);
+					.destroy(overlaidTitleImageDescriptor);
 			overlaidTitleImageDescriptor = newOverlaidDesc;
 		}
 	}

--- a/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
+++ b/bndtools.core/src/org/bndtools/core/ui/resource/R5LabelFormatter.java
@@ -42,7 +42,6 @@ import bndtools.Plugin;
 public class R5LabelFormatter {
 
 	private final static Pattern				EE_PATTERN		= Pattern.compile("osgi.ee=([^)]*).*version=([^)]*)");
-	private final static Pattern				FEATURE_PATTERN	= Pattern.compile(".*type=org\\.eclipse\\.update\\.feature.*");
 	private final static Pattern				FEATURE_IDENTITY_PATTERN = Pattern.compile("osgi\\.identity=([^)]+)");
 	private final static Pattern				FEATURE_VERSION_PATTERN = Pattern.compile("version=([^)]+)");
 	private final static Pattern				FEATURE_VERSION_GTE_PATTERN = Pattern.compile("\\(version>=([^)]+)\\)");
@@ -277,13 +276,13 @@ public class R5LabelFormatter {
 		} else {
 			try {
 				Expression exp = fp.parse(filter);
-				
+
 				// Handle osgi.identity namespace specially for clean display
 				if (IdentityNamespace.IDENTITY_NAMESPACE.equals(namespace)) {
 					// Extract identity name and show a specific version or version range
 					Matcher identityMatcher = FEATURE_IDENTITY_PATTERN.matcher(filter);
 					Matcher versionMatcher = FEATURE_VERSION_PATTERN.matcher(filter);
-					
+
 					if (identityMatcher.find()) {
 						String identityName = identityMatcher.group(1);
 						label.append(identityName, BoldStyler.INSTANCE_DEFAULT);

--- a/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
+++ b/bndtools.m2e/src/bndtools/m2e/BndConfigurator.java
@@ -38,6 +38,8 @@ import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.lifecyclemapping.model.IPluginExecutionMetadata;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
+import org.eclipse.m2e.core.project.IProjectConfiguration;
+import org.eclipse.m2e.core.project.ResolverConfiguration;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant;
 import org.eclipse.m2e.core.project.configurator.AbstractBuildParticipant2;
 import org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant;
@@ -298,8 +300,10 @@ public class BndConfigurator extends ServiceAwareM2EConfigurator {
 	private void execJarMojo(IMaven maven, IMavenProjectRegistry projectRegistry,
 		final IMavenProjectFacade projectFacade, IProgressMonitor monitor, boolean isTest)
 		throws CoreException {
-		projectFacade.getResolverConfiguration()
-			.setResolveWorkspaceProjects(true);
+		IProjectConfiguration configuration = projectFacade.getConfiguration();
+		if (configuration instanceof ResolverConfiguration rc) {
+			rc.setResolveWorkspaceProjects(true);
+		}
 
 		projectRegistry.execute(projectFacade, (context1, monitor1) -> {
 			SubMonitor progress = SubMonitor.convert(monitor1);

--- a/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
@@ -153,7 +153,7 @@ public interface MavenRunListenerHelper {
 			.map(executionPrefix::concat)
 			.collect(toList());
 
-		MavenExecutionPlan plan = maven.calculateExecutionPlan(mavenProject, tasks, true, monitor);
+		MavenExecutionPlan plan = projectFacade.calculateExecutionPlan(tasks, monitor);
 		return plan.getMojoExecutions()
 			.stream()
 			.filter(predicate)

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -633,7 +633,7 @@ public class BndPlugin implements Plugin<Project> {
 								// case for sonatype release)
 								tt.getLogger()
 									.lifecycle("bnd: Last release bundle ({}) {}", count, bndProject.getName());
-								bndProject.release(new ReleaseParameter(null, false, true));
+								releaseLastBundle(bndProject);
 							}
 						} catch (Exception e) {
 							throw new GradleException(
@@ -1035,5 +1035,11 @@ public class BndPlugin implements Plugin<Project> {
 			logger.debug("Could not find getter method for field {}", name, e);
 		}
 		return null;
+	}
+
+	@SuppressWarnings("removal")
+	private void releaseLastBundle(aQute.bnd.build.Project bndProject) throws Exception {
+		ReleaseParameter param = new ReleaseParameter(null, false, true);
+		bndProject.release(param);
 	}
 }

--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/ReleaseCounterService.java
@@ -18,6 +18,12 @@ public abstract class ReleaseCounterService
 	 */
 	public ReleaseCounterService() {}
 
+	/**
+	 * Set the initial number of artifacts/tasks 
+	 * from which is counted down.
+	 * 
+	 * @param n the count
+	 */
 	public void setInitialCount(int n) {
 		remaining.set(n);
 	}
@@ -33,6 +39,8 @@ public abstract class ReleaseCounterService
     }
 
 	/**
+	 * Returs the remaining tasks count.
+	 * 
 	 * @return the current count of remaining.
 	 */
 	public int getRemaining() {

--- a/maven-plugins/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
+++ b/maven-plugins/bnd-baseline-maven-plugin/src/main/java/aQute/bnd/maven/baseline/plugin/BaselineMojo.java
@@ -26,7 +26,7 @@ import org.apache.maven.RepositoryUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -95,7 +95,7 @@ public class BaselineMojo extends AbstractMojo {
 	@Parameter(property = "bnd.baseline.releaseversions", defaultValue = "false")
 	private boolean					releaseversions;
 
-	@Component
+	@Inject
 	private RepositorySystem		system;
 
 	@Parameter(property = "bnd.baseline.report.file", defaultValue = "${project.build.directory}/baseline/${project.build.finalName}.txt")

--- a/maven-plugins/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
+++ b/maven-plugins/bnd-export-maven-plugin/src/main/java/aQute/bnd/maven/export/plugin/ExportMojo.java
@@ -30,7 +30,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -104,13 +104,13 @@ public class ExportMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.basedir}")
 	private File 												bndrunDir;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver							resolver;
 
-	@Component
+	@Inject
 	@SuppressWarnings("deprecation")
 	protected org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
 

--- a/maven-plugins/bnd-generate-maven-plugin/src/main/java/aQute/bnd/maven/generate/plugin/AbstractGenerateMojo.java
+++ b/maven-plugins/bnd-generate-maven-plugin/src/main/java/aQute/bnd/maven/generate/plugin/AbstractGenerateMojo.java
@@ -18,7 +18,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
@@ -68,7 +68,7 @@ public abstract class AbstractGenerateMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${session}", readonly = true)
 	private MavenSession										session;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
 	/**

--- a/maven-plugins/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
+++ b/maven-plugins/bnd-indexer-maven-plugin/src/main/java/aQute/bnd/maven/indexer/plugin/IndexerMojo.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import aQute.bnd.maven.lib.resolve.DependencyResolver;
 import aQute.bnd.maven.lib.resolve.LocalURLs;
 import aQute.bnd.maven.lib.resolve.RemotePostProcessor;
@@ -34,11 +36,9 @@ import org.apache.maven.artifact.repository.metadata.io.MetadataReader;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -123,17 +123,14 @@ public class IndexerMojo extends AbstractMojo {
 	@Parameter(property = "altDeploymentRepository")
 	private String						altDeploymentRepository;
 
-	@Component
+	@Inject
 	private RepositorySystem			system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver	resolver;
 
-	@Component
+	@Inject
 	private MetadataReader				metadataReader;
-
-	@Component
-	private MavenProjectHelper			projectHelper;
 
 	private boolean						fail;
 

--- a/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
+++ b/maven-plugins/bnd-maven-plugin/src/main/java/aQute/bnd/maven/plugin/AbstractBndMavenPlugin.java
@@ -60,7 +60,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
@@ -166,13 +166,13 @@ public abstract class AbstractBndMavenPlugin extends AbstractMojo {
 	@SuppressWarnings("unused")
 	String					bnd;
 
-	@Component
+	@Inject
 	BuildContext			buildContext;
 
-	@Component
+	@Inject
 	MavenProjectHelper		projectHelper;
 
-	@Component
+	@Inject
 	ArtifactHandlerManager artifactHandlerManager;
 
 	File					propertiesFile;

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/ResolverMojo.java
@@ -24,7 +24,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -100,13 +100,13 @@ public class ResolverMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.basedir}")
 	private File 												outputBndrunDir;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver							resolver;
 
-	@Component
+	@Inject
 	@SuppressWarnings("deprecation")
 	private org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
 

--- a/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
+++ b/maven-plugins/bnd-resolver-maven-plugin/src/main/java/aQute/bnd/maven/resolver/plugin/VerifierMojo.java
@@ -33,7 +33,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -98,13 +98,13 @@ public class VerifierMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.basedir}")
 	private File 												bndrunDir;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver							resolver;
 
-	@Component
+	@Inject
 	@SuppressWarnings("deprecation")
 	private org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
 

--- a/maven-plugins/bnd-run-maven-plugin/src/main/java/aQute/bnd/maven/run/plugin/RunMojo.java
+++ b/maven-plugins/bnd-run-maven-plugin/src/main/java/aQute/bnd/maven/run/plugin/RunMojo.java
@@ -19,7 +19,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -65,13 +65,13 @@ public class RunMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.directory}", readonly = true)
 	private File												targetDir;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver							resolver;
 
-	@Component
+	@Inject
 	@SuppressWarnings("deprecation")
 	private org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
 

--- a/maven-plugins/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
+++ b/maven-plugins/bnd-testing-maven-plugin/src/main/java/aQute/bnd/maven/testing/plugin/TestingMojo.java
@@ -23,7 +23,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
+import javax.inject.Inject;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -111,17 +111,17 @@ public class TestingMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.basedir}")
 	private File 												bndrunDir;
 
-	@Component
+	@Inject
 	private RepositorySystem									system;
 
-	@Component
+	@Inject
 	private ProjectDependenciesResolver							resolver;
 
-	@Component
+	@Inject
 	@SuppressWarnings("deprecation")
 	private org.apache.maven.artifact.factory.ArtifactFactory	artifactFactory;
 
-	@Component
+	@Inject
 	private ToolchainManager									toolchainManager;
 
 	private Glob												glob	= Glob.ALL;


### PR DESCRIPTION
Closes #7316 
Add `@SuppressWarnings` annotations for deprecated and removal APIs across multiple modules. Update ExtendedFormEditor to use current JFaceResources API methods (destroy/create instead of destroyImage/createImage). Remove deprecated servicefactory parameter from Component annotation in test.