### PR TITLE
Show inherited entries from -include files in Run editor

### DIFF
--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/BndEditModel.java
@@ -307,6 +307,7 @@ public class BndEditModel {
 		// converters.put(BndConstants.RUNVMARGS, stringConverter);
 		converters.put(Constants.TESTCASES, listConverter);
 		converters.put(Constants.RUNREQUIRES, requirementListConverter);
+		converters.put(Constants.RUNBLACKLIST, requirementListConverter);
 		converters.put(Constants.RUNEE, eeConverter);
 		converters.put(Constants.RUNREPOS, listConverter);
 		// converters.put(BndConstants.RESOLVE_MODE, resolveModeConverter);
@@ -349,6 +350,7 @@ public class BndEditModel {
 		// formatters.put(BndConstants.TESTSUITES, stringListFormatter);
 		formatters.put(Constants.TESTCASES, stringListFormatter);
 		formatters.put(Constants.RUNREQUIRES, requirementListFormatter);
+		formatters.put(Constants.RUNBLACKLIST, requirementListFormatter);
 		formatters.put(Constants.RUNEE, eeFormatter);
 		formatters.put(Constants.RUNREPOS, runReposFormatter);
 		// formatters.put(BndConstants.RESOLVE_MODE, resolveModeFormatter);
@@ -1435,6 +1437,38 @@ public class BndEditModel {
 
 	public void setGenericString(String name, String value) {
 		doSetObject(name, getGenericString(name), value, stringConverter);
+	}
+
+	/**
+	 * Get a property value using the converter registered for the key's stem,
+	 * so merge keys such as {@code -runrequires.extra} are converted to the
+	 * same type as their stem key. Falls back to the raw string value when no
+	 * converter is registered.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getTypedProperty(String key) {
+		Converter<? extends T, ? super String> converter = getConverter(converters, key);
+		if (converter == null)
+			return (T) getGenericString(key);
+		return doGetObject(key, converter);
+	}
+
+	/**
+	 * Set a property value using the formatter registered for the key's stem,
+	 * so merge keys such as {@code -runrequires.extra} are formatted exactly
+	 * like their stem key. Unlike {@link #setGenericString(String, String)}
+	 * this keeps the internal object cache consistently typed for keys that
+	 * also have typed getters/setters, avoiding ClassCastExceptions.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> void setTypedProperty(String key, T value) {
+		Converter<String, ? super T> formatter = getConverter(formatters, key);
+		if (formatter == null) {
+			setGenericString(key, value == null ? null : value.toString());
+			return;
+		}
+		T oldValue = getTypedProperty(key);
+		doSetObject(key, oldValue, value, formatter);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/model/package-info.java
@@ -1,4 +1,4 @@
-@Version("4.5.0")
+@Version("4.6.0")
 package aQute.bnd.build.model;
 
 import org.osgi.annotation.versioning.Version;

--- a/bndtools.core/_plugin.xml
+++ b/bndtools.core/_plugin.xml
@@ -105,7 +105,7 @@
 			icon="icons/repoindex.png" name="OSGi Repository Index"
 			project="false">
 		</wizard>
-		
+
 		<wizard name="OSGi Declarative Services Component"
 			icon="${icons.component}" category="bndtools.wizardCategory"
 			id="bndtools.newDsComponentWizard">
@@ -137,7 +137,7 @@
             class="bndtools.wizards.newworkspace.NewWorkspaceWizard"
             finalPerspective="bndtools.perspective"
             preferredPerspectives="bndtools.perspective"
-            icon="icons/bndtools-logo-16x16.png" 
+            icon="icons/bndtools-logo-16x16.png"
             name="Bnd Workspace (Fragments)"
             project="true">
 			<description>
@@ -149,14 +149,14 @@
 			class="bndtools.wizards.workspace.WorkspaceSetupWizard"
 			finalPerspective="bndtools.perspective"
 			preferredPerspectives="bndtools.perspective"
-			icon="icons/bndtools-logo-16x16.png" 
+			icon="icons/bndtools-logo-16x16.png"
 			name="Bnd OSGi Workspace"
             project="true">
 			<description>
 			Create a new bnd workspace
 			</description>
 		</wizard>
-        
+
 		<wizard id="bndtools.importProject"
 			category="bndtools.wizardCategory"
 			class="bndtools.wizards.project.ImportBndWorkspaceWizard"
@@ -178,7 +178,18 @@
 		</wizard>
 	</extension>
 
+	<extension point="org.eclipse.core.resources.markers"
+		id="includeconflict"
+		name="Bnd Include Conflict Marker">
+		<persistent value="true"/>
+		<super type="org.eclipse.core.resources.problemmarker"/>
+		<super type="org.eclipse.core.resources.textmarker"/>
+	</extension>
+
 	<extension point="org.eclipse.ui.ide.markerResolution">
+		<markerResolutionGenerator
+			markerType="bndtools.core.includeconflict"
+			class="bndtools.editor.project.IncludeConflictMarkerResolutionGenerator" />
 		<markerResolutionGenerator
 			markerType="bndtools.builder.missingworkspace"
 			class="bndtools.wizards.workspace.MissingWorkspaceMarkerResolutionGenerator" />
@@ -486,7 +497,7 @@
 			sourceLocatorId="bndtools.launch.sourcelookup.BndDependencySourceLookupDirector"
 			sourcePathComputerId="org.eclipse.jdt.launching.sourceLookup.javaSourcePathComputer" />
 		<launchConfigurationType
-			id="bndtools.launch.bnd.NativeBndLaunchDelegate" 
+			id="bndtools.launch.bnd.NativeBndLaunchDelegate"
 			delegate="org.bndtools.facade.ExtensionFacade:org.eclipse.debug.core.model.ILaunchConfigurationDelegate2"
 			modes="run, debug" name="bnd Native"
 			sourceLocatorId="bndtools.launch.sourcelookup.BndDependencySourceLookupDirector"
@@ -889,7 +900,7 @@
 			helpUrl="https://bnd.bndtools.org/plugins/osgirepo.html">
 			<property name="name" type="string"
 				description="Name of the repository" />
-			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />	
+			<property name="tags" type="combo" description="Comma separated list ('resolve' used for resolution. See -runrepos instruction for details). Use &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution." options="resolve,&lt;&lt;EMPTY&gt;&gt;"  />
 			<property name="locations" type="string"
 				description="Index locations (comma-separated list of URLs)" />
 			<property name="cache" type="string"
@@ -988,7 +999,7 @@
 		    <property name="poll_time" type="int" description="Sets the time in seconds when to check for changes in the pom-files" default="300" />
 		    <property name="dependencyManagement" type="boolean" description="Also considers the dependency management section of a POM. Default is false." default="false" />
 		</plugin>
-		
+
 	</extension>
 
 	<extension point="org.eclipse.ui.intro.configExtension">
@@ -1046,7 +1057,7 @@
                tooltip="Analyzes a .bndrun file e.g. for unused bundles in repositories and other aspects.">
          </action>
       </objectContribution>
-	
+
 		<objectContribution adaptable="true"
 			id="bndtools.nonBndProjectContribution"
 			objectClass="org.eclipse.core.resources.IProject">
@@ -1209,7 +1220,7 @@
 			id="bndtools.core.BndtoolsJavaWorkingSet">
 		</workingSet>
 	</extension>
-	
+
 	<!-- =========================================================================== -->
 	<!-- Remote Bundle Install Support -->
 	<!-- =========================================================================== -->

--- a/bndtools.core/bndtools.win32.x86_64.bndrun
+++ b/bndtools.core/bndtools.win32.x86_64.bndrun
@@ -20,6 +20,10 @@
 	osgi.arch=x86_64,\
 	osgi.os=win32
 
+# include this property to open a workspace without selection dialog
+#-runproperties.workspace: \
+#	osgi.instance.area=C:/git/github.com/peterkir/bnd-rcp-sample-workspace
+
 -runblacklist.win32: \
 	osgi.identity;filter:='(osgi.identity=*macosx*)',\
 	osgi.identity;filter:='(osgi.identity=*linux*)',\

--- a/bndtools.core/src/bndtools/editor/BndEditor.java
+++ b/bndtools.core/src/bndtools/editor/BndEditor.java
@@ -41,6 +41,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
@@ -97,6 +98,7 @@ import bndtools.editor.pages.ProjectBuildPage;
 import bndtools.editor.pages.ProjectRunPage;
 import bndtools.editor.pages.TestSuitesPage;
 import bndtools.editor.pages.WorkspacePage;
+import bndtools.editor.project.IncludeConflictDetector;
 import bndtools.launch.util.LaunchUtils;
 import bndtools.preferences.BndPreferences;
 import bndtools.types.Pair;
@@ -657,6 +659,7 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 								IDocument document = docProvider.getDocument(getEditorInput());
 								model.loadFrom(new IDocumentWrapper(document));
 								model.setDirty(false);
+								IncludeConflictDetector.updateMarkers(inputResource, model);
 							} catch (IOException e) {
 								logger.logError("Unable to load edit model", e);
 								completed.fail(e);
@@ -775,6 +778,41 @@ public class BndEditor extends ExtendedFormEditor implements IResourceChangeList
 		IResourceDelta delta = event.getDelta();
 		if (delta == null)
 			return;
+
+		// When an included file is saved, refresh the owner processor and reload
+		// so merged properties (e.g. -runrequires, -runproperties) reflect the change.
+		aQute.bnd.osgi.Processor owner = model.getOwner();
+		if (owner != null && !saving.get()) {
+			final IResourceDelta fullDelta = delta; // delta is reassigned below; capture before
+			boolean includedChanged = owner.getIncluded()
+				.stream()
+				.anyMatch(includedFile -> {
+					IFile wsFile = ResourcesPlugin.getWorkspace()
+						.getRoot()
+						.getFileForLocation(new Path(includedFile.getAbsolutePath()));
+					if (wsFile == null)
+						return false;
+					IResourceDelta d = fullDelta.findMember(wsFile.getFullPath());
+					return d != null
+						&& (d.getKind() & IResourceDelta.CHANGED) != 0
+						&& (d.getFlags() & IResourceDelta.CONTENT) != 0;
+				});
+			if (includedChanged) {
+				final IDocumentProvider docProvider = sourcePage.getDocumentProvider();
+				if (docProvider != null) {
+					final IDocument document = docProvider.getDocument(getEditorInput());
+					SWTConcurrencyUtil.execForControl(getEditorSite().getShell(), true, () -> {
+						try {
+							owner.forceRefresh();
+							model.loadFrom(new IDocumentWrapper(document));
+							IncludeConflictDetector.updateMarkers(inputResource, model);
+						} catch (IOException e) {
+							logger.logError("Failed to reload model after included file change", e);
+						}
+					});
+				}
+			}
+		}
 		IPath fullPath = myResource.getFullPath();
 		delta = delta.findMember(fullPath);
 		if (delta == null)

--- a/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
+++ b/bndtools.core/src/bndtools/editor/pages/ProjectRunPage.java
@@ -175,18 +175,12 @@ public class ProjectRunPage extends FormPage {
 		RepositorySelectionPart reposPart = new RepositorySelectionPart(getEditor(), left, tk,
 			ExpandableComposite.TITLE_BAR | ExpandableComposite.TWISTIE);
 		managedForm.addPart(reposPart);
-		gd = new GridData(SWT.FILL, SWT.FILL, true, true);
-		gd.widthHint = 50;
-		gd.heightHint = 50;
 		reposPart.getSection()
 			.setLayoutData(PageLayoutUtils.createCollapsed());
 
 		AvailableBundlesPart availableBundlesPart = new AvailableBundlesPart(left, tk,
 			ExpandableComposite.TITLE_BAR | ExpandableComposite.EXPANDED);
 		managedForm.addPart(availableBundlesPart);
-		gd = new GridData(SWT.FILL, SWT.FILL, true, true);
-		gd.widthHint = 50;
-		gd.heightHint = 50;
 		availableBundlesPart.getSection()
 			.setLayoutData(PageLayoutUtils.createExpanded());
 

--- a/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
+++ b/bndtools.core/src/bndtools/editor/project/AbstractRequirementListPart.java
@@ -2,47 +2,66 @@ package bndtools.editor.project;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.bndtools.core.ui.resource.RequirementLabelProvider;
 import org.bndtools.utils.dnd.AbstractViewerDropAdapter;
 import org.bndtools.utils.dnd.SupportedTransfer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
+import org.eclipse.ui.part.FileEditorInput;
 import org.osgi.resource.Requirement;
 
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.osgi.resource.CapReqBuilder;
 import bndtools.Plugin;
+import bndtools.editor.BndEditor;
 import bndtools.editor.common.BndEditorPart;
 import bndtools.model.repo.DependencyPhase;
 import bndtools.model.repo.FeatureVersionNode;
@@ -62,24 +81,106 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 		super(parent, toolkit, style);
 	}
 
-	private final BndPreferences	preferences	= new BndPreferences();
-	private final List<Requirement>	requires	= new ArrayList<>();
+	private final BndPreferences	preferences				= new BndPreferences();
+	/** Local requirements: written to this file's own merge key. */
+	private final List<Requirement>	requires				= new ArrayList<>();
+	/** Inherited requirements: from included files, shown in gray (read-only). */
+	private final List<Requirement>	inheritedRequires		= new ArrayList<>();
 
 	private TableViewer				viewer;
 	private ToolItem				addBundleTool;
 	private ToolItem				removeTool;
 
-	private boolean					committing	= false;
+	private boolean					committing				= false;
+	/** Per-requirement provenance: maps each inherited requirement to the file path that defines it. */
+	private Map<Requirement, String>	inheritedProvenances	= new java.util.LinkedHashMap<>();
+	/** Local entries that are a single unexpanded macro reference (e.g. {@code ${name}}), mapped to their raw definition text. */
+	private Map<Requirement, String>	macroExpansions	= new java.util.LinkedHashMap<>();
+	/** Maps a local macro-reference entry to the file path where the referenced macro/property is defined. */
+	private Map<Requirement, String>	macroProvenances		= new java.util.LinkedHashMap<>();
+	/** The key used to write local requirements (plain stem or stem.local). */
+	private String					localKey				= null;
+	/** Extra property key subscribed dynamically (the localKey when it's a suffix). */
+	private String					subscribedLocalKey		= null;
+
+	/** Returns the primary bnd property key this part displays (e.g. {@code -runrequires}). */
+	protected abstract String getPrimaryPropertyKey();
+
+	/** Returns the local write key (plain stem or stem.local) determined during the last refresh. */
+	protected final String getLocalKey() {
+		return localKey != null ? localKey : getPrimaryPropertyKey();
+	}
+
+	/** Colors inherited items gray and local items with the default foreground. */
+	private class MixedRequirementLabelProvider extends RequirementLabelProvider {
+		private final Color grey;
+
+		MixedRequirementLabelProvider(Display display) {
+			grey = display.getSystemColor(SWT.COLOR_DARK_GRAY);
+		}
+
+		@Override
+		public void update(ViewerCell cell) {
+			super.update(cell);
+			if (inheritedRequires.contains(cell.getElement())) {
+				cell.setForeground(grey);
+				// clear styled ranges so the grey foreground is not overridden
+				cell.setStyleRanges(new StyleRange[0]);
+			}
+		}
+
+		@Override
+		public String getToolTipText(Object element) {
+			String definition = macroExpansions.get(element);
+			if (definition != null) {
+				StringBuilder sb = new StringBuilder(definition);
+				String prov = macroProvenances.get(element);
+				if (prov != null) {
+					sb.append("\n\nDouble-click to open ")
+						.append(BndEditModelAccessor.getDisplayProvenance(model, prov));
+				}
+				return sb.toString();
+			}
+			if (inheritedRequires.contains(element)) {
+				String prov = inheritedProvenances.get(element);
+				return prov != null
+					? "Inherited from " + BndEditModelAccessor.getDisplayProvenance(model, prov)
+						+ "\nDouble-click to open source."
+					: "Inherited from an included file.";
+			}
+			return null;
+		}
+	}
 
 	protected TableViewer createViewer(Composite parent, FormToolkit tk) {
 		Table table = tk.createTable(parent, SWT.FULL_SELECTION | SWT.MULTI | SWT.BORDER);
 		viewer = new TableViewer(table);
 		viewer.setContentProvider(ArrayContentProvider.getInstance());
-		viewer.setLabelProvider(new RequirementLabelProvider());
+		viewer.setLabelProvider(new MixedRequirementLabelProvider(table.getDisplay()));
+		ColumnViewerToolTipSupport.enableFor(viewer);
 
 		// Listeners
-		viewer.addSelectionChangedListener(event -> removeTool.setEnabled(!viewer.getSelection()
-			.isEmpty()));
+		viewer.addSelectionChangedListener(event -> {
+			IStructuredSelection sel = (IStructuredSelection) viewer.getSelection();
+			boolean hasLocalSelected = !sel.isEmpty()
+				&& sel.toList().stream().anyMatch(e -> requires.contains(e));
+			removeTool.setEnabled(hasLocalSelected);
+		});
+		viewer.addDoubleClickListener(new IDoubleClickListener() {
+			@Override
+			public void doubleClick(DoubleClickEvent event) {
+				IStructuredSelection sel = (IStructuredSelection) viewer.getSelection();
+				if (sel.isEmpty())
+					return;
+				Requirement req = (Requirement) sel.getFirstElement();
+				// Macro entries navigate to where the referenced macro/property is defined;
+				// plain inherited entries navigate to the file that defines the merge key.
+				String prov = macroProvenances.containsKey(req) ? macroProvenances.get(req)
+					: inheritedProvenances.get(req);
+				if (prov != null)
+					openProvenanceFile(prov);
+			}
+		});
 		table.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyReleased(KeyEvent e) {
@@ -193,14 +294,11 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 	private void doRemove() {
 		IStructuredSelection selection = (IStructuredSelection) viewer.getSelection();
 		if (!selection.isEmpty()) {
-			Iterator<?> elements = selection.iterator();
-			List<Object> removed = new LinkedList<>();
-			while (elements.hasNext()) {
-				Object element = elements.next();
-				if (this.requires.remove(element))
-					removed.add(element);
-			}
-
+			// Only local items may be removed; inherited ones stay in their source file.
+			@SuppressWarnings("unchecked")
+			List<Object> removed = ((List<Object>) selection.toList()).stream()
+				.filter(e -> this.requires.remove(e))
+				.collect(Collectors.toList());
 			if (!removed.isEmpty()) {
 				viewer.remove(removed.toArray());
 				markDirty();
@@ -220,16 +318,107 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 
 	@Override
 	protected final void refreshFromModel() {
-		List<Requirement> loadedReqs = doRefreshFromModel();
-		if (loadedReqs == null)
-			loadedReqs = Collections.emptyList();
+		// Local requirements: only what is defined in this file's own merge keys.
+		List<Requirement> newLocal = doRefreshFromModel();
+		if (newLocal == null)
+			newLocal = Collections.emptyList();
 
-		if (loadedReqs.equals(this.requires))
+		// Inherited requirements: merged view minus local.
+		String primaryKey = getPrimaryPropertyKey();
+		List<Requirement> newInherited = Collections.emptyList();
+		if (primaryKey != null && model != null) {
+			List<Requirement> merged = BndEditModelAccessor.getMergedRequirements(model, primaryKey);
+			if (merged != null && !merged.isEmpty()) {
+				Set<Requirement> localSet = new HashSet<>(newLocal);
+				newInherited = merged.stream()
+					.filter(r -> !localSet.contains(r))
+					.collect(Collectors.toList());
+			}
+		}
+
+		// Local entries that are a single unexpanded macro reference (e.g. ${name}) are kept
+		// collapsed as-is (whether defined locally or inherited from an included file); their
+		// definition text is only shown via tooltip/double-click.
+		Map<Requirement, String> newMacroExpansions = new java.util.LinkedHashMap<>();
+		Map<Requirement, String> newMacroProvenances = new java.util.LinkedHashMap<>();
+		if (model != null) {
+			List<Requirement> candidates = new ArrayList<>(newLocal.size() + newInherited.size());
+			candidates.addAll(newLocal);
+			candidates.addAll(newInherited);
+			for (Requirement candidate : candidates) {
+				Optional<String> macroName = BndEditModelAccessor.getMacroReferenceName(candidate);
+				if (macroName.isEmpty())
+					continue;
+				String definition = BndEditModelAccessor.getMacroDefinitionText(model, macroName.get());
+				if (definition == null)
+					continue;
+				newMacroExpansions.put(candidate, definition);
+				BndEditModelAccessor.getPropertyProvenance(model, macroName.get())
+					.ifPresent(prov -> newMacroProvenances.put(candidate, prov));
+			}
+		}
+		this.macroExpansions = newMacroExpansions;
+		this.macroProvenances = newMacroProvenances;
+
+		// Determine which key local additions should be written to.
+		String newLocalKey = primaryKey;
+		if (primaryKey != null && model != null) {
+			String existingKey = BndEditModelAccessor.findLocalMergeKey(model, primaryKey);
+			if (existingKey != null) {
+				newLocalKey = existingKey;
+			} else if (!newInherited.isEmpty()) {
+				// No local key yet but inherited items exist: use a suffix so bnd merges them.
+				newLocalKey = primaryKey + ".local";
+			}
+		}
+		localKey = newLocalKey;
+
+		// Keep the property-change subscription aligned with the local key.
+		if (!Objects.equals(subscribedLocalKey, newLocalKey)) {
+			if (subscribedLocalKey != null && model != null)
+				model.removePropertyChangeListener(subscribedLocalKey, this);
+			subscribedLocalKey = newLocalKey;
+			if (newLocalKey != null && model != null
+				&& !Arrays.asList(getProperties()).contains(newLocalKey))
+				model.addPropertyChangeListener(newLocalKey, this);
+		}
+
+		// Update provenance tooltip for inherited items.
+		if (!newInherited.isEmpty()) {
+			inheritedProvenances = BndEditModelAccessor.getInheritedRequirementProvenances(model, primaryKey);
+			String tip = inheritedProvenances.values().stream().findAny().isPresent()
+				? "Some requirements are inherited from included files. Double-click an inherited item to open its source."
+				: "Some requirements are inherited from included files.";
+			viewer.getControl().setToolTipText(tip);
+		} else {
+			inheritedProvenances = Collections.emptyMap();
+			viewer.getControl().setToolTipText(null);
+		}
+
+		addBundleTool.setEnabled(true);
+		removeTool.setEnabled(false);
+
+		if (newInherited.equals(this.inheritedRequires) && newLocal.equals(this.requires))
 			return;
 
+		this.inheritedRequires.clear();
+		this.inheritedRequires.addAll(newInherited);
 		this.requires.clear();
-		this.requires.addAll(loadedReqs);
-		viewer.setInput(this.requires);
+		this.requires.addAll(newLocal);
+
+		List<Requirement> combined = new ArrayList<>(this.inheritedRequires.size() + this.requires.size());
+		combined.addAll(this.inheritedRequires);
+		combined.addAll(this.requires);
+		viewer.setInput(combined);
+	}
+
+	@Override
+	public void dispose() {
+		if (subscribedLocalKey != null && model != null) {
+			model.removePropertyChangeListener(subscribedLocalKey, this);
+			subscribedLocalKey = null;
+		}
+		super.dispose();
 	}
 
 	@Override
@@ -244,19 +433,32 @@ public abstract class AbstractRequirementListPart extends BndEditorPart implemen
 		}
 	}
 
-	/**
-	 * Update the requirements already available with new ones. Already existing
-	 * requirements will be removed from the given set.
-	 *
-	 * @param adding Set with {@link Requirement}s to add
-	 * @return true if requirements were added.
-	 */
-	private boolean updateViewerWithNewRequirements(Set<Requirement> adding) {
-		// remove duplicates
-		adding.removeAll(this.requires);
-		if (adding.isEmpty()) {
-			return false;
+	private void openProvenanceFile(String absolutePath) {
+		File file = new File(absolutePath);
+		if (!file.isFile())
+			return;
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace()
+			.getRoot();
+		IFile iFile = root.getFileForLocation(new Path(absolutePath));
+		if (iFile == null || !iFile.exists())
+			return;
+		try {
+			PlatformUI.getWorkbench()
+				.getActiveWorkbenchWindow()
+				.getActivePage()
+				.openEditor(new FileEditorInput(iFile), BndEditor.WORKSPACE_EDITOR);
+		} catch (PartInitException e) {
+			ErrorDialog.openError(getSection().getShell(), "Error", null,
+				new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Failed to open source file.", e));
 		}
+	}
+
+	/** Adds new requirements as local items. Items already in inherited or local lists are skipped. */
+	private boolean updateViewerWithNewRequirements(Set<Requirement> adding) {
+		adding.removeAll(this.inheritedRequires);
+		adding.removeAll(this.requires);
+		if (adding.isEmpty())
+			return false;
 		this.requires.addAll(adding);
 		viewer.add(adding.toArray());
 		markDirty();

--- a/bndtools.core/src/bndtools/editor/project/BndEditModelAccessor.java
+++ b/bndtools.core/src/bndtools/editor/project/BndEditModelAccessor.java
@@ -1,0 +1,439 @@
+package bndtools.editor.project;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.osgi.resource.Requirement;
+
+import aQute.bnd.build.model.BndEditModel;
+import aQute.bnd.build.model.clauses.VersionedClause;
+import aQute.bnd.build.model.conversions.Converter;
+import aQute.bnd.build.model.conversions.HeaderClauseListConverter;
+import aQute.bnd.build.model.conversions.RequirementListConverter;
+import aQute.bnd.build.model.conversions.VersionedClauseConverter;
+import aQute.bnd.header.OSGiHeader;
+import aQute.bnd.osgi.Processor;
+import aQute.bnd.osgi.Processor.PropertyKey;
+
+/** Convenience accessors for {@link BndEditModel} used by UI components that need to distinguish local vs inherited properties. */
+class BndEditModelAccessor {
+
+	private static final RequirementListConverter requirementListConverter = new RequirementListConverter();
+
+	private static final Converter<List<VersionedClause>, String> versionedClauseListConverter =
+		new HeaderClauseListConverter<>(new VersionedClauseConverter());
+
+	/** Returns true if any local property key matches the stem or a stem.* variant. */
+	static boolean hasLocalMergeProperty(BndEditModel model, String stem) {
+		return !getLocalMergeKeys(model, stem).isEmpty();
+	}
+
+	/**
+	 * Returns requirements merged across all stem.* variants from the owner processor (includes inherited
+	 * files), using each key's raw (unexpanded) text so a clause that is itself a single macro reference
+	 * (e.g. {@code ${name}}) stays collapsed instead of being expanded into its constituent requirements.
+	 */
+	static List<Requirement> getMergedRequirements(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return null;
+		List<PropertyKey> keys = PropertyKey.findVisible(p.getMergePropertyKeys(stem));
+		if (keys.isEmpty())
+			return null;
+		List<Requirement> result = new ArrayList<>();
+		for (PropertyKey pk : keys) {
+			String raw = pk.getRawValue();
+			if (raw == null || raw.isBlank())
+				continue;
+			List<Requirement> reqs = requirementListConverter.convert(raw);
+			if (reqs != null)
+				result.addAll(reqs);
+		}
+		return result.isEmpty() ? null : result;
+	}
+
+	/**
+	 * Returns requirements from all local document merge keys (stem and stem.*).
+	 * Reads from the saved document state; uncommitted in-memory drops are tracked
+	 * separately in the viewer and committed on save.
+	 */
+	static List<Requirement> getLocalMergeRequirements(BndEditModel model, String stem) {
+		List<Requirement> result = new ArrayList<>();
+		for (String key : getLocalMergeKeys(model, stem)) {
+			List<Requirement> reqs = model.getTypedProperty(key);
+			if (reqs != null)
+				result.addAll(reqs);
+		}
+		return result;
+	}
+
+	/** Writes requirements to an arbitrary merge key using the formatter registered for the stem. */
+	static void setRequirementListByKey(BndEditModel model, String key, List<Requirement> requires) {
+		model.setTypedProperty(key, requires);
+	}
+
+	/** Matches a requirement clause consisting of nothing but a single, unexpanded macro reference, e.g. {@code ${name}}. */
+	private static final Pattern MACRO_REFERENCE = Pattern.compile("^\\$\\{([^${}]+)\\}$");
+
+	/**
+	 * Returns the referenced property/macro name if {@code req} is a single unexpanded macro
+	 * reference clause (e.g. {@code ${fea_org.eclipse.e4.rcp_4.35.0.v20250228-0640}}), or empty
+	 * otherwise.
+	 */
+	static Optional<String> getMacroReferenceName(Requirement req) {
+		if (req == null)
+			return Optional.empty();
+		Matcher m = MACRO_REFERENCE.matcher(req.getNamespace());
+		return m.matches() ? Optional.of(m.group(1)) : Optional.empty();
+	}
+
+	/** Matches a single {@code ${name}} (or {@code ${name;arg;...}}) macro token, non-nested. */
+	private static final Pattern MACRO_TOKEN = Pattern.compile("\\$\\{([^{}]*)\\}");
+
+	/**
+	 * Returns the raw (one-level) definition text of the given macro/property name, i.e. what is
+	 * literally written for it (merged across its stem.* variants), without recursively expanding
+	 * references to other defined properties. Any embedded built-in bnd macros that are not
+	 * themselves defined properties (e.g. {@code ${workspace}}) are resolved to their actual value,
+	 * since those are short and useful, while references to other (potentially large) properties are
+	 * left as literal {@code ${name}} text so the result stays compact.
+	 */
+	static String getMacroDefinitionText(BndEditModel model, String macroName) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return null;
+		List<PropertyKey> keys = PropertyKey.findVisible(p.getMergePropertyKeys(macroName));
+		if (keys.isEmpty())
+			return null;
+		StringBuilder combined = new StringBuilder();
+		for (PropertyKey pk : keys) {
+			String raw = pk.getRawValue();
+			if (raw == null || raw.isBlank())
+				continue;
+			if (combined.length() > 0)
+				combined.append(',');
+			combined.append(raw);
+		}
+		if (combined.length() == 0)
+			return null;
+		// One clause per line so the tooltip wraps readably (bnd's own line-continuation
+		// backslash-newlines are collapsed away by the properties parser).
+		String oneClausePerLine = String.join("\n", splitClauses(combined.toString()));
+		return resolveBuiltinMacros(p, oneClausePerLine);
+	}
+
+	/** Splits a comma-separated header-clause-like value into its top-level clauses, respecting quotes and parens/braces. */
+	static List<String> splitClauses(String raw) {
+		List<String> result = new ArrayList<>();
+		if (raw == null)
+			return result;
+		StringBuilder cur = new StringBuilder();
+		int depth = 0;
+		boolean inSingle = false, inDouble = false;
+		for (int i = 0; i < raw.length(); i++) {
+			char c = raw.charAt(i);
+			if (c == '\'' && !inDouble) {
+				inSingle = !inSingle;
+			} else if (c == '"' && !inSingle) {
+				inDouble = !inDouble;
+			} else if (!inSingle && !inDouble) {
+				if (c == '(' || c == '{')
+					depth++;
+				else if (c == ')' || c == '}')
+					depth--;
+				else if (c == ',' && depth == 0) {
+					String clause = cur.toString()
+						.strip();
+					if (!clause.isEmpty())
+						result.add(clause);
+					cur.setLength(0);
+					continue;
+				}
+			}
+			cur.append(c);
+		}
+		String last = cur.toString()
+			.strip();
+		if (!last.isEmpty())
+			result.add(last);
+		return result;
+	}
+
+	/**
+	 * Returns a display string for the given provenance file path: if this model's own {@code -include}
+	 * entry (raw, unexpanded) resolves to that file, the literal include entry is returned instead
+	 * (keeping any macro such as {@code ${workspace}} unresolved); otherwise the absolute path itself.
+	 */
+	static String getDisplayProvenance(BndEditModel model, String absolutePath) {
+		if (absolutePath == null)
+			return null;
+		Processor p = model.getOwner();
+		if (p == null)
+			return absolutePath;
+		// The owner processor removes -include from its properties once processed, so read the
+		// raw (unexpanded) value from the edited document instead.
+		String includeRaw = model.getDocumentProperties()
+			.getProperty(aQute.bnd.osgi.Constants.INCLUDE);
+		if (includeRaw == null || includeRaw.isBlank())
+			return absolutePath;
+		java.io.File target = new java.io.File(absolutePath);
+		for (String clause : splitClauses(includeRaw)) {
+			// Strip the optional leading modifier characters bnd allows on -include entries (~, -, !).
+			String path = clause.replaceFirst("^[~\\-!]+", "");
+			String resolved = p.getReplacer()
+				.process(path);
+			java.io.File resolvedFile = p.getFile(resolved);
+			if (resolvedFile == null)
+				continue;
+			try {
+				if (resolvedFile.getCanonicalFile()
+					.equals(target.getCanonicalFile()))
+					return clause;
+			} catch (java.io.IOException ignore) {
+				// fall through to next candidate
+			}
+		}
+		return absolutePath;
+	}
+
+	/** Resolves only "built-in" macros (not backed by a defined property) found in {@code raw}. */
+	private static String resolveBuiltinMacros(Processor p, String raw) {
+		if (raw == null || raw.indexOf("${") < 0)
+			return raw;
+		Matcher m = MACRO_TOKEN.matcher(raw);
+		StringBuilder out = new StringBuilder();
+		int last = 0;
+		while (m.find()) {
+			String name = m.group(1)
+				.split(";", 2)[0].trim();
+			out.append(raw, last, m.start());
+			if (name.isEmpty() || !p.getMergePropertyKeys(name).isEmpty()) {
+				// Empty, or a reference to another defined (potentially large) property: keep collapsed.
+				out.append(m.group());
+			} else {
+				// A built-in/system macro (e.g. ${workspace}): resolve to its actual value.
+				out.append(p.getReplacer().process(m.group()));
+			}
+			last = m.end();
+		}
+		out.append(raw.substring(last));
+		return out.toString();
+	}
+
+	// ---- VersionedClause (runbundles, buildpath) ----------------------------
+
+	/** Returns merged VersionedClause list from the owner processor (includes inherited files). */
+	static List<VersionedClause> getMergedVersionedClauses(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return null;
+		String merged = p.mergeProperties(stem);
+		if (merged == null || merged.isBlank())
+			return null;
+		return versionedClauseListConverter.convert(merged);
+	}
+
+	/** Returns VersionedClause items from all local document merge keys (stem and stem.*). */
+	static List<VersionedClause> getLocalVersionedClauses(BndEditModel model, String stem) {
+		Set<String> keys = getLocalMergeKeys(model, stem);
+		if (keys.isEmpty())
+			return null;
+		List<VersionedClause> result = new ArrayList<>();
+		for (String key : keys) {
+			List<VersionedClause> clauses = model.getTypedProperty(key);
+			if (clauses != null)
+				result.addAll(clauses);
+		}
+		return result;
+	}
+
+	/** Writes a VersionedClause list to an arbitrary merge key using the formatter registered for the stem. */
+	static void setVersionedClausesByKey(BndEditModel model, String key, List<VersionedClause> clauses) {
+		model.setTypedProperty(key, clauses);
+	}
+
+	// ---- Map<String,String> (runproperties) ---------------------------------
+
+	/** Returns merged properties map from the owner processor (includes inherited files). */
+	static Map<String, String> getMergedProperties(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return null;
+		String merged = p.mergeProperties(stem);
+		if (merged == null || merged.isBlank())
+			return null;
+		return OSGiHeader.parseProperties(merged);
+	}
+
+	/** Returns properties map from all local document merge keys (stem and stem.*). */
+	static Map<String, String> getLocalProperties(BndEditModel model, String stem) {
+		Set<String> keys = getLocalMergeKeys(model, stem);
+		if (keys.isEmpty())
+			return null;
+		Map<String, String> result = new LinkedHashMap<>();
+		for (String key : keys) {
+			Map<String, String> props = model.getTypedProperty(key);
+			if (props != null)
+				result.putAll(props);
+		}
+		return result;
+	}
+
+	/** Writes a properties map to an arbitrary merge key using the formatter registered for the stem. */
+	static void setPropertiesByKey(BndEditModel model, String key, Map<String, String> props) {
+		model.setTypedProperty(key, props);
+	}
+
+	/**
+	 * Returns per-entry provenance for inherited properties: maps each inherited property key
+	 * to the absolute path of the file where that specific merge key was defined.
+	 * First definition wins (matches bnd merge semantics).
+	 */
+	static Map<String, String> getInheritedPropertiesProvenance(BndEditModel model, String stem) {
+		return getInheritedEntryProvenances(model, stem,
+			raw -> OSGiHeader.parseProperties(raw).keySet());
+	}
+
+	/**
+	 * Returns per-bundle provenance for inherited bundles: maps each BSN to the absolute path
+	 * of the file where that bundle was defined.
+	 */
+	static Map<String, String> getInheritedBundleProvenances(BndEditModel model, String stem) {
+		return getInheritedEntryProvenances(model, stem, raw -> {
+			List<VersionedClause> clauses = versionedClauseListConverter.convert(raw);
+			if (clauses == null)
+				return Collections.emptySet();
+			Set<String> bsns = new LinkedHashSet<>();
+			for (VersionedClause vc : clauses)
+				bsns.add(vc.getName());
+			return bsns;
+		});
+	}
+
+	/**
+	 * Returns per-requirement provenance: maps each inherited Requirement to the absolute path
+	 * of the file where it was defined.
+	 */
+	static Map<Requirement, String> getInheritedRequirementProvenances(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return Collections.emptyMap();
+		Set<String> localDocKeys = getLocalMergeKeys(model, stem);
+		Map<Requirement, String> result = new LinkedHashMap<>();
+		for (PropertyKey pk : PropertyKey.findVisible(p.getMergePropertyKeys(stem))) {
+			if (localDocKeys.contains(pk.key()))
+				continue;
+			Optional<String> prov = pk.getProvenance();
+			if (prov.isEmpty())
+				continue;
+			// Use the raw (unexpanded) value so a clause that is itself a macro reference stays
+			// collapsed and matches the entries produced by getMergedRequirements.
+			String raw = pk.getRawValue();
+			if (raw == null || raw.isBlank())
+				continue;
+			List<Requirement> reqs = requirementListConverter.convert(raw);
+			if (reqs != null)
+				for (Requirement req : reqs)
+					result.putIfAbsent(req, prov.get());
+		}
+		return result;
+	}
+
+	/** Shared helper: maps each string entry (key/bsn) to its provenance file. */
+	private static Map<String, String> getInheritedEntryProvenances(BndEditModel model, String stem,
+		java.util.function.Function<String, java.util.Collection<String>> entryExtractor) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return Collections.emptyMap();
+		Set<String> localDocKeys = getLocalMergeKeys(model, stem);
+		Map<String, String> result = new LinkedHashMap<>();
+		for (PropertyKey pk : PropertyKey.findVisible(p.getMergePropertyKeys(stem))) {
+			if (localDocKeys.contains(pk.key()))
+				continue;
+			Optional<String> prov = pk.getProvenance();
+			if (prov.isEmpty())
+				continue;
+			// Use the macro-expanded value (not the raw text) so parsed entries match the merged view.
+			String raw = pk.getValue();
+			if (raw == null || raw.isBlank())
+				continue;
+			for (String entry : entryExtractor.apply(raw))
+				result.putIfAbsent(entry, prov.get());
+		}
+		return result;
+	}
+
+	// ---- String (runvm, runprogramargs) -------------------------------------
+
+	/** Returns merged string value from the owner processor (includes inherited files). */
+	static String getMergedString(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return null;
+		return p.mergeProperties(stem);
+	}
+
+	/** Returns visible non-local merge keys for the stem that carry a provenance (inherited from included files). */
+	static List<PropertyKey> getInheritedPropertyKeys(BndEditModel model, String stem) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return Collections.emptyList();
+		Set<String> localDocKeys = getLocalMergeKeys(model, stem);
+		List<PropertyKey> result = new ArrayList<>();
+		for (PropertyKey pk : PropertyKey.findVisible(p.getMergePropertyKeys(stem))) {
+			if (localDocKeys.contains(pk.key()))
+				continue;
+			if (pk.getProvenance()
+				.isPresent())
+				result.add(pk);
+		}
+		return result;
+	}
+
+	// ---- Local key resolution -----------------------------------------------
+
+	/**
+	 * Returns the first existing local merge key for stem (plain stem takes precedence over stem.*),
+	 * or {@code null} if no local key exists.
+	 */
+	static String findLocalMergeKey(BndEditModel model, String stem) {
+		Set<String> keys = getLocalMergeKeys(model, stem);
+		if (keys.contains(stem))
+			return stem;
+		return keys.stream().findFirst().orElse(null);
+	}
+
+	/** Returns the provenance (file path) of the first visible merge key for the given stem, or empty if local/unknown. */
+	static Optional<String> getPropertyProvenance(BndEditModel model, String key) {
+		Processor p = model.getOwner();
+		if (p == null)
+			return Optional.empty();
+		return PropertyKey.findVisible(p.getMergePropertyKeys(key))
+			.stream()
+			.findFirst()
+			.flatMap(PropertyKey::getProvenance);
+	}
+
+	/** Returns all local document property keys matching {@code stem} or {@code stem.*}. */
+	static Set<String> getLocalMergeKeys(BndEditModel model, String stem) {
+		String prefix = stem + ".";
+		Properties docProps = model.getDocumentProperties();
+		Set<String> keys = new LinkedHashSet<>();
+		docProps.stringPropertyNames()
+			.stream()
+			.filter(k -> k.equals(stem) || k.startsWith(prefix))
+			.forEach(keys::add);
+		return keys;
+	}
+
+	private BndEditModelAccessor() {}
+}

--- a/bndtools.core/src/bndtools/editor/project/IncludeConflictDetector.java
+++ b/bndtools.core/src/bndtools/editor/project/IncludeConflictDetector.java
@@ -1,0 +1,386 @@
+package bndtools.editor.project;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+
+import aQute.bnd.build.model.BndEditModel;
+import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Processor;
+import aQute.lib.io.IO;
+import aQute.lib.utf8properties.UTF8Properties;
+
+/**
+ * Detects merge-property conflicts: plain merge-stem properties (e.g.
+ * {@code -runprogramargs}) defined in more than one file of the include tree
+ * (values shadow each other instead of merging), and any property key defined
+ * more than once inside the same file (later definitions silently overwrite
+ * earlier ones). Include-tree conflict markers go on the including (edited)
+ * file; in-file duplicate markers go on the file containing the duplicates.
+ */
+public class IncludeConflictDetector {
+
+	public static final String	MARKER_TYPE		= "bndtools.core.includeconflict";
+	public static final String	ATTR_KEY		= "conflictKey";
+	/** ';'-joined absolute paths of the files defining the conflicting key. */
+	public static final String	ATTR_SOURCES	= "conflictSources";
+	/** Boolean: true when the key is duplicated within a single file. */
+	public static final String	ATTR_IN_FILE	= "conflictInFile";
+
+	/** Recomputes the conflict markers for the edited resource and its include tree. Never throws. */
+	public static void updateMarkers(IResource resource, BndEditModel model) {
+		if (resource == null || !resource.exists() || model == null)
+			return;
+		try {
+			Map<String, List<File>> conflicts = findConflicts(model);
+			List<InFileDuplicate> duplicates = findInFileDuplicates(model);
+			List<IFile> includedFiles = new ArrayList<>();
+			Processor owner = model.getOwner();
+			if (owner != null && owner.getIncluded() != null) {
+				for (File included : owner.getIncluded()) {
+					IFile iFile = ResourcesPlugin.getWorkspace()
+						.getRoot()
+						.getFileForLocation(new Path(included.getAbsolutePath()));
+					if (iFile != null && iFile.exists())
+						includedFiles.add(iFile);
+				}
+			}
+			IWorkspaceRunnable runnable = monitor -> {
+				resource.deleteMarkers(MARKER_TYPE, false, IResource.DEPTH_ZERO);
+				// In-file duplicate markers on included files are context-free: recomputed
+				// identically by any editor, so deleting and recreating them is idempotent.
+				for (IFile included : includedFiles) {
+					for (IMarker m : included.findMarkers(MARKER_TYPE, false, IResource.DEPTH_ZERO)) {
+						if (m.getAttribute(ATTR_IN_FILE, false))
+							m.delete();
+					}
+				}
+				for (Map.Entry<String, List<File>> e : conflicts.entrySet()) {
+					String key = e.getKey();
+					String files = e.getValue()
+						.stream()
+						.map(File::getName)
+						.collect(Collectors.joining(", "));
+					IMarker marker = resource.createMarker(MARKER_TYPE);
+					marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+					marker.setAttribute(IMarker.MESSAGE, "Property '" + key
+						+ "' is defined in multiple files of the include tree (" + files
+						+ "); the values shadow each other instead of merging. Rename to merged syntax, e.g. '" + key
+						+ ".<suffix>'.");
+					marker.setAttribute(IMarker.LINE_NUMBER, findLineNumber(resource, key));
+					marker.setAttribute(ATTR_KEY, key);
+					marker.setAttribute(ATTR_SOURCES, e.getValue()
+						.stream()
+						.map(File::getAbsolutePath)
+						.collect(Collectors.joining(";")));
+				}
+				for (InFileDuplicate d : duplicates) {
+					// Marker goes on the file containing the duplicates, not on files including it.
+					IResource target = ResourcesPlugin.getWorkspace()
+						.getRoot()
+						.getFileForLocation(new Path(d.file()
+							.getAbsolutePath()));
+					if (target == null || !target.exists())
+						continue;
+					IMarker marker = target.createMarker(MARKER_TYPE);
+					marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+					marker.setAttribute(IMarker.MESSAGE, "Property '" + d.key() + "' is defined " + d.count()
+						+ " times in " + d.file()
+							.getName()
+						+ "; later definitions silently overwrite earlier ones. Rename to merged syntax, e.g. '"
+						+ d.key() + ".<suffix>'.");
+					marker.setAttribute(IMarker.LINE_NUMBER, findDuplicateLine(d));
+					marker.setAttribute(ATTR_KEY, d.key());
+					marker.setAttribute(ATTR_SOURCES, d.file()
+						.getAbsolutePath());
+					marker.setAttribute(ATTR_IN_FILE, true);
+				}
+			};
+			resource.getWorkspace()
+				.run(runnable, resource.getWorkspace()
+					.getRoot(), IWorkspace.AVOID_UPDATE, null);
+		} catch (Exception e) {
+			// validation only: never break the editor
+		}
+	}
+
+	/** Maps each plain merge-stem key to the files defining it; entries with more than one source conflict. */
+	private static Map<String, List<File>> findConflicts(BndEditModel model) throws Exception {
+		Map<String, List<File>> sources = new LinkedHashMap<>();
+		File docFile = model.getBndResource();
+		if (docFile != null) {
+			for (String key : model.getDocumentProperties()
+				.stringPropertyNames()) {
+				if (isPlainMergeStem(key))
+					sources.computeIfAbsent(key, k -> new ArrayList<>())
+						.add(docFile);
+			}
+		}
+		Processor owner = model.getOwner();
+		if (owner != null && owner.getIncluded() != null) {
+			for (File included : owner.getIncluded()) {
+				if (!included.isFile())
+					continue;
+				UTF8Properties p = new UTF8Properties();
+				p.load(IO.collect(included), included, null);
+				for (String key : p.stringPropertyNames()) {
+					if (isPlainMergeStem(key))
+						sources.computeIfAbsent(key, k -> new ArrayList<>())
+							.add(included);
+				}
+			}
+		}
+		Map<String, List<File>> conflicts = new LinkedHashMap<>();
+		sources.forEach((key, files) -> {
+			if (files.size() > 1)
+				conflicts.put(key, files);
+		});
+		return conflicts;
+	}
+
+	/** Plain key without suffix that supports merged syntax. */
+	private static boolean isPlainMergeStem(String key) {
+		return Constants.MERGED_HEADERS.contains(key);
+	}
+
+	/** A key defined more than once within a single file. */
+	record InFileDuplicate(File file, String key, int count) {}
+
+	/** Finds keys defined more than once inside the edited file or any included file. */
+	private static List<InFileDuplicate> findInFileDuplicates(BndEditModel model) {
+		List<File> files = new ArrayList<>();
+		File docFile = model.getBndResource();
+		if (docFile != null && docFile.isFile())
+			files.add(docFile);
+		Processor owner = model.getOwner();
+		if (owner != null && owner.getIncluded() != null) {
+			for (File included : owner.getIncluded())
+				if (included.isFile())
+					files.add(included);
+		}
+		List<InFileDuplicate> result = new ArrayList<>();
+		for (File file : files) {
+			try {
+				Map<String, Integer> counts = new LinkedHashMap<>();
+				scanLogicalKeys(IO.collect(file), (key, line) -> counts.merge(key, 1, Integer::sum));
+				counts.forEach((key, count) -> {
+					if (count > 1)
+						result.add(new InFileDuplicate(file, key, count));
+				});
+			} catch (Exception e) {
+				// skip unreadable file
+			}
+		}
+		return result;
+	}
+
+	/** Calls the consumer with each logical property key and its 1-based physical line number. */
+	private static void scanLogicalKeys(String content, java.util.function.ObjIntConsumer<String> consumer) {
+		String[] lines = content.split("\r?\n", -1);
+		boolean continuation = false;
+		for (int i = 0; i < lines.length; i++) {
+			String line = lines[i];
+			if (continuation) {
+				continuation = endsWithContinuation(line);
+				continue;
+			}
+			String t = line.stripLeading();
+			if (t.isEmpty() || t.charAt(0) == '#' || t.charAt(0) == '!') {
+				continue;
+			}
+			String key = keyToken(t);
+			if (!key.isEmpty())
+				consumer.accept(key, i + 1);
+			continuation = endsWithContinuation(line);
+		}
+	}
+
+	/** The key token at the start of a (left-trimmed) logical property line. */
+	private static String keyToken(String trimmedLine) {
+		int end = 0;
+		while (end < trimmedLine.length()) {
+			char c = trimmedLine.charAt(end);
+			if (c == ':' || c == '=' || Character.isWhitespace(c))
+				break;
+			end++;
+		}
+		return trimmedLine.substring(0, end);
+	}
+
+	/** True when the line ends with an odd number of backslashes (property line continuation). */
+	private static boolean endsWithContinuation(String line) {
+		int end = line.length();
+		while (end > 0 && (line.charAt(end - 1) == '\r' || line.charAt(end - 1) == '\n'))
+			end--;
+		int backslashes = 0;
+		for (int i = end - 1; i >= 0 && line.charAt(i) == '\\'; i--)
+			backslashes++;
+		return (backslashes & 1) == 1;
+	}
+
+	/** Line of the second occurrence of the duplicated key within its file, else 1. */
+	private static int findDuplicateLine(InFileDuplicate d) {
+		try {
+			List<Integer> occurrences = new ArrayList<>();
+			scanLogicalKeys(IO.collect(d.file()), (key, line) -> {
+				if (key.equals(d.key()))
+					occurrences.add(line);
+			});
+			if (occurrences.size() > 1)
+				return occurrences.get(1);
+			if (!occurrences.isEmpty())
+				return occurrences.get(0);
+		} catch (Exception e) {
+			// fall through
+		}
+		return 1;
+	}
+
+	/** Line of the key in the edited file, else the first -include line, else 1. */
+	private static int findLineNumber(IResource resource, String key) {
+		try {
+			String content = IO.collect(resource.getLocation()
+				.toFile());
+			String[] lines = content.split("\r?\n", -1);
+			int includeLine = 1;
+			boolean includeSeen = false;
+			for (int i = 0; i < lines.length; i++) {
+				String t = lines[i].trim();
+				if (matchesKey(t, key))
+					return i + 1;
+				if (!includeSeen && matchesKey(t, Constants.INCLUDE)) {
+					includeLine = i + 1;
+					includeSeen = true;
+				}
+			}
+			return includeLine;
+		} catch (Exception e) {
+			return 1;
+		}
+	}
+
+	private static boolean matchesKey(String line, String key) {
+		if (!line.startsWith(key))
+			return false;
+		String rest = line.substring(key.length());
+		return rest.isEmpty() || rest.charAt(0) == ':' || rest.charAt(0) == '='
+			|| Character.isWhitespace(rest.charAt(0));
+	}
+
+	/**
+	 * Suffix for renaming a plain key in the given file: the sanitized file
+	 * name without extension, made unique against keys already present in the
+	 * file.
+	 */
+	static String suggestSuffixForFile(File file, String key) {
+		String name = suffixBase(file);
+		try {
+			UTF8Properties p = new UTF8Properties();
+			p.load(IO.collect(file), file, null);
+			String suffix = name;
+			int n = 2;
+			while (p.containsKey(key + "." + suffix))
+				suffix = name + "-" + n++;
+			return suffix;
+		} catch (Exception e) {
+			return name;
+		}
+	}
+
+	/** Sanitized file name without .bnd/.bndrun extension, for use as a merge-key suffix. */
+	private static String suffixBase(File file) {
+		String name = file.getName();
+		if (name.endsWith(".bndrun"))
+			name = name.substring(0, name.length() - ".bndrun".length());
+		else if (name.endsWith(".bnd"))
+			name = name.substring(0, name.length() - ".bnd".length());
+		name = name.replaceAll("[^A-Za-z0-9._-]", "-");
+		return name.isEmpty() ? "local" : name;
+	}
+
+	/** Renames the first occurrence of the key at line start, preserving indentation and separator. */
+	static void renameKeyInFile(File file, String key, String newKey) throws Exception {
+		String content = IO.collect(file);
+		Pattern pattern = Pattern.compile("(?m)^([ \\t]*)" + Pattern.quote(key) + "(?=\\s*[:=\\s])");
+		Matcher matcher = pattern.matcher(content);
+		if (!matcher.find())
+			return;
+		String updated = new StringBuilder(content).replace(matcher.start(), matcher.end(),
+			matcher.group(1) + newKey)
+			.toString();
+		storeContent(file, updated);
+	}
+
+	/**
+	 * Renames the second and later occurrences of the key within the file to
+	 * unique merged-syntax keys (filename-based suffix), keeping the first
+	 * occurrence unchanged. Preserves line endings and layout.
+	 */
+	static void renameDuplicateKeysInFile(File file, String key) throws Exception {
+		String content = IO.collect(file);
+		UTF8Properties existing = new UTF8Properties();
+		existing.load(content, file, null);
+		String base = suffixBase(file);
+		Set<String> planned = new LinkedHashSet<>();
+		// split keeping the EOL attached to each line so layout is preserved
+		String[] lines = content.split("(?<=\n)", -1);
+		StringBuilder out = new StringBuilder(content.length() + 64);
+		boolean continuation = false;
+		int seen = 0;
+		for (String line : lines) {
+			String emit = line;
+			if (continuation) {
+				continuation = endsWithContinuation(line);
+			} else {
+				String t = line.stripLeading();
+				boolean comment = t.isEmpty() || t.charAt(0) == '#' || t.charAt(0) == '!';
+				if (!comment && keyToken(t).equals(key)) {
+					seen++;
+					if (seen > 1) {
+						String newKey = key + "." + base;
+						int n = 2;
+						while (existing.containsKey(newKey) || planned.contains(newKey))
+							newKey = key + "." + base + "-" + n++;
+						planned.add(newKey);
+						int idx = line.indexOf(key);
+						emit = line.substring(0, idx) + newKey + line.substring(idx + key.length());
+					}
+				}
+				continuation = !comment && endsWithContinuation(line);
+			}
+			out.append(emit);
+		}
+		storeContent(file, out.toString());
+	}
+
+	/** Writes updated content through the workspace file when possible, else directly to disk. */
+	private static void storeContent(File file, String updated) throws Exception {
+		IFile iFile = ResourcesPlugin.getWorkspace()
+			.getRoot()
+			.getFileForLocation(new Path(file.getAbsolutePath()));
+		if (iFile != null && iFile.exists()) {
+			iFile.setContents(new ByteArrayInputStream(updated.getBytes(StandardCharsets.UTF_8)), true, true, null);
+		} else {
+			IO.store(updated, file);
+		}
+	}
+
+	private IncludeConflictDetector() {}
+}

--- a/bndtools.core/src/bndtools/editor/project/IncludeConflictMarkerResolutionGenerator.java
+++ b/bndtools.core/src/bndtools/editor/project/IncludeConflictMarkerResolutionGenerator.java
@@ -1,0 +1,105 @@
+package bndtools.editor.project;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolution2;
+import org.eclipse.ui.IMarkerResolutionGenerator2;
+
+import org.bndtools.api.ILogger;
+import org.bndtools.api.Logger;
+
+/** Quickfixes for {@link IncludeConflictDetector#MARKER_TYPE}: rename the plain key in one of the conflicting files to merged syntax. */
+public class IncludeConflictMarkerResolutionGenerator implements IMarkerResolutionGenerator2 {
+
+	private static final ILogger logger = Logger.getLogger(IncludeConflictMarkerResolutionGenerator.class);
+
+	@Override
+	public boolean hasResolutions(IMarker marker) {
+		return marker.getAttribute(IncludeConflictDetector.ATTR_KEY, null) != null;
+	}
+
+	@Override
+	public IMarkerResolution[] getResolutions(IMarker marker) {
+		String key = marker.getAttribute(IncludeConflictDetector.ATTR_KEY, null);
+		String sources = marker.getAttribute(IncludeConflictDetector.ATTR_SOURCES, "");
+		if (key == null || sources.isEmpty())
+			return new IMarkerResolution[0];
+
+		if (marker.getAttribute(IncludeConflictDetector.ATTR_IN_FILE, false)) {
+			File file = new File(sources);
+			if (!file.isFile())
+				return new IMarkerResolution[0];
+			return new IMarkerResolution[] {
+				new IMarkerResolution2() {
+					@Override
+					public String getLabel() {
+						return "Rename duplicate occurrences of '" + key + "' in " + file.getName()
+							+ " to merged syntax";
+					}
+
+					@Override
+					public String getDescription() {
+						return "Keeps the first definition and renames later occurrences in " + file.getAbsolutePath()
+							+ " to unique '" + key + ".<suffix>' keys so bnd merges them instead of overwriting.";
+					}
+
+					@Override
+					public Image getImage() {
+						return null;
+					}
+
+					@Override
+					public void run(IMarker m) {
+						try {
+							IncludeConflictDetector.renameDuplicateKeysInFile(file, key);
+							m.delete();
+						} catch (Exception e) {
+							logger.logError("Failed to rename duplicates of " + key + " in " + file, e);
+						}
+					}
+				}
+			};
+		}
+
+		List<IMarkerResolution> resolutions = new ArrayList<>();
+		for (String path : sources.split(";")) {
+			File file = new File(path);
+			if (!file.isFile())
+				continue;
+			String newKey = key + "." + IncludeConflictDetector.suggestSuffixForFile(file, key);
+			resolutions.add(new IMarkerResolution2() {
+				@Override
+				public String getLabel() {
+					return "Rename '" + key + "' to '" + newKey + "' in " + file.getName();
+				}
+
+				@Override
+				public String getDescription() {
+					return "Renames the plain property in " + file.getAbsolutePath()
+						+ " so bnd merges it with the other definitions instead of shadowing them.";
+				}
+
+				@Override
+				public Image getImage() {
+					return null;
+				}
+
+				@Override
+				public void run(IMarker m) {
+					try {
+						IncludeConflictDetector.renameKeyInFile(file, key, newKey);
+						m.delete();
+					} catch (Exception e) {
+						logger.logError("Failed to rename " + key + " in " + file, e);
+					}
+				}
+			});
+		}
+		return resolutions.toArray(new IMarkerResolution[0]);
+	}
+}

--- a/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RepositoryBundleSelectionPart.java
@@ -5,26 +5,40 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.IBaseLabelProvider;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StyledCellLabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.jface.viewers.ViewerDropAdapter;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTargetEvent;
 import org.eclipse.swt.dnd.FileTransfer;
@@ -33,8 +47,11 @@ import org.eclipse.swt.dnd.TransferData;
 import org.eclipse.swt.dnd.URLTransfer;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -43,18 +60,22 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
+import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.ResourceTransfer;
+import org.osgi.framework.namespace.IdentityNamespace;
 
 import aQute.bnd.build.model.BndEditModel;
 import aQute.bnd.build.model.clauses.VersionedClause;
 import aQute.bnd.header.Attrs;
 import aQute.bnd.osgi.Constants;
 import bndtools.Plugin;
+import bndtools.editor.BndEditor;
 import bndtools.editor.common.BndEditorPart;
 import bndtools.model.clauses.VersionedClauseLabelProvider;
 import bndtools.model.repo.DependencyPhase;
@@ -79,6 +100,10 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 
 	protected BndEditModel			model;
 	protected List<VersionedClause>	bundles;
+	/** Bundles inherited from included files; shown gray, not committable. */
+	protected List<VersionedClause>	inheritedBundles		= new ArrayList<>();
+	/** Per-BSN provenance: maps each inherited bundle's BSN to the file path that defines it. */
+	private Map<String, String>		inheritedBundleProvenances	= Collections.emptyMap();
 	protected ToolItem				removeItemTool;
 
 	protected RepositoryBundleSelectionPart(String propertyName, DependencyPhase phase, Composite parent,
@@ -144,7 +169,34 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 	}
 
 	protected IBaseLabelProvider getLabelProvider() {
-		return new VersionedClauseLabelProvider();
+		return new MixedVersionedClauseLabelProvider();
+	}
+
+	/** A label provider that colors inherited bundles gray and local bundles with the default foreground. */
+	protected class MixedVersionedClauseLabelProvider extends VersionedClauseLabelProvider {
+		private Color grey;
+
+		@Override
+		public void update(ViewerCell cell) {
+			super.update(cell);
+			if (inheritedBundles.contains(cell.getElement())) {
+				if (grey == null)
+					grey = cell.getItem().getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
+				cell.setForeground(grey);
+				cell.setStyleRanges(new StyleRange[0]);
+			}
+		}
+
+		@Override
+		public String getToolTipText(Object element) {
+			if (!(element instanceof VersionedClause) || !inheritedBundles.contains(element))
+				return null;
+			String path = inheritedBundleProvenances.get(((VersionedClause) element).getName());
+			return path != null
+				? "Inherited from " + BndEditModelAccessor.getDisplayProvenance(model, path)
+					+ "\nDouble-click to open source."
+				: "Inherited from an included file.";
+		}
 	}
 
 	void createSection(Section section, FormToolkit toolkit) {
@@ -161,12 +213,25 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 		viewer = new TableViewer(table);
 		viewer.setContentProvider(new ArrayContentProvider());
 		viewer.setLabelProvider(getLabelProvider());
+		ColumnViewerToolTipSupport.enableFor(viewer);
 
 		// Listeners
 		viewer.addSelectionChangedListener(event -> {
 			ToolItem remove = getRemoveItemTool();
 			if (remove != null)
 				remove.setEnabled(isRemovable(event.getSelection()));
+		});
+		// Double-click on an inherited row opens the file that defines that specific bundle.
+		table.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseDoubleClick(MouseEvent e) {
+				IStructuredSelection sel = (IStructuredSelection) viewer.getSelection();
+				if (sel.isEmpty()) return;
+				Object first = sel.getFirstElement();
+				if (!(first instanceof VersionedClause) || !inheritedBundles.contains(first)) return;
+				String path = inheritedBundleProvenances.get(((VersionedClause) first).getName());
+				if (path != null) openProvenanceByPath(path);
+			}
 		});
 		ViewerDropAdapter dropAdapter = new ViewerDropAdapter(viewer) {
 			@Override
@@ -297,19 +362,9 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 						adding.add(newClause);
 					} else if (item instanceof RepositoryFeature) {
 						RepositoryFeature feature = (RepositoryFeature) item;
-						// Create VersionedClause with "feature:id" BSN and feature=true attribute
-						VersionedClause newClause = new VersionedClause("feature:" + feature.getFeature()
-							.getId(), new Attrs());
-						// Set version if available
-						if (feature.getFeature()
-							.getVersion() != null) {
-							newClause.setVersionRange(feature.getFeature()
-								.getVersion());
-						}
-						// Add feature=true attribute for resolver identification
-						newClause.getAttribs()
-							.put("feature", "true");
-						adding.add(newClause);
+						// Create a clause in the canonical feature syntax:
+						// id;version='V';type=org.eclipse.update.feature
+						adding.add(RepositoryBundleUtils.convertRepoFeature(feature));
 					} else if (item instanceof IncludedBundleItem) {
 						IncludedBundleItem bundleItem = (IncludedBundleItem) item;
 						VersionedClause newClause = new VersionedClause(bundleItem.getPlugin().id, new Attrs());
@@ -336,7 +391,11 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 					for (ListIterator<VersionedClause> iter = bundles.listIterator(); iter.hasNext();) {
 						VersionedClause existing = iter.next();
 						if (newClause.getName()
-							.equals(existing.getName())) {
+							.equals(existing.getName())
+							&& Objects.equals(newClause.getAttribs()
+								.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE),
+								existing.getAttribs()
+									.get(IdentityNamespace.CAPABILITY_TYPE_ATTRIBUTE))) {
 							int index = iter.previousIndex();
 							iter.set(newClause);
 							viewer.replace(newClause, index);
@@ -404,6 +463,11 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 		return false;
 	}
 
+	/** Returns null to disable inherited display; subclasses may override. */
+	protected List<VersionedClause> loadMergedFromModel(BndEditModel m) {
+		return null;
+	}
+
 	protected int getTableHeightHint() {
 		return SWT.DEFAULT;
 	}
@@ -415,7 +479,15 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 	protected void setBundles(final List<VersionedClause> bundles) {
 		this.bundles = bundles;
 		Display.getDefault()
-			.asyncExec(() -> viewer.setInput(bundles));
+			.asyncExec(() -> viewer.setInput(buildDisplayList()));
+	}
+
+	private List<Object> buildDisplayList() {
+		List<Object> combined = new ArrayList<>(inheritedBundles.size() + (bundles != null ? bundles.size() : 0));
+		combined.addAll(inheritedBundles);
+		if (bundles != null)
+			combined.addAll(bundles);
+		return combined;
 	}
 
 	private void doAdd() {
@@ -444,7 +516,8 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 			List<Object> removed = new LinkedList<>();
 			while (elements.hasNext()) {
 				Object element = elements.next();
-				if (bundles.remove(element))
+				// Only local bundles can be removed; inherited stay in their source file.
+				if (!inheritedBundles.contains(element) && bundles.remove(element))
 					removed.add(element);
 			}
 
@@ -476,11 +549,48 @@ public abstract class RepositoryBundleSelectionPart extends BndEditorPart implem
 
 	@Override
 	public void refreshFromModel() {
-		List<VersionedClause> bundles = loadFromModel(model);
-		if (bundles != null) {
-			setBundles(new ArrayList<>(bundles));
+		// Compute inherited bundles (merged view minus local).
+		List<VersionedClause> merged = loadMergedFromModel(model);
+		List<VersionedClause> local = loadFromModel(model);
+		if (local == null) local = new ArrayList<>();
+		if (merged != null) {
+			Set<String> localNames = new HashSet<>();
+			for (VersionedClause vc : local)
+				localNames.add(vc.getName());
+			inheritedBundles.clear();
+			for (VersionedClause vc : merged)
+				if (!localNames.contains(vc.getName()))
+					inheritedBundles.add(vc);
 		} else {
-			setBundles(new ArrayList<VersionedClause>());
+			inheritedBundles.clear();
+		}
+
+		// Per-bundle provenance for the double-click handler.
+		inheritedBundleProvenances = inheritedBundles.isEmpty() ? Collections.emptyMap()
+			: BndEditModelAccessor.getInheritedBundleProvenances(model, propertyName);
+
+		table.setToolTipText(inheritedBundles.isEmpty() ? null
+			: "Some bundles are inherited from included files. Double-click an inherited item to open its source.");
+
+		setBundles(new ArrayList<>(local));
+	}
+
+	private void openProvenanceByPath(String absolutePath) {
+		File file = new File(absolutePath);
+		if (!file.isFile())
+			return;
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		IFile iFile = root.getFileForLocation(new Path(absolutePath));
+		if (iFile == null || !iFile.exists())
+			return;
+		try {
+			PlatformUI.getWorkbench()
+				.getActiveWorkbenchWindow()
+				.getActivePage()
+				.openEditor(new FileEditorInput(iFile), BndEditor.WORKSPACE_EDITOR);
+		} catch (PartInitException e) {
+			ErrorDialog.openError(getSection().getShell(), "Error", null,
+				new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Failed to open source file.", e));
 		}
 	}
 

--- a/bndtools.core/src/bndtools/editor/project/RunBlacklistPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunBlacklistPart.java
@@ -29,6 +29,11 @@ public class RunBlacklistPart extends AbstractRequirementListPart {
 		return SUBSCRIBE_PROPS;
 	}
 
+	@Override
+	protected String getPrimaryPropertyKey() {
+		return Constants.RUNBLACKLIST;
+	}
+
 	private void createSection(Section section, FormToolkit tk) {
 		section.setText("Run Blacklist");
 		section.setDescription("The specified requirements will be excluded from the resolution.");
@@ -65,12 +70,17 @@ public class RunBlacklistPart extends AbstractRequirementListPart {
 
 	@Override
 	protected void doCommitToModel(List<Requirement> requires) {
-		model.setRunBlacklist(requires);
+		String key = getLocalKey();
+		if (Constants.RUNBLACKLIST.equals(key)) {
+			model.setRunBlacklist(requires);
+		} else {
+			BndEditModelAccessor.setRequirementListByKey(model, key, requires);
+		}
 	}
 
 	@Override
 	protected List<Requirement> doRefreshFromModel() {
-		return model.getRunBlacklist();
+		return BndEditModelAccessor.getLocalMergeRequirements(model, Constants.RUNBLACKLIST);
 	}
 
 	@Override

--- a/bndtools.core/src/bndtools/editor/project/RunBundlesPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunBundlesPart.java
@@ -95,7 +95,7 @@ public class RunBundlesPart extends RepositoryBundleSelectionPart {
 
 	@Override
 	protected IBaseLabelProvider getLabelProvider() {
-		return new VersionedClauseLabelProvider() {
+		return new MixedVersionedClauseLabelProvider() {
 			@Override
 			public void update(ViewerCell cell) {
 				Object element = cell.getElement();
@@ -160,12 +160,26 @@ public class RunBundlesPart extends RepositoryBundleSelectionPart {
 
 	@Override
 	protected void saveToModel(BndEditModel model, List<aQute.bnd.build.model.clauses.VersionedClause> bundles) {
-		model.setRunBundles(bundles);
+		// Write to the same local merge key the part reads from, so included
+		// plain -runbundles definitions are merged instead of shadowed.
+		String key = BndEditModelAccessor.findLocalMergeKey(model, Constants.RUNBUNDLES);
+		if (key == null)
+			key = inheritedBundles.isEmpty() ? Constants.RUNBUNDLES : Constants.RUNBUNDLES + ".local";
+		if (Constants.RUNBUNDLES.equals(key)) {
+			model.setRunBundles(bundles);
+		} else {
+			BndEditModelAccessor.setVersionedClausesByKey(model, key, bundles);
+		}
 	}
 
 	@Override
 	protected List<aQute.bnd.build.model.clauses.VersionedClause> loadFromModel(BndEditModel model) {
-		return model.getRunBundles();
+		return BndEditModelAccessor.getLocalVersionedClauses(model, aQute.bnd.osgi.Constants.RUNBUNDLES);
+	}
+
+	@Override
+	protected List<aQute.bnd.build.model.clauses.VersionedClause> loadMergedFromModel(BndEditModel model) {
+		return BndEditModelAccessor.getMergedVersionedClauses(model, aQute.bnd.osgi.Constants.RUNBUNDLES);
 	}
 
 	@Override

--- a/bndtools.core/src/bndtools/editor/project/RunPropertiesPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunPropertiesPart.java
@@ -1,30 +1,55 @@
 package bndtools.editor.project;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.bndtools.utils.swt.AddRemoveButtonBarPart;
 import org.bndtools.utils.swt.AddRemoveButtonBarPart.AddRemoveListener;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.ViewerCell;
+import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ControlAdapter;
 import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.forms.editor.IFormPage;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
+import org.eclipse.ui.part.FileEditorInput;
 
 import aQute.bnd.osgi.Constants;
+import aQute.bnd.osgi.Processor.PropertyKey;
+import bndtools.Plugin;
+import bndtools.editor.BndEditor;
 import bndtools.editor.common.BndEditorPart;
 import bndtools.editor.common.MapContentProvider;
 import bndtools.editor.common.MapEntryCellModifier;
@@ -32,18 +57,42 @@ import bndtools.editor.common.PropertiesTableLabelProvider;
 import bndtools.editor.utils.ToolTips;
 import bndtools.utils.ModificationLock;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.ErrorDialog;
+
 public class RunPropertiesPart extends BndEditorPart {
 
 	private final ModificationLock					lock					= new ModificationLock();
 
-	private Map<String, String>						runProperties;
+	/** Local properties that are written to this file. */
+	private final Map<String, String>				localProperties			= new LinkedHashMap<>();
+	/** Keys present in included files but absent locally (shown gray, non-editable). */
+	private final Map<String, String>				inheritedProperties		= new LinkedHashMap<>();
+	/** Combined view used as viewer input: inherited entries first, then local. */
+	private final Map<String, String>				displayProperties		= new LinkedHashMap<>();
+	/** Keys from inheritedProperties (for label provider and modifier). */
+	private final Set<String>						inheritedKeys			= new java.util.LinkedHashSet<>();
+	/** Per-key provenance: maps each inherited property name to the file path that defines it. */
+	private Map<String, String>						inheritedProvenances	= new java.util.LinkedHashMap<>();
+
 	private String									programArgs				= null;
+	private String									inheritedProgramArgs	= null;
 	private String									vmArgs					= null;
+	private String									inheritedVmArgs			= null;
+
+	/** Key used to write local properties; may be plain or a .local suffix. */
+	private String									localPropertiesKey		= Constants.RUNPROPERTIES;
+	/** Key used to write local programArgs. */
+	private String									localProgramArgsKey		= Constants.RUNPROGRAMARGS;
+	/** Key used to write local vmArgs. */
+	private String									localVmArgsKey			= Constants.RUNVM;
 
 	private final AddRemoveButtonBarPart			createRemovePropsPart	= new AddRemoveButtonBarPart();
 
 	private Table									tblRunProperties;
 	private TableViewer								viewRunProperties;
+	private final TableColumn[]						tblCols					= new TableColumn[2];
 	private MapEntryCellModifier<String, String>	runPropertiesModifier;
 
 	private Text									txtProgramArgs;
@@ -58,44 +107,83 @@ public class RunPropertiesPart extends BndEditorPart {
 		createSection(getSection(), toolkit);
 	}
 
+	/** Colors inherited table rows gray; local rows use the default foreground. */
+	private class MixedPropertiesLabelProvider extends PropertiesTableLabelProvider {
+		private final Color grey;
+
+		MixedPropertiesLabelProvider(Display display) {
+			grey = display.getSystemColor(SWT.COLOR_DARK_GRAY);
+		}
+
+		@Override
+		public void update(ViewerCell cell) {
+			super.update(cell);
+			if (inheritedKeys.contains(cell.getElement())) {
+				cell.setForeground(grey);
+			}
+		}
+
+		@Override
+		public String getToolTipText(Object element) {
+			if (!(element instanceof String) || !inheritedKeys.contains(element))
+				return null;
+			String path = inheritedProvenances.get(element);
+			return path != null
+				? "Inherited from " + BndEditModelAccessor.getDisplayProvenance(model, path)
+					+ "\nDouble-click to open source."
+				: "Inherited from an included file.";
+		}
+	}
+
+	/** Prevents editing of inherited (gray) entries. */
+	private class LocalOnlyModifier extends MapEntryCellModifier<String, String> {
+		LocalOnlyModifier(TableViewer viewer) {
+			super(viewer);
+		}
+
+		@Override
+		public boolean canModify(Object element, String property) {
+			return !inheritedKeys.contains(element) && super.canModify(element, property);
+		}
+	}
+
 	private void createSection(Section section, FormToolkit toolkit) {
 		section.setText("Runtime Properties");
 
 		final Composite composite = toolkit.createComposite(section);
 		section.setClient(composite);
 
-		// Create controls: Run Properties
 		Label lblRunProperties = toolkit.createLabel(composite, "OSGi Framework properties:");
 		tblRunProperties = toolkit.createTable(composite, SWT.FULL_SELECTION | SWT.MULTI | SWT.BORDER);
 		viewRunProperties = new TableViewer(tblRunProperties);
-		runPropertiesModifier = new MapEntryCellModifier<>(viewRunProperties);
+		runPropertiesModifier = new LocalOnlyModifier(viewRunProperties);
 
 		tblRunProperties.setHeaderVisible(true);
-		final TableColumn tblRunPropsCol1 = new TableColumn(tblRunProperties, SWT.NONE);
-		tblRunPropsCol1.setText("Name");
-		tblRunPropsCol1.setWidth(100);
-		final TableColumn tblRunPropsCol2 = new TableColumn(tblRunProperties, SWT.NONE);
-		tblRunPropsCol1.setText("Value");
-		tblRunPropsCol1.setWidth(100);
+		tblCols[0] = new TableColumn(tblRunProperties, SWT.NONE);
+		tblCols[0].setText("Name");
+		tblCols[0].setWidth(100);
+		tblCols[1] = new TableColumn(tblRunProperties, SWT.NONE);
+		tblCols[1].setText("Value");
+		tblCols[1].setWidth(100);
 
 		viewRunProperties.setUseHashlookup(true);
 		viewRunProperties.setColumnProperties(MapEntryCellModifier.getColumnProperties());
 		runPropertiesModifier.addCellEditorsToViewer();
 		viewRunProperties.setCellModifier(runPropertiesModifier);
-
 		viewRunProperties.setContentProvider(new MapContentProvider());
-		viewRunProperties.setLabelProvider(new PropertiesTableLabelProvider());
+		viewRunProperties.setLabelProvider(new MixedPropertiesLabelProvider(tblRunProperties.getDisplay()));
+		ColumnViewerToolTipSupport.enableFor(viewRunProperties);
 		Control createRemovePropsToolBar = createRemovePropsPart.createControl(composite, SWT.FLAT | SWT.VERTICAL);
 
-		// Create controls: program args
 		Label lblProgramArgs = toolkit.createLabel(composite, "Launcher Arguments:");
 		txtProgramArgs = toolkit.createText(composite, "", SWT.MULTI | SWT.BORDER);
 		ToolTips.setupMessageAndToolTipFromSyntax(txtProgramArgs, Constants.RUNPROGRAMARGS);
+		txtProgramArgs.addMouseListener(inheritedArgsNavigator(txtProgramArgs, Constants.RUNPROGRAMARGS));
 
-		// Create controls: vm args
 		Label lblVmArgs = toolkit.createLabel(composite, "JVM Arguments:");
 		txtVmArgs = toolkit.createText(composite, "", SWT.MULTI | SWT.BORDER);
 		ToolTips.setupMessageAndToolTipFromSyntax(txtVmArgs, Constants.RUNVM);
+		txtVmArgs.addMouseListener(inheritedArgsNavigator(txtVmArgs, Constants.RUNVM));
 
 		// Layout
 		GridLayout gl;
@@ -108,47 +196,70 @@ public class RunPropertiesPart extends BndEditorPart {
 
 		lblRunProperties.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 
-		gd = new GridData(SWT.FILL, SWT.FILL, true, false);
+		// All three content areas grab vertical space equally (equal heightHint = equal base share).
+		gd = new GridData(SWT.FILL, SWT.FILL, true, true);
 		gd.heightHint = 50;
 		gd.widthHint = 50;
 		tblRunProperties.setLayoutData(gd);
 
-		gd = new GridData(SWT.FILL, SWT.TOP, false, true);
+		gd = new GridData(SWT.FILL, SWT.TOP, false, false);
 		createRemovePropsToolBar.setLayoutData(gd);
 
 		lblProgramArgs.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		gd = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
-		gd.heightHint = 40;
+		gd.heightHint = 50;
 		gd.widthHint = 50;
 		txtProgramArgs.setLayoutData(gd);
 
 		lblVmArgs.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
 		gd = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
-		gd.heightHint = 40;
+		gd.heightHint = 50;
 		gd.widthHint = 50;
 		txtVmArgs.setLayoutData(gd);
 
 		// Listeners
-		viewRunProperties.addSelectionChangedListener(
-			event -> createRemovePropsPart.setRemoveEnabled(!viewRunProperties.getSelection()
-				.isEmpty()));
+		viewRunProperties.addSelectionChangedListener(event -> {
+			IStructuredSelection sel = (IStructuredSelection) viewRunProperties.getSelection();
+			boolean hasLocal = !sel.isEmpty() && sel.toList().stream().anyMatch(k -> !inheritedKeys.contains(k));
+			createRemovePropsPart.setRemoveEnabled(hasLocal);
+		});
+		// Double-click on an inherited row opens the file that defines that specific key.
+		tblRunProperties.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseDoubleClick(MouseEvent e) {
+				IStructuredSelection sel = (IStructuredSelection) viewRunProperties.getSelection();
+				if (sel.isEmpty()) return;
+				String propKey = (String) sel.getFirstElement();
+				if (!inheritedKeys.contains(propKey)) return;
+				String path = inheritedProvenances.get(propKey);
+				if (path != null) openProvenanceByPath(path);
+			}
+		});
 		createRemovePropsPart.addListener(new AddRemoveListener() {
 			@Override
 			public void addSelected() {
-				runProperties.put("name", "");
-				viewRunProperties.add("name");
+				// New entries always go into local display; local key will be resolved on commit.
+				String newKey = "name";
+				// Avoid collision with existing keys
+				int n = 1;
+				while (displayProperties.containsKey(newKey))
+					newKey = "name" + n++;
+				displayProperties.put(newKey, "");
+				viewRunProperties.add(newKey);
 				markDirty();
-				viewRunProperties.editElement("name", 0);
+				viewRunProperties.editElement(newKey, 0);
 			}
 
 			@Override
 			public void removeSelected() {
-				@SuppressWarnings("rawtypes")
-				Iterator iter = ((IStructuredSelection) viewRunProperties.getSelection()).iterator();
+				@SuppressWarnings("unchecked")
+				Iterator<Object> iter = ((IStructuredSelection) viewRunProperties.getSelection()).iterator();
 				while (iter.hasNext()) {
 					Object item = iter.next();
-					runProperties.remove(item);
-					viewRunProperties.remove(item);
+					if (!inheritedKeys.contains(item)) {
+						displayProperties.remove(item);
+						viewRunProperties.remove(item);
+					}
 				}
 				markDirty();
 			}
@@ -157,13 +268,13 @@ public class RunPropertiesPart extends BndEditorPart {
 		txtProgramArgs.addModifyListener(ev -> lock.ifNotModifying(() -> {
 			markDirty();
 			programArgs = txtProgramArgs.getText();
-			if (programArgs.length() == 0)
+			if (programArgs.isEmpty())
 				programArgs = null;
 		}));
 		txtVmArgs.addModifyListener(ev -> lock.ifNotModifying(() -> {
 			markDirty();
 			vmArgs = txtVmArgs.getText();
-			if (vmArgs.length() == 0)
+			if (vmArgs.isEmpty())
 				vmArgs = null;
 		}));
 		composite.addControlListener(new ControlAdapter() {
@@ -173,27 +284,19 @@ public class RunPropertiesPart extends BndEditorPart {
 				Point preferredSize = tblRunProperties.computeSize(SWT.DEFAULT, SWT.DEFAULT);
 				int width = area.width - 2 * tblRunProperties.getBorderWidth();
 				if (preferredSize.y > area.height + tblRunProperties.getHeaderHeight()) {
-					// Subtract the scrollbar width from the total column width
-					// if a vertical scrollbar will be required
 					Point vBarSize = tblRunProperties.getVerticalBar()
 						.getSize();
 					width -= vBarSize.x;
 				}
 				Point oldSize = tblRunProperties.getSize();
 				if (oldSize.x > area.width) {
-					// table is getting smaller so make the columns
-					// smaller first and then resize the table to
-					// match the client area width
-					tblRunPropsCol1.setWidth(width / 3);
-					tblRunPropsCol2.setWidth(width - tblRunPropsCol1.getWidth());
+					tblCols[0].setWidth(width / 3);
+					tblCols[1].setWidth(width - tblCols[0].getWidth());
 					tblRunProperties.setSize(area.width, area.height);
 				} else {
-					// table is getting bigger so make the table
-					// bigger first and then make the columns wider
-					// to match the client area width
 					tblRunProperties.setSize(area.width, area.height);
-					tblRunPropsCol1.setWidth(width / 3);
-					tblRunPropsCol2.setWidth(width - tblRunPropsCol1.getWidth());
+					tblCols[0].setWidth(width / 3);
+					tblCols[1].setWidth(width - tblCols[0].getWidth());
 				}
 			}
 		});
@@ -206,36 +309,212 @@ public class RunPropertiesPart extends BndEditorPart {
 
 	@Override
 	protected void refreshFromModel() {
-		Map<String, String> tmp = model.getRunProperties();
-		if (tmp == null)
-			this.runProperties = new HashMap<>();
-		else
-			this.runProperties = new HashMap<>(tmp);
-		viewRunProperties.setInput(runProperties);
+		// --- Properties table ------------------------------------------------
+		Map<String, String> mergedProps = BndEditModelAccessor.getMergedProperties(model, Constants.RUNPROPERTIES);
+		Map<String, String> localProps = BndEditModelAccessor.getLocalProperties(model, Constants.RUNPROPERTIES);
+		if (mergedProps == null) mergedProps = new LinkedHashMap<>();
+		if (localProps == null) localProps = new LinkedHashMap<>();
+
+		inheritedProperties.clear();
+		localProperties.clear();
+		inheritedKeys.clear();
+		for (Map.Entry<String, String> e : mergedProps.entrySet()) {
+			if (localProps.containsKey(e.getKey())) {
+				localProperties.put(e.getKey(), e.getValue());
+			} else {
+				inheritedProperties.put(e.getKey(), e.getValue());
+				inheritedKeys.add(e.getKey());
+			}
+		}
+		// Local-only keys (not in merged) are also local
+		for (Map.Entry<String, String> e : localProps.entrySet()) {
+			if (!mergedProps.containsKey(e.getKey()))
+				localProperties.put(e.getKey(), e.getValue());
+		}
+
+		displayProperties.clear();
+		displayProperties.putAll(inheritedProperties);
+		displayProperties.putAll(localProperties);
+
+		// Per-key provenance for the double-click handler.
+		inheritedProvenances = BndEditModelAccessor.getInheritedPropertiesProvenance(model, Constants.RUNPROPERTIES);
+
+		// Table tooltip.
+		tblRunProperties.setToolTipText(
+			inheritedProperties.isEmpty() ? null
+				: "Some entries are inherited from included files. Double-click an inherited row to open its source.");
+		viewRunProperties.setInput(displayProperties);
+
+		// Determine local key for properties.
+		String existingKey = BndEditModelAccessor.findLocalMergeKey(model, Constants.RUNPROPERTIES);
+		localPropertiesKey = (existingKey != null) ? existingKey
+			: (!inheritedProperties.isEmpty() ? Constants.RUNPROPERTIES + ".local" : Constants.RUNPROPERTIES);
+
+		// --- Launcher Arguments text field -----------------------------------
+		refreshTextArg(txtProgramArgs, Constants.RUNPROGRAMARGS,
+			s -> programArgs = s, this::setLocalProgramArgsKey);
+
+		// --- JVM Arguments text field ----------------------------------------
+		refreshTextArg(txtVmArgs, Constants.RUNVM,
+			s -> vmArgs = s, this::setLocalVmArgsKey);
+	}
+
+	@FunctionalInterface
+	private interface StringSetter { void set(String v); }
+	@FunctionalInterface
+	private interface StringKeySetter { void set(String key); }
+
+	private void refreshTextArg(Text txt, String stem,
+		StringSetter localSetter, StringKeySetter keySetter) {
+
+		String merged = BndEditModelAccessor.getMergedString(model, stem);
+		boolean hasLocal = BndEditModelAccessor.hasLocalMergeProperty(model, stem);
+		String existing = BndEditModelAccessor.findLocalMergeKey(model, stem);
+		String key = (existing != null) ? existing
+			: (!hasLocal && merged != null && !merged.isBlank()
+				? stem + ".local" : stem);
+		keySetter.set(key);
 
 		lock.modifyOperation(() -> {
-			programArgs = model.getRunProgramArgs();
-			if (programArgs == null)
-				programArgs = ""; //$NON-NLS-1$
-			txtProgramArgs.setText(programArgs);
-
-			vmArgs = model.getRunVMArgs();
-			if (vmArgs == null)
-				vmArgs = "";
-			txtVmArgs.setText(vmArgs);
+			if (hasLocal) {
+				// Show the local value, editable.
+				String localVal = model.getTypedProperty(existing != null ? existing : stem);
+				String display = localVal != null ? localVal : "";
+				txt.setText(display);
+				localSetter.set(localVal);
+				txt.setEditable(true);
+				txt.setForeground(null);
+				txt.setToolTipText(null);
+			} else if (merged != null && !merged.isBlank()) {
+				// Show inherited value grayed out; editable=false keeps mouse events (enabled=false would swallow them).
+				txt.setText(merged);
+				localSetter.set(null);
+				txt.setEditable(false);
+				Color grey = txt.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY);
+				txt.setForeground(grey);
+				List<PropertyKey> inherited = BndEditModelAccessor.getInheritedPropertyKeys(model, stem);
+				String tip;
+				if (inherited.size() > 1) {
+					tip = "Inherited from multiple included files. Double-click to choose and open a source.";
+				} else {
+					tip = BndEditModelAccessor.getPropertyProvenance(model, stem)
+						.map(p -> "Inherited from " + BndEditModelAccessor.getDisplayProvenance(model, p)
+							+ ". Double-click to open source.")
+						.orElse("Inherited from an included file.");
+				}
+				txt.setToolTipText(tip);
+			} else {
+				txt.setText("");
+				localSetter.set(null);
+				txt.setEditable(true);
+				txt.setForeground(null);
+				txt.setToolTipText(null);
+			}
 		});
 	}
 
+	private void setLocalProgramArgsKey(String key) { localProgramArgsKey = key; }
+	private void setLocalVmArgsKey(String key) { localVmArgsKey = key; }
+
 	@Override
 	protected void commitToModel(boolean onSave) {
-		model.setRunProperties(runProperties);
-		model.setRunProgramArgs(emptyToNull(programArgs));
-		model.setRunVMArgs(emptyToNull(vmArgs));
+		// Properties: local entries = displayProperties minus inherited keys.
+		Map<String, String> toSave = new LinkedHashMap<>(displayProperties);
+		toSave.keySet().removeAll(inheritedKeys);
+		String propsKey = localPropertiesKey != null ? localPropertiesKey : Constants.RUNPROPERTIES;
+		if (Constants.RUNPROPERTIES.equals(propsKey)) {
+			model.setRunProperties(toSave);
+		} else {
+			BndEditModelAccessor.setPropertiesByKey(model, propsKey, toSave);
+		}
+
+		// getEditable(): inherited fields are editable=false; enabled state is unreliable during save
+		if (txtProgramArgs.getEditable()) {
+			String value = emptyToNull(txtProgramArgs.getText());
+			String key = localProgramArgsKey != null ? localProgramArgsKey : Constants.RUNPROGRAMARGS;
+			if (Constants.RUNPROGRAMARGS.equals(key)) {
+				model.setRunProgramArgs(value);
+			} else {
+				model.setTypedProperty(key, value);
+			}
+		}
+		if (txtVmArgs.getEditable()) {
+			String value = emptyToNull(txtVmArgs.getText());
+			String key = localVmArgsKey != null ? localVmArgsKey : Constants.RUNVM;
+			if (Constants.RUNVM.equals(key)) {
+				model.setRunVMArgs(value);
+			} else {
+				model.setTypedProperty(key, value);
+			}
+		}
+	}
+
+	private MouseAdapter inheritedArgsNavigator(Text txt, String stem) {
+		return new MouseAdapter() {
+			@Override
+			public void mouseDoubleClick(MouseEvent e) {
+				if (txt.getEditable())
+					return;
+				openInheritedArgsProvenance(stem);
+			}
+		};
+	}
+
+	/** Opens the defining file of an inherited args value; multiple sources show a chooser. */
+	private void openInheritedArgsProvenance(String stem) {
+		List<PropertyKey> inherited = BndEditModelAccessor.getInheritedPropertyKeys(model, stem);
+		if (inherited.isEmpty())
+			return;
+		if (inherited.size() == 1) {
+			inherited.get(0)
+				.getProvenance()
+				.ifPresent(this::openProvenanceByPath);
+			return;
+		}
+		ElementListSelectionDialog dialog = new ElementListSelectionDialog(getSection().getShell(),
+			new LabelProvider() {
+				@Override
+				public String getText(Object element) {
+					PropertyKey pk = (PropertyKey) element;
+					String value = pk.getRawValue() != null ? pk.getRawValue() : "";
+					String file = pk.getProvenance()
+						.map(p -> new File(p).getName())
+						.orElse("?");
+					return pk.key() + " = " + value + "  \u2014  " + file;
+				}
+			});
+		dialog.setTitle("Inherited " + stem);
+		dialog.setMessage("Select an entry to open its defining file:");
+		dialog.setElements(inherited.toArray());
+		dialog.setMultipleSelection(false);
+		if (dialog.open() == Window.OK) {
+			PropertyKey pk = (PropertyKey) dialog.getFirstResult();
+			if (pk != null)
+				pk.getProvenance()
+					.ifPresent(this::openProvenanceByPath);
+		}
 	}
 
 	private String emptyToNull(String s) {
-		if (s != null && s.isEmpty())
-			return null;
-		return s;
+		return (s != null && !s.isEmpty()) ? s : null;
+	}
+
+	private void openProvenanceByPath(String absolutePath) {
+		File file = new File(absolutePath);
+		if (!file.isFile())
+			return;
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		IFile iFile = root.getFileForLocation(new Path(absolutePath));
+		if (iFile == null || !iFile.exists())
+			return;
+		try {
+			PlatformUI.getWorkbench()
+				.getActiveWorkbenchWindow()
+				.getActivePage()
+				.openEditor(new FileEditorInput(iFile), BndEditor.WORKSPACE_EDITOR);
+		} catch (PartInitException e) {
+			ErrorDialog.openError(getSection().getShell(), "Error", null,
+				new Status(IStatus.ERROR, Plugin.PLUGIN_ID, 0, "Failed to open source file.", e));
+		}
 	}
 }

--- a/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
+++ b/bndtools.core/src/bndtools/editor/project/RunRequirementsPart.java
@@ -14,7 +14,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -45,7 +44,6 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 		RUNREQUIRE, Constants.RUNREQUIRES, Constants.RESOLVE
 	};
 
-	private final static Image		resolveIcon				= Icons.image("resolve");
 	private Button					btnResolveNow;
 	private JobChangeAdapter		resolveJobListener;
 	private Combo					comboResolveMode;
@@ -59,6 +57,11 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 	@Override
 	protected String[] getProperties() {
 		return SUBSCRIBE_PROPS;
+	}
+
+	@Override
+	protected String getPrimaryPropertyKey() {
+		return Constants.RUNREQUIRES;
 	}
 
 	private void createSection(Section section, FormToolkit tk) {
@@ -104,7 +107,7 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 		resolveModeComposite.setLayout(new FillLayout());
 
 		btnResolveNow = tk.createButton(composite, "Resolve", SWT.PUSH);
-		btnResolveNow.setImage(resolveIcon);
+		setResolveButtonImage();
 
 		btnResolveNow.addSelectionListener(new SelectionAdapter() {
 			@Override
@@ -180,7 +183,12 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 	@Override
 	protected void doCommitToModel(List<Requirement> requires) {
 		if (isDirty()) {
-			model.setRunRequires(requires);
+			String key = getLocalKey();
+			if (Constants.RUNREQUIRES.equals(key)) {
+				model.setRunRequires(requires);
+			} else {
+				BndEditModelAccessor.setRequirementListByKey(model, key, requires);
+			}
 		}
 	}
 
@@ -189,18 +197,33 @@ public class RunRequirementsPart extends AbstractRequirementListPart {
 		comboResolveMode.select(model.getResolveMode()
 			.ordinal());
 		updateResolveModeDescription();
-
-		return model.getRunRequires();
+		// Return only requirements defined in this file's own merge keys (inherited items are
+		// computed separately by the base class and displayed in gray).
+		return BndEditModelAccessor.getLocalMergeRequirements(model, Constants.RUNREQUIRES);
 	}
 
 	private void updateResolveModeDescription() {
 		if (lblResolveModeDescription == null || lblResolveModeDescription.isDisposed())
 			return;
+		if (btnResolveNow != null && !btnResolveNow.isDisposed()) {
+			setResolveButtonImage();
+		}
 		ResolveMode mode = model.getResolveMode();
 		String description = getResolveModeDescription(mode);
 		lblResolveModeDescription.setText(description != null ? description : "");
-		lblResolveModeDescription.getParent()
-			.layout();
+		Composite parent = lblResolveModeDescription.getParent();
+		if (parent != null && !parent.isDisposed()) {
+			parent.layout();
+		}
+	}
+
+	private void setResolveButtonImage() {
+		if (btnResolveNow == null || btnResolveNow.isDisposed())
+			return;
+		if (btnResolveNow.getImage() == null || btnResolveNow.getImage()
+			.isDisposed()) {
+			btnResolveNow.setImage(Icons.image("resolve"));
+		}
 	}
 
 	private static String getResolveModeDescription(ResolveMode mode) {

--- a/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
+++ b/bndtools.core/src/bndtools/model/repo/RepositoryBundleUtils.java
@@ -151,4 +151,30 @@ public class RepositoryBundleUtils {
 		return new VersionRange(true, l.getWithoutQualifier(), h, false);
 	}
 
+	/**
+	 * Converts a RepositoryFeature into a VersionedClause in the canonical feature syntax:
+	 * id;version='V';feature=true;type=org.eclipse.update.feature
+	 *
+	 * @param feature
+	 * @return a VersionedClause for the feature
+	 */
+	public static VersionedClause convertRepoFeature(RepositoryFeature feature) {
+		Attrs attribs = new Attrs();
+		String featureId = feature.getFeature().getId();
+		VersionedClause clause = new VersionedClause("feature:" + featureId, attribs);
+		
+		// Set version if available
+		if (feature.getFeature().getVersion() != null) {
+			clause.setVersionRange(feature.getFeature().getVersion());
+		}
+		
+		// Add feature=true attribute for resolver identification
+		clause.getAttribs().put("feature", "true");
+		
+		// Add type attribute for Eclipse update compatibility
+		clause.getAttribs().put("type", "org.eclipse.update.feature");
+		
+		return clause;
+	}
+
 }

--- a/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
+++ b/bndtools.core/src/org/bndtools/core/ui/icons/Icons.java
@@ -155,7 +155,7 @@ public final class Icons {
 		Key k = new Key(name);
 		synchronized (images) {
 			Image image = images.get(k);
-			if (image == null) {
+			if (image == null || image.isDisposed()) {
 				image = desc.createImage();
 				images.put(k, image);
 			}


### PR DESCRIPTION
The bnd/bndrun editor previously displayed only properties defined in the edited file itself. Entries contributed via -include files were invisible, silently shadowed, or lost on save.

The Run page parts (-runrequires, -runblacklist, -runbundles, -runproperties, -runvm, -runprogramargs) now:

* show inherited entries gray and read-only (merged view via the owner Processor), local entries editable as before
* show per-entry provenance tooltips and open the defining file on double-click; macro-reference clauses (e.g. ${feature.xyz}) stay collapsed and show their one-level definition in the tooltip
* write local additions to the correct merge key: an existing local key is reused, otherwise "<stem>.local" is created when inherited entries exist, so bnd merges instead of shadows
* raise error markers with rename quickfixes for two conflict kinds (marker type bndtools.core.includeconflict): plain merge-stem keys defined in multiple files of the include tree (values shadow each other), and keys defined twice within one file (later definition silently overwrites the earlier one)
* reload the editor model and recompute markers when an included file is saved

API changes (aQute.bnd.build.model 4.5.0 -> 4.6.0, minor bump):

* BndEditModel.getTypedProperty/setTypedProperty added. The UI must read and write suffixed merge keys (e.g. -runrequires.local) with the same conversion as their stem. No existing public API supports this: setGenericString would store a raw String in the typed object cache and cause ClassCastExceptions in the typed getters. The new methods resolve converter/formatter via the key stem (Constants.MERGED_HEADERS) and fall back to strings for unknown keys.
* RUNBLACKLIST registered in the converter/formatter maps so -runblacklist merge keys convert like -runrequires.

No other bndlib API is touched; all remaining logic builds on existing API (Processor.getMergePropertyKeys, PropertyKey provenance, mergeProperties) and lives in the package-private BndEditModelAccessor inside bndtools.core, which exports no affected package. The only new externally visible Eclipse surface is the marker type and its resolution generator in plugin.xml, where a public class is required by the extension registry. New protected hooks (getPrimaryPropertyKey, loadMergedFromModel) are internal; loadMergedFromModel defaults to null so unrelated subclasses keep their previous behavior.