### PR TITLE
fix: highlight first-line bnd comments

### DIFF
--- a/bndtools.core/src/bndtools/editor/completion/BndScanner.java
+++ b/bndtools.core/src/bndtools/editor/completion/BndScanner.java
@@ -50,7 +50,7 @@ public class BndScanner extends RuleBasedScanner {
 			do {
 				c = scanner.read();
 				n++;
-			} while ((c == ' ' || c == '\t'));
+			} while ((c == ' ' || c == '\t' || c == '\uFEFF'));
 
 			if (c == '#' || c == '!') {
 				while (true) {


### PR DESCRIPTION
adding U+FEFF is known as the Byte Order Mark (BOM) or Zero Width No-Break Space