### PR TITLE
Implement resolution:=conditional directive for flexible Import-Package handling

### DIFF
--- a/biz.aQute.bndlib.tests/build.gradle
+++ b/biz.aQute.bndlib.tests/build.gradle
@@ -1,3 +1,7 @@
+dependencies {
+	testImplementation files('jar/asm.jar')
+}
+
 tasks.named("compileTestJava") {
 	options.compilerArgs.add("-parameters")
 }

--- a/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
+++ b/biz.aQute.bndlib.tests/test/test/AnalyzerTest.java
@@ -1504,4 +1504,116 @@ public class AnalyzerTest {
 			return null;
 		return clauses.get(attr);
 	}
+
+	/**
+	 * Test Import-Packages marked with resolution:=conditional.
+	 * When package is from an OSGi bundle, it should be imported normally.
+	 */
+	@Test
+	public void testConditionalImportWithOSGiBundle() throws Exception {
+		Builder a = new Builder();
+		try {
+			Properties p = new Properties();
+			// Use resolution:=conditional for OSGi packages
+			p.put("Import-Package", "*;resolution:=conditional");
+			p.put("Private-Package", "test.conditionalimport");
+
+			a.addClasspath(new File("bin_test"));
+			a.addClasspath(IO.getFile("jar/osgi.jar")); // OSGi bundle
+
+			a.setProperties(p);
+			Jar jar = a.build();
+			assertTrue(a.check());
+
+			String imports = jar.getManifest()
+				.getMainAttributes()
+				.getValue("Import-Package");
+
+			// org.osgi.framework should be imported normally (from OSGi bundle)
+			assertNotNull(imports);
+			assertTrue(imports.contains("org.osgi.framework"));
+			// Should have version from OSGi bundle
+			assertTrue(imports.contains("version="));
+			assertFalse(imports.contains("resolution:=optional"));
+			assertFalse(imports.contains("resolution:=conditional"));
+
+		} finally {
+			a.close();
+		}
+	}
+
+	/**
+	 * Test Import-Packages marked with resolution:=conditional for non-OSGi jar.
+	 * The package should be embedded, not imported.
+	 */
+	@Test
+	public void testConditionalImportWithNonOSGiJar() throws Exception {
+		Builder a = new Builder();
+		try {
+			Properties p = new Properties();
+			// Use resolution:=conditional which should embed packages from non-OSGi jars
+			p.put("Import-Package", "*;resolution:=conditional");
+			p.put("Private-Package", "test.dynamicimport");
+
+			a.addClasspath(new File("bin_test"));
+			a.addClasspath(IO.getFile("jar/asm.jar")); // Non-OSGi jar
+			a.addClasspath(IO.getFile("jar/osgi.jar")); // OSGi bundle
+
+			a.setProperties(p);
+			Jar jar = a.build();
+			assertTrue(a.check());
+
+			String imports = jar.getManifest()
+				.getMainAttributes()
+				.getValue("Import-Package");
+
+			// org.osgi.framework should be imported (from OSGi bundle)
+			assertNotNull(imports);
+			assertTrue(imports.contains("org.osgi.framework"));
+
+			// ASM classes come from a non-OSGi jar, so they should be embedded
+			assertNotNull(jar.getResource("org/objectweb/asm/ClassReader.class"));
+			// and NOT imported
+			assertFalse(imports.contains("org.objectweb.asm"));
+
+		} finally {
+			a.close();
+		}
+	}
+
+	@Test
+	public void testConditionalImportWithTransitiveNonOSGiJar() throws Exception {
+		try (Jar dependency = new Jar("dependency")) {
+			dependency.putResource("test/conditionalimportlibrary/a/A.class",
+				new FileResource(IO.getFile("bin_test/test/conditionalimportlibrary/a/A.class")));
+			dependency.putResource("test/conditionalimportlibrary/b/B.class",
+				new FileResource(IO.getFile("bin_test/test/conditionalimportlibrary/b/B.class")));
+
+			try (Builder a = new Builder()) {
+				Properties p = new Properties();
+				p.put("Import-Package", "*;resolution:=conditional");
+				p.put("Private-Package", "test.conditionalimporttransitive");
+
+				a.addClasspath(new File("bin_test"));
+				a.addClasspath(dependency);
+
+				a.setProperties(p);
+				Jar jar = a.build();
+				assertTrue(a.check());
+
+				assertNotNull(jar.getResource("test/conditionalimportlibrary/a/A.class"));
+				assertNotNull(jar.getResource("test/conditionalimportlibrary/b/B.class"));
+
+				String imports = jar.getManifest()
+					.getMainAttributes()
+					.getValue("Import-Package");
+				if (imports != null) {
+					assertFalse(imports.contains("test.conditionalimportlibrary.a"));
+					assertFalse(imports.contains("test.conditionalimportlibrary.b"));
+				}
+			}
+		}
+	}
+
+
 }

