### PR TITLE
Apply JAXP entity size limits to XML parsers

### DIFF
--- a/aQute.libg/src/aQute/lib/xml/XML.java
+++ b/aQute.libg/src/aQute/lib/xml/XML.java
@@ -3,12 +3,14 @@ package aQute.lib.xml;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.TransformerFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
@@ -16,6 +18,11 @@ import org.xml.sax.SAXNotSupportedException;
 
 public final class XML {
 	private static final Logger logger = LoggerFactory.getLogger(XML.class);
+
+	private static final int		DEFAULT_XML_ENTITY_SIZE_LIMIT	= Integer.getInteger("bnd.xml.entitySizeLimit", 0);
+	private static final String[]	JAXP_ENTITY_SIZE_LIMITS			= {
+		"jdk.xml.totalEntitySizeLimit", "jdk.xml.maxGeneralEntitySizeLimit"
+	};
 
 	private XML() {}
 
@@ -87,6 +94,8 @@ public final class XML {
 				e);
 		}
 
+		setJaxpLimits(instance);
+
 		return instance;
 	}
 
@@ -95,6 +104,14 @@ public final class XML {
 	 * <p>
 	 * The returned SAXParserFactory is configured to avoid XML External Entity
 	 * (XXE) attacks.
+	 * </p>
+	 * <p>
+	 * Note that JAXP processing limits such as
+	 * {@code jdk.xml.totalEntitySizeLimit} and
+	 * {@code jdk.xml.maxGeneralEntitySizeLimit} cannot be configured on a
+	 * {@link SAXParserFactory}. Callers that want bnd's configured JAXP limits
+	 * should use {@link #newSAXParser()} instead.
+	 * </p>
 	 *
 	 * @return A properly configured SAXParserFactory instance.
 	 */
@@ -138,6 +155,26 @@ public final class XML {
 		return instance;
 	}
 
+
+	/**
+	 * Create and return a {@link SAXParser} instance configured using
+	 * {@link #newSAXParserFactory()}.
+	 * <p>
+	 * In addition to the factory's XML security configuration, the parser is
+	 * configured with bnd's JAXP entity-size limits. Explicit {@code jdk.xml.*}
+	 * system properties are honored; otherwise bnd's defaults are used.
+	 *
+	 * @return a properly configured SAXParser instance
+	 * @throws ParserConfigurationException if a parser cannot be created
+	 * @throws SAXException if a SAX parser cannot be created
+	 */
+	public static SAXParser newSAXParser() throws Exception {
+
+		SAXParser instance = newSAXParserFactory().newSAXParser();
+		setJaxpLimits(instance);
+		return instance;
+	}
+
 	/**
 	 * Create and return a XMLInputFactory instance.
 	 * <p>
@@ -160,6 +197,9 @@ public final class XML {
 			logger.info("Unable to set property {} to false: XML External Entity (XXE) attack risk",
 				XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, e);
 		}
+
+		setJaxpLimits(instance);
+
 		return instance;
 	}
 
@@ -187,4 +227,43 @@ public final class XML {
 		}
 		return instance;
 	}
+
+	private static void setJaxpLimits(XMLInputFactory factory) {
+		for (String property : JAXP_ENTITY_SIZE_LIMITS) {
+			int value = Integer.getInteger(property, DEFAULT_XML_ENTITY_SIZE_LIMIT);
+
+			try {
+				factory.setProperty(property, value);
+			} catch (IllegalArgumentException e) {
+				// Not supported by this XML implementation.
+				logger.info("Unable to set property {} to : {}", property, value, e);
+			}
+		}
+	}
+
+	private static void setJaxpLimits(SAXParser parser) {
+		for (String property : JAXP_ENTITY_SIZE_LIMITS) {
+			int value = Integer.getInteger(property, DEFAULT_XML_ENTITY_SIZE_LIMIT);
+
+			try {
+				parser.setProperty(property, value);
+			} catch (Exception e) {
+				// Not supported by this XML implementation.
+				logger.info("Unable to set property {} to : {}", property, value, e);
+			}
+		}
+	}
+
+	private static void setJaxpLimits(DocumentBuilderFactory factory) {
+		for (String property : JAXP_ENTITY_SIZE_LIMITS) {
+			int value = Integer.getInteger(property, DEFAULT_XML_ENTITY_SIZE_LIMIT);
+			try {
+				factory.setAttribute(property, value);
+			} catch (IllegalArgumentException e) {
+				// Not supported by this XML implementation.
+				logger.info("Unable to set property {} to : {}", property, value, e);
+			}
+		}
+	}
+
 }

--- a/aQute.libg/src/aQute/lib/xml/package-info.java
+++ b/aQute.libg/src/aQute/lib/xml/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("1.1.0")
 package aQute.lib.xml;
 
 import org.osgi.annotation.versioning.Version;

--- a/aQute.libg/src/aQute/libg/sax/SAXUtil.java
+++ b/aQute.libg/src/aQute/libg/sax/SAXUtil.java
@@ -1,5 +1,6 @@
 package aQute.libg.sax;
 
+import javax.xml.parsers.SAXParser;
 import javax.xml.transform.Result;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
@@ -22,8 +23,9 @@ public class SAXUtil {
 				filter.setParent(last);
 				last = filter;
 			}
-		XMLReader reader = XML.newSAXParserFactory()
-			.newSAXParser()
+
+		SAXParser newSAXParser = XML.newSAXParser();
+		XMLReader reader = newSAXParser
 			.getXMLReader();
 		reader.setContentHandler(last);
 

--- a/biz.aQute.bndlib/src/aQute/bnd/build/MagicBnd.java
+++ b/biz.aQute.bndlib/src/aQute/bnd/build/MagicBnd.java
@@ -26,6 +26,7 @@ import aQute.bnd.result.Result;
 import aQute.lib.io.IO;
 import aQute.lib.strings.Strings;
 import aQute.lib.utf8properties.UTF8Properties;
+import aQute.lib.xml.XML;
 import aQute.libg.re.Catalog;
 import aQute.libg.re.RE;
 import aQute.libg.re.RE.Match;
@@ -87,7 +88,7 @@ public class MagicBnd {
 	}
 
 	private static String getName(File file, String defaultName) throws FactoryConfigurationError {
-		XMLInputFactory factory = XMLInputFactory.newInstance();
+		XMLInputFactory factory = XML.newXMLInputFactory();
 		try (InputStream inputStream = new FileInputStream(file);) {
 			XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
 

--- a/docs/_chapters/880-settings.md
+++ b/docs/_chapters/880-settings.md
@@ -1,48 +1,80 @@
 ---
+
 title: Settings
 layout: bnd
 parent: Configuration and Troubleshooting
 nav_order: 1
----
-For a build model it is crucial that it has no dependencies on the machine it is running on. One of the  most frustrating developer experiences is the phrase: 'Yes, but it runs on my machine!'. For this reason bnd goes out of it is way to have no dependencies outside its workspace. That is, until we hit security. It is in the nature of security to have secrets and by definitions these secrets cannot be in the workspace, or, well, they will not be that secret for long. Though the best solution is to keep the secret in your head, there are times when this is impossible or plain cumbersome.
+------------
 
-For this reason, bnd maintains a settings file in ~/.bnd/settings.json. This file contains ordinary settings ...
+bnd can be configured from several sources, depending on the scope and purpose of the setting.
 
-TBD
+Workspace and project configuration should normally be kept with the build so that builds remain reproducible across different machines. Some settings, however, are specific to the local user or environment and should not be stored in the workspace. Examples include credentials, local identity information, and process-level configuration.
+
+For these cases, bnd supports:
+
+* a user-specific settings file at `~/.bnd/settings.json`
+* Java system properties
+* environment variables
+
+The settings file is intended for persistent user-specific configuration that should remain outside the workspace. System properties and environment variables are useful for configuration supplied by the launcher, build environment, CI system, or operating system.
+
+## User Settings
+
+bnd stores user-specific settings in:
+
+```text
+~/.bnd/settings.json
+```
+
+The settings file can contain configuration such as identity and authorization information. Depending on the environment, it can also be protected with a password using the `BND_SETTINGS_PASSWORD` environment variable.
 
 ## Authorization
 
 ## The bnd settings Command
 
 ## The global macro
-	
 
 ## Authorizing a New System
 
-The settings automatically generate a private and public key when they are initialized. However, in certain cases it is necessary to explicitly authorize a system. For example, [Travis][1] always starts a build from a completely freshly initialized VM. In such a case it is necessary to authorize the machine explicitly. Though it is possible to just copy an existing settings file to this machine, it is more elegant to use the bnd commands. Do the following steps to authorize a machine.
+The settings automatically generate a private and public key when they are initialized. However, in certain cases it is necessary to explicitly authorize a system. For example, CI environments often start each build on a newly initialized machine. In such a case it may be necessary to explicitly provision the required identity.
 
 On a trusted host, get the current private and public key and the email:
 
-	$ bnd identity
-	--publicKey 08E...CF --privateKey C7FE...D3 --email bnd@example.org
+```
+$ bnd identity
+--publicKey 08E...CF --privateKey C7FE...D3 --email bnd@example.org
+```
 
-The output is a bit longer than shown because these keys are darned long, you know, security is hard. You should copy the output and then on the target system run:
+Copy the output and run the following command on the target system:
 
-	$ bnd identity <copied output>
+```
+$ bnd identity <copied output>
+```
 
- This will use the same authorization as the original machine. If you want to create a more unique authorization, then it is possible to create a new private/public key pair. 
- 
-     $ bnd settings -l temp.json -g
-     $ bnd identity -l temp.json 
-     --publicKey 08E...CF --privateKey C7FE...D3 --email bnd@example.org
-     ...
-     $ bnd identity <copied output>
-	
+This configures the target system with the same authorization as the original machine.
 
+If you instead want to create a separate private/public key pair, you can create a temporary settings file:
 
+```
+$ bnd settings -l temp.json -g
+$ bnd identity -l temp.json
+--publicKey 08E...CF --privateKey C7FE...D3 --email bnd@example.org
+...
+$ bnd identity <copied output>
+```
 
+## System Properties and Environment Variables
 
+Some bnd behavior can be configured using Java system properties or environment variables. These are particularly useful for process-wide settings, launcher configuration, and CI environments.
 
+### System Properties
 
-[1]: https://travis-ci.org/
+| Property Name             | Description                                                                                                                                                                                                                                                                                                                                     | Default | Type  |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----- |
+| `bnd.xml.entitySizeLimit` | Default entity-size limit used by XML parsers created by bnd. The value is used as the fallback for the JAXP `jdk.xml.totalEntitySizeLimit` and `jdk.xml.maxGeneralEntitySizeLimit` properties. A value of `0` means unlimited. The corresponding `jdk.xml.*` system property, when explicitly set, takes precedence for that individual limit. | `0`     | `int` |
 
+### Environment Variables
+
+| Variable Name           | Description                                                                                                            | Example                                         |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `BND_SETTINGS_PASSWORD` | Password used to encrypt or decrypt `~/.bnd/settings.json`. If it is not set, the settings file is stored unencrypted. | `export BND_SETTINGS_PASSWORD=mysecretpassword` |


### PR DESCRIPTION
Closes #7412

Add configurable JAXP entity-size limits (jdk.xml.totalEntitySizeLimit, jdk.xml.maxGeneralEntitySizeLimit) to DocumentBuilderFactory, SAXParser, and XMLInputFactory instances created by XML utility class.

A new XML.newSAXParser() factory method is introduced so callers get both the XXE-safe SAXParserFactory configuration and the JAXP limits in one call. SAXUtil is updated to use this new method. Package version bumped to 1.1.0.

Also use secure XML.newXMLInputFactory() in MagicBnd instead of using it directly which makes it vulnerable to bad xml.