### PR TITLE
Allow explicit index filenames for P2 repositories

### DIFF
--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Config.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Config.java
@@ -23,16 +23,18 @@ public interface P2Config {
 	URI url();
 
 	/**
-	 * The location to store the index file. A location ending in {@code /} is a
-	 * directory in which {@code index.xml.gz} is stored. Otherwise, the location
-	 * specifies the complete index filename.
+	 * The location to store the index file and downloaded bundles. A location ending
+	 * in {@code /} is a directory in which {@code index.xml.gz} is stored. Otherwise,
+	 * the location specifies the complete index filename and bundles are stored in
+	 * its parent directory.
 	 */
 	String location();
 
 	/**
-	 * The location to store the index file with a default passed. A location
-	 * ending in {@code /} is a directory in which {@code index.xml.gz} is stored.
-	 * Otherwise, the location specifies the complete index filename.
+	 * The location to store the index file and downloaded bundles with a default
+	 * passed. A location ending in {@code /} is a directory in which
+	 * {@code index.xml.gz} is stored. Otherwise, the location specifies the complete
+	 * index filename and bundles are stored in its parent directory.
 	 */
 	String location(String string);
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Config.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Config.java
@@ -23,12 +23,16 @@ public interface P2Config {
 	URI url();
 
 	/**
-	 * The location to store the index file.
+	 * The location to store the index file. A location ending in {@code /} is a
+	 * directory in which {@code index.xml.gz} is stored. Otherwise, the location
+	 * specifies the complete index filename.
 	 */
 	String location();
 
 	/**
-	 * The location to store the index file with a default passed.
+	 * The location to store the index file with a default passed. A location
+	 * ending in {@code /} is a directory in which {@code index.xml.gz} is stored.
+	 * Otherwise, the location specifies the complete index filename.
 	 */
 	String location(String string);
 

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
@@ -76,10 +76,15 @@ class P2Indexer implements Closeable {
 
 	P2Indexer(Unpack200 processor, Reporter reporter, File location, HttpClient client, URI url, String name)
 		throws Exception {
+		this(processor, reporter, location, new File(location, "index.xml.gz"), client, url, name);
+	}
+
+	P2Indexer(Unpack200 processor, Reporter reporter, File location, File indexFile, HttpClient client, URI url,
+		String name) throws Exception {
 		this.processor = processor;
 		this.reporter = reporter;
 		this.location = location;
-		this.indexFile = new File(location, "index.xml.gz");
+		this.indexFile = indexFile;
 		this.client = client;
 		this.promiseFactory = client.promiseFactory();
 		this.url = url;

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Indexer.java
@@ -90,6 +90,8 @@ class P2Indexer implements Closeable {
 		this.url = url;
 		this.name = name;
 		this.urlHash = client.toName(url);
+		if (this.indexFile.isDirectory())
+			throw new IllegalArgumentException(this.indexFile + " is a directory, not an index file");
 		IO.mkdirs(this.location);
 
 		validate();

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Repository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Repository.java
@@ -75,7 +75,9 @@ public class P2Repository extends BaseRepository
 			File configuredFile = workspace.getFile(configuredLocation);
 			File indexFile;
 			File location;
-			if (configuredLocation.endsWith("/")) {
+			boolean directoryLocation = configuredLocation.endsWith("/") || configuredLocation.endsWith("\\")
+				|| configuredFile.isDirectory();
+			if (directoryLocation) {
 				location = configuredFile;
 				indexFile = new File(location, "index.xml.gz");
 			} else {

--- a/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Repository.java
+++ b/biz.aQute.repository/src/aQute/bnd/repository/p2/provider/P2Repository.java
@@ -71,11 +71,19 @@ public class P2Repository extends BaseRepository
 
 		try {
 			name = config.name(client.toName(url));
-			File location = workspace.getFile(config.location("cnf/cache/p2-" + name));
-			IO.mkdirs(location);
-			File indexFile = new File(location, "index.xml.gz");
+			String configuredLocation = config.location("cnf/cache/p2-" + name + "/");
+			File configuredFile = workspace.getFile(configuredLocation);
+			File indexFile;
+			File location;
+			if (configuredLocation.endsWith("/")) {
+				location = configuredFile;
+				indexFile = new File(location, "index.xml.gz");
+			} else {
+				indexFile = configuredFile;
+				location = indexFile.getParentFile();
+			}
 
-			return new P2Indexer(new Unpack200(this.workspace), reporter, location, client, url, name);
+			return new P2Indexer(new Unpack200(this.workspace), reporter, location, indexFile, client, url, name);
 		} catch (Exception e) {
 			throw Exceptions.duck(e);
 		}

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
@@ -42,6 +42,7 @@ public class P2RepositoryTest {
 	public void testLocationAsDirectory() throws Exception {
 		File repository = IO.getFile("testdata/p2/macbadge");
 		File location = new File(tmp, "directory-location");
+		assertThat(location.mkdirs()).isTrue();
 		try (Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
 			P2Repository p2r = new P2Repository()) {
 			w.setProperty(Constants.CONNECTION_SETTINGS, "false");
@@ -52,8 +53,7 @@ public class P2RepositoryTest {
 			config.put("url", repository.toURI()
 				.toString());
 			config.put("name", "test");
-			config.put("location", location.getAbsolutePath()
-				.replace(File.separatorChar, '/') + "/");
+			config.put("location", location.getAbsolutePath());
 			p2r.setProperties(config);
 
 			assertThat(p2r.list(null)).isNotEmpty();

--- a/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
+++ b/biz.aQute.repository/test/aQute/bnd/repository/p2/provider/P2RepositoryTest.java
@@ -30,12 +30,62 @@ import aQute.bnd.osgi.resource.ResourceUtils.ContentCapability;
 import aQute.bnd.service.RepositoryPlugin.DownloadListener;
 import aQute.bnd.test.jupiter.InjectTemporaryDirectory;
 import aQute.bnd.version.Version;
+import aQute.lib.io.IO;
 import aQute.p2.packed.Unpack200;
 import aQute.p2.provider.Feature;
 
 public class P2RepositoryTest {
 	@InjectTemporaryDirectory
 	File tmp;
+
+	@Test
+	public void testLocationAsDirectory() throws Exception {
+		File repository = IO.getFile("testdata/p2/macbadge");
+		File location = new File(tmp, "directory-location");
+		try (Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			P2Repository p2r = new P2Repository()) {
+			w.setProperty(Constants.CONNECTION_SETTINGS, "false");
+			w.setBase(tmp);
+			p2r.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("url", repository.toURI()
+				.toString());
+			config.put("name", "test");
+			config.put("location", location.getAbsolutePath()
+				.replace(File.separatorChar, '/') + "/");
+			p2r.setProperties(config);
+
+			assertThat(p2r.list(null)).isNotEmpty();
+			assertThat(new File(location, "index.xml.gz")).isFile();
+			assertThat(p2r.getRoot()).isEqualTo(location);
+		}
+	}
+
+	@Test
+	public void testLocationAsIndexFile() throws Exception {
+		File repository = IO.getFile("testdata/p2/macbadge");
+		File location = new File(tmp, "file-location");
+		File indexFile = new File(location, "custom-index.xml.gz");
+		try (Workspace w = Workspace.createStandaloneWorkspace(new Processor(), tmp.toURI());
+			P2Repository p2r = new P2Repository()) {
+			w.setProperty(Constants.CONNECTION_SETTINGS, "false");
+			w.setBase(tmp);
+			p2r.setRegistry(w);
+
+			Map<String, String> config = new HashMap<>();
+			config.put("url", repository.toURI()
+				.toString());
+			config.put("name", "test");
+			config.put("location", indexFile.getAbsolutePath());
+			p2r.setProperties(config);
+
+			assertThat(p2r.list(null)).isNotEmpty();
+			assertThat(indexFile).isFile();
+			assertThat(new File(location, "index.xml.gz")).doesNotExist();
+			assertThat(p2r.getRoot()).isEqualTo(location);
+		}
+	}
 
 	@Test
 	public void testSimple() throws Exception {

--- a/docs/_chapters/310-testing.md
+++ b/docs/_chapters/310-testing.md
@@ -159,7 +159,7 @@ As noted above, `biz.aQute.tester.junit-platform` requires JUnit Platform (and i
         aQute.bnd.repository.p2.provider.P2Repository;\
             name="Eclipse Local";\
             url="file:///path/to/eclipse/";\
-            location="${workspace}/cnf/cache/stable/EclipseLocal"
+			location="${workspace}/cnf/cache/stable/EclipseLocal/"
 ```
 
 Alternatively, it is not difficult to download the required (non-OSGi) modules from Maven Central and include them as-is on `-runpath`, or else (preferably) wrap them into bundles and include them in `-runrequires`/`-runbundles`. 

--- a/docs/_plugins/p2repo.md
+++ b/docs/_plugins/p2repo.md
@@ -18,7 +18,7 @@ It can take the following configuration properties:
 | ----------------- | --------- | ---------- | --------------- |
 | `name`           | `NAME`    | p2 + `url` | The name of the repository. |
 | `url`            | `URI`     |            | The URL to either the P2 repository (a directory) or an Eclipse target platform definition file. |
-| `location`       | `STRING`  |            | The location to store the _index_ file and where bundles will be downloaded to. |
+| `location`       | `STRING`  | `cnf/cache/p2-<name>/` | The location to store the index and downloaded bundles. A value ending in `/` is a directory and stores the index as `index.xml.gz`; otherwise, the value specifies the complete index filename and bundles are stored in its parent directory. |
 | `tags`           | `STRING`|  | Comma separated list of tags. (e.g. resolve, baseline, release) Use a placeholder like &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution. The `resolve` tag is picked up by the [-runrepos](/instructions/runrepos.html) instruction.|
 
 ## Example
@@ -28,6 +28,16 @@ It can take the following configuration properties:
  	aQute.bnd.repository.p2.provider.P2Repository; \
  	url = https://download.eclipse.org/modeling/emf/emf/builds/release/2.21; \
  	name = EMF
+```
+
+To select the index filename explicitly:
+
+```
+-plugin.p2: \
+	aQute.bnd.repository.p2.provider.P2Repository; \
+	url = https://download.eclipse.org/modeling/emf/emf/builds/release/2.21; \
+	name = EMF; \
+	location = cnf/cache/emf-index.xml.gz
 ```
 
 ## Tagging

--- a/docs/_plugins/p2repo.md
+++ b/docs/_plugins/p2repo.md
@@ -18,7 +18,7 @@ It can take the following configuration properties:
 | ----------------- | --------- | ---------- | --------------- |
 | `name`           | `NAME`    | p2 + `url` | The name of the repository. |
 | `url`            | `URI`     |            | The URL to either the P2 repository (a directory) or an Eclipse target platform definition file. |
-| `location`       | `STRING`  | `cnf/cache/p2-<name>/` | The location to store the index and downloaded bundles. A value ending in `/` is a directory and stores the index as `index.xml.gz`; otherwise, the value specifies the complete index filename and bundles are stored in its parent directory. |
+| `location`       | `STRING`  | `cnf/cache/p2-<name>/` | The location to store the index and downloaded bundles. A value ending in `/` is a directory and stores the index as `index.xml.gz`; an existing directory is also treated as a directory. Otherwise, the value specifies the complete index filename and bundles are stored in its parent directory. |
 | `tags`           | `STRING`|  | Comma separated list of tags. (e.g. resolve, baseline, release) Use a placeholder like &lt;&lt;EMPTY&gt;&gt; to exclude the repo from resolution. The `resolve` tag is picked up by the [-runrepos](/instructions/runrepos.html) instruction.|
 
 ## Example


### PR DESCRIPTION
Treat P2 repository locations ending in a slash as directories containing index.xml.gz. Treat other locations as complete index filenames and store downloaded bundles in the parent directory.

Add tests for both location forms and update the documentation.