--- a/biz.aQute.bndlib.tests/test/test/conditionalimport/ConditionalImport.java
+++ b/biz.aQute.bndlib.tests/test/test/conditionalimport/ConditionalImport.java
@@ -1,0 +1,14 @@
+package test.conditionalimport;
+
+import org.osgi.framework.BundleContext;
+
+/**
+ * Test class that imports:
+ * 1. org.osgi.framework (from OSGi bundle)
+ */
+public class ConditionalImport {
+	
+	public ConditionalImport(BundleContext bc) {
+		// Use the imports
+	}
+}

--- a/biz.aQute.bndlib.tests/test/test/conditionalimportlibrary/a/A.java
+++ b/biz.aQute.bndlib.tests/test/test/conditionalimportlibrary/a/A.java
@@ -1,0 +1,7 @@
+package test.conditionalimportlibrary.a;
+
+import test.conditionalimportlibrary.b.B;
+
+public class A {
+	B b = new B();
+}

--- a/biz.aQute.bndlib.tests/test/test/conditionalimportlibrary/b/B.java
+++ b/biz.aQute.bndlib.tests/test/test/conditionalimportlibrary/b/B.java
@@ -1,0 +1,3 @@
+package test.conditionalimportlibrary.b;
+
+public class B {}

--- a/biz.aQute.bndlib.tests/test/test/conditionalimporttransitive/ConditionalImportTransitive.java
+++ b/biz.aQute.bndlib.tests/test/test/conditionalimporttransitive/ConditionalImportTransitive.java
@@ -1,0 +1,7 @@
+package test.conditionalimporttransitive;
+
+import test.conditionalimportlibrary.a.A;
+
+public class ConditionalImportTransitive {
+	A a = new A();
+}

--- a/biz.aQute.bndlib.tests/test/test/dynamicimport/AsmUser.java
+++ b/biz.aQute.bndlib.tests/test/test/dynamicimport/AsmUser.java
@@ -1,0 +1,10 @@
+package test.dynamicimport;
+
+import org.objectweb.asm.ClassReader;
+
+public class AsmUser {
+
+	public ClassReader createClassReader(byte[] bytes) {
+		return new ClassReader(bytes);
+	}
+}

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Analyzer.java
@@ -134,6 +134,7 @@ public class Analyzer extends Processor {
 		PackageRef.class, true);
 	private final Contracts							contracts				= new Contracts(this);
 	private final Packages							classpathExports		= new Packages();
+	private final Packages							stagedConditionalPackages = new Packages();
 	private final Descriptors						descriptors				= new Descriptors();
 	private final List<Jar>							classpath				= list();
 	private final Map<TypeRef, Clazz>				classspace				= map();
