### PR TITLE
Fix duplicate cnf entry in Bnd Workspace import wizard

### DIFF
--- a/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizardPageOne.java
+++ b/bndtools.core/src/bndtools/wizards/project/ImportBndWorkspaceWizardPageOne.java
@@ -260,8 +260,16 @@ public class ImportBndWorkspaceWizardPageOne extends WizardPage {
 				try {
 					bndWorkspace = Workspace.getWorkspace(chosenDirectory);
 					setErrorMessage(null);
-					List<Object> tableEntries = new ArrayList<>(bndWorkspace.getAllProjects());
-					tableEntries.add(bndWorkspace.getBuildDir());
+					File buildDir = bndWorkspace.getBuildDir();
+					List<Object> tableEntries = new ArrayList<>();
+					// avoid listing the cnf project twice, as it is also returned by getAllProjects()
+					for (Project project : bndWorkspace.getAllProjects()) {
+						if (!project.getBase()
+							.equals(buildDir)) {
+							tableEntries.add(project);
+						}
+					}
+					tableEntries.add(buildDir);
 					tableViewer.setInput(tableEntries);
 					result = true;
 				} catch (Exception e) {


### PR DESCRIPTION
## Problem

The Bnd Workspace import wizard lists the `cnf` configuration project twice, which is confusing to users:

- Once as `cnf - configuration project` (added explicitly for the workspace build directory)
- Once as plain `cnf` (already included via `Workspace.getAllProjects()`, since `cnf` is itself a bnd project)

## Fix

Filter the `cnf` project out of the regular project list (matched by comparing `Project#getBase()` to the workspace build dir) before adding the dedicated "configuration project" entry for the build dir. This keeps the single, clearly-labeled `cnf - configuration project` row and removes the duplicate.

## Screenshot

Wizard before the fix, showing the duplicate `cnf` entries:

<img width="514" height="543" alt="image" src="https://github.com/user-attachments/assets/224609d0-81cf-4964-86d9-04a51155efdc" />

