### PR TITLE
biz.aQute.tester.junit-platform: support OSGi-registered PostDiscoveryFilter services

### DIFF
--- a/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
+++ b/biz.aQute.tester.junit-platform/src/aQute/tester/junit/platform/Activator.java
@@ -42,6 +42,7 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherConstants;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.core.LauncherConfig;
@@ -79,6 +80,7 @@ public class Activator implements BundleActivator, Runnable {
 	private File							reportDir;
 	private SummaryGeneratingListener		summary;
 	private List<TestExecutionListener>		listeners	= new ArrayList<>();
+	private ServiceTracker<PostDiscoveryFilter, PostDiscoveryFilter>	filterTracker;
 	final BlockingDeque<DiscoverySelector>	queue		= new LinkedBlockingDeque<>();
 
 	public Activator() {}
@@ -111,6 +113,9 @@ public class Activator implements BundleActivator, Runnable {
 			thread.interrupt();
 			thread.join(10000);
 		}
+		if (filterTracker != null) {
+			filterTracker.close();
+		}
 	}
 
 	public boolean active() {
@@ -140,6 +145,8 @@ public class Activator implements BundleActivator, Runnable {
 		} finally {
 			thread.setContextClassLoader(contextClassLoader);
 		}
+		filterTracker = new ServiceTracker<>(context, PostDiscoveryFilter.class, null);
+		filterTracker.open();
 		List<TestExecutionListener> listenerList = new ArrayList<>();
 
 		setTesterNames(context.getProperty(TESTER_NAMES));
@@ -381,11 +388,14 @@ public class Activator implements BundleActivator, Runnable {
 			.ofNullable(context.getProperty(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME));
 		Optional<String> captureStderr = Optional
 			.ofNullable(context.getProperty(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME));
+		PostDiscoveryFilter[] filters = filterTracker != null ? filterTracker.getServices(new PostDiscoveryFilter[0])
+			: new PostDiscoveryFilter[0];
 		return LauncherDiscoveryRequestBuilder.request()
 			.configurationParameter(BundleEngine.CHECK_UNRESOLVED, unresolved)
 			.configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, captureStdout.orElse("true"))
 			.configurationParameter(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, captureStderr.orElse("true"))
 			.selectors(selectors)
+			.filters(filters)
 			.build();
 	}
 

--- a/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/AbstractActivatorJUnitPlatformTest.java
+++ b/biz.aQute.tester.test/test/aQute/tester/junit/platform/test/AbstractActivatorJUnitPlatformTest.java
@@ -37,6 +37,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.platform.commons.JUnitException;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.MultipleFailuresError;
@@ -740,5 +744,51 @@ abstract class AbstractActivatorJUnitPlatformTest extends AbstractActivatorCommo
 		assertThat(methods).containsExactly("testPlanExecutionStarted", "executionStarted", "executionStarted",
 			"executionStarted", "executionStarted", "executionStarted", "executionFinished", "executionFinished",
 			"executionFinished", "executionFinished", "executionFinished", "testPlanExecutionFinished");
+	}
+
+	public static class FilterGenerator implements BundleActivator, PostDiscoveryFilter {
+
+		ServiceRegistration<PostDiscoveryFilter> reg;
+
+		@Override
+		public FilterResult apply(TestDescriptor descriptor) {
+			return descriptor.getSource()
+				.filter(MethodSource.class::isInstance)
+				.map(MethodSource.class::cast)
+				.filter(source -> source.getClassName()
+					.equals(With2Failures.class.getName())
+					&& source.getMethodName()
+						.equals("test1"))
+				.map(source -> FilterResult.excluded("excluded by test"))
+				.orElseGet(() -> FilterResult.included(null));
+		}
+
+		@Override
+		public void start(BundleContext context) throws Exception {
+			reg = context.registerService(PostDiscoveryFilter.class, this, null);
+		}
+
+		@Override
+		public void stop(BundleContext context) throws Exception {
+			reg.unregister();
+		}
+	}
+
+	@Test
+	public void testFilters_excludeSpecificTest() throws Exception {
+		final ExitCode exitCode = runTests(() -> {
+			lp.bundle()
+				.addResourceWithCopy(FilterGenerator.class)
+				.bundleActivator(FilterGenerator.class.getName())
+				.importPackage("org.junit.platform.engine")
+				.importPackage("org.junit.platform.engine.support.descriptor")
+				.importPackage("org.junit.platform.launcher")
+				.importPackage("*")
+				.start();
+		}, With2Failures.class);
+
+		// test1 is excluded, so only test3's failure should be counted
+		assertThat(exitCode.exitCode).as("exit code")
+			.isEqualTo(1);
 	}
 }


### PR DESCRIPTION
## Problem

`aQute.tester.junit.platform.Activator` already tracks `TestExecutionListener` OSGi services registered by other bundles and hands them to `Launcher.execute(...)` for every test run. This is a nice extension point used e.g. by Tycho's `org.eclipse.tycho.bnd.executionlistener` bundle for reporting purposes.

However, there is currently no equivalent way to *exclude* specific tests from a run. The only test-selection mechanism is `tester.names`, which is include-only (bare class name, or `ClassName#methodName`), enumerated ahead of time. Consumers that need to exclude just a handful of test methods out of an otherwise "run everything" selection (e.g. a build tool that wants to skip a single incompatible TCK test method while still running an entire test class/bundle) have no way to do this without either:
- reflectively enumerating every test method of the affected class(es) at build time and explicitly listing all-but-the-excluded ones via `tester.names`, or
- forking/patching the test itself.

## Fix

This adds a `ServiceTracker<PostDiscoveryFilter, PostDiscoveryFilter>`, symmetric to the existing `TestExecutionListener` tracker, and passes any registered filters into `LauncherDiscoveryRequestBuilder.filters(...)` when building each discovery request.

This lets any bundle contribute a `@Component(service = PostDiscoveryFilter.class)` that operates on the already fully-discovered `TestDescriptor` tree (e.g. matching by `MethodSource`/`ClassSource`) to exclude specific tests - engine-agnostically, i.e. it works the same for JUnit 3 (vintage), JUnit 4 and JUnit 5 test classes, without any build-time reflection.

## Testing

Added `testFilters_excludeSpecificTest` to `AbstractActivatorJUnitPlatformTest`, registering a `PostDiscoveryFilter` OSGi service that excludes `With2Failures#test1`, and verifying via the exit code (and the generated JUnit XML report) that the excluded test never executes while its sibling methods still run normally.

Ran the full `biz.aQute.tester.test` suite locally - all green.

## Motivation / context

This came out of investigating an OSGi TCK incompatibility for a mediator-pattern implementation that runs as a framework extension: one specific TCK test method stops/restarts the mediator bundle, which - in a self-hosted TCK run inside the very framework under test - happens to resolve to the *system* bundle, making that one assertion fundamentally unsafe to execute in that configuration. An upstream fix for that specific test (osgi/osgi#969) is proposed separately, but until that lands (and for any other similarly narrow exclusion needs), a generic, engine-agnostic way to exclude a single test method from an otherwise full bnd/JUnit-Platform run is useful independent of that particular case.