### PR TITLE
Add import wizard to Bnd perspective

### DIFF
--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -431,6 +431,10 @@
 	</extension>
 
 	<extension point="org.eclipse.ui.perspectiveExtensions">
+		<perspectiveExtension targetID="bndtools.perspective">
+			<newWizardShortcut id="bndtools.importProject" />
+		</perspectiveExtension>
+
 		<!-- Add lots of lovely Bndtools stuff to the Java perspective -->
 		<perspectiveExtension
 			targetID="org.eclipse.jdt.ui.JavaPerspective">


### PR DESCRIPTION
## Summary

Make **Existing Bnd Workspace** appear in Bndtools Explorer empty-workspace quick links for existing Bndtools perspectives.

#7259 adds wizard shortcut from BndPerspective.createInitialLayout(). Eclipse runs that method only when it creates a perspective, so users with an already persisted Bndtools perspective do not receive new quick link. Add an org.eclipse.ui.perspectiveExtensions contribution targeting bndtools.perspective, allowing Eclipse to add shortcut to existing layouts.

Follow-up to #7259.

## Validation

- ./gradlew :bndtools.core:jar