### PR TITLE
Fix Maven bndrun resolution with current m2e

### DIFF
--- a/bndtools.m2e/bnd.bnd
+++ b/bndtools.m2e/bnd.bnd
@@ -41,6 +41,8 @@
 	org.eclipse.osgi,\
 	org.codehaus.plexus:plexus-build-api
 
+-testpath: ${junit}
+
 Bundle-SymbolicName: ${p};singleton:=true
 Bundle-ActivationPolicy: lazy
 

--- a/bndtools.m2e/src/bndtools/m2e/MavenBndrunContainer.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenBndrunContainer.java
@@ -61,8 +61,11 @@ public class MavenBndrunContainer {
 					bundles = new Bundles();
 				}
 
-				useMavenDependencies = maven.getMojoParameterValue(mavenProject, mojoExecution, "useMavenDependencies",
-					Boolean.class, monitor);
+				Boolean configuredUseMavenDependencies = maven.getMojoParameterValue(mavenProject, mojoExecution,
+					"useMavenDependencies", Boolean.class, monitor);
+				if (configuredUseMavenDependencies != null) {
+					useMavenDependencies = configuredUseMavenDependencies;
+				}
 
 				// Comparing OSGi versions makes '4.2.0.SNAPSHOT' > '4.2.0'.
 				// Comparing Maven versions fails because '4.2.0-SNAPSHOT' is <
