### PR TITLE
Negative cache for 404 NOT_FOUND

### DIFF
--- a/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
+++ b/biz.aQute.bndlib.comm.tests/test/aQute/bnd/comm/tests/HttpClientTest.java
@@ -491,7 +491,8 @@ public class HttpClientTest {
 				.go(cheshire);
 			assertNotNull(tag);
 			assertEquals(404, tag.getResponseCode());
-			assertThat(cache.isCached(cheshire)).isFalse();
+			// we cache 404 NOT FOUND now
+			assertThat(cache.isCached(cheshire)).isTrue();
 		}
 	}
 

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -508,8 +508,6 @@ public class HttpClient implements Closeable, URLConnector {
 						if (tag.isNotFound()) {
 							// Negative cache: Just save the .json metadata
 							info.updateNegativeCache();
-							// Clear the content file, keep metadata
-							cache().clear(uri);
 						} else if (tag.getState() == State.UPDATED) {
 							//
 							// update the cache from the input stream
@@ -546,8 +544,6 @@ public class HttpClient implements Closeable, URLConnector {
 				if (tag.isNotFound()) {
 					// Negative cache: Just save the .json metadata
 					info.updateNegativeCache();
-					// Clear the content file, keep metadata
-					cache().clear(uri);
 				} else if (tag.isOk()) {
 					info.update(tag.getInputStream(), tag.getTag(), tag.getModified());
 				}

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -477,6 +477,7 @@ public class HttpClient implements Closeable, URLConnector {
 
 				request.useCacheFile = info.file;
 				if (info.isPresent()) {
+
 					//
 					// We have a file in the cache, check if it is within
 					// our accepted stale period
@@ -504,8 +505,9 @@ public class HttpClient implements Closeable, URLConnector {
 
 						TaggedData tag = connect();
 
-						if (tag.getState() == State.NOT_FOUND) {
-							cache().clear(uri);
+						if (tag.isNotFound()) {
+							// Negative cache: Just save the .json metadata
+							info.updateNegativeCache();
 						} else if (tag.getState() == State.UPDATED) {
 							//
 							// update the cache from the input stream
@@ -520,6 +522,11 @@ public class HttpClient implements Closeable, URLConnector {
 					}
 					return new TaggedData(uri, HTTP_NOT_MODIFIED, info.file);
 				}
+				else if (info.hasNegativeCache(request.maxStale)) {
+					// Has .json but no .content - negative cache hit
+					return new TaggedData(uri, HTTP_NOT_FOUND, info.file);
+				}
+
 				//
 				// No entry in the cache, but we are cached
 				//
@@ -534,7 +541,10 @@ public class HttpClient implements Closeable, URLConnector {
 
 				TaggedData tag = connect();
 
-				if (tag.isOk()) {
+				if (tag.isNotFound()) {
+					// Negative cache: Just save the .json metadata
+					info.updateNegativeCache();
+				} else if (tag.isOk()) {
 					info.update(tag.getInputStream(), tag.getTag(), tag.getModified());
 				}
 				return tag;

--- a/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/HttpClient.java
@@ -477,6 +477,7 @@ public class HttpClient implements Closeable, URLConnector {
 
 				request.useCacheFile = info.file;
 				if (info.isPresent()) {
+
 					//
 					// We have a file in the cache, check if it is within
 					// our accepted stale period
@@ -504,7 +505,10 @@ public class HttpClient implements Closeable, URLConnector {
 
 						TaggedData tag = connect();
 
-						if (tag.getState() == State.NOT_FOUND) {
+						if (tag.isNotFound()) {
+							// Negative cache: Just save the .json metadata
+							info.updateNegativeCache();
+							// Clear the content file, keep metadata
 							cache().clear(uri);
 						} else if (tag.getState() == State.UPDATED) {
 							//
@@ -520,6 +524,11 @@ public class HttpClient implements Closeable, URLConnector {
 					}
 					return new TaggedData(uri, HTTP_NOT_MODIFIED, info.file);
 				}
+				else if (info.hasNegativeCache(request.maxStale)) {
+					// Has .json but no .content - negative cache hit
+					return new TaggedData(uri, HTTP_NOT_FOUND, info.file);
+				}
+
 				//
 				// No entry in the cache, but we are cached
 				//
@@ -534,7 +543,12 @@ public class HttpClient implements Closeable, URLConnector {
 
 				TaggedData tag = connect();
 
-				if (tag.isOk()) {
+				if (tag.isNotFound()) {
+					// Negative cache: Just save the .json metadata
+					info.updateNegativeCache();
+					// Clear the content file, keep metadata
+					cache().clear(uri);
+				} else if (tag.isOk()) {
 					info.update(tag.getInputStream(), tag.getTag(), tag.getModified());
 				}
 				return tag;

--- a/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
@@ -95,6 +95,7 @@ public class URLCache {
 
 		public void updateNegativeCache() throws Exception {
 			this.dto.notFound = true;
+			IO.mkdirs(this.jsonFile.getParentFile());
 			this.dto.modified = System.currentTimeMillis();
 		    codec.enc()
 		        .to(jsonFile)
@@ -130,7 +131,7 @@ public class URLCache {
 		@Override
 		public String toString() {
 			return "Info [file=" + file + ", etag=" + dto.etag + ", modified=" + Instant.ofEpochMilli(dto.modified)
-				+ ", url=" + url + ", lock=" + lock + "]";
+				+ ", url=" + url + ", lock=" + lock + ", notFound=" + dto.notFound + "]";
 		}
 
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
@@ -37,6 +37,7 @@ public class URLCache {
 		public long		modified;
 		public URI		uri;
 		public String	sha_256;
+		public boolean	notFound	= false;	// true = cached 404 response
 	}
 
 	public class Info implements Closeable {
@@ -92,6 +93,14 @@ public class URLCache {
 				.put(this.dto);
 		}
 
+		public void updateNegativeCache() throws Exception {
+			this.dto.notFound = true;
+			this.dto.modified = System.currentTimeMillis();
+		    codec.enc()
+		        .to(jsonFile)
+		        .put(this.dto);
+		}
+
 		public boolean isPresent() {
 			boolean f = file.isFile();
 			boolean j = jsonFile.isFile();
@@ -109,6 +118,13 @@ public class URLCache {
 
 		public long getModified() {
 			return dto.modified;
+		}
+
+		public boolean hasNegativeCache(long ttl) {
+			if (!jsonFile.isFile()) {
+				return false;
+			}
+			return dto.notFound && System.currentTimeMillis() - dto.modified < ttl;
 		}
 
 		@Override

--- a/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/URLCache.java
@@ -37,6 +37,7 @@ public class URLCache {
 		public long		modified;
 		public URI		uri;
 		public String	sha_256;
+		public boolean	notFound	= false;	// true = cached 404 response
 	}
 
 	public class Info implements Closeable {
@@ -92,6 +93,15 @@ public class URLCache {
 				.put(this.dto);
 		}
 
+		public void updateNegativeCache() throws Exception {
+			this.dto.notFound = true;
+			IO.mkdirs(this.jsonFile.getParentFile());
+			this.dto.modified = System.currentTimeMillis();
+		    codec.enc()
+		        .to(jsonFile)
+		        .put(this.dto);
+		}
+
 		public boolean isPresent() {
 			boolean f = file.isFile();
 			boolean j = jsonFile.isFile();
@@ -111,10 +121,17 @@ public class URLCache {
 			return dto.modified;
 		}
 
+		public boolean hasNegativeCache(long ttl) {
+			if (!jsonFile.isFile()) {
+				return false;
+			}
+			return dto.notFound && System.currentTimeMillis() - dto.modified < ttl;
+		}
+
 		@Override
 		public String toString() {
 			return "Info [file=" + file + ", etag=" + dto.etag + ", modified=" + Instant.ofEpochMilli(dto.modified)
-				+ ", url=" + url + ", lock=" + lock + "]";
+				+ ", url=" + url + ", lock=" + lock + ", notFound=" + dto.notFound + "]";
 		}
 
 	}

--- a/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/http/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.1.0")
+@Version("2.2.0")
 package aQute.bnd.http;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.repository/test/aQute/maven/provider/RemoteRepoTest.java
+++ b/biz.aQute.repository/test/aQute/maven/provider/RemoteRepoTest.java
@@ -78,7 +78,9 @@ public class RemoteRepoTest {
 		// Fetch it, must exist now
 		//
 
-		assertEquals(State.UPDATED, repo.fetch("foo/bar", localFoobar)
+		// force cache refresh because we cache 404 NOT_FOUND now
+		boolean forceCacheRefresh = true;
+		assertEquals(State.UPDATED, repo.fetch("foo/bar", localFoobar, forceCacheRefresh )
 			.getState());
 		assertTrue(localFoobar.isFile());
 		assertEquals(3L, localFoobar.length());


### PR DESCRIPTION
Closes #7310 

This pull request introduces negative caching for HTTP 404 (Not Found) responses in the HTTP client and cache system. Now, when a resource is not found, the system records this state in the cache, allowing future requests to avoid unnecessary network calls until the cache entry expires. The changes also update related tests and increment the package version.

**Negative caching implementation:**

* Added a `notFound` flag to the cache metadata (`InfoDTO`) and methods to record and check negative cache entries (`updateNegativeCache`, `hasNegativeCache`) in `URLCache.java`. [[1]](diffhunk://#diff-c6f559af9d3f1ebcf6e4d9dd09bccd53e7ceed3bd4ea587e3a4b4542b7acd768R40) [[2]](diffhunk://#diff-c6f559af9d3f1ebcf6e4d9dd09bccd53e7ceed3bd4ea587e3a4b4542b7acd768R96-R104) [[3]](diffhunk://#diff-c6f559af9d3f1ebcf6e4d9dd09bccd53e7ceed3bd4ea587e3a4b4542b7acd768R124-R134)
* Updated `HttpClient.java` to save negative cache entries when a 404 is received, and to return cached 404 responses if present and valid. [[1]](diffhunk://#diff-cf36ecd059319481907bc1911739e180d0198efa529b2427f034ff56af962886L507-R510) [[2]](diffhunk://#diff-cf36ecd059319481907bc1911739e180d0198efa529b2427f034ff56af962886R525-R529) [[3]](diffhunk://#diff-cf36ecd059319481907bc1911739e180d0198efa529b2427f034ff56af962886L537-R547)

**Test updates for negative caching:**

* Modified tests in `HttpClientTest.java` and `RemoteRepoTest.java` to reflect the new behavior: 404 responses are now cached, and tests force cache refreshes as needed. [[1]](diffhunk://#diff-19ccd36ba7544313840ac8cd957413fd7b01f979e1307fd3b39ee686856d8aedL494-R495) [[2]](diffhunk://#diff-64e2b86075e36fe08f521c1e554e2c76fe4841c8c95720d4b011ef932d2a61b1L81-R83)

**Version update:**

* Bumped the package version in `package-info.java` to `2.2.0` to reflect these changes.