### PR TITLE
Remove needs dependency for build-others job

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -122,7 +122,6 @@ jobs:
             gradle-plugins/build/reports/*
 
   build-others:
-    needs: [build-canonical]
     strategy:
       fail-fast: ${{ (github.repository != 'bndtools/bnd') || ((github.ref != 'refs/heads/master') && (github.ref != 'refs/heads/next')) || (github.event_name == 'pull_request') }}
       matrix:


### PR DESCRIPTION
Removed dependency on build-canonical for build-others job.
Attempt to fix the `skipped` CIBuilds in contributor branches