### PR TITLE
Enhance workspace template fragments - add archive prop and UI accessibility improvements

### DIFF
--- a/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
+++ b/biz.aQute.bnd/src/aQute/bnd/main/AddCommands.java
@@ -59,6 +59,8 @@ public class AddCommands {
 	@Description("Add template fragment(s) to the current workspace. Leave the name empty to see a list of available templates at the index."
 		+ "\\n\\nExample:\\n bnd add fragment osgi gradle ")
 	interface AddTemplateOptions extends Options {
+		@Description("Show archived template fragments when listing available templates")
+		boolean showArchived();
 	}
 
 	@Description("Add template fragment(s) to the current workspace.")
@@ -73,7 +75,7 @@ public class AddCommands {
 
 		List<String> selectedFragmentNames = args;
 		String indexUrl = DEFAULT_INDEX;
-		installTemplateFragment(ws, selectedFragmentNames, indexUrl);
+		installTemplateFragment(ws, selectedFragmentNames, indexUrl, options.showArchived());
 
 	}
 
@@ -88,6 +90,9 @@ public class AddCommands {
 		@Description("Specify template fragment(s) by name to install together with the created workspace. Fragments are identified by the 'name' attribute in the index. Specify multiple fragments by repeating the -f option. "
 			+ "To see a list of available templates use 'bnd add fragment' without arguments.")
 		List<String> fragment();
+
+		@Description("Show archived template fragments when listing available templates")
+		boolean showArchived();
 
 	}
 
@@ -112,7 +117,7 @@ public class AddCommands {
 		if (fragments != null && !fragments
 			.isEmpty()) {
 			String indexUrl = DEFAULT_INDEX;
-			installTemplateFragment(ws, fragments, indexUrl);
+			installTemplateFragment(ws, fragments, indexUrl, options.showArchived());
 		}
 
 
@@ -167,19 +172,25 @@ public class AddCommands {
 	}
 
 	private void showTemplatesFragments(List<TemplateInfo> availableTemplates) {
-		availableTemplates.forEach(ti -> bnd.out.format("%s - %s%n  - Repo: %s %n", ti.name(), ti.description(),
+		availableTemplates.forEach(ti -> bnd.out.format("%s%s - %s%n  - Repo: %s %n", ti.name(),
+			ti.archived() ? " (archived)" : "", ti.description(),
 			ti.id()
 				.repoUrl()));
 	}
 
-	private void installTemplateFragment(Workspace ws, List<String> selectedFragmentNames, String index)
+	private void installTemplateFragment(Workspace ws, List<String> selectedFragmentNames, String index,
+		boolean showArchived)
 		throws MalformedURLException {
 		FragmentTemplateEngine engine = initFragmentTemplateEngine(ws, index);
 		List<TemplateInfo> availableTemplates = engine.getAvailableTemplates();
 
 		if (selectedFragmentNames == null || selectedFragmentNames.isEmpty()) {
 			bnd.out.format("Available template fragments:%n");
-			showTemplatesFragments(availableTemplates);
+			List<TemplateInfo> toShow = showArchived ? availableTemplates
+				: availableTemplates.stream()
+					.filter(ti -> !ti.archived())
+					.toList();
+			showTemplatesFragments(toShow);
 			return;
 		}
 		List<TemplateInfo> selectedTemplates = availableTemplates.stream()

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/FragmentTemplateEngine.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -59,6 +60,7 @@ public class FragmentTemplateEngine {
 	private static final String		TAG					= "tag";
 	private static final String		REQUIRE				= "require";
 	private static final String		DESCRIPTION			= "description";
+	private static final String		ARCHIVED			= "archived";
 	private static final String		WORKSPACE_TEMPLATES	= "-workspace-templates";
 	private static final String		NAME				= "name";
 	private static final Pattern	COMMIT_SHA			= Pattern.compile("[a-f0-9]{40}$");
@@ -80,8 +82,13 @@ public class FragmentTemplateEngine {
 	 * Info about a template, comes from the index files.
 	 */
 
-	public record TemplateInfo(TemplateID id, String name, String description, String[] require, String... tag)
+	public record TemplateInfo(TemplateID id, String name, String description, boolean archived, String[] require,
+		String... tag)
 		implements Comparable<TemplateInfo> {
+
+		public TemplateInfo(TemplateID id, String name, String description, String[] require, String... tag) {
+			this(id, name, description, false, require, tag);
+		}
 
 		@Override
 		public int compareTo(TemplateInfo o) {
@@ -208,10 +215,13 @@ public class FragmentTemplateEngine {
 			TemplateID templateId = TemplateID.from(id);
 			String name = attrs.getOrDefault(NAME, id.toString());
 			String description = attrs.getOrDefault(DESCRIPTION, "");
+			boolean archived = attrs.containsKey(ARCHIVED)
+				&& (attrs.get(ARCHIVED) == null || attrs.get(ARCHIVED)
+					.isEmpty() || Processor.isTrue(attrs.get(ARCHIVED)));
 			String require[] = toArray(attrs.get(REQUIRE));
 			String tags[] = toArray(attrs.get(TAG));
 
-			templates.add(new TemplateInfo(templateId, name, description, require, tags));
+			templates.add(new TemplateInfo(templateId, name, description, archived, require, tags));
 		}
 		return templates;
 	}
@@ -224,6 +234,15 @@ public class FragmentTemplateEngine {
 		if (!templates.contains(info)) {
 			this.templates.add(info);
 		}
+	}
+
+	/**
+	 * Remove template information from the available templates.
+	 *
+	 * @param infos template information to remove.
+	 */
+	public void removeAll(Collection<TemplateInfo> infos) {
+		templates.removeAll(infos);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/wstemplates/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.2.0")
+@Version("1.4.0")
 package aQute.bnd.wstemplates;
 
 import org.osgi.annotation.versioning.Version;

--- a/biz.aQute.bndlib/test/aQute/bnd/wstemplates/TemplateFragmentsTest.java
+++ b/biz.aQute.bndlib/test/aQute/bnd/wstemplates/TemplateFragmentsTest.java
@@ -180,6 +180,37 @@ class TemplateFragmentsTest {
 	}
 
 	@Test
+	void testArchivedAttribute() throws Exception {
+		try (Workspace w = getworkSpace()) {
+			FragmentTemplateEngine tfs = new FragmentTemplateEngine(w);
+
+			Result<List<TemplateInfo>> result = tfs.read("-workspace-templates "
+				+ "t1;name=t1;archived=true,"
+				+ "t2;name=t2;archived=false,"
+				+ "t3;name=t3;description=standard,"
+				+ "t4;name=t4;archived=\"true\"");
+
+			assertThat(result.isOk()).describedAs(result.toString())
+				.isTrue();
+
+			List<TemplateInfo> infos = result.unwrap();
+			assertThat(infos).hasSize(4);
+
+			assertThat(infos.get(0).name()).isEqualTo("t1");
+			assertThat(infos.get(0).archived()).isTrue();
+
+			assertThat(infos.get(1).name()).isEqualTo("t2");
+			assertThat(infos.get(1).archived()).isFalse();
+
+			assertThat(infos.get(2).name()).isEqualTo("t3");
+			assertThat(infos.get(2).archived()).isFalse();
+
+			assertThat(infos.get(3).name()).isEqualTo("t4");
+			assertThat(infos.get(3).archived()).isTrue();
+		}
+	}
+
+	@Test
 	void testRequireField() throws Exception {
 		try (Workspace w = getworkSpace()) {
 			FragmentTemplateEngine tfs = new FragmentTemplateEngine(w);

--- a/bndtools.core.test/src/bndtools/wizards/newworkspace/NewWorkspaceWizardTest.java
+++ b/bndtools.core.test/src/bndtools/wizards/newworkspace/NewWorkspaceWizardTest.java
@@ -1,0 +1,37 @@
+package bndtools.wizards.newworkspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+class NewWorkspaceWizardTest {
+
+	@Test
+	void plainTextGlobMatchesSubstring() {
+		Pattern pattern = Pattern.compile(NewWorkspaceWizard.NewWorkspaceWizardPage.globToRegex("eclipse"),
+			Pattern.CASE_INSENSITIVE);
+
+		assertThat(pattern.matcher("Eclipse Workspace").matches()).isTrue();
+		assertThat(pattern.matcher("workspace").matches()).isFalse();
+	}
+
+	@Test
+	void wildcardGlobMatchesExpectedText() {
+		Pattern pattern = Pattern.compile(NewWorkspaceWizard.NewWorkspaceWizardPage.globToRegex("*eclipse?"),
+			Pattern.CASE_INSENSITIVE);
+
+		assertThat(pattern.matcher("bndtools eclipseX").matches()).isTrue();
+		assertThat(pattern.matcher("bndtools eclipse").matches()).isFalse();
+	}
+
+	@Test
+	void regexCharactersRemainLiteral() {
+		Pattern pattern = Pattern.compile(NewWorkspaceWizard.NewWorkspaceWizardPage.globToRegex("a[b].c"),
+			Pattern.CASE_INSENSITIVE);
+
+		assertThat(pattern.matcher("template a[b].c").matches()).isTrue();
+		assertThat(pattern.matcher("template abc").matches()).isFalse();
+	}
+}

--- a/bndtools.core/src/bndtools/util/ui/UI.java
+++ b/bndtools.core/src/bndtools/util/ui/UI.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.eclipse.jface.viewers.CheckboxTableViewer;
+import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -462,11 +463,18 @@ public class UI<M> implements AutoCloseable {
 
 			@Override
 			public AutoCloseable subscribe(Consumer<Object[]> subscription) {
-				ISelectionChangedListener listener = se -> {
+				ISelectionChangedListener selectionListener = se -> {
 					subscription.accept(widget.getCheckedElements());
 				};
-				widget.addSelectionChangedListener(listener);
-				return () -> widget.removeSelectionChangedListener(listener);
+				ICheckStateListener checkStateListener = cse -> {
+					subscription.accept(widget.getCheckedElements());
+				};
+				widget.addSelectionChangedListener(selectionListener);
+				widget.addCheckStateListener(checkStateListener);
+				return () -> {
+					widget.removeSelectionChangedListener(selectionListener);
+					widget.removeCheckStateListener(checkStateListener);
+				};
 			}
 		};
 	}

--- a/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/Model.java
@@ -47,6 +47,7 @@ public class Model implements Runnable {
 	boolean				clean				= false;
 	boolean				updateWorkspace		= false;
 	boolean				switchWorkspace		= true;
+	boolean				showArchived		= false;
 	List<TemplateInfo>	templates			= new ArrayList<>();
 	List<TemplateInfo>	selectedTemplates	= new ArrayList<>();
 	Progress			validatedUrl		= Progress.init;

--- a/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/NewWorkspaceWizard.java
@@ -6,7 +6,12 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -15,20 +20,24 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnPixelData;
 import org.bndtools.core.ui.StickyToolTipSupport;
-import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -69,12 +78,21 @@ import bndtools.util.ui.UI;
  */
 public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWizard {
 
+	private static final String		SETTINGS_SECTION			= "NewWorkspaceWizard";
+	private static final String		SETTING_CLEAN				= "clean";
+	private static final String		SETTING_SWITCH_WORKSPACE	= "switchWorkspace";
+	private static final String		SETTING_SHOW_ARCHIVED		= "showArchived";
+	private static final String		SETTING_UPDATE_WORKSPACE	= "updateWorkspace";
+	private static final Point		MINIMUM_DIALOG_SIZE			= new Point(880, 480);
+
 	static final Logger				log					= LoggerFactory.getLogger(NewWorkspaceWizard.class);
 
 	final Model						model;
 	final UI<Model>					ui;
 	final NewWorkspaceWizardPage	page				= new NewWorkspaceWizardPage();
 	final FragmentTemplateEngine	templates;
+	final Set<String>					loadingTemplateIndexes	= new HashSet<>();
+	final Map<String, List<TemplateInfo>>	templateIndexes			= new HashMap<>();
 
 	final static Image				verified			= Icons.image("icons/tick.png", false);
 	final static Image				verifiedGreyedOut	= new Image(Display.getDefault(), verified, SWT.IMAGE_DISABLE);
@@ -85,13 +103,37 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 		this.model = new Model(workspace);
 		this.ui = new UI<>(model);
 		templates = new FragmentTemplateEngine(workspace);
+		IDialogSettings workbenchSettings = Plugin.getDefault()
+			.getDialogSettings();
+		IDialogSettings section = workbenchSettings.getSection(SETTINGS_SECTION);
+		if (section == null) {
+			section = workbenchSettings.addNewSection(SETTINGS_SECTION);
+		}
+		setDialogSettings(section);
+
+		if (section.get(SETTING_CLEAN) != null) {
+			model.clean = section.getBoolean(SETTING_CLEAN);
+		}
+		if (section.get(SETTING_SWITCH_WORKSPACE) != null) {
+			model.switchWorkspace = section.getBoolean(SETTING_SWITCH_WORKSPACE);
+		}
+		if (section.get(SETTING_SHOW_ARCHIVED) != null) {
+			model.showArchived = section.getBoolean(SETTING_SHOW_ARCHIVED);
+		}
+		if (section.get(SETTING_UPDATE_WORKSPACE) != null) {
+			model.updateWorkspace(section.getBoolean(SETTING_UPDATE_WORKSPACE));
+		} else {
+			model.updateWorkspace(true);
+		}
+
 		try {
 			Job job = Job.create("load index", mon -> {
 				try {
 					for (String uri : new BndPreferences().getWorkspaceTemplateIndexes()) {
-						templates.read(new URL(uri))
-							.unwrap()
-							.forEach(templates::add);
+						List<TemplateInfo> indexTemplates = templates.read(new URL(uri))
+							.unwrap();
+						indexTemplates.forEach(templates::add);
+						templateIndexes.put(URI.create(uri).normalize().toString(), indexTemplates);
 					}
 					Parameters p = workspace.getMergedParameters(Constants.WORKSPACE_TEMPLATES);
 					templates.read(p)
@@ -160,6 +202,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 		}
 
 		if (model.valid == null) {
+			saveDialogSettings();
 			ui.write(() -> {
 				TemplateUpdater updater = templates.updater(model.location, model.selectedTemplates);
 				model.execute(updater);
@@ -168,6 +211,27 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 		} else
 			return false;
 
+	}
+
+	@Override
+	public void dispose() {
+		saveDialogSettings();
+		super.dispose();
+	}
+
+	@Override
+	public Point getMinimumWizardSize() {
+		return MINIMUM_DIALOG_SIZE;
+	}
+
+	private void saveDialogSettings() {
+		IDialogSettings settings = getDialogSettings();
+		if (settings != null) {
+			settings.put(SETTING_CLEAN, model.clean);
+			settings.put(SETTING_SWITCH_WORKSPACE, model.switchWorkspace);
+			settings.put(SETTING_SHOW_ARCHIVED, model.showArchived);
+			settings.put(SETTING_UPDATE_WORKSPACE, model.updateWorkspace);
+		}
 	}
 
 
@@ -208,12 +272,67 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			switchWorkspace.setText("Show workspace select dialog to switch to new workspace after finish");
 			switchWorkspace.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 8, 1));
 
+			Button showArchived = new Button(container, SWT.CHECK);
+			showArchived.setText("Show archived");
+			showArchived.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 8, 1));
+
+			Label filterLabel = new Label(container, SWT.NONE);
+			filterLabel.setText("Filter");
+			filterLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
+
+			Text filterText = new Text(container, SWT.BORDER | SWT.SEARCH | SWT.ICON_CANCEL);
+			filterText.setMessage("glob pattern, e.g. *eclipse*");
+			GridData filterTextLayoutData = new GridData(SWT.LEFT, SWT.CENTER, false, false, 7, 1);
+			GC gc = new GC(filterText);
+			filterTextLayoutData.widthHint = gc.stringExtent("MMMMMMMMMMMMMMMMMMMMMMMMMMMMMM").x;
+			gc.dispose();
+			filterText.setLayoutData(filterTextLayoutData);
+
 			CheckboxTableViewer selectedTemplates = CheckboxTableViewer.newCheckList(container,
 				SWT.BORDER | SWT.FULL_SELECTION);
 			StickyToolTipSupport.enableFor(selectedTemplates);
 			selectedTemplates.setContentProvider(ArrayContentProvider.getInstance());
+			selectedTemplates.addFilter(new ViewerFilter() {
+				@Override
+				public boolean select(Viewer viewer, Object parentElement, Object element) {
+					if (model.showArchived) {
+						return true;
+					}
+					if (element instanceof TemplateInfo ti) {
+						return !ti.archived();
+					}
+					return true;
+				}
+			});
+			selectedTemplates.addFilter(new ViewerFilter() {
+				@Override
+				public boolean select(Viewer viewer, Object parentElement, Object element) {
+					String glob = filterText.getText()
+						.trim();
+					if (glob.isEmpty()) {
+						return true;
+					}
+					if (!(element instanceof TemplateInfo ti)) {
+						return true;
+					}
+					Pattern pattern = Pattern.compile(globToRegex(glob), Pattern.CASE_INSENSITIVE);
+					String author = ti.isOfficial() ? "bndtools (Official)"
+						: ti.id()
+							.organisation() + " (3rd Party)";
+					return pattern.matcher(ti.name())
+						.matches()
+						|| pattern.matcher(ti.description())
+							.matches()
+						|| pattern.matcher(author)
+							.matches();
+				}
+			});
+			filterText.addModifyListener(e -> selectedTemplates.refresh());
 			Table table = selectedTemplates.getTable();
-			table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 6, 10));
+			GridData tableLayoutData = new GridData(SWT.FILL, SWT.FILL, true, true, 6, 10);
+			tableLayoutData.widthHint = 820;
+			tableLayoutData.heightHint = 360;
+			table.setLayoutData(tableLayoutData);
 			TableLayout tableLayout = new TableLayout();
 			table.setLayout(tableLayout);
 			table.setHeaderVisible(true);
@@ -231,6 +350,23 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 				}
 			});
 
+			TableViewerColumn checkboxColumn = new TableViewerColumn(selectedTemplates, SWT.NONE);
+			checkboxColumn.setLabelProvider(new ColumnLabelProvider());
+
+			TableViewerColumn indexColumn = new TableViewerColumn(selectedTemplates, SWT.NONE);
+			indexColumn.getColumn()
+				.setText("#");
+			indexColumn.setLabelProvider(new ColumnLabelProvider() {
+
+				@Override
+				public String getText(Object element) {
+					if (element instanceof TemplateInfo ti) {
+						return String.valueOf(localIndex(ti));
+					}
+					return super.getText(element);
+				}
+			});
+
 			TableViewerColumn nameColumn = new TableViewerColumn(selectedTemplates, SWT.NONE);
 			nameColumn.getColumn()
 				.setText("Name");
@@ -239,7 +375,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 				@Override
 				public String getText(Object element) {
 					if (element instanceof TemplateInfo ti) {
-						return ti.name();
+						return ti.name() + (ti.archived() ? " (archived)" : "");
 					}
 					return super.getText(element);
 				}
@@ -281,6 +417,9 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 				@Override
 				public Image getImage(Object element) {
 					if (element instanceof TemplateInfo ti) {
+						if (ti.archived()) {
+							return verifiedGreyedOut;
+						}
 						boolean officialOrSHA = ti.isOfficial() || ti.isCommitSHA();
 						return officialOrSHA ? verified : verifiedGreyedOut;
 					}
@@ -298,17 +437,7 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 				@Override
 				public String getText(Object element) {
 					if (element instanceof TemplateInfo ti) {
-						List<TemplateInfo> reqs = NewWorkspaceWizard.this.templates
-							.resolveRequirements(Collections.singletonList(ti));
-
-						long num3rdParty = reqs != null && reqs.size() > 1 ? reqs.stream()
-							.filter(rti -> !rti.isOfficial())
-							.count() : 0;
-
-						return reqs != null && reqs.size() > 1
-							? String.valueOf(reqs.size() - 1)
-								+ (num3rdParty > 0 ? " (" + num3rdParty + " 3rd Party)" : "")
-							: "0";
+						return requiredIndices(ti);
 					}
 					return super.getText(element);
 				}
@@ -328,11 +457,12 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 					return super.getToolTipText(element);
 				}
 			});
-
-			tableLayout.addColumnData(new ColumnWeightData(1, 200, false));
-			tableLayout.addColumnData(new ColumnWeightData(10, 460, true));
-			tableLayout.addColumnData(new ColumnWeightData(20, 100, true));
-			tableLayout.addColumnData(new ColumnWeightData(30, 50, true));
+			tableLayout.addColumnData(new ColumnPixelData(20, false));
+			tableLayout.addColumnData(new ColumnPixelData(30, false));
+			tableLayout.addColumnData(new ColumnPixelData(120, false));
+			tableLayout.addColumnData(new ColumnPixelData(460, false));
+			tableLayout.addColumnData(new ColumnPixelData(120, false));
+			tableLayout.addColumnData(new ColumnPixelData(60, false));
 
 			Button addButton = new Button(container, SWT.PUSH);
 			addButton.setText("+");
@@ -343,23 +473,24 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			formText.setText("Double click to open the fragment template Github-Repo in your browser.", false, false);
 			formText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 6, 1));
 
-			model.updateWorkspace(true);
 			ui.u("location", model.location, UI.text(location)
 				.map(File::getAbsolutePath, File::new));
 			ui.u("clean", model.clean, UI.checkbox(clean));
+			ui.u("switchWorkspace", model.switchWorkspace, UI.checkbox(switchWorkspace));
+			ui.u("showArchived", model.showArchived, UI.checkbox(showArchived))
+				.bind(v -> selectedTemplates.refresh());
 			ui.u("updateWorkspace", model.updateWorkspace, UI.checkbox(useEclipseWorkspace))
 				.bind(v -> location.setEnabled(!v))
 				.bind(v -> browseButton.setEnabled(!v))
 				.bind(v -> switchWorkspace.setEnabled(!v))
 				.bind(v -> clean.setEnabled(!v))
 				.bind(v -> setTitle(
-					v ? "Update Workspace with template fragment" : "Create New Workspace from template fragment"))
-				.bind(v -> setWindowTitle(v ? "Update Workspace" : "Create New Workspace"));
+					v ? "Update Workspace from template fragment" : "Create New Workspace from template fragment"))
+				.bind(v -> setWindowTitle(v ? "Update Workspace from template fragment" : "Create New Workspace"));
 
 			ui.u("valid", model.valid, this::setErrorMessage);
 			ui.u("error", model.error, this::setErrorMessage);
 			ui.u("valid", model.valid, v -> setPageComplete(v == null));
-			ui.u("switchWorkspace", model.switchWorkspace, UI.checkbox(switchWorkspace));
 			ui.u("templates", model.templates, l -> selectedTemplates.setInput(l.toArray()));
 			ui.u("selectedTemplates", model.selectedTemplates, UI.widget(selectedTemplates)
 				.map(List::toArray, this::toTemplates));
@@ -368,29 +499,24 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			UI.checkbox(browseButton)
 				.subscribe(this::browseForLocation);
 
-			centerShell();
+			configureShellSize();
 			ui.update();
 		}
 
-		private void centerShell() {
+		private void configureShellSize() {
 			Shell shell = getShell();
-			shell.setSize(840, 480);
+			shell.setMinimumSize(MINIMUM_DIALOG_SIZE);
 			Shell parent = (Shell) shell.getParent();
 			if (parent != null) {
-				Rectangle parentBounds = parent.getBounds();
-				Point shellSize = shell.getSize();
-				int x = parentBounds.x + (parentBounds.width - shellSize.x) / 2;
-				int y = parentBounds.y + (parentBounds.height - shellSize.y) / 2;
-				shell.setLocation(x, y);
-			} else {
-				// If no parent, center on the display
-				Rectangle displayBounds = shell.getDisplay()
-					.getPrimaryMonitor()
-					.getBounds();
-				Point shellSize = shell.getSize();
-				int x = (displayBounds.width - shellSize.x) / 2;
-				int y = (displayBounds.height - shellSize.y) / 2;
-				shell.setLocation(x, y);
+				Rectangle parentBounds = parent.getClientArea();
+				shell.setMaximumSize(parentBounds.width, parentBounds.height);
+				Point preferredSize = shell.computeSize(SWT.DEFAULT, SWT.DEFAULT, true);
+				Point shellSize = new Point(Math.min(preferredSize.x, parentBounds.width),
+					Math.min(preferredSize.y, parentBounds.height));
+				shell.setSize(shellSize);
+				Point parentOrigin = parent.toDisplay(parentBounds.x, parentBounds.y);
+				shell.setLocation(parentOrigin.x + (parentBounds.width - shellSize.x) / 2,
+					parentOrigin.y + (parentBounds.height - shellSize.y) / 2);
 			}
 		}
 
@@ -398,6 +524,47 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			return Stream.of(selection)
 				.map(o -> (TemplateInfo) o)
 				.toList();
+		}
+
+		int localIndex(TemplateInfo template) {
+			return model.templates.indexOf(template) + 1;
+		}
+
+		String requiredIndices(TemplateInfo template) {
+					List<TemplateInfo> requirements = NewWorkspaceWizard.this.templates
+						.resolveRequirements(Collections.singletonList(template));
+					if (requirements.size() <= 1) {
+				return "-";
+			}
+					String indices = requirements.stream()
+						.filter(required -> !required.equals(template))
+						.map(this::localIndex)
+						.map(String::valueOf)
+				.collect(Collectors.joining(", "));
+			return indices;
+		}
+
+		// converts a shell-style glob (* and ?) into a case-insensitive regex; plain text without glob
+		// special characters is treated as a substring search
+		static String globToRegex(String glob) {
+			boolean hasWildcard = glob.indexOf('*') >= 0 || glob.indexOf('?') >= 0;
+			StringBuilder sb = new StringBuilder();
+			if (!hasWildcard) {
+				sb.append(".*");
+			}
+			for (char c : glob.toCharArray()) {
+				switch (c) {
+					case '*' -> sb.append(".*");
+					case '?' -> sb.append('.');
+					case '.', '(', ')', '+', '|', '^', '$', '@', '%', '[', ']', '{', '}', '\\' -> sb.append('\\')
+						.append(c);
+					default -> sb.append(c);
+				}
+			}
+			if (!hasWildcard) {
+				sb.append(".*");
+			}
+			return sb.toString();
 		}
 
 		void browseForLocation() {
@@ -414,27 +581,48 @@ public class NewWorkspaceWizard extends Wizard implements IImportWizard, INewWiz
 			if (dialog.open() == Window.OK) {
 				String selectedPath = dialog.getSelectedPath();
 				if (selectedPath != null && !selectedPath.isBlank()) {
+					URI uri;
+					try {
+						uri = toURI(selectedPath).normalize();
+					} catch (Exception e) {
+						model.error = "failed to add the index: " + e;
+						return;
+					}
+					String uriStr = uri.toString();
+					if (!loadingTemplateIndexes.add(uriStr)) {
+						model.error = "index is already being added: " + uriStr;
+						return;
+					}
 					Job job = Job.create("read " + selectedPath, mon -> {
 						try {
-							URI uri = toURI(selectedPath);
 							Result<List<TemplateInfo>> result = templates.read(uri.toURL());
 
 							if (result.isErr()) {
-								ui.write(() -> model.error = result.toString());
+								ui.write(() -> {
+									loadingTemplateIndexes.remove(uriStr);
+									model.error = result.toString();
+								});
 							} else {
-								result.unwrap()
-									.forEach(templates::add);
-								String uriStr = uri.toString();
+								List<TemplateInfo> indexTemplates = result.unwrap();
+								templates.removeAll(templateIndexes.getOrDefault(uriStr, Collections.emptyList()));
+								indexTemplates.forEach(templates::add);
+								templateIndexes.put(uriStr, indexTemplates);
 								BndPreferences prefs = new BndPreferences();
 								List<String> indexes = new ArrayList<>(prefs.getWorkspaceTemplateIndexes());
 								if (!indexes.contains(uriStr)) {
 									indexes.add(uriStr);
 									prefs.setWorkspaceTemplateIndexes(indexes);
 								}
-								ui.write(() -> model.templates = templates.getAvailableTemplates());
+								ui.write(() -> {
+									loadingTemplateIndexes.remove(uriStr);
+									model.templates = templates.getAvailableTemplates();
+								});
 							}
 						} catch (Exception e) {
-							ui.write(() -> model.error = "failed to add the index: " + e);
+							ui.write(() -> {
+								loadingTemplateIndexes.remove(uriStr);
+								model.error = "failed to add the index: " + e;
+							});
 						}
 					});
 					job.schedule();

--- a/bndtools.core/src/bndtools/wizards/newworkspace/TemplateDefinitionDialog.java
+++ b/bndtools.core/src/bndtools/wizards/newworkspace/TemplateDefinitionDialog.java
@@ -18,7 +18,7 @@ import bndtools.util.ui.UI;
  */
 class TemplateDefinitionDialog extends Dialog {
 	final UI<TemplateDefinitionDialog>	ui	= new UI<>(this);
-	String								path;
+	String								path	= "";
 
 	public TemplateDefinitionDialog(Shell parentShell) {
 		super(parentShell);
@@ -42,8 +42,6 @@ class TemplateDefinitionDialog extends Dialog {
 		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 12, 1));
 
 		Text textField = new Text(container, SWT.BORDER);
-		textField.setText(
-			"https://raw.githubusercontent.com/bndtools/workspace-templates/refs/heads/master/index.bnd");
 		GridData textFieldLayoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 11, 1);
 		textFieldLayoutData.minimumWidth = 200;
 		textField.setLayoutData(textFieldLayoutData);

--- a/docs/_chapters/620-template-fragments.md
+++ b/docs/_chapters/620-template-fragments.md
@@ -67,6 +67,7 @@ The index has the following attributes for a clause:
 * `description` – A human readable description for the template fragment
 * `require` – A comma separated list of fragment ids. Do not forget to quote when multiple fragments are required
 * `tag` – A comma separated list of tags, quotes are needed when there are multiple.
+* `archived` – (Optional) Boolean flag (`true`/`false`) indicating that the template fragment is archived.
 
 ## Example
 


### PR DESCRIPTION
- Add optional 'archived' attribute parsing to FragmentTemplateEngine
- Bump aQute.bnd.wstemplates package version to 1.3.0 for baseline
- Add 'Show archived' filter checkbox and dialog settings persistence in NewWorkspaceWizard
- Add '--showArchived' option to bnd CLI add fragment/workspace commands
- Update template fragments documentation