### PR TITLE
Fix task order between compileJava and processResources.

### DIFF
--- a/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
+++ b/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java
@@ -262,9 +262,12 @@ public class BndPlugin implements Plugin<Project> {
 				sourceSet.setCompileClasspath(jarLibraryElements(project, sourceSet.getCompileClasspathConfigurationName()));
 				sourceSet.setRuntimeClasspath(objects.fileCollection()
 					.from(sourceSet.getOutput(), jarLibraryElements(project, sourceSet.getRuntimeClasspathConfigurationName())));
+				TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
+				TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(),
+					AbstractCompile.class, t -> t.mustRunAfter(processResourcesTask));
 				generateInputAction.ifPresent(action -> {
-					tasks.named(sourceSet.getCompileJavaTaskName()).configure(action);
-					tasks.named(sourceSet.getProcessResourcesTaskName()).configure(action);
+					compileTask.configure(action);
+					processResourcesTask.configure(action);
 				});
 			});
 			sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME, sourceSet -> {
@@ -287,6 +290,8 @@ public class BndPlugin implements Plugin<Project> {
 					.from(mainSourceSet.getOutput(), jarLibraryElements(project, sourceSet.getCompileClasspathConfigurationName())));
 				sourceSet.setRuntimeClasspath(objects.fileCollection()
 					.from(sourceSet.getOutput(), mainSourceSet.getOutput(), jarLibraryElements(project, sourceSet.getRuntimeClasspathConfigurationName())));
+				tasks.named(sourceSet.getCompileJavaTaskName(),
+					AbstractCompile.class,t -> t.mustRunAfter(tasks.named(sourceSet.getProcessResourcesTaskName())));
 			});
 			/* Configure srcDirs for any additional languages */
 			project.afterEvaluate(p -> {
@@ -304,16 +309,14 @@ public class BndPlugin implements Plugin<Project> {
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
 					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
 						try {
-							TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileTaskName(name),
-								AbstractCompile.class, t -> t.getInputs()
-									.files(processResourcesTask)
-									.withPropertyName(processResourcesTask.getName())
-							);
 							sourceDirectorySet.setSrcDirs(sourceSet.getJava()
 								.getSrcDirs());
 							sourceDirectorySet.getDestinationDirectory()
 								.value(sourceSet.getJava()
 									.getDestinationDirectory());
+							TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileTaskName(name),
+								AbstractCompile.class, t -> t.mustRunAfter(processResourcesTask)
+							);
 							generateInputAction.ifPresent(compileTask::configure);
 						} catch (UnknownDomainObjectException e) {
 							// no such task
@@ -334,16 +337,14 @@ public class BndPlugin implements Plugin<Project> {
 					TaskProvider<Task> processResourcesTask = tasks.named(sourceSet.getProcessResourcesTaskName());
 					sourceDirectorySets.forEach((name, sourceDirectorySet) -> {
 						try {
-							TaskProvider<AbstractCompile> compileTask = tasks.named(sourceSet.getCompileTaskName(name),
-								AbstractCompile.class, t -> t.getInputs()
-									.files(processResourcesTask)
-									.withPropertyName(processResourcesTask.getName())
-							);
 							sourceDirectorySet.setSrcDirs(sourceSet.getJava()
 								.getSrcDirs());
 							sourceDirectorySet.getDestinationDirectory()
 								.value(sourceSet.getJava()
 									.getDestinationDirectory());
+							tasks.named(sourceSet.getCompileTaskName(name),
+								AbstractCompile.class, t -> t.mustRunAfter(processResourcesTask)
+							);
 						} catch (UnknownDomainObjectException e) {
 							// no such task
 						}


### PR DESCRIPTION
Fix for https://github.com/bndtools/bnd/issues/6896 in the Gradle case only.

Both these tasks have the same output directory. If `compileJava` runs first, which can sometimes happen when cached state is reused, then `processResources` [clears out the output directory when it runs](https://github.com/gradle/gradle/blob/cbe914f9a3dbe91a5d83fbe4d5493ed1751544e1/platforms/jvm/language-jvm/src/main/java/org/gradle/language/jvm/tasks/ProcessResources.java#L34), deleting all the classes. But if `processResources` runs first, `compileJava` happily writes classes into the same directory tree without deleting the resources.

I've done the same thing for the `test` source set.

I noticed that when the source sets have extensions for other languages, `BndPlugin` [adds the outputs of `processResources` as inputs](https://github.com/bndtools/bnd/blob/cdd3fe3b81817c9b393905e8ea27e8b9b9656ca9/gradle-plugins/biz.aQute.bnd.gradle/src/main/java/aQute/bnd/gradle/BndPlugin.java#L339) to the extra `AbstractCompile` tasks. This was added recently in https://github.com/bndtools/bnd/pull/7313. I'm not sure whether this was done to enforce a task ordering dependency or if the inputs are actually needed for some reason. I know that they're not needed for Java compilation, so I opted for a simple ordering between the tasks.

I tried to write a test:

* Start with a Bnd workspace containing a bundle that has a Java class and a resource
* In the bundle's Gradle configuration, add a `doLast` block to the `jar` task to verify that the jar contained a class
* Repeatedly run the tasks `clean` and `jar` to see if the check ever failed

Unfortunately I couldn't get the build to ever fail. I think it's because the Gradle Test Kit doesn't use a Gradle daemon in the usual way, so there's no opportunity for the cache to get into a state where it starts changing the task order.