### PR TITLE
Fix docs links in postrelease.yml

### DIFF
--- a/.github/workflows/postrelease.yml
+++ b/.github/workflows/postrelease.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: Gemfile
       BUNDLE_PATH: vendor/bundle
+      V1: ${{ github.event.inputs.V1 }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1


### PR DESCRIPTION
Add V1 environment variable to postrelease workflow
this should make the sed command work which currently had the ${V1} empty, which could be the reason why the links and urls were not correct