### PR TITLE
#7267 fix postrelease.yml

### DIFF
--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -53,9 +53,10 @@ jobs:
         mv tmp cnf/build.bnd        
     - name: create release docs for ${{ github.event.inputs.V1 }}
       run: |
+        # keep the following in-sync with docs/ADDING_RELEASE_DOCS.md
         cd docs
         echo "releasename: ${V1}" >tmp
-        echo "baseurl: /release/${V1}" >>tmp
+        echo "baseurl: /releases/${V1}" >>tmp
         echo "repository: bndtools/bnd" >>tmp
         cat _config.yml | sed '/^releasename: /d' | sed '/^baseurl: /d' | sed '/^repository: /d' >>tmp
         mv tmp _config.yml
@@ -64,7 +65,15 @@ jobs:
         bundle exec jekyll build
 
         rm -rf _site/releases
-        find _site -type f ! -name "*.html" -exec rm -f {} +
+        # Remove unwanted root-level files (keeping only the ones you specified)
+        find _site -maxdepth 1 -type f ! -name "404.html" \
+                           ! -name "favicon.ico" \
+                           ! -name "index.html" \
+                           ! -name "robots.txt" \
+                           ! -name "sitemap.xml" \
+                           ! -name "snapshot.html" \
+                           -delete
+        
 
     - uses: actions/upload-artifact@v7.0.1
       with:

--- a/docs/ADDING_RELEASE_DOCS.md
+++ b/docs/ADDING_RELEASE_DOCS.md
@@ -1,5 +1,7 @@
 ## Adding Release Docs
 
+This is the manual process done in `./github/workflows/postrelease.yml`. Keep both in sync.
+
 * checkout the release tag
 * edit `docs/_config.yml` setting the properties
   ```
@@ -7,8 +9,20 @@
   baseurl: /releases/<version>
   ```
   replacing `<version>` for the actual version
-* run `./build.sh`
-* copy the generated contents of `docs/_site` into a temporary location
+* run `./build.sh` (this generates a `docs/_site` folder)
+* run `rm -rf _site/releases` (this removes the old archived releases temporarily)
+* run 
+```shell
+# Remove unwanted root-level files (keeping only the ones you specified)
+find _site -maxdepth 1 -type f ! -name "404.html" \
+  ! -name "favicon.ico" \
+  ! -name "index.html" \
+  ! -name "robots.txt" \
+  ! -name "sitemap.xml" \
+  ! -name "snapshot.html" \
+  -delete
+```                           
+* copy the remaining generated contents of `docs/_site` into a temporary location
 * checkout the master branch
 * copy previously saved content into `docs/release/<version>`
 * commit & push


### PR DESCRIPTION
Closes #7267

Fix release docs baseurl and clarify cleanup
Change baseurl from /release to /releases (plural) and improve the file cleanup logic in postrelease workflow to be more explicit and maintainable. Update ADDING_RELEASE_DOCS.md to document the manual process and keep it in sync with the workflow automation.