### PR TITLE
tester: Clean up launcher after failed preparation

### DIFF
--- a/biz.aQute.bndlib.tests/test/test/ProjectTest.java
+++ b/biz.aQute.bndlib.tests/test/test/ProjectTest.java
@@ -5,7 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +42,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import aQute.bnd.build.Container;
 import aQute.bnd.build.Project;
 import aQute.bnd.build.ProjectBuilder;
+import aQute.bnd.build.ProjectLauncher;
+import aQute.bnd.build.ProjectTester;
 import aQute.bnd.build.RepoCollector;
 import aQute.bnd.build.Workspace;
 import aQute.bnd.osgi.About;
@@ -57,6 +68,47 @@ import aQute.lib.io.IO;
 public class ProjectTest {
 	@InjectTemporaryDirectory
 	File tmp;
+
+	@Test
+	public void testTestingCleansUpLauncherWhenPreparationReportsError() throws Exception {
+		IO.mkdirs(new File(tmp, Workspace.CNFDIR));
+		try (Workspace workspace = new Workspace(tmp); Project project = spy(new Project(workspace, tmp))) {
+			ProjectTester tester = mock(ProjectTester.class);
+			ProjectLauncher launcher = mock(ProjectLauncher.class);
+			doReturn(tester).when(project)
+				.getProjectTester();
+			when(tester.getProjectLauncher()).thenReturn(launcher);
+			doAnswer(invocation -> {
+				project.error("Test preparation failed");
+				return true;
+			}).when(tester)
+				.prepare();
+
+			project.test(null, null);
+
+			verify(launcher).cleanup();
+			verify(tester, never()).test();
+		}
+	}
+
+	@Test
+	public void testTestingCleansUpLauncherWhenPreparationThrows() throws Exception {
+		IO.mkdirs(new File(tmp, Workspace.CNFDIR));
+		try (Workspace workspace = new Workspace(tmp); Project project = spy(new Project(workspace, tmp))) {
+			ProjectTester tester = mock(ProjectTester.class);
+			ProjectLauncher launcher = mock(ProjectLauncher.class);
+			doReturn(tester).when(project)
+				.getProjectTester();
+			when(tester.getProjectLauncher()).thenReturn(launcher);
+			doThrow(new IOException("Test preparation failed")).when(tester)
+				.prepare();
+
+			assertThrows(IOException.class, () -> project.test(null, null));
+
+			verify(launcher).cleanup();
+			verify(tester, never()).test();
+		}
+	}
 
 	@Test
 	public void testAliasbuild() throws Exception {

--- a/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/Project.java
@@ -2604,32 +2604,37 @@ public class Project extends Processor {
 
 	public void test(File reportDir, List<String> tests) throws Exception {
 		ProjectTester tester = getProjectTester();
-		if (reportDir != null) {
-			logger.debug("Setting reportDir {}", reportDir);
-			IO.delete(reportDir);
-			tester.setReportDir(reportDir);
-		}
-		if (tests != null) {
-			logger.debug("Adding tests {}", tests);
-			for (String test : tests) {
-				tester.addTest(test);
+		try {
+			if (reportDir != null) {
+				logger.debug("Setting reportDir {}", reportDir);
+				IO.delete(reportDir);
+				tester.setReportDir(reportDir);
 			}
-		}
-		tester.prepare();
+			if (tests != null) {
+				logger.debug("Adding tests {}", tests);
+				for (String test : tests) {
+					tester.addTest(test);
+				}
+			}
+			tester.prepare();
 
-		if (!isOk()) {
-			logger.error("Tests not run because project has errors");
-			return;
-		}
-		int errors = tester.test();
-		if (errors == 0) {
-			logger.info("No Errors");
-		} else {
-			if (errors > 0) {
-				logger.info("{} Error(s)", errors);
-			} else {
-				logger.info("Error {}", errors);
+			if (!isOk()) {
+				logger.error("Tests not run because project has errors");
+				return;
 			}
+			int errors = tester.test();
+			if (errors == 0) {
+				logger.info("No Errors");
+			} else {
+				if (errors > 0) {
+					logger.info("{} Error(s)", errors);
+				} else {
+					logger.info("Error {}", errors);
+				}
+			}
+		} finally {
+			tester.getProjectLauncher()
+				.cleanup();
 		}
 	}
 


### PR DESCRIPTION
- Always clean up the project launcher after a test run attempt.
- Cover preparation exceptions and errors that prevent the launcher from starting.
- Prevent temporary launch*.properties files from being left behind.
- Add regression tests for both preparation failure paths.

Fixes #7372