@@ -70,8 +73,11 @@ public class MavenBndrunContainer {
 				Version mojoVersion = new MavenVersion(mojoExecution.getVersion()).getOSGiVersion();
 
 				if (mojoVersion.compareTo(scopesVersion) >= 0) {
-					includeDependencyManagement = maven.getMojoParameterValue(mavenProject, mojoExecution,
-						"includeDependencyManagement", Boolean.class, monitor);
+					Boolean configuredIncludeDependencyManagement = maven.getMojoParameterValue(mavenProject,
+						mojoExecution, "includeDependencyManagement", Boolean.class, monitor);
+					if (configuredIncludeDependencyManagement != null) {
+						includeDependencyManagement = configuredIncludeDependencyManagement;
+					}
 
 					@SuppressWarnings({
 						"rawtypes", "unchecked"

--- a/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -26,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import aQute.bnd.build.Run;
 import aQute.bnd.exceptions.Exceptions;
 import aQute.bnd.maven.lib.resolve.BndrunContainer;
-import aQute.bnd.osgi.resource.ResourceUtils;
 import aQute.bnd.repository.fileset.FileSetRepository;
 import aQute.bnd.service.Refreshable;
 import aQute.bnd.version.Version;
@@ -37,10 +37,11 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	private static final org.slf4j.Logger	logger	= LoggerFactory.getLogger(MavenImplicitProjectRepository.class);
 
-	private volatile FileSetRepository		fileSetRepository;
-	private final IMavenProjectFacade		projectFacade;
-	private final Run						run;
-	private final IPath						bndrunFilePath;
+	private final CompletableFuture<FileSetRepository>	initialRepository	= new CompletableFuture<>();
+	private volatile FileSetRepository					fileSetRepository;
+	private final IMavenProjectFacade					projectFacade;
+	private final Run									run;
+	private final IPath									bndrunFilePath;
 
 	public MavenImplicitProjectRepository(IMavenProjectRegistry mavenProjectRegistry,
 		IMavenProjectFacade projectFacade, Run run) {
@@ -53,19 +54,13 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-		if (fileSetRepository == null) {
-			return ResourceUtils.emptyProviders(requirements);
-		}
-		return fileSetRepository.findProviders(requirements);
+		return getFileSetRepository().findProviders(requirements);
 	}
 
 	@Override
 	public File get(final String bsn, final Version version, Map<String, String> properties,
 		final DownloadListener... listeners) throws Exception {
-		if (fileSetRepository == null) {
-			return null;
-		}
-		return fileSetRepository.get(bsn, version, properties, listeners);
+		return getFileSetRepository().get(bsn, version, properties, listeners);
 	}
 
 	@Override
@@ -81,10 +76,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public List<String> list(String pattern) throws Exception {
-		if (fileSetRepository == null) {
-			return Collections.emptyList();
-		}
-		return fileSetRepository.list(pattern);
+		return getFileSetRepository().list(pattern);
 	}
 
 	@Override
@@ -121,10 +113,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public SortedSet<Version> versions(String bsn) throws Exception {
-		if (fileSetRepository == null) {
-			return new TreeSet<>();
-		}
-		return fileSetRepository.versions(bsn);
+		return getFileSetRepository().versions(bsn);
 	}
 
 	protected void createRepo(IMavenProjectFacade projectFacade, IProgressMonitor monitor) {
@@ -132,8 +121,10 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 		try {
 			BndrunContainer bndrunContainer = run.getPlugin(BndrunContainer.class);
 
-			fileSetRepository = bndrunContainer.getFileSetRepository(mavenProject);
-			fileSetRepository.list(null);
+			FileSetRepository repository = bndrunContainer.getFileSetRepository(mavenProject);
+			repository.list(null);
+			fileSetRepository = repository;
+			initialRepository.complete(repository);
 
 			fullRefresh();
 		} catch (Exception e) {
@@ -143,13 +134,21 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 				String name = mavenProject.getName()
 					.isEmpty() ? mavenProject.getArtifactId() : mavenProject.getName();
 
-				fileSetRepository = new FileSetRepository(name, Collections.emptyList());
+				FileSetRepository repository = new FileSetRepository(name, Collections.emptyList());
+				fileSetRepository = repository;
+				initialRepository.complete(repository);
 
 				fullRefresh();
 			} catch (Exception e2) {
+				initialRepository.completeExceptionally(e2);
 				throw Exceptions.duck(e2);
 			}
 		}
+	}
+
+	private FileSetRepository getFileSetRepository() {
+		FileSetRepository repository = fileSetRepository;
+		return (repository != null) ? repository : initialRepository.join();
 	}
 
 	private void fullRefresh() throws Exception {

--- a/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenImplicitProjectRepository.java
@@ -37,8 +37,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	private static final org.slf4j.Logger	logger	= LoggerFactory.getLogger(MavenImplicitProjectRepository.class);
 
-	private final CompletableFuture<FileSetRepository>	initialRepository	= new CompletableFuture<>();
-	private volatile FileSetRepository					fileSetRepository;
+	private final RepositoryHolder<FileSetRepository>	repositoryHolder	= new RepositoryHolder<>();
 	private final IMavenProjectFacade					projectFacade;
 	private final Run									run;
 	private final IPath									bndrunFilePath;
@@ -54,13 +53,15 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public Map<Requirement, Collection<Capability>> findProviders(Collection<? extends Requirement> requirements) {
-		return getFileSetRepository().findProviders(requirements);
+		return repositoryHolder.get()
+			.findProviders(requirements);
 	}
 
 	@Override
 	public File get(final String bsn, final Version version, Map<String, String> properties,
 		final DownloadListener... listeners) throws Exception {
-		return getFileSetRepository().get(bsn, version, properties, listeners);
+		return repositoryHolder.get()
+			.get(bsn, version, properties, listeners);
 	}
 
 	@Override
@@ -76,7 +77,8 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public List<String> list(String pattern) throws Exception {
-		return getFileSetRepository().list(pattern);
+		return repositoryHolder.get()
+			.list(pattern);
 	}
 
 	@Override
@@ -113,7 +115,8 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 	@Override
 	public SortedSet<Version> versions(String bsn) throws Exception {
-		return getFileSetRepository().versions(bsn);
+		return repositoryHolder.get()
+			.versions(bsn);
 	}
 
 	protected void createRepo(IMavenProjectFacade projectFacade, IProgressMonitor monitor) {
@@ -123,8 +126,7 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 
 			FileSetRepository repository = bndrunContainer.getFileSetRepository(mavenProject);
 			repository.list(null);
-			fileSetRepository = repository;
-			initialRepository.complete(repository);
+			repositoryHolder.set(repository);
 
 			fullRefresh();
 		} catch (Exception e) {
@@ -135,20 +137,33 @@ public class MavenImplicitProjectRepository extends AbstractMavenRepository
 					.isEmpty() ? mavenProject.getArtifactId() : mavenProject.getName();
 
 				FileSetRepository repository = new FileSetRepository(name, Collections.emptyList());
-				fileSetRepository = repository;
-				initialRepository.complete(repository);
+				repositoryHolder.set(repository);
 
 				fullRefresh();
 			} catch (Exception e2) {
-				initialRepository.completeExceptionally(e2);
+				repositoryHolder.fail(e2);
 				throw Exceptions.duck(e2);
 			}
 		}
 	}
 
-	private FileSetRepository getFileSetRepository() {
-		FileSetRepository repository = fileSetRepository;
-		return (repository != null) ? repository : initialRepository.join();
+	static final class RepositoryHolder<T> {
+		private final CompletableFuture<T>	initialRepository	= new CompletableFuture<>();
+		private volatile T				repository;
+
+		T get() {
+			T current = repository;
+			return (current != null) ? current : initialRepository.join();
+		}
+
+		void set(T repository) {
+			this.repository = repository;
+			initialRepository.complete(repository);
+		}
+
+		void fail(Throwable throwable) {
+			initialRepository.completeExceptionally(throwable);
+		}
 	}
 
 	private void fullRefresh() throws Exception {

--- a/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
+++ b/bndtools.m2e/src/bndtools/m2e/MavenRunListenerHelper.java
@@ -206,8 +206,16 @@ public interface MavenRunListenerHelper {
 		try {
 			Bndruns bndruns = maven.getMojoParameterValue(mavenProject, mojoExecution, "bndruns", Bndruns.class,
 				monitor);
+			if (bndruns == null) {
+				bndruns = new Bndruns();
+			}
 
-			return bndruns.getFiles(mavenProject.getBasedir())
+			File bndrunDir = maven.getMojoParameterValue(mavenProject, mojoExecution, "bndrunDir", File.class, monitor);
+			if (bndrunDir == null) {
+				bndrunDir = mavenProject.getBasedir();
+			}
+
+			return bndruns.getFiles(bndrunDir, "*.bndrun")
 				.contains(bndrunFile);
 		} catch (Exception e) {
 			throw Exceptions.duck(e);

--- a/bndtools.m2e/test/bndtools/m2e/MavenImplicitProjectRepositoryTest.java
+++ b/bndtools.m2e/test/bndtools/m2e/MavenImplicitProjectRepositoryTest.java
@@ -1,0 +1,40 @@
+package bndtools.m2e;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import bndtools.m2e.MavenImplicitProjectRepository.RepositoryHolder;
+
+public class MavenImplicitProjectRepositoryTest {
+
+	@Test
+	public void waitsForInitialRepository() throws Exception {
+		RepositoryHolder<Object> holder = new RepositoryHolder<>();
+		Object repository = new Object();
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		try {
+			executor.schedule(() -> holder.set(repository), 100, TimeUnit.MILLISECONDS);
+			assertSame(repository, holder.get());
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void returnsLatestRepository() {
+		RepositoryHolder<Object> holder = new RepositoryHolder<>();
+		Object first = new Object();
+		Object second = new Object();
+
+		holder.set(first);
+		assertSame(first, holder.get());
+
+		holder.set(second);
+		assertSame(second, holder.get());
+	}
+}


### PR DESCRIPTION
## Summary

Fix Maven-backed `.bndrun` resolution when m2e does not expose optional Maven plugin parameters and when the implicit Maven repository is still being initialized asynchronously.

This has affected the openHAB Eclipse setup since Bndtools 7.1.0. openHAB had to [pin Bndtools to 7.0.x](https://github.com/openhab/openhab-distro/pull/1803) in its [`openHAB2.setup`](https://github.com/openhab/openhab-distro/blob/main/launch/openHAB2.setup) because resolving the Maven-backed [`app.bndrun`](https://github.com/openhab/openhab-distro/blob/main/launch/app/app.bndrun) stopped working with newer versions. This is also related to the Maven workspace resolution problem reported in #6380.

With current m2e versions, `getMojoParameterValue(...)` can return `null` for parameters that rely on Maven plugin defaults. Bndtools assumed these values were always populated. This caused an NPE for `bndruns` and could also result in null values being unboxed for `useMavenDependencies` and `includeDependencyManagement`.

After fixing those parameter handling issues, another problem became visible: in editor mode, Bndtools creates the implicit Maven repository asynchronously, but resolution can start before that initialization has finished. In that case the resolver sees an empty repository and reports bundles as unavailable even though they are present in the Maven dependency graph.

This race is particularly easy to reproduce with openHAB because its [`launch/app` Maven project](https://github.com/openhab/openhab-distro/blob/main/launch/app/pom.xml) has a relatively large Maven dependency graph and resulting implicit repository. During testing, the implicit Maven repository contained 387 bundles, so creating and indexing it takes long enough for resolution to overtake the background initialization more easily than in smaller Maven projects.

## Changes

* Apply the resolver Maven plugin defaults when m2e returns `null` for:

  * `bndruns`
  * `bndrunDir`
  * `useMavenDependencies`
  * `includeDependencyManagement`
* Keep implicit Maven repository initialization asynchronous in editor mode.
* Wait for the initial repository to become available when it is accessed before initialization has completed.
* Continue using refreshed repository instances after Maven/project changes.
* Add regression tests for waiting on initial repository creation and using updated repository instances.

## Testing

Tested with the openHAB [`launch/app` project](https://github.com/openhab/openhab-distro/tree/main/launch/app) using Eclipse 2026-06 and Bndtools 7.4.

Before these changes, opening/resolving [`app.bndrun`](https://github.com/openhab/openhab-distro/blob/main/launch/app/app.bndrun) could first fail with an NPE caused by the missing `bndruns` Maven parameter value. After that was addressed, immediate resolution could still fail with bundles such as `org.eclipse.osgi` and `org.eclipse.equinox.metatype` reported as unavailable.

During diagnosis, the initialized implicit Maven repository contained 387 bundles and included both of those bundles, confirming that the remaining failure was caused by resolution accessing the repository before its asynchronous initialization completed.

With these changes, `app.bndrun` resolves successfully while repository initialization remains asynchronous.

## Backport

Since this fixes Maven `.bndrun` resolution with current Eclipse/m2e versions and restores functionality that has been broken for openHAB since Bndtools 7.1.0, it would be great if this could also be cherry-picked to the 7.4.x branch.