@@ -441,6 +442,7 @@ public class Analyzer extends Processor {
 		uses.clear();
 		apiUses.clear();
 		classpathExports.clear();
+		stagedConditionalPackages.clear();
 		contracts.clear();
 		packagesVisited.clear();
 		nonClassReferences.clear();
@@ -980,6 +982,28 @@ public class Analyzer extends Processor {
 	}
 
 	protected Jar getExtra() throws Exception {
+		stageConditionalImports();
+		Iterator<Entry<PackageRef, Attrs>> stagedIterator = stagedConditionalPackages.entrySet()
+			.iterator();
+		while (stagedIterator.hasNext()) {
+			Entry<PackageRef, Attrs> staged = stagedIterator.next();
+			PackageRef packageRef = staged.getKey();
+			stagedIterator.remove();
+			Jar extra = new Jar(Constants.IMPORT_PACKAGE);
+			addClose(extra);
+			for (Jar cpe : getClasspath()) {
+				Map<String, Resource> packageDir = cpe.getDirectory(packageRef.getPath());
+				if (packageDir != null && !packageDir.isEmpty()) {
+					JarCopyUtil.copyPackageWithPreprocessing(extra, cpe, packageRef.getPath(), false, this);
+
+					if (!extra.getDirectories()
+						.isEmpty()) {
+						return extra;
+					}
+					break;
+				}
+			}
+		}
 		return null;
 	}
 
@@ -2191,6 +2215,9 @@ public class Analyzer extends Processor {
 		Packages regularImports = new Packages(imports);
 		Parameters dynamicImports = getDynamicImportPackage();
 
+		// First, handle conditional imports before processing dynamic imports
+		processConditionalImports(regularImports);
+
 		Iterator<Entry<PackageRef, Attrs>> regularImportsIterator = regularImports.entrySet()
 			.iterator();
 		while (regularImportsIterator.hasNext()) {
@@ -2205,6 +2232,85 @@ public class Analyzer extends Processor {
 			}
 		}
 		return new Pair<>(regularImports, dynamicImports);
+	}
+
+	/**
+	 * Process imports with resolution:=conditional directive.
+	 * For each conditional import:
+	 * 1. If package is from an OSGi bundle (in classpathExports with INTERNAL_EXPORTED_DIRECTIVE),
+	 *    keep it as a regular import (remove the resolution directive)
+	 * 2. If package is from a non-OSGi jar (in classpathExports but without INTERNAL_EXPORTED_DIRECTIVE),
+	 *    remove from imports and add to conditional packages to be embedded
+	 * 3. If package is not on classpath at all, change resolution to optional
+	 */
+	private void processConditionalImports(Packages regularImports) {
+		Iterator<Entry<PackageRef, Attrs>> importsIterator = regularImports.entrySet()
+			.iterator();
+		while (importsIterator.hasNext()) {
+			Entry<PackageRef, Attrs> packageEntry = importsIterator.next();
+			PackageRef packageRef = packageEntry.getKey();
+			Attrs attrs = packageEntry.getValue();
+			String resolution = attrs.get(Constants.RESOLUTION_DIRECTIVE);
+
+			if (Constants.RESOLUTION_CONDITIONAL.equals(resolution)) {
+				attrs.remove(Constants.RESOLUTION_DIRECTIVE);
+
+				Attrs classpathAttrs = classpathExports.get(packageRef);
+				if (classpathAttrs != null) {
+					// Package is on the classpath
+					if (classpathAttrs.containsKey(Constants.INTERNAL_EXPORTED_DIRECTIVE)) {
+						// Package is from an OSGi bundle - keep as regular import
+						// Directive already removed, nothing else to do
+					} else if (contained.containsKey(packageRef)) {
+						// Package is already embedded through conditional processing
+						importsIterator.remove();
+					} else {
+						// Package is from a non-OSGi jar - stage it for embedding
+						stagedConditionalPackages.put(packageRef, new Attrs(attrs));
+						importsIterator.remove();
+					}
+				} else {
+					// Package not found in classpathExports; check classpath directly
+					// (e.g. non-OSGi jars with a non-null manifest are not added to
+					// classpathExports by learnPackage but may still supply the package)
+					boolean foundOnNonOSGiClasspath = false;
+					for (Jar cpe : getClasspath()) {
+						Map<String, Resource> packageDir = cpe.getDirectory(packageRef.getPath());
+						if (packageDir != null && !packageDir.isEmpty()) {
+							try {
+								if (cpe.getBsn() == null) {
+									// Non-OSGi jar - stage for embedding
+									foundOnNonOSGiClasspath = true;
+								}
+							} catch (Exception e) {
+								// ignore, treat as non-OSGi
+								foundOnNonOSGiClasspath = true;
+							}
+							break;
+						}
+					}
+					if (foundOnNonOSGiClasspath && !contained.containsKey(packageRef)) {
+						stagedConditionalPackages.put(packageRef, new Attrs(attrs));
+						importsIterator.remove();
+					} else if (!foundOnNonOSGiClasspath) {
+						// Package not found on classpath - make it optional
+						attrs.put(Constants.RESOLUTION_DIRECTIVE, Constants.OPTIONAL);
+					}
+				}
+			}
+		}
+	}
+
+	private void stageConditionalImports() {
+		String h = getProperty(IMPORT_PACKAGE);
+		if (h == null) {
+			h = "*";
+		}
+		Instructions filter = new Instructions(h);
+		Packages conditionalImports = filter(filter, new Packages(referred), Create.set());
+		if (!conditionalImports.isEmpty()) {
+			processConditionalImports(conditionalImports);
+		}
 	}
 
 	String applyVersionPolicy(String exportVersion, String importRange, boolean provider) {

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Builder.java
@@ -424,6 +424,10 @@ public class Builder extends Analyzer {
 	 */
 	@Override
 	protected Jar getExtra() throws Exception {
+		Jar extra = super.getExtra();
+		if (extra != null) {
+			return extra;
+		}
 		Parameters conditionals = getMergedParameters(CONDITIONAL_PACKAGE);
 		conditionals.putAll(decorated(CONDITIONALPACKAGE));
 		if (conditionals.isEmpty())
@@ -803,28 +807,7 @@ public class Builder extends Analyzer {
 	 * Copy
 	 */
 	private void copy(Jar dest, Jar srce, String path, boolean overwrite) {
-		logger.debug("copy d={} s={} p={}", dest, srce, path);
-		dest.copy(srce, path, overwrite);
-		if (hasSources()) {
-			dest.copy(srce, appendPath("OSGI-OPT/src", path), overwrite);
-		}
-
-		// bnd.info sources must be preprocessed
-		String bndInfoPath = appendPath(path, "bnd.info");
-		Resource r = dest.getResource(bndInfoPath);
-		if (r != null && !(r instanceof PreprocessResource)) {
-			logger.debug("preprocessing bnd.info");
-			PreprocessResource pp = new PreprocessResource(this, r);
-			dest.putResource(bndInfoPath, pp);
-		}
-
-		if (hasSources()) {
-			String srcPath = appendPath("OSGI-OPT/src", path);
-			Map<String, Resource> srcContents = srce.getDirectory(srcPath);
-			if (srcContents != null) {
-				dest.addDirectory(srcContents, overwrite);
-			}
-		}
+		JarCopyUtil.copyPackageWithPreprocessing(dest, srce, path, overwrite, this);
 	}
 
 	/**

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/Constants.java
@@ -405,6 +405,7 @@ public interface Constants {
 	String		CLASS_ATTRIBUTE								= "class";
 	String		NAME_ATTRIBUTE								= "name";
 	String		RESOLUTION_DYNAMIC							= "dynamic";
+	String		RESOLUTION_CONDITIONAL						= "conditional";
 	String		DESCRIPTION_ATTRIBUTE						= "description";
 	String		OSNAME_ATTRIBUTE							= "osname";
 	String		OSVERSION_ATTRIBUTE							= "osversion";

--- a/biz.aQute.bndlib/src/aQute/bnd/osgi/JarCopyUtil.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/osgi/JarCopyUtil.java
@@ -1,0 +1,51 @@
+package aQute.bnd.osgi;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class JarCopyUtil {
+    private static final Logger logger = LoggerFactory.getLogger(JarCopyUtil.class);
+
+    /**
+     * Copy package resources from source JAR to destination JAR with preprocessing.
+     * This method handles:
+     * - Standard package content copying
+     * - Source file copying (when -sources is enabled)
+     * - bnd.info preprocessing
+     *
+     * @param dest destination JAR
+     * @param srce source JAR
+     * @param path package path
+     * @param overwrite whether to overwrite existing resources
+     * @param processor the processor context (for hasSources check and preprocessing)
+     */
+	static void copyPackageWithPreprocessing(Jar dest, Jar srce, String path,
+                                                     boolean overwrite, Processor processor) {
+        logger.debug("copy d={} s={} p={}", dest, srce, path);
+        dest.copy(srce, path, overwrite);
+
+        if (Processor.isTrue(processor.getProperty(Constants.SOURCES))) {
+            dest.copy(srce, Processor.appendPath("OSGI-OPT/src", path), overwrite);
+        }
+
+        // bnd.info sources must be preprocessed
+        String bndInfoPath = Processor.appendPath(path, "bnd.info");
+        Resource r = dest.getResource(bndInfoPath);
+        if (r != null && !(r instanceof PreprocessResource)) {
+            logger.debug("preprocessing bnd.info");
+            PreprocessResource pp = new PreprocessResource(processor, r);
+            dest.putResource(bndInfoPath, pp);
+        }
+
+        if (Processor.isTrue(processor.getProperty(Constants.SOURCES))) {
+            String srcPath = Processor.appendPath("OSGI-OPT/src", path);
+            Map<String, Resource> srcContents = srce.getDirectory(srcPath);
+            if (srcContents != null) {
+                dest.addDirectory(srcContents, overwrite);
+            }
+        }
+
+    }
+}

--- a/docs/_heads/_ext/import_package.md
+++ b/docs/_heads/_ext/import_package.md
@@ -44,6 +44,30 @@ Packages with directive `resolution:=dynamic` will be removed from `Import-Packa
 
     Import-Package: org.slf4j.*;resolution:=dynamic, *
 
+## Conditional Resolution
+
+Packages with directive `resolution:=conditional` provide a flexible way to handle imports based on the classpath configuration. This is particularly useful when wrapping third-party libraries where you want automatic handling of dependencies:
+
+    Import-Package: *;resolution:=conditional
+
+When a package is marked with `resolution:=conditional`, bnd will:
+
+1. **Import normally** if the package is found on the classpath and comes from an OSGi bundle (has Export-Package metadata)
+2. **Embed the package** if it's found on the classpath but comes from a non-OSGi jar (no OSGi metadata)
+3. **Mark as optional** (`resolution:=optional`) if the package is not found on the classpath at all
+
+This behavior is especially useful when:
+- Wrapping existing JARs that mix OSGi and non-OSGi dependencies
+- Creating flexible bundles that can adapt to different deployment scenarios
+- Avoiding the need to manually specify which packages should be imported vs. embedded
+
+Example use case: Wrapping a third-party library that depends on both OSGi frameworks (like org.osgi.framework) and plain Java libraries (like Apache Commons):
+
+    Import-Package: *;resolution:=conditional
+    Private-Package: com.thirdparty.*
+
+In this case, OSGi packages will be imported with proper version ranges, while non-OSGi dependencies will be embedded directly into the bundle, and any optional dependencies not on the classpath will be marked as optional imports.
+
 If an imported package uses mandatory attributes, then bnd will attempt to add those attributes to the import statement. However, in certain (bizarre!) cases this is not wanted. It is therefore possible to remove an attribute from the import clause. This is done with the `-remove-attribute` directive or by setting the value of an attribute to `!`. The parameter of the `-remove-attribute` directive is an instruction and can use the standard options with `!`, `*`, `?`, etc.
 
     Import-Package: org.eclipse.core.runtime;-remove-attribute:="common",*


### PR DESCRIPTION
Closes https://github.com/bndtools/bnd/issues/6465 (original PR https://github.com/laeubi/bnd/pull/2#issuecomment-5444678652 )

This is a copy of https://github.com/bndtools/bnd/pull/7403 to the bndtools repo. The main purpose is that we are currently not allowed to use copilot in the fork of PR #7403 so we need to have it in this repo. 

**Original PR description**

## Overview

This PR implements the `resolution:=conditional` directive for Import-Package as requested in issue #6465. This new directive provides a flexible and automated way to handle package imports based on classpath configuration, particularly useful when wrapping third-party libraries that mix OSGi and non-OSGi dependencies.

## Problem

Currently, when wrapping third-party code or working with mixed dependencies, developers must manually specify which packages should be imported, embedded, or marked as optional. This is tedious and error-prone, especially when dealing with libraries that have dependencies on both OSGi bundles and plain JAR files.

## Solution

The new `resolution:=conditional` directive automatically determines how to handle each package based on its presence and type on the classpath:

1. **Packages from OSGi bundles** → Imported normally with version ranges
2. **Packages from non-OSGi JARs** → Embedded directly into the bundle
3. **Packages not on classpath** → Marked as `resolution:=optional`

## Usage Example

```properties
Import-Package: *;resolution:=conditional
Private-Package: com.thirdparty.*
```

When building a bundle that wraps a third-party library:
- OSGi framework packages (e.g., `org.osgi.framework`) are automatically imported with proper versions
- Plain Java library packages (e.g., Apache Commons from non-OSGi JARs) are automatically embedded
- Optional dependencies not on the classpath are marked as optional imports

## Implementation Details

## Benefits

- **Reduces manual configuration** - No need to explicitly list packages for embedding vs. importing
- **Adapts to deployment scenarios** - Same bundle configuration works with different classpaths
- **Simplifies third-party wrapping** - Ideal for creating OSGi bundles from non-OSGi libraries
- **Backward compatible** - Existing code continues to work unchanged

