### PR TITLE
Fix thread-safety in aQute.junit.Tee class

### DIFF
--- a/biz.aQute.tester/src/aQute/junit/Tee.java
+++ b/biz.aQute.tester/src/aQute/junit/Tee.java
@@ -18,7 +18,7 @@ public class Tee extends PrintStream {
 	}
 
 	protected Object lock() {
-		return out;
+		return this;
 	}
 
 	@Override
@@ -258,6 +258,13 @@ public class Tee extends PrintStream {
 	public PrintStream append(char c) {
 		synchronized (lock()) {
 			return super.append(c);
+		}
+	}
+
+	@Override
+	public void flush() {
+		synchronized (lock()) {
+			super.flush();
 		}
 	}
 


### PR DESCRIPTION
Closes #7214 

Changed lock() to use 'this' instead of 'out' for proper per-instance synchronization, and added synchronized flush() method to make the locking intent explicit, that flush() takes part in the